### PR TITLE
Sort X-ray lines return by _get_lines_from_elements

### DIFF
--- a/hyperspy/_signals/eds.py
+++ b/hyperspy/_signals/eds.py
@@ -400,6 +400,7 @@ class EDSSpectrum(Spectrum):
 
         Returns
         -------
+        list of X-ray lines alphabetically sorted
 
         """
 
@@ -434,6 +435,7 @@ class EDSSpectrum(Spectrum):
                       "in the data spectral range")
             else:
                 lines.extend(element_lines)
+        lines.sort()
         return lines
 
     def get_lines_intensity(self,


### PR DESCRIPTION
To prevent bug, ``_get_lines_from_elements`` returns X-ray lines in the same order than ``metadata.Sample.elements``.