### PR TITLE
BUG-FIX: Signal.__iter__ was not restarting the AxesManager iterator ind...

### DIFF
--- a/hyperspy/signal.py
+++ b/hyperspy/signal.py
@@ -4037,6 +4037,8 @@ class Signal(MVA,
         return s
 
     def __iter__(self):
+        # Reset AxesManager iteration index
+        self.axes_manager.__iter__()
         return self
 
     def next(self):

--- a/hyperspy/tests/signal/test_tools.py
+++ b/hyperspy/tests/signal/test_tools.py
@@ -107,4 +107,11 @@ class Test4D:
         im.unfold()
         assert_equal(im.data.shape, (30, 12))
 
+def test_signal_iterator():
+    s = Signal(np.arange(3).reshape((3, 1)))
+    assert_equal(s.next().data[0], 0)
+    # If the following fails it can be because the iteration index was not
+    # restarted
+    for i, signal in enumerate(s):
+        assert_equal(i, signal.data[0])
 


### PR DESCRIPTION
...ex.
