### PR TITLE
estimate_shift1D raised an exception because of numpy.clip function

### DIFF
--- a/hyperspy/signal.py
+++ b/hyperspy/signal.py
@@ -563,7 +563,7 @@ class Signal1DTools(object):
         if max_shift is not None:
             if interpolate is True:
                 max_shift *= ip
-            shift_array.clip(a_min=-max_shift, a_max=max_shift)
+            shift_array.clip(-max_shift, max_shift)
         if interpolate is True:
             shift_array /= ip
         shift_array *= axis.scale


### PR DESCRIPTION
Dear All, 

I found that "estimate_shift1D" is raising an exception when the kwarg "max_shift" was used. The exception is related with the np.clip function parameters "a_min" and "a_max", which could not be used by name. I guess the solution is not to use these parameter names and pass the values to the np.clip function directly.

I've implemented this solution in this pull request.

Best wishes,
Alberto.
