### PR TITLE
ENH: Fix EDS line intensity labels to go from generic -> specific

### DIFF
--- a/hyperspy/_signals/eds.py
+++ b/hyperspy/_signals/eds.py
@@ -561,11 +561,12 @@ class EDSSpectrum(Spectrum):
             img = self[..., line_energy - det:line_energy + det
                        ].integrate1D(-1)
             img.metadata.General.title = (
-                'Intensity of %s at %.2f %s from %s' %
-                (Xray_line,
+                'X-ray line intensity of %s: %s at %.2f %s' %
+                (self.metadata.General.title,
+                 Xray_line,
                  line_energy,
                  self.axes_manager.signal_axes[0].units,
-                 self.metadata.General.title))
+                 ))
             if img.axes_manager.navigation_dimension >= 2:
                 img = img.as_image([0, 1])
             elif img.axes_manager.navigation_dimension == 1:


### PR DESCRIPTION
Related to Issue #484.

Fixes the labeling of EDS line intensity.

This is the output when used with the `plot_images()` function from PR #454:

```python
im = si_EDS.get_lines_intensity()
utils.plot.plot_images(im, per_row=5, tight_layout=False, axes_decor='off', suptitle_fontsize=20,
                       colorbar='single', label='auto',cmap='RdYlBu_r')
```

![plot_images-eds](https://cloud.githubusercontent.com/assets/1278301/6598837/aae9b436-c7dc-11e4-8a95-eeb4345b289f.png)
