### PR TITLE
BugFix to spikes_removal_tool, diagnosis part

### DIFF
--- a/hyperspy/_signals/spectrum.py
+++ b/hyperspy/_signals/spectrum.py
@@ -18,6 +18,7 @@
 
 import warnings
 
+import numpy as np
 import matplotlib.pyplot as plt
 
 from hyperspy.exceptions import DataDimensionError


### PR DESCRIPTION
Hello, 

I have found that "_spikes_diagnosis", used in "spikes_removal_tool" is not working properly. One problem is that it seems to raise an exception when called, due to numpy not being imported as "np". This pull request fixes that and it works now. 

Also, when the spikes diagnosis window is closed, the spikes_removal_tool widget window is closed too. I don't kniow if this is intentional, but it seems to be a faulty behavior.

Best wishes,
Alberto E.
