### PR TITLE
ENH: components.Bleasdale: do not use NaNs, better use zeros

### DIFF
--- a/hyperspy/_components/bleasdale.py
+++ b/hyperspy/_components/bleasdale.py
@@ -46,7 +46,8 @@ class Bleasdale(Component):
         a = self.a.value
         b = self.b.value
         c = self.c.value
-        return (a + b * x) ** (-1. / c)
+        abx = (a+b*x)
+        return np.where(abx > 0., (abx)**(-1/c), 0.)
 
     def grad_a(self, x):
         """


### PR DESCRIPTION
Dear All, 

I propose this small enhancement to the bleasdale component, to avoid it from returning NaN for negative (a+b*x). Instead, I think the function should return zeros, hopefully this won't break anything. 

What do you think?

Best wishes,
Alberto.
