### PR TITLE
BUG: Image plot axis connection args

### DIFF
--- a/hyperspy/drawing/mpl_he.py
+++ b/hyperspy/drawing/mpl_he.py
@@ -103,7 +103,7 @@ class MPL_HyperExplorer(object):
                         self.axes_manager.navigation_axes,
                         title=self.signal_title + " navigation sliders")
                     for axis in self.axes_manager.navigation_axes[2:]:
-                        axis.connect(imf.update)
+                        axis.connect(imf._update)
 
             imf.title = self.signal_title + ' Navigator'
             imf.plot()


### PR DESCRIPTION
Use the argument-free signature of update, so that traits doesn't fill
keyword args.