### PR TITLE
ENH: Disconnected Signal(.data) iterators

### DIFF
--- a/hyperspy/signal.py
+++ b/hyperspy/signal.py
@@ -4627,6 +4627,80 @@ for name in (
     exec("setattr(Signal, \'%s\', %s)" % (name, name))
 
 
+class DisconnectedIterator(object):
+    """
+    Iterator class for iteration through a Signal's navigation axes, but 
+    working with a copy of the axes_manager so it doesn't trigger any 
+    AxesManager connections, which means the iteration is fast even in 
+    interactive mode, and without modifying existing connections.
+    
+    Signals of the same dimensions can be iterated in parallel by using the
+    slices property for its __getitem__() function, either on the signal or on
+    the AxesManager.
+    """
+    def __init__(self, signal):
+        self.signal = signal
+        self.axes_manager = None
+        
+    def __iter__(self):
+        self.axes_manager = AxesManager(self.signal.axes_manager._get_axes_dicts())
+        self.axes_manager.__iter__()
+        return self
+    
+    def next(self):
+        try:
+            self.axes_manager.next()
+        except AttributeError:
+            raise StopIteration()
+        except StopIteration:
+            self.axes_manager = None
+            raise
+        return self.signal[self.axes_manager._getitem_tuple]
+        
+    @property
+    def slices(self):
+        return self.axes_manager._getitem_tuple
+    
+    
+class DataIterator(object):
+    """
+    Iterator class for fast iteration through a Signal's navigation axes,
+    returning its signal axes data. Faster than normal signal iteration since:
+    a) No signal copies are made, only a copy of the axes_manager.
+    b) No connections to plots, so it is fast even in interactive mode, without
+       modifying existing connections on the signal.
+       
+    Signals of the same dimensions can be iterated in parallel by using the
+    slices property for its __getitem__() function, either on the signal or on 
+    the AxesManager.
+    """
+    def __init__(self, signal):
+        self.signal = signal
+        self.axes_manager = None
+        
+    def __iter__(self):
+        self.axes_manager = AxesManager(self.signal.axes_manager._get_axes_dicts())
+        self.axes_manager.__iter__()
+        return self
+    
+    def next(self):
+        try:
+            self.axes_manager.next()
+        except AttributeError:
+            raise StopIteration()
+        except StopIteration:
+            self.axes_manager = None
+            raise
+        return self.signal.data[self.axes_manager._getitem_tuple]
+        
+    def set_current(self, data):
+        self.signal.data[self.axes_manager._getitem_tuple] = data
+        
+    @property
+    def slices(self):
+        return self.axes_manager._getitem_tuple
+
+
 class SpecialSlicers:
 
     def __init__(self, signal, isNavigation):


### PR DESCRIPTION
Implements two iterators for iterating through the navigation axes of a Signal, and returning either a sub-Signal, or a slice of the data array. As it works with a copy of the AxesManager, it does not trigger any indexing connections on the original one, which can improve speed for those applications where those triggers are unnecessary. A good example for this is when the iteration triggers replots for each step, as this will many-double the time of processing.