### PR TITLE
DataAxis bugfix + value2index takes ndarray

### DIFF
--- a/hyperspy/tests/axes/test_data_axis.py
+++ b/hyperspy/tests/axes/test_data_axis.py
@@ -1,4 +1,5 @@
 import copy
+import math
 
 import nose.tools
 import numpy as np
@@ -44,3 +45,37 @@ class TestDataAxis:
         ac = copy.deepcopy(self.axis)
         ac.offset = 100
         nose.tools.assert_equal(ac.axis[0], ac.offset)
+
+    def test_value2index_float_in(self):
+        nose.tools.assert_equal(self.axis.value2index(10.15), 2)
+
+    def test_value2index_float_end_point_left(self):
+        nose.tools.assert_equal(self.axis.value2index(10.), 0)
+
+    def test_value2index_float_end_point_right(self):
+        nose.tools.assert_equal(self.axis.value2index(10.9), 9)
+
+    @nose.tools.raises(ValueError)
+    def test_value2index_float_out(self):
+        self.axis.value2index(11)
+
+    def test_value2index_array_in(self):
+        nose.tools.assert_equal(
+            self.axis.value2index(np.array([10.15, 10.15])).tolist(),
+            [2, 2])
+
+    def test_value2index_array_in_ceil(self):
+        nose.tools.assert_equal(
+            self.axis.value2index(np.array([10.14, 10.14]),
+                                  rounding=math.ceil).tolist(),
+            [2, 2])
+
+    def test_value2index_array_in_floor(self):
+        nose.tools.assert_equal(
+            self.axis.value2index(np.array([10.15, 10.15]),
+                                  rounding=math.floor).tolist(),
+            [1, 1])
+
+    @nose.tools.raises(ValueError)
+    def test_value2index_array_out(self):
+        self.axis.value2index(np.array([10, 11]))


### PR DESCRIPTION
Fixed a bug in DataAxis._get_name() when the axes_manager was not set.
Also, DataAxis.value2index() now accepts ndarrays as input.
