### PR TITLE
Make navigation_shape and signal_shape () when their dimension is 0.

### DIFF
--- a/hyperspy/axes.py
+++ b/hyperspy/axes.py
@@ -669,17 +669,17 @@ class AxesManager(t.HasTraits):
             self.navigation_shape = tuple([
                 axis.size for axis in self.navigation_axes])
         else:
-            self.navigation_shape = (0,)
+            self.navigation_shape = ()
 
         if self.signal_dimension != 0:
             self.signal_shape = tuple([
                 axis.size for axis in self.signal_axes])
         else:
-            self.signal_shape = (0,)
-        self.navigation_size = \
-            np.cumprod(self.navigation_shape)[-1]
-        self.signal_size = \
-            np.cumprod(self.signal_shape)[-1]
+            self.signal_shape = ()
+        self.navigation_size = (np.cumprod(self.navigation_shape)[-1]
+                                if self.navigation_shape else 0)
+        self.signal_size = (np.cumprod(self.signal_shape)[-1]
+                            if self.signal_shape else 0)
         self._update_max_index()
 
     def set_signal_dimension(self, value):

--- a/hyperspy/component.py
+++ b/hyperspy/component.py
@@ -353,7 +353,7 @@ class Parameter(object):
 
         """
         shape = self._axes_manager._navigation_shape_in_array
-        if len(shape) == 1 and shape[0] == 0:
+        if not shape:
             shape = [1, ]
         dtype_ = np.dtype([
             ('values', 'float', self._number_of_elements),

--- a/hyperspy/tests/model/test_parameter.py
+++ b/hyperspy/tests/model/test_parameter.py
@@ -34,7 +34,7 @@ class Dummy:
 
 
 class DummyAxesManager:
-    navigation_shape = [0, ]
+    navigation_shape = ()
     indices = ()
 
     @property


### PR DESCRIPTION
Currently, when the navigation or signal dimension is 0, the navigation/signal shape is (0,). This is in contrast with numpy where the shape would be (). This changes HyperSpy behaviour to be more consistent with numpy, e.g.

    In [1]: s = signals.Spectrum((np.zeros((10))))
    In [2]: s.axes_manager.navigation_shape
    Out[2]: ()
