### PR TITLE
BUG_powerlaw_zerorange

### DIFF
--- a/hyperspy/_components/power_law.py
+++ b/hyperspy/_components/power_law.py
@@ -105,6 +105,8 @@ class PowerLaw(Component):
         i1, i2 = axis.value_range_to_indices(x1, x2)
         if not (i2 + i1) % 2 == 0:
             i2 -= 1
+        if i2 == i1:
+            i2 += 2
         i3 = (i2 + i1) / 2
         x1 = axis.index2value(i1)
         x2 = axis.index2value(i2)


### PR DESCRIPTION
If estimate_parameters was passed a range of 0 or 1, it would cause
strange errors, as it tried to fit a zero-sized range. This solution
assures a range of at least one for the two regions.