### PR TITLE
Fixed bug, power_law_extrapolation parameter A scaling

### DIFF
--- a/hyperspy/_signals/eels.py
+++ b/hyperspy/_signals/eels.py
@@ -851,7 +851,7 @@ class EELSSpectrum(Spectrum):
             _A[_r <= 0] = 0
             pl.A.map['values'] = _A
         s.data[..., axis.size:] = (
-            pl.A.map['values'][..., np.newaxis] *
+            s.axes_manager[-1].scale*pl.A.map['values'][..., np.newaxis] *
             s.axes_manager.signal_axes[0].axis[np.newaxis, axis.size:] ** (
                 -pl.r.map['values'][..., np.newaxis]))
         return s


### PR DESCRIPTION
Dear All,

I found that "power_law_extrapolation" was giving bad results: the extrapolated tail intensity was multiplyed by some unknown and _huge_ factor :). It seems the proble is related with A parameter of the PowerLaw component, that is now scaled by the energy spacing in the channels of the spectral dimension. I guess the easy solution is just to multiply A by this spacing in the function "power_law_extrapolation". 

I've implemented this solution in this pull request, but I'm not sure of the behavior of the A parameter in all cases.

Best wishes,
Alberto.
