### PR TITLE
BUGFIX: TEM parameters

### DIFF
--- a/hyperspy/io_plugins/fei.py
+++ b/hyperspy/io_plugins/fei.py
@@ -391,7 +391,6 @@ def ser_reader(filename, objects=None, verbose=False, *args, **kwds):
         axes[-1]['name'] = 'Energy'
         axes[-1]['scale'] *= 0.001
 
-
         array_shape.append(data['ArrayLength'][0])
 
     elif record_by == 'image':


### PR DESCRIPTION
Change metadata name to fit to the structure. `beam_voltage` into `beam_energy`

Suppress `beam_intensity`, as not defined in metadata. 
