### PR TITLE
Fix tests fails round off error

### DIFF
--- a/hyperspy/tests/model/test_model.py
+++ b/hyperspy/tests/model/test_model.py
@@ -139,9 +139,9 @@ class TestModelFitBinned:
     def test_fit_fmin_ml(self):
         self.m.fit(fitter="fmin", method="ml")
         nose.tools.assert_almost_equal(self.m[0].A.value, 10001.39613936,
-                places=3)
+                                       places=3)
         nose.tools.assert_almost_equal(self.m[0].centre.value, -0.104151206314,
-                places=6)
+                                       places=6)
         nose.tools.assert_almost_equal(self.m[0].sigma.value, 2.00053642434)
 
     def test_fit_leastsq(self):


### PR DESCRIPTION
#376  fixed these tests for (presumably) numpy 1.9, but it broke them for older versions. This PR hopefully solves the issue.
