### PR TITLE
TYPO: Fixed the word length in the code

### DIFF
--- a/doc/user_guide/tools.rst
+++ b/doc/user_guide/tools.rst
@@ -165,8 +165,8 @@ scanning over a sample in two dimensions. In HyperSpy's terminology the
 spectrum dimension would be the signal dimension and the two other dimensions
 would be the navigation dimensions. We could see the same dataset as an image
 stack instead.  Actually it could has been acquired by capturing two
-dimensional images at different wavelenghts. Then it would be natural to
-identify the two spatial dimensions as the signal dimensions and the wavelenght
+dimensional images at different wavelengths. Then it would be natural to
+identify the two spatial dimensions as the signal dimensions and the wavelength
 dimension as the navigation dimension.  However, for data analysis purposes,
 one may like to operate with an image stack as if it was a set of spectra or
 viceversa. One can easily switch between these two alternative ways of

--- a/hyperspy/component.py
+++ b/hyperspy/component.py
@@ -155,7 +155,7 @@ class Parameter(t.HasTraits):
             # TypeError when calling. See issue #349.
             if len(arg) != self._number_of_elements:
                 raise ValueError(
-                    "The lenght of the parameter must be ",
+                    "The length of the parameter must be ",
                     self._number_of_elements)
             else:
                 if not isinstance(arg, tuple):
@@ -163,7 +163,7 @@ class Parameter(t.HasTraits):
         except TypeError:
             if self._number_of_elements != 1:
                 raise ValueError(
-                    "The lenght of the parameter must be ",
+                    "The length of the parameter must be ",
                     self._number_of_elements)
         old_value = self.__value
 
@@ -641,13 +641,13 @@ class Component(t.HasTraits):
             parameters = self.parameters
         i = 0
         for parameter in parameters:
-            lenght = parameter._number_of_elements
-            parameter.value = (p[i] if lenght == 1 else p[i:i + lenght])
+            length = parameter._number_of_elements
+            parameter.value = (p[i] if length == 1 else p[i:i + length])
             if p_std is not None:
-                parameter.std = (p_std[i] if lenght == 1 else
-                                 tuple(p_std[i:i + lenght]))
+                parameter.std = (p_std[i] if length == 1 else
+                                 tuple(p_std[i:i + length]))
 
-            i += lenght
+            i += length
 
     def _create_active_array(self):
         shape = self._axes_manager._navigation_shape_in_array

--- a/hyperspy/defaults_parser.py
+++ b/hyperspy/defaults_parser.py
@@ -135,8 +135,8 @@ class EELSConfig(t.HasTraits):
                                       label='GOS directory',
                                       desc='The GOS files are required to create the EELS edge components')
     fine_structure_width = t.CFloat(30,
-                                    label='Fine structure lenght',
-                                    desc='The default lenght of the fine structure from the edge onset')
+                                    label='Fine structure length',
+                                    desc='The default length of the fine structure from the edge onset')
     fine_structure_active = t.CBool(False,
                                     label='Enable fine structure',
                                     desc="If enabled, the regions of the EELS spectrum defined as fine "

--- a/hyperspy/drawing/widgets.py
+++ b/hyperspy/drawing/widgets.py
@@ -324,7 +324,7 @@ class DraggableLabel(DraggablePatch):
 class Scale_Bar():
 
     def __init__(self, ax, units, pixel_size=None, color='white',
-                 position=None, max_size_ratio=0.25, lw=2, lenght=None,
+                 position=None, max_size_ratio=0.25, lw=2, length=None,
                  animated=False):
         """Add a scale bar to an image.
 
@@ -341,11 +341,11 @@ class Scale_Bar():
             If None the position is automatically determined.
         max_size_ratio : float
             The maximum size of the scale bar in respect to the
-            lenght of the x axis
+            length of the x axis
         lw : int
             The line width
-        lenght : {None, float}
-            If None the lenght is automatically calculated using the
+        length : {None, float}
+            If None the length is automatically calculated using the
             max_size_ratio.
 
         """
@@ -359,10 +359,10 @@ class Scale_Bar():
         self.text = None
         self.line = None
         self.tex_bold = False
-        if lenght is None:
+        if length is None:
             self.calculate_size(max_size_ratio=max_size_ratio)
         else:
-            self.lenght = lenght
+            self.length = length
         if position is None:
             self.position = self.calculate_line_position()
         else:
@@ -375,12 +375,12 @@ class Scale_Bar():
         if self.tex_bold is True:
             if (self.units[0] and self.units[-1]) == '$':
                 return r'$\mathbf{%g\,%s}$' % \
-                    (self.lenght, self.units[1:-1])
+                    (self.length, self.units[1:-1])
             else:
                 return r'$\mathbf{%g\,}$\textbf{%s}' % \
-                    (self.lenght, self.units)
+                    (self.length, self.units)
         else:
-            return r'$%g\,$%s' % (self.lenght, self.units)
+            return r'$%g\,$%s' % (self.length, self.units)
 
     def calculate_line_position(self, pad=0.05):
         return ((1 - pad) * self.xmin + pad * self.xmax,
@@ -389,7 +389,7 @@ class Scale_Bar():
     def calculate_text_position(self, pad=1 / 100.):
         ps = self.pixel_size if self.pixel_size is not None else 1
         x1, y1 = self.position
-        x2, y2 = x1 + self.lenght / ps, y1
+        x2, y2 = x1 + self.length / ps, y1
 
         self.text_position = ((x1 + x2) / 2.,
                               y2 + (self.ymax - self.ymin) / ps * pad)
@@ -398,7 +398,7 @@ class Scale_Bar():
         ps = self.pixel_size if self.pixel_size is not None else 1
         size = closest_nice_number(ps * (self.xmax - self.xmin) *
                                    max_size_ratio)
-        self.lenght = size
+        self.length = size
 
     def remove(self):
         if self.line is not None:
@@ -410,7 +410,7 @@ class Scale_Bar():
         self.remove()
         ps = self.pixel_size if self.pixel_size is not None else 1
         x1, y1 = self.position
-        x2, y2 = x1 + self.lenght / ps, y1
+        x2, y2 = x1 + self.length / ps, y1
         self.line, = self.ax.plot([x1, x2], [y1, y2],
                                   linestyle='-',
                                   lw=line_width,
@@ -434,9 +434,9 @@ class Scale_Bar():
         self.text.set_color(c)
         self.ax.figure.canvas.draw_idle()
 
-    def set_lenght(self, lenght):
+    def set_length(self, length):
         color = self.line.get_color()
-        self.lenght = lenght
+        self.length = length
         self.calculate_scale_size()
         self.calculate_text_position()
         self.plot_scale(line_width=self.line.get_linewidth())

--- a/hyperspy/gui/tools.py
+++ b/hyperspy/gui/tools.py
@@ -474,7 +474,7 @@ class SmoothingSavitzkyGolay(Smoothing):
             self.window_length = nwl
         else:
             print(
-                "The window lenght must be greated than the polynomial order")
+                "The window length must be greated than the polynomial order")
 
     def _polynomial_order_changed(self, old, new):
         if self.window_length <= new:

--- a/hyperspy/io_plugins/digital_micrograph.py
+++ b/hyperspy/io_plugins/digital_micrograph.py
@@ -333,8 +333,8 @@ class DigitalMicrographReader(object):
         """
         if skip is True:
             offset = self.f.tell()
-            self.f.seek(lenght, 1)
-            return {'size': lenght,
+            self.f.seek(length, 1)
+            return {'size': length,
                     'size_bytes': size_bytes,
                     'offset': offset,
                     'endian': self.endian, }

--- a/hyperspy/tests/drawing/test_figure_title.py
+++ b/hyperspy/tests/drawing/test_figure_title.py
@@ -3,7 +3,7 @@ import nose.tools
 from hyperspy.drawing.figure import BlittedFigure
 
 
-def test_title_lenght():
+def test_title_length():
     f = BlittedFigure()
     f.title = "Test" * 50
     nose.tools.assert_less(max(


### PR DESCRIPTION
Throughout the code, the word `length` was repeatedly misspelled as `lenght`. Using a find and replace in the whole directory, I have fixed this throughout the whole code base.