### PR TITLE
Fixed DraggablePatch picking

### DIFF
--- a/hyperspy/drawing/widgets.py
+++ b/hyperspy/drawing/widgets.py
@@ -113,8 +113,8 @@ class DraggablePatch(object):
         self.set_on(False)
 
     def onpick(self, event):
-        if event.artist is self.patch:
-            self.picked = True
+        self.picked = (event.artist is self.patch)
+            
 
     def onmove(self, event):
         """This method must be provided by the subclass"""


### PR DESCRIPTION
Previously, there was no mechanism for setting a DraggablePatch.picked
to False when it was no longer picked.

Fixes #270.
