### PR TITLE
ENH: add **kwargs for get_histogram

### DIFF
--- a/hyperspy/signal.py
+++ b/hyperspy/signal.py
@@ -3744,9 +3744,10 @@ class Signal(MVA,
         range_bins : tuple or None (optional)
             the minimum and maximum range for the histogram. If not specified,
             it will be (x.min(), x.max())
-            
-        other keyword arguments (weight and density) are described in 
-        np.histogram().
+        
+        **kwargs
+            other keyword arguments (weight and density) are described in 
+            np.histogram().
 
         Returns
         -------


### PR DESCRIPTION
**kwargs to access other options of np.histogram
