### PR TITLE
BUG-FIX: shift1D was not cropping as expected positive shifts when shift...

### DIFF
--- a/hyperspy/axes.py
+++ b/hyperspy/axes.py
@@ -274,7 +274,7 @@ class DataAxis(t.HasTraits):
     def update_value(self):
         self.value = self.axis[self.index]
 
-    def value2index(self, value):
+    def value2index(self, value, rounding=round):
         """Return the closest index to the given value if between the limit.
 
         Parameters
@@ -293,7 +293,7 @@ class DataAxis(t.HasTraits):
         if value is None:
             return None
         else:
-            index = int(round((value - self.offset) / 
+            index = int(rounding((value - self.offset) / 
                               self.scale))
             if self.size > index >= 0:
                 return index

--- a/hyperspy/signal.py
+++ b/hyperspy/signal.py
@@ -19,6 +19,7 @@
 import copy
 import os.path
 import warnings
+import math
 
 import numpy as np
 import numpy.ma as ma
@@ -394,14 +395,20 @@ class Signal1DTools(object):
         axis.offset = offset
 
         if crop is True:
-            mini, maxi = shift_array.min(), shift_array.max()
-            if mini < 0:
+            minimum, maximum = shift_array.min(), shift_array.max()
+            if minimum < 0:
+                iminimum = 1 + axis.value2index(
+                        axis.high_value + minimum,
+                        rounding=math.floor)
+                print iminimum
                 self.crop(axis.index_in_axes_manager,
                           None,
-                          axis.axis[-1] + mini + axis.scale)
-            if maxi > 0:
+                          iminimum)
+            if maximum > 0:
+                imaximum = axis.value2index(offset + maximum,
+                                            rounding=math.ceil) 
                 self.crop(axis.index_in_axes_manager,
-                          float(offset + maxi))
+                          imaximum)
             
     def interpolate_in_between(self, start, end, delta=3, **kwargs):
         """Replace the data in a given range by interpolation.

--- a/hyperspy/tests/signal/test_1D_tools.py
+++ b/hyperspy/tests/signal/test_1D_tools.py
@@ -21,7 +21,7 @@ import os
 import numpy as np
 
 from nose.tools import assert_true, assert_equal, assert_not_equal
-from hyperspy._signals.spectrum import Spectrum
+from hyperspy.signals import Spectrum
 
 class TestAlignTools:
     def setUp(self):
@@ -87,6 +87,22 @@ class TestAlignTools:
         # Check that the calibration is correct
         assert_equal(s.axes_manager._axes[1].offset, self.new_offset)
         assert_equal(s.axes_manager._axes[1].scale, self.scale)
+
+class TestShift1D():
+    def setUp(self):
+        self.s = Spectrum(np.arange(10))
+        self.s.axes_manager[0].scale = 0.2
+    def test_crop_left(self):
+        s = self.s
+        s.shift1D(np.array((0.01)), crop=True)
+        assert_equal(tuple(s.axes_manager[0].axis), tuple(np.arange(0.2,2.,0.2)))
+    def test_crop_right(self):
+        s = self.s
+        s.shift1D(np.array((-0.01)), crop=True)
+        assert_equal(tuple(s.axes_manager[0].axis), tuple(np.arange(0.,1.8,0.2)))
+
+
+
         
 class TestFindPeaks1D:
     def setUp(self):


### PR DESCRIPTION
This fixes an old bug in shift1D that in some corner cases was not cropping properly the signal axis. It also adds tests to detect the bug.
