### PR TITLE
Fix and rename Model.set_current_values_to

### DIFF
--- a/hyperspy/model.py
+++ b/hyperspy/model.py
@@ -1498,17 +1498,37 @@ class Model(list):
             The operation won't be performed where mask is True.
 
         """
+
+        warnings.warn(
+            "This method has been renamed to `assign_current_values_to_all` "
+            "and it will be removed in the next release", DeprecationWarning)
+        return self.assign_current_values_to_all(
+            components_list=components_list, mask=mask)
+
+    def assign_current_values_to_all(self, components_list=None, mask=None):
+        """Set parameter values for all positions to the current ones.
+
+        Parameters
+        ----------
+        component_list : list of components, optional
+            If a list of components is given, the operation will be performed
+            only in the value of the parameters of the given components.
+            The components can be specified by name, index or themselves.
+        mask : boolean numpy array or None, optional
+            The operation won't be performed where mask is True.
+
+        """
         if components_list is None:
             components_list = []
             for comp in self:
                 if comp.active:
                     components_list.append(comp)
         else:
-            component_list = [self._get_component(x) for x in component_list]
+            components_list = [self._get_component(x) for x in components_list]
 
         for comp in components_list:
             for parameter in comp.parameters:
-                parameter.set_current_value_to(mask=mask)
+                parameter.assign_current_value_to_all(mask=mask)
 
     def _enable_ext_bounding(self, components=None):
         """

--- a/hyperspy/tests/model/test_model.py
+++ b/hyperspy/tests/model/test_model.py
@@ -416,3 +416,25 @@ class TestStoreCurrentValues:
         self.o.offset.std = 3
         self.m.store_current_values()
         nose.tools.assert_not_equal(self.o.offset.map["values"][0], 2)
+
+
+class TestSetCurrentValuesTo:
+
+    def setUp(self):
+        self.m = hs.create_model(hs.signals.Spectrum(
+            np.arange(10).reshape(2, 5)))
+        self.comps = [hs.components.Offset(), hs.components.Offset()]
+        self.m.extend(self.comps)
+
+    def test_set_all(self):
+        for c in self.comps:
+            c.offset.value = 2
+        self.m.assign_current_values_to_all()
+        nose.tools.assert_true((self.comps[0].offset.map["values"] == 2).all())
+        nose.tools.assert_true((self.comps[1].offset.map["values"] == 2).all())
+
+    def test_set_1(self):
+        self.comps[1].offset.value = 2
+        self.m.assign_current_values_to_all([self.comps[1]])
+        nose.tools.assert_true((self.comps[0].offset.map["values"] != 2).all())
+        nose.tools.assert_true((self.comps[1].offset.map["values"] == 2).all())


### PR DESCRIPTION
The method was broken due to a couple of issues, one being the renaming
of the equivalent parameter function that has been undetected til now
because this method does not have unittest.
- Add unittests
- Rename it to `assign_current_values_to_all`
