### PR TITLE
Enh animate legend

### DIFF
--- a/hyperspy/drawing/utils.py
+++ b/hyperspy/drawing/utils.py
@@ -331,6 +331,7 @@ def plot_spectra(
         line_style=None,
         padding=1.,
         legend=None,
+        legend_picking=True,
         fig=None,):
     """Plot several spectra in the same figure.
 
@@ -365,6 +366,9 @@ def plot_spectra(
        If list of string, legend for "cascade" or title for "mosaic" is
        displayed. If 'auto', the title of each spectra (mapped_parameters.title)
        is used.
+    legend_picking: bool
+        If true, a spectrum can be toggle on and off by clicking on
+        the legended line.
     fig : {matplotlib figure, None}
         If None, a default figure will be created.
 
@@ -430,7 +434,8 @@ def plot_spectra(
                           line_style=line_style,)
         if legend is not None:
             plt.legend(legend)
-            animate_legend(figure=fig)
+            if legend_picking is True:
+                animate_legend(figure=fig)
     elif style == 'cascade':
         if fig is None:
             fig = plt.figure()
@@ -474,13 +479,21 @@ def plot_spectra(
     return ax
     
 def animate_legend(figure='last'):
-    """Animate the legend of a figure
+    """Animate the legend of a figure   
+    
+    A spectrum can be toggle on and off by clicking on the legended line.
     
     Parameters
     ---------
     
     figure: 'last' | matplolib.figure
         If 'last' pick the last figure
+        
+    Note
+    ----
+    
+    Code inspired from legend_picking.py in the matplotlib gallery
+    
     """
     if figure=='last':
         figure = plt.gcf()


### PR DESCRIPTION
A spectrum can be toggle on and off by clicking on the legended line. Added to `plot_spectra(style='overlap')` with legend.

I'll do the doc when #168 and #169 will be merged...
