### PR TITLE
BUG-FIX: wrong error message when reading rpl file

### DIFF
--- a/hyperspy/io_plugins/ripple.py
+++ b/hyperspy/io_plugins/ripple.py
@@ -182,7 +182,7 @@ def parse_ripple(fp):
         raise IOError(err)
     if rpl_info['data-length'] == '1' and rpl_info['byte-order'] != 'dont-care':
         err = '"data-length" and "byte-order" mismatch.\n'
-        err += '"data-length" cannot be "1" if "byte-order" is "dont-care" '
+        err += '"data-length" cannot be "1" if "byte-order" is not "dont-care" '
         err += 'and vice versa.'
         err += 'Check %s' % fp.name
         raise IOError(err)


### PR DESCRIPTION
A ripple file with data-length 1 should have byte-order don-care and viceversa. When loading a Ripple file that does not follow this rule an exception is raised and the file cannot be loaded. The (mildly) faulty file can be easily fixed by editing the rpl file to set "data-length" to "1" or "byte-order" to "dont-care". However, due to a typo that this PR fixes, it is currently impossible to guess this from the current error message:

```
IOError: "data-length" and "byte-order" mismatch.
"data-length" cannot be "1" if "byte-order" is not "dont-care" and vice versa.Check 500pA_001_0deg.rpl
```
