### PR TITLE
ENH: add check in _get_component to check if component is in the model

### DIFF
--- a/hyperspy/model.py
+++ b/hyperspy/model.py
@@ -218,7 +218,10 @@ class Model(list):
             object = self[object]
         elif not isinstance(object, Component):
             raise ValueError("Not a component or component id.")
-        return object
+        if object in self:
+            return object
+        else:
+            raise ValueError("The component is not in the model.")
 
     def insert(self):
         raise NotImplementedError


### PR DESCRIPTION
Fixes confusing expection when m.fit_component is called with a component which is not in the model.
