### PR TITLE
BUGFIX: more general dictionary construction for DictionaryTreeBrowser

### DIFF
--- a/hyperspy/misc/utils.py
+++ b/hyperspy/misc/utils.py
@@ -291,7 +291,7 @@ class DictionaryTreeBrowser(object):
                 key = item_['key']
                 if key == "_db_index":
                     continue
-                if isinstance(item_['value'], DictionaryTreeBrowser):
+                if hasattr(item_['value'], 'as_dictionary'):
                     item = item_['value'].as_dictionary()
                 else:
                     item = item_['value']


### PR DESCRIPTION
Constructs dictionaries not only from included DictionaryTreeBrowsers, but from
any items that have 'as_dictionary()' method.
Fixes a bug where , after unfolding a signal and exporting it to dictionary, you have
objects that can be represented as dictionaries but are left as-is.
Because of this bug dictionaries were not passable with pickle.dump and pickle.load
for multiprocessing and similar