### PR TITLE
BUGFIX: Proposed patch to allow Hyperspy to run with wx3 installed

### DIFF
--- a/hyperspy/component.py
+++ b/hyperspy/component.py
@@ -21,6 +21,14 @@ import os
 import numpy as np
 import warnings
 
+# Hack to ensure that the gui toolkit is correctly set. Prevents problems
+# described in https://github.com/hyperspy/hyperspy/issues/435
+from traits.etsconfig.api import ETSConfig
+import matplotlib.pyplot as plt
+
+if "Qt" in plt.get_backend():
+    ETSConfig.toolkit = 'qt4'
+
 import traits.api as t
 import traitsui.api as tu
 from traits.trait_numeric import Array


### PR DESCRIPTION
Added (ugly) patch to component.py to allow hyperspy to run with the qt4 toolkit if wx3 is installed

NB: this does not provide compatibility with wx 3, but merely prevents its presence from bombing the whole program when using the qt4 toolkit.

Resolves https://github.com/hyperspy/hyperspy/issues/435