### PR TITLE
FIXES #366, the Qt api was set to 1 when not starting with the hyperspy script.

### DIFF
--- a/bin/hyperspy
+++ b/bin/hyperspy
@@ -32,14 +32,7 @@ except ImportError:
     argp = False
     import optparse
 
-try:
-    import PyQt4
-    import sip
-    # Set the QT_API environmental variable so that matplotlib uses API v2
-    # instead of API v1 that is the default in Python 2.x
-    os.environ['QT_API'] = "pyqt"
-except:
-    pass
+
 import IPython
 import traits.etsconfig.etsconfig
 

--- a/hyperspy/__init__.py
+++ b/hyperspy/__init__.py
@@ -32,7 +32,14 @@ More details in the :mod:`~hyperspy.hspy` docstring.
 """
 # -*- coding: utf-8 -*-
 
+import os
+
+os.environ['QT_API'] = "pyqt"
+
 
 import Release
 
 __version__ = Release.version
+
+
+


### PR DESCRIPTION
The problem is that matplotlib uses Qt API 1 by default in Python 2.7, while traitsui needs API 2. This fixes the issue by settin the "QT_API"  variable to "pyqt" so that matplotlib uses API 2.