### PR TITLE
ENH: allow for specification of legend location in plot_spectra()

### DIFF
--- a/hyperspy/drawing/utils.py
+++ b/hyperspy/drawing/utils.py
@@ -380,9 +380,8 @@ def plot_spectra(
         If true, a spectrum can be toggle on and off by clicking on
         the legended line.
     legend_loc : str or int
-        This parameter will be control where the legend is placed on the figure
-        (when plotting with 'cascade' or 'overlap' styles) according to
-        the pyplot legend documentation <http://matplotlib.org/1.3.1/api/pyplot_api.html#matplotlib.pyplot.legend>
+        This parameter controls where the legend is placed on the figure;
+        see the pyplot.legend docstring for valid values
     fig : matplotlib figure or None
         If None, a default figure will be created. Specifying fig will
         not work for the 'heatmap' style.

--- a/hyperspy/drawing/utils.py
+++ b/hyperspy/drawing/utils.py
@@ -382,7 +382,7 @@ def plot_spectra(
     legend_loc : str or int
         This parameter will be control where the legend is placed on the figure
         (when plotting with 'cascade' or 'overlap' styles) according to
-        the `pyplot legend documentation <http://matplotlib.org/1.3.1/api/pyplot_api.html#matplotlib.pyplot.legend>`_
+        the pyplot legend documentation <http://matplotlib.org/1.3.1/api/pyplot_api.html#matplotlib.pyplot.legend>
     fig : matplotlib figure or None
         If None, a default figure will be created. Specifying fig will
         not work for the 'heatmap' style.

--- a/hyperspy/drawing/utils.py
+++ b/hyperspy/drawing/utils.py
@@ -341,6 +341,7 @@ def plot_spectra(
         padding=1.,
         legend=None,
         legend_picking=True,
+        legend_loc='upper right',
         fig=None,
         ax=None,):
     """Plot several spectra in the same figure.
@@ -378,6 +379,10 @@ def plot_spectra(
     legend_picking: bool
         If true, a spectrum can be toggle on and off by clicking on
         the legended line.
+    legend_loc : str or int
+        This parameter will be control where the legend is placed on the figure
+        (when plotting with 'cascade' or 'overlap' styles) according to
+        the `pyplot legend documentation <http://matplotlib.org/1.3.1/api/pyplot_api.html#matplotlib.pyplot.legend>`_
     fig : matplotlib figure or None
         If None, a default figure will be created. Specifying fig will
         not work for the 'heatmap' style.
@@ -446,7 +451,7 @@ def plot_spectra(
                            color=color,
                            line_style=line_style,)
         if legend is not None:
-            plt.legend(legend)
+            plt.legend(legend, loc=legend_loc)
             if legend_picking is True:
                 animate_legend(figure=fig)
     elif style == 'cascade':
@@ -460,7 +465,7 @@ def plot_spectra(
                               line_style=line_style,
                               padding=padding)
         if legend is not None:
-            plt.legend(legend)
+            plt.legend(legend, loc=legend_loc)
     elif style == 'mosaic':
         default_fsize = plt.rcParams["figure.figsize"]
         figsize = (default_fsize[0], default_fsize[1] * len(spectra))


### PR DESCRIPTION
Exactly as it says. Enables a parameter to plot_spectra() named `legend_loc` that allows a user to pass in the location of the legend that is plotted, so it isn't always put in the default place. This is only relevant for the `overlap` and `cascade` styles.