### PR TITLE
BUG_FIX: the dmreader sometimes fails to load single spectrum.

### DIFF
--- a/hyperspy/io_plugins/digital_micrograph.py
+++ b/hyperspy/io_plugins/digital_micrograph.py
@@ -562,7 +562,8 @@ class ImageObject(object):
         if len(self.scales) == 1:
             return "spectrum"
         elif (('ImageTags.Meta_Data.Format' in self.imdict and
-               self.imdict.ImageTags.Meta_Data.Format == "Spectrum image") or (
+               self.imdict.ImageTags.Meta_Data.Format in ("Spectrum image",
+                                                          "Spectrum")) or (
                 "ImageTags.spim" in self.imdict)) and len(self.scales) == 2:
             return "spectrum"
         else:


### PR DESCRIPTION
Sometimes DM stores single spectrum in 2D array with one dimension equal to 1. HyperSpy was failing to load those files.
