### PR TITLE
BUG-FIX: the ripple IO plugin was wrongly raising an exception when

### DIFF
--- a/hyperspy/io_plugins/ripple.py
+++ b/hyperspy/io_plugins/ripple.py
@@ -137,12 +137,6 @@ def parse_ripple(fp):
         err = '"data-length" for float "data-type" must be "4" or "8".\n'
         err += 'Check %s' % fp.name
         raise IOError, err
-    if rpl_info['data-length'] == '1' and rpl_info['byte-order'] != 'dont-care':
-        err = '"data-length" and "byte-order" mismatch.\n'
-        err += '"data-length" cannot be "1" if "byte-order" is "dont-care" '
-        err += 'and vice versa.'
-        err += 'Check %s' % fp.name
-        raise IOError, err
     return rpl_info
 
 def read_raw(rpl_info, fp, mmap_mode='c'):


### PR DESCRIPTION
data-leng=1 and byte-order=dont-cate
