### PR TITLE
Improve save model documentation.

### DIFF
--- a/doc/user_guide/model.rst
+++ b/doc/user_guide/model.rst
@@ -628,10 +628,32 @@ datasets**.
 Saving and loading the result of the fit
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-To save the result of the fit to a single file use
-:py:meth:`~.model.Model.save_parameters2file` and
-:py:meth:`~.model.Model.load_parameters_from_file` to load back the results
-into the same model structure.
+As of HyperSpy 0.7.4, the following is the only way to save a model to  a file
+and load it back. Note that this method is known to be brittle i.e. there is no
+guarantee that a version of HyperSpy different from the one used to save the
+model will be able to load it sucessfully.  Also, it is advisable not to use
+this method in combination with functions that alter the value of the
+parameters interactively (e.g.  `enable_adjust_position`) as the modifications
+made by this functions are normally not stored in the IPython notebook or
+Python script.
+
+To save a model:
+
+1. Save the parameter arrays to a file using
+   :py:meth:`~.model.Model.save_parameters2file`.
+
+2. Save all the commands that used to create the model to a file. This
+   can be done in the form of an IPython notebook or a Python script.
+   
+3.  (Optional) Comment out or delete the fitting commangs (e.g. `multifit`).
+
+To recreate the model:
+
+1. Execute the IPython notebook or Python script.
+
+2. Use :py:meth:`~.model.Model.load_parameters_from_file` to load back the
+   parameter values and arrays.
+
 
 Exporting the result of the fit
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/hyperspy/model.py
+++ b/hyperspy/model.py
@@ -1351,11 +1351,26 @@ class Model(list):
             os.remove(autosave_fn + '.npz')
 
     def save_parameters2file(self, filename):
-        """Save the parameters array in binary format
+        """Save the parameters array in binary format.
+
+        The data is saved to a single file in numpy's uncompressed ``.npz``
+        format.
 
         Parameters
         ----------
         filename : str
+
+        See Also
+        --------
+        load_parameters_from_file, export_results
+
+        Notes
+        -----
+        This method can be used to save the current state of the model in a way
+        that can be loaded back to recreate the it using `load_parameters_from
+        file`. Actually, before HyperSpy 0.8 this is the only way to do so.
+        However, this is known to be brittle. For example see
+        https://github.com/hyperspy/hyperspy/issues/341.
 
         """
         kwds = {}
@@ -1369,15 +1384,25 @@ class Model(list):
         np.savez(filename, **kwds)
 
     def load_parameters_from_file(self, filename):
-        """Loads the parameters array from  a binary file written with
-        the 'save_parameters2file' function
+        """Loads the parameters array from  a binary file written with the
+        'save_parameters2file' function.
 
         Parameters
         ---------
         filename : str
 
-        """
+        See Also
+        --------
+        save_parameters2file, export_results
 
+        Notes
+        -----
+        In combination with `save_parameters2file`, this method can be used to
+        recreate a model stored in a file. Actually, before HyperSpy 0.8 this
+        is the only way to do so.  However, this is known to be brittle. For
+        example see https://github.com/hyperspy/hyperspy/issues/341.
+
+        """
         f = np.load(filename)
         i = 0
         for component in self:  # Cut the parameters list


### PR DESCRIPTION
The procedure to save and load a model was poorly documented. Following #341, the text now explicitly warns users about the brittlesness of the method.