### PR TITLE
ENH: Added only_current checkbox to ComponentFit

### DIFF
--- a/hyperspy/gui/tools.py
+++ b/hyperspy/gui/tools.py
@@ -757,9 +757,12 @@ class ImageContrastEditor(t.HasTraits):
 
 class ComponentFit(SpanSelectorInSpectrum):
     fit = t.Button()
+    only_current = t.List(t.Bool(True))
 
     view = tu.View(
         tu.Item('fit', show_label=False),
+        tu.Item('only_current', show_label=False, style='custom',
+                editor=tu.CheckListEditor(values=[(True, 'Only current')])),
         buttons=[OKButton, CancelButton],
         title='Fit single component',
         handler=SpanSelectorInSpectrumHandler,
@@ -774,6 +777,7 @@ class ComponentFit(SpanSelectorInSpectrum):
         self.signal = model.spectrum
         self.axis = self.signal.axes_manager.signal_axes[0]
         self.span_selector = None
+        self.only_current = [True]
         self.model = model
         self.component = component
         self.signal_range = signal_range
@@ -817,6 +821,7 @@ class ComponentFit(SpanSelectorInSpectrum):
 
         # Setting reasonable initial value for parameters through
         # the components estimate_parameters function (if it has one)
+        only_current = len(self.only_current) > 0
         if self.estimate_parameters:
             if hasattr(self.component, 'estimate_parameters'):
                 if (self.signal_range != "interactive" and
@@ -825,13 +830,13 @@ class ComponentFit(SpanSelectorInSpectrum):
                         self.signal,
                         self.signal_range[0],
                         self.signal_range[1],
-                        only_current=True)
+                        only_current=only_current)
                 elif self.signal_range == "interactive":
                     self.component.estimate_parameters(
                         self.signal,
                         self.ss_left_value,
                         self.ss_right_value,
-                        only_current=True)
+                        only_current=only_current)
 
         self.model.fit(**self.fit_kwargs)
 


### PR DESCRIPTION
Added a only_current option for the ComponentFit traitsui view.
Implemented it using the CheckListEditor as I could make the label come
on the right of the tickbox, instead of having the label screw up the
layout.

Useful shortcut if you're fitting interactively.