### PR TITLE
ENH: Rename widgets' "add_axes" to "set_mpl_ax"

### DIFF
--- a/hyperspy/drawing/mpl_he.py
+++ b/hyperspy/drawing/mpl_he.py
@@ -80,7 +80,7 @@ class MPL_HyperExplorer(object):
             # Add the line to the figure
             sf.add_line(sl)
             sf.plot()
-            self.pointer.add_axes(sf.ax)
+            self.pointer.set_mpl_ax(sf.ax)
             if self.axes_manager.navigation_dimension > 1:
                 navigation_sliders(
                     self.axes_manager.navigation_axes,
@@ -107,7 +107,7 @@ class MPL_HyperExplorer(object):
 
             imf.title = self.signal_title + ' Navigator'
             imf.plot()
-            self.pointer.add_axes(imf.ax)
+            self.pointer.set_mpl_ax(imf.ax)
             self.navigator_plot = imf
 
     def close_navigator_plot(self):

--- a/hyperspy/drawing/mpl_hse.py
+++ b/hyperspy/drawing/mpl_hse.py
@@ -54,7 +54,7 @@ class MPL_HyperSpectrum_Explorer(MPL_HyperExplorer):
             line.auto_update = value
         if self.pointer is not None:
             if value is True:
-                self.pointer.add_axes(self.navigator_plot.ax)
+                self.pointer.set_mpl_ax(self.navigator_plot.ax)
             else:
                 self.pointer.disconnect(self.navigator_plot.ax)
 
@@ -149,7 +149,7 @@ class MPL_HyperSpectrum_Explorer(MPL_HyperExplorer):
                 self.signal_plot.right_axes_manager)
             self.right_pointer.size = self.pointer.size
             self.right_pointer.color = 'blue'
-            self.right_pointer.add_axes(self.navigator_plot.ax)
+            self.right_pointer.set_mpl_ax(self.navigator_plot.ax)
 
         if self.right_pointer is not None:
             for axis in self.axes_manager.navigation_axes[

--- a/hyperspy/drawing/utils.py
+++ b/hyperspy/drawing/utils.py
@@ -141,7 +141,7 @@ def plot_RGB_map(im_list, normalization='single', dont_plot=False):
         ax.frameon = False
         ax.set_axis_off()
         ax.imshow(rgb, interpolation='nearest')
-#        cursors.add_axes(ax)
+#        cursors.set_mpl_ax(ax)
         figure.canvas.draw()
     else:
         return rgb

--- a/hyperspy/drawing/widgets.py
+++ b/hyperspy/drawing/widgets.py
@@ -83,7 +83,7 @@ class DraggablePatch(object):
         ax.add_artist(self.patch)
         self.patch.set_animated(hasattr(ax, 'hspy_fig'))
 
-    def add_axes(self, ax):
+    def set_mpl_ax(self, ax):
         self.ax = ax
         canvas = ax.figure.canvas
         if self.is_on() is True:

--- a/hyperspy/gui/tools.py
+++ b/hyperspy/gui/tools.py
@@ -225,7 +225,7 @@ class LineInSpectrum(t.HasTraits):
 
         if new is True and old is False:
             self._line = DraggableVerticalLine(self.axes_manager)
-            self._line.add_axes(self.signal._plot.signal_plot.ax)
+            self._line.set_mpl_ax(self.signal._plot.signal_plot.ax)
             self._line.patch.set_linewidth(2)
             self._color_changed("black", "black")
             # There is not need to call draw because setting the

--- a/hyperspy/model.py
+++ b/hyperspy/model.py
@@ -1709,8 +1709,8 @@ class Model(list):
             w = self._position_widgets[-1]
             w.string = component._get_short_description().replace(
                 ' component', '')
-            w.add_axes(self._plot.signal_plot.ax)
-            self._position_widgets[-2].add_axes(
+            w.set_mpl_ax(self._plot.signal_plot.ax)
+            self._position_widgets[-2].set_mpl_ax(
                 self._plot.signal_plot.ax)
         else:
             self._position_widgets.extend((
@@ -1718,7 +1718,7 @@ class Model(list):
             # Store the component for bookkeeping, and to reset
             # its twin when disabling adjust position
             self._position_widgets[-1].component = component
-            self._position_widgets[-1].add_axes(
+            self._position_widgets[-1].set_mpl_ax(
                 self._plot.signal_plot.ax)
         # Create widget -> parameter connection
         am._axes[0].continuous_value = True


### PR DESCRIPTION
Makes it less ambiguous what kind of axes that is being used, which will
be especially useful w.r.t. proposed changes for new ROIs, where widgets
also take hyperspy's DataAxis as parameters.

Cons are of course that it will break existing code. Backwards
compatibility with a deprecation warning is easy to implement, and might be
useful.