### PR TITLE
bugfix: fit_background was wrongfully erasing the first active edge

### DIFF
--- a/hyperspy/models/eelsmodel.py
+++ b/hyperspy/models/eelsmodel.py
@@ -390,7 +390,7 @@ class EELSModel(Model):
         ea = self.axis.axis[self.channel_switches]
         #~print "Fitting the", self._backgroundtype, "background"
         edges = copy.copy(self._active_edges)
-        edge = edges.pop(0)
+        edge = edges[0]
         if start_energy is None:
             start_energy = ea[0]
         i = 0


### PR DESCRIPTION
Dear all, 

I think this fixes issue #315

The problem was that the first _active_edge of the list was always erased.

Hope this works.
