### PR TITLE
ENH: Add logos to context menu in installer functions

### DIFF
--- a/bin/install_hyperspy_here.py
+++ b/bin/install_hyperspy_here.py
@@ -3,7 +3,7 @@ import sys
 import os
 
 
-def install_hyperspy_here():
+def install_hyperspy_here(hspy_qtconsole_logo_path, hspy_notebook_logo_path):
     # First uninstall old HyperSpy context menu entries
     try:
         if sys.getwindowsversion()[0] < 6.:  # Older than Windows Vista:
@@ -33,6 +33,7 @@ def install_hyperspy_here():
 
     # Install the context menu entries for the qtconsole and the IPython
     # notebook
+    logos = {'qtconsole': hspy_qtconsole_logo_path, 'notebook': hspy_notebook_logo_path}
     for env in ('qtconsole', 'notebook'):
         script = os.path.join(sys.prefix, 'Scripts', "hyperspy_%s.bat" % env)
         if sys.getwindowsversion()[0] < 6.:  # Before Windows Vista
@@ -72,6 +73,13 @@ def install_hyperspy_here():
                 _winreg.REG_SZ,
                 "HyperSpy %s here" %
                 env)
+            _winreg.SetValueEx(
+                key,
+                'Icon',
+                0,
+                _winreg.REG_SZ,
+                logos[env]
+            )
             key.Close()
             key = _winreg.CreateKey(
                 _winreg.HKEY_CLASSES_ROOT,
@@ -96,6 +104,13 @@ def install_hyperspy_here():
                 _winreg.REG_SZ,
                 "HyperSpy %s Here" %
                 env)
+            _winreg.SetValueEx(
+                key,
+                'Icon',
+                0,
+                _winreg.REG_SZ,
+                logos[env]
+            )
             key.Close()
             key = _winreg.CreateKey(
                 _winreg.HKEY_CLASSES_ROOT,
@@ -107,4 +122,12 @@ def install_hyperspy_here():
     print("HyperSpy here correctly installed")
 
 if __name__ == "__main__":
-    install_hyperspy_here()
+    import hyperspy
+    hyperspy_install_path = os.path.dirname(hyperspy.__file__)
+    logo_path = os.path.expandvars(os.path.join(hyperspy_install_path,
+                                   'data'))
+    hspy_qt_logo_path = os.path.join(logo_path,
+                                     'hyperspy_qtconsole_logo.ico')
+    hspy_nb_logo_path = os.path.join(logo_path,
+                                     'hyperspy_notebook_logo.ico')
+    install_hyperspy_here(hspy_qt_logo_path, hspy_nb_logo_path)

--- a/bin/win_post_installation.py
+++ b/bin/win_post_installation.py
@@ -73,7 +73,7 @@ def uninstall_hyperspy_here():
             print("Failed to uninstall HyperSpy %s here" % env)
 
 
-def install_hyperspy_here():
+def install_hyperspy_here(hspy_qtconsole_logo_path, hspy_notebook_logo_path):
     # First uninstall old HyperSpy context menu entries
     try:
         if sys.getwindowsversion()[0] < 6.:  # Older than Windows Vista:
@@ -103,6 +103,7 @@ def install_hyperspy_here():
 
     # Install the context menu entries for the qtconsole and the IPython
     # notebook
+    logos = {'qtconsole': hspy_qtconsole_logo_path, 'notebook': hspy_notebook_logo_path}
     for env in ('qtconsole', 'notebook'):
         script = os.path.join(sys.prefix, 'Scripts', "hyperspy_%s.bat" % env)
         if sys.getwindowsversion()[0] < 6.:  # Before Windows Vista
@@ -142,6 +143,13 @@ def install_hyperspy_here():
                 _winreg.REG_SZ,
                 "HyperSpy %s here" %
                 env)
+            _winreg.SetValueEx(
+                key,
+                'Icon',
+                0,
+                _winreg.REG_SZ,
+                logos[env]
+            )
             key.Close()
             key = _winreg.CreateKey(
                 _winreg.HKEY_CLASSES_ROOT,
@@ -166,6 +174,13 @@ def install_hyperspy_here():
                 _winreg.REG_SZ,
                 "HyperSpy %s Here" %
                 env)
+            _winreg.SetValueEx(
+                key,
+                'Icon',
+                0,
+                _winreg.REG_SZ,
+                logos[env]
+            )
             key.Close()
             key = _winreg.CreateKey(
                 _winreg.HKEY_CLASSES_ROOT,
@@ -188,6 +203,10 @@ def install():
     hyperspy_install_path = os.path.dirname(hyperspy.__file__)
     logo_path = os.path.expandvars(os.path.join(hyperspy_install_path,
                                    'data'))
+    hspy_qt_logo_path = os.path.join(logo_path,
+                                     'hyperspy_qtconsole_logo.ico')
+    hspy_nb_logo_path = os.path.join(logo_path,
+                                     'hyperspy_notebook_logo.ico')
     hyperspy_qtconsole_bat = os.path.join(sys.prefix,
                                           'Scripts',
                                           'hyperspy_qtconsole.bat')
@@ -246,7 +265,7 @@ def install():
         create_weblink(**link)
 
     if admin_rights() is True:
-        install_hyperspy_here()
+        install_hyperspy_here(hspy_qt_logo_path, hspy_nb_logo_path)
     else:
         print("To start HyperSpy from the context menu install HyperSpy "
               "with administrator rights")


### PR DESCRIPTION
Fairly self explanatory (see https://github.com/hyperspy/hyperspy/pull/417). Looks up the logos on the path and includes them as a registry key during installation so the context menus will have logos.