### PR TITLE
BUGFIX: Edit to plot_spectra() such that it can now handle passing keyword arguments

### DIFF
--- a/hyperspy/drawing/utils.py
+++ b/hyperspy/drawing/utils.py
@@ -343,7 +343,8 @@ def plot_spectra(
         legend_picking=True,
         legend_loc='upper right',
         fig=None,
-        ax=None,):
+        ax=None,
+        **kwargs):
     """Plot several spectra in the same figure.
 
     Extra keyword arguments are passed to `matplotlib.figure`.
@@ -388,6 +389,9 @@ def plot_spectra(
     ax : matplotlib ax (subplot) or None
         If None, a default ax will be created. Will not work for 'mosaic'
         or 'heatmap' style.
+    **kwargs
+        remaining keyword arguments are passed to matplotlib.figure() or
+        matplotlib.subplots(). Has no effect on 'heatmap' style.
 
     Example
     -------
@@ -442,7 +446,7 @@ def plot_spectra(
 
     if style == 'overlap':
         if fig is None:
-            fig = plt.figure()
+            fig = plt.figure(**kwargs)
         if ax is None:
             ax = fig.add_subplot(111)
         _make_overlap_plot(spectra,
@@ -455,7 +459,7 @@ def plot_spectra(
                 animate_legend(figure=fig)
     elif style == 'cascade':
         if fig is None:
-            fig = plt.figure()
+            fig = plt.figure(**kwargs)
         if ax is None:
             ax = fig.add_subplot(111)
         _make_cascade_subplot(spectra,
@@ -468,7 +472,7 @@ def plot_spectra(
     elif style == 'mosaic':
         default_fsize = plt.rcParams["figure.figsize"]
         figsize = (default_fsize[0], default_fsize[1] * len(spectra))
-        fig, subplots = plt.subplots(len(spectra), 1, figsize=figsize)
+        fig, subplots = plt.subplots(len(spectra), 1, figsize=figsize, **kwargs)
         if legend is None:
             legend = [legend] * len(spectra)
         for spectrum, ax, color, line_style, legend in zip(spectra,


### PR DESCRIPTION
Fixes #430. Tested with the following code and it seems to work as expected, handling both subplot arguments and figure `**kwargs`. This code uses the `dpi` argument to test `**kwargs` and also the `subplot_kw` argument:

    s1 = signals.Spectrum(range(500))
    s2 = signals.Spectrum(range(500))/3
    s3 = signals.Spectrum(range(500))**2/500
    utils.plot.plot_spectra([s1,s2,s3],style='mosaic',legend=['$m=1$','$m=0.333$','Quadratic'],subplot_kw=dict(snap=True, projection='lambert'),dpi=5)

Results in: 
![figure_2](https://cloud.githubusercontent.com/assets/1278301/5763971/a09d3d40-9cbc-11e4-8b15-e2f5f4059882.png)
