### PR TITLE
Fix Fourier ratio default treshold

### DIFF
--- a/hyperspy/_signals/eels.py
+++ b/hyperspy/_signals/eels.py
@@ -590,6 +590,10 @@ class EELSSpectrum(Spectrum):
         """
         self._check_signal_dimension_equals_one()
         orig_cl_size = self.axes_manager.signal_axes[0].size
+            
+        if threshold is None:
+            threshold = ll.estimate_elastic_scattering_threshold()
+
         if extrapolate_coreloss is True:
             cl = self.power_law_extrapolation(
                 window_size=20,


### PR DESCRIPTION
EELS.fourier_ratio_deconvlution bug: Docstring say default treshold of
None should make method use first minimum. The feature was not
implemented, and caused an exception in
estimate_elastic_scattering_intensity. Fixed by calling
elastic_scattering_treshold if treshold is None.
