### PR TITLE
Bugfix: signal variance axes_manager is now a reference

### DIFF
--- a/hyperspy/signal.py
+++ b/hyperspy/signal.py
@@ -3137,8 +3137,8 @@ class Signal(MVA,
                     self.tmp_parameters.folder,
                     self.tmp_parameters.filename)
                 extension = (self.tmp_parameters.extension
-                            if not extension
-                            else extension)
+                             if not extension
+                             else extension)
             elif self.metadata.has_item('General.original_filename'):
                 filename = self.metadata.General.original_filename
             else:

--- a/hyperspy/signal.py
+++ b/hyperspy/signal.py
@@ -4301,8 +4301,8 @@ class Signal(MVA,
         variance = (dc * gain_factor + gain_offset) * correlation_factor
         # The lower bound of the variance is the gaussian noise.
         variance = np.clip(variance, gain_offset * correlation_factor, np.inf)
-        variance = type(self)(variance,
-                              axes=self.axes_manager._get_axes_dicts())
+        variance = type(self)(variance)
+        variance.axes_manager = self.axes_manager
         variance.metadata.General.title = ("Variance of " +
                                            self.metadata.General.title)
         self.metadata.set_item(


### PR DESCRIPTION
Variance now does not have its own axes_manager, instead shares the same one with the original signal

As a consequence, now changing axes scale and/or offset is correctly reflected in the variance signal, allowing for correct slicing

(previously if you changed scale/offset of an axis once the variance was already calculated/saved, the corresponding parameter did not change, and hence fancy indexing with floats would work incorrectly (additionally, plotted axis values would be wrong as well))