### PR TITLE
Bugfix stack axis

### DIFF
--- a/hyperspy/misc/utils.py
+++ b/hyperspy/misc/utils.py
@@ -782,7 +782,7 @@ def stack(signal_list, axis=None, new_axis_name='stack_element',
     signal.metadata._HyperSpy.set_item(
         'Stacking_history.step_sizes',
         step_sizes)
-        
+
     signal.__init__(**signal._to_dictionary())
 
     return signal


### PR DESCRIPTION
The `stack` function generates a bug:

```
s = [signals.Spectrum(range(i,10+i)) for i in range(4)]
s1=utils.stack(s)
s1.axes_manager.signal_axes[0].scale = 0.005
s1.plot()
```

The signal scale of the plot is not updated.

I fixed `stack`, but it might be a problem coming from deeper.
