### PR TITLE
BUG: dynamic_explorer update_attributes

### DIFF
--- a/hyperspy/signal.py
+++ b/hyperspy/signal.py
@@ -3035,6 +3035,7 @@ class Signal(MVA,
         def get_dynamic_explorer_wrapper(*args, **kwargs):
             navigator.axes_manager.indices = self.axes_manager.indices[
                 navigator.axes_manager.signal_dimension:]
+            navigator.axes_manager._update_attributes()
             return navigator()
 
         if not isinstance(navigator, Signal) and navigator == "auto":


### PR DESCRIPTION
If
1) get_dynamic_explorer_wrapper is called (directly or indirectly) via
axes_managers index/indices/values change notifier, and
2) get_dynamic_explorer_wrapper is called before
axes_manager._update_attributes
... then the axes_manager might be in an invalid state. This change
force an update of the axes_manager attributes before trying to
navigate.