### PR TITLE
BUG: Decomposition did not undo transpose

### DIFF
--- a/hyperspy/learn/mva.py
+++ b/hyperspy/learn/mva.py
@@ -669,7 +669,10 @@ class MVA():
         self._unfolded4decomposition = self.unfold_if_multidim()
 
         sc = self.deepcopy()
-        sc.data = a.T.reshape(self.data.shape)
+        if self.axes_manager[0].index_in_array == 0:
+            sc.data = a.T.reshape(self.data.shape)
+        else:
+            sc.data = a.reshape(self.data.shape)
         sc.metadata.General.title += signal_name
         if target.mean is not None:
             sc.data += target.mean

--- a/hyperspy/signal.py
+++ b/hyperspy/signal.py
@@ -3135,7 +3135,7 @@ class Signal(MVA,
                 filename = os.path.join(
                     self.tmp_parameters.folder,
                     self.tmp_parameters.filename)
-                extesion = (self.tmp_parameters.extension
+                extension = (self.tmp_parameters.extension
                             if not extension
                             else extension)
             elif self.metadata.has_item('General.original_filename'):


### PR DESCRIPTION
MVA.decomposition() performs a transpose if the first data axis is not
the navigation axis, but does not undo this in
get_decomposition_model(). Copy and paste fix.

Also fixed a typo in Signal.save().
