### PR TITLE
Add kargs to Signal.plot to control image plotting options.

### DIFF
--- a/hyperspy/_signals/image.py
+++ b/hyperspy/_signals/image.py
@@ -109,7 +109,7 @@ class Image(Signal):
             If True, plot the axes ticks. If None axes_ticks are only
             plotted when the scale bar is not plotted. If False the axes ticks
             are never plotted.
-        contrast_adjustment : bool, optional
+        auto_contrast : bool, optional
             If True, the contrast is stretched for each image using the
             percentile value.
         percentile : float
@@ -117,7 +117,7 @@ class Image(Signal):
             scalar in the 0 to 1 range.
         vmin, vmax : scalar, optional
             `vmin` and `vmax` are used to normalize luminance data. If
-            `contrast_adjustment` is True these values are ignore.
+            `auto_contrast` is True these values are ignore.
         no_nans : bool, optional
             If True, set nans to zero for plotting.
         **kwargs, optional
@@ -125,13 +125,13 @@ class Image(Signal):
 
         """
         super(Image, self).plot(
-            colorbar=True,
-            scalebar=True,
-            scalebar_color="white",
-            axes_ticks=None,
-            auto_contrast=True,
-            percentile=0.1,
-            vmin=None,
-            vmax=None,
-            no_nans=False,
+            colorbar=colorbar,
+            scalebar=scalebar,
+            scalebar_color=scalebar_color,
+            axes_ticks=axes_ticks,
+            auto_contrast=auto_contrast,
+            percentile=percentile,
+            vmin=vmin,
+            vmax=vmax,
+            no_nans=no_nans,
         )

--- a/hyperspy/_signals/image.py
+++ b/hyperspy/_signals/image.py
@@ -40,3 +40,98 @@ class Image(Signal):
 
         """
         return self.as_spectrum(0 + 3j)
+
+    def plot(self,
+             colorbar=True,
+             scalebar=True,
+             scalebar_color="white",
+             axes_ticks=None,
+             auto_contrast=True,
+             percentile=0.1,
+             vmin=None,
+             vmax=None,
+             no_nans=False,
+             ):
+        """Plot image.
+
+        For multidimensional datasets an optional figure,
+        the "navigator", with a cursor to navigate that data is
+        raised. In any case it is possible to navigate the data using
+        the sliders. Currently only signals with signal_dimension equal to
+        0, 1 and 2 can be plotted.
+
+        Parameters
+        ----------
+        navigator : {"auto", None, "slider", "spectrum", Signal}
+            If "auto", if navigation_dimension > 0, a navigator is
+            provided to explore the data.
+            If navigation_dimension is 1 and the signal is an image
+            the navigator is a spectrum obtained by integrating
+            over the signal axes (the image).
+            If navigation_dimension is 1 and the signal is a spectrum
+            the navigator is an image obtained by stacking horizontally
+            all the spectra in the dataset.
+            If navigation_dimension is > 1, the navigator is an image
+            obtained by integrating the data over the signal axes.
+            Additionaly, if navigation_dimension > 2 a window
+            with one slider per axis is raised to navigate the data.
+            For example,
+            if the dataset consists of 3 navigation axes X, Y, Z and one
+            signal axis, E, the default navigator will be an image
+            obtained by integrating the data over E at the current Z
+            index and a window with sliders for the X, Y and Z axes
+            will be raised. Notice that changing the Z-axis index
+            changes the navigator in this case.
+            If "slider" and the navigation dimension > 0 a window
+            with one slider per axis is raised to navigate the data.
+            If "spectrum" and navigation_dimension > 0 the navigator
+            is always a spectrum obtained by integrating the data
+            over all other axes.
+            If None, no navigator will be provided.
+            Alternatively a Signal instance can be provided. The signal
+            dimension must be 1 (for a spectrum navigator) or 2 (for a
+            image navigator) and navigation_shape must be 0 (for a static
+            navigator) or navigation_shape + signal_shape must be equal
+            to the navigator_shape of the current object (for a dynamic
+            navigator).
+            If the signal dtype is RGB or RGBA this parameters has no
+            effect and is always "slider".
+        axes_manager : {None, axes_manager}
+            If None `axes_manager` is used.
+        colorbar : bool, optional
+             If true, a colorbar is plotted for non-RGB images.
+        scalebar : bool, optional
+            If True and the units and scale of the x and y axes are the same a
+            scale bar is plotted.
+        scalebar_color : str, optional
+            A valid MPL color string; will be used as the scalebar color.
+        axes_ticks : {None, bool}, optional
+            If True, plot the axes ticks. If None axes_ticks are only
+            plotted when the scale bar is not plotted. If False the axes ticks
+            are never plotted.
+        contrast_adjustment : bool, optional
+            If True, the contrast is stretched for each image using the
+            percentile value.
+        percentile : float
+            The percentile to be used for contrast stretching. It should be a
+            scalar in the 0 to 1 range.
+        vmin, vmax : scalar, optional
+            `vmin` and `vmax` are used to normalize luminance data. If
+            `contrast_adjustment` is True these values are ignore.
+        no_nans : bool, optional
+            If True, set nans to zero for plotting.
+        **kwargs, optional
+            Additional key word arguments passed to matplotlib.imshow()
+
+        """
+        super(Image, self).plot(
+            colorbar=True,
+            scalebar=True,
+            scalebar_color="white",
+            axes_ticks=None,
+            auto_contrast=True,
+            percentile=0.1,
+            vmin=None,
+            vmax=None,
+            no_nans=False,
+        )

--- a/hyperspy/drawing/image.py
+++ b/hyperspy/drawing/image.py
@@ -44,7 +44,7 @@ class ImagePlot(BlittedFigure):
         arguments.
     pixel_units : {None, string}
         The pixel units for the scale bar. Normally
-    scalebar, plot_ticks, plot_colorbar, plot_indices : bool
+    scalebar, plot_ticks, colorbar, plot_indices : bool
     title : str
         The title is printed at the top of the image.
     vmin, vmax : float
@@ -64,7 +64,7 @@ class ImagePlot(BlittedFigure):
         self.data_function = None
         self.pixel_units = None
         self.plot_ticks = False
-        self.plot_colorbar = True
+        self.colorbar = True
         self._colorbar = None
         self.figure = None
         self.ax = None
@@ -84,6 +84,7 @@ class ImagePlot(BlittedFigure):
         self.yaxis = None
         self.min_aspect = 0.1
         self.perc = 0.01
+        self.scalebar_color = "white"
         self._user_scalebar = None
         self._auto_scalebar = False
         self._user_axes_ticks = None
@@ -205,7 +206,7 @@ class ImagePlot(BlittedFigure):
             self.create_axis()
         data = self.data_function(axes_manager=self.axes_manager)
         if rgb_tools.is_rgbx(data):
-            self.plot_colorbar = False
+            self.colorbar = False
             data = rgb_tools.rgbx2regular_array(data, plot_friendly=True)
         if self.auto_contrast is True:
             self.optimize_contrast(data)
@@ -229,9 +230,10 @@ class ImagePlot(BlittedFigure):
                     ax=self.ax,
                     units=self.pixel_units,
                     animated=True,
+                    color=self.scalebar_color,
                 )
 
-        if self.plot_colorbar is True:
+        if self.colorbar is True:
             self._colorbar = plt.colorbar(self.ax.images[0], ax=self.ax)
             self._colorbar.ax.yaxis.set_animated(True)
 

--- a/hyperspy/drawing/image.py
+++ b/hyperspy/drawing/image.py
@@ -44,7 +44,7 @@ class ImagePlot(BlittedFigure):
         arguments.
     pixel_units : {None, string}
         The pixel units for the scale bar. Normally
-    plot_scalebar, plot_ticks, plot_colorbar, plot_indices : bool
+    scalebar, plot_ticks, plot_colorbar, plot_indices : bool
     title : str
         The title is printed at the top of the image.
     vmin, vmax : float
@@ -63,7 +63,6 @@ class ImagePlot(BlittedFigure):
     def __init__(self):
         self.data_function = None
         self.pixel_units = None
-        self.plot_scalebar = True
         self.plot_ticks = False
         self.plot_colorbar = True
         self._colorbar = None
@@ -85,6 +84,37 @@ class ImagePlot(BlittedFigure):
         self.yaxis = None
         self.min_aspect = 0.1
         self.perc = 0.01
+        self._user_scalebar = None
+        self._auto_scalebar = False
+        self._user_axes_ticks = None
+        self._auto_axes_ticks = True
+        self.no_nans = False
+
+    @property
+    def axes_ticks(self):
+        if self._user_axes_ticks is None:
+            return self._auto_axes_ticks
+        else:
+            return self._user_axes_ticks
+
+    @axes_ticks.setter
+    def axes_ticks(self, value):
+        self._user_axes_ticks = value
+
+    @property
+    def scalebar(self):
+        if self._user_scalebar is None:
+            return self._auto_scalebar
+        else:
+            return self._user_scalebar
+
+    @scalebar.setter
+    def scalebar(self, value):
+        if value is False:
+            self._user_scalebar = value
+        else:
+            self._user_scalebar = None
+
 
     def configure(self):
         xaxis = self.xaxis
@@ -100,12 +130,12 @@ class ImagePlot(BlittedFigure):
 
         if (xaxis.units == yaxis.units) and (
                 xaxis.scale == yaxis.scale):
-            self.plot_scalebar = True
-            self.plot_ticks = False
+            self._auto_scalebar = True
+            self._auto_axes_ticks = False
             self.pixel_units = xaxis.units
         else:
-            self.plot_scalebar = False
-            self.plot_ticks = True
+            self._auto_scalebar = False
+            self._auto_axes_ticks = True
 
         # Calibrate the axes of the navigator image
         self._extent = (xaxis.axis[0] - xaxis.scale / 2.,
@@ -117,12 +147,12 @@ class ImagePlot(BlittedFigure):
             min_asp = self.min_aspect
             if yaxis.size / xaxis.size < min_asp:
                 factor = min_asp * xaxis.size / yaxis.size
-                self.plot_scalebar = False
-                self.plot_ticks = True
+                self._auto_scalebar = False
+                self._auto_axes_ticks = True
             elif yaxis.size / xaxis.size > min_asp ** -1:
                 factor = min_asp ** -1 * xaxis.size / yaxis.size
-                self.plot_scalebar = False
-                self.plot_ticks = True
+                self._auto_scalebar = False
+                self._auto_axes_ticks = True
             else:
                 factor = 1
         self._aspect = np.abs(factor * xaxis.scale / yaxis.scale)
@@ -141,7 +171,7 @@ class ImagePlot(BlittedFigure):
         self.vmax = vmax
 
     def create_figure(self, max_size=8, min_size=2):
-        if self.plot_scalebar is True:
+        if self.scalebar is True:
 
             wfactor = 1.1
         else:
@@ -163,7 +193,7 @@ class ImagePlot(BlittedFigure):
         self.ax.set_title(self.title)
         self.ax.set_xlabel(self._xlabel)
         self.ax.set_ylabel(self._ylabel)
-        if self.plot_ticks is False:
+        if self.axes_ticks is False:
             self.ax.set_xticks([])
             self.ax.set_yticks([])
         self.ax.hspy_fig = self
@@ -193,7 +223,7 @@ class ImagePlot(BlittedFigure):
                 color='red',
                 animated=True)
         self.update()
-        if self.plot_scalebar is True:
+        if self.scalebar is True:
             if self.pixel_units is not None:
                 self.ax.scalebar = widgets.Scale_Bar(
                     ax=self.ax,
@@ -250,6 +280,8 @@ class ImagePlot(BlittedFigure):
             data = np.log(np.abs(data))
         if self.plot_indices is True:
             self._text.set_text((self.axes_manager.indices))
+        if self.no_nans:
+            data = np.nan_to_num(data)
         if ims:
             ims[0].set_data(data)
             ims[0].norm.vmax, ims[0].norm.vmin = self.vmax, self.vmin

--- a/hyperspy/drawing/mpl_he.py
+++ b/hyperspy/drawing/mpl_he.py
@@ -117,14 +117,14 @@ class MPL_HyperExplorer(object):
     def is_active(self):
         return True if self.signal_plot.figure else False
 
-    def plot(self):
+    def plot(self, **kwargs):
         if self.pointer is None:
             pointer = self.assign_pointer()
             if pointer is not None:
                 self.pointer = pointer(self.axes_manager)
                 self.pointer.color = 'red'
             self.plot_navigator()
-        self.plot_signal()
+        self.plot_signal(**kwargs)
 
     def assign_pointer(self):
         if self.navigator_data_function is None:

--- a/hyperspy/drawing/mpl_hie.py
+++ b/hyperspy/drawing/mpl_hie.py
@@ -48,7 +48,7 @@ class MPL_HyperImage_Explorer(MPL_HyperExplorer):
             If True, plot the axes ticks. If None axes_ticks are only
             plotted when the scale bar is not plotted. If False the axes ticks
             are never plotted.
-        contrast_adjustment : bool, optional
+        auto_contrast : bool, optional
             If True, the contrast is stretched for each image using the 
             percentile value.
         percentile : float
@@ -56,7 +56,7 @@ class MPL_HyperImage_Explorer(MPL_HyperExplorer):
             scalar in the 0 to 1 range.
         vmin, vmax : scalar, optional
             `vmin` and `vmax` are used to normalize luminance data. If
-            `contrast_adjustment` is True these values are ignore.
+            `auto_contrast` is True these values are ignore.
         no_nans : bool, optional
             If True, set nans to zero for plotting.
 
@@ -69,12 +69,14 @@ class MPL_HyperImage_Explorer(MPL_HyperExplorer):
         imf.data_function = self.signal_data_function
         imf.title = self.signal_title + " Signal"
         imf.xaxis, imf.yaxis = self.axes_manager.signal_axes
-        imf.plot_colorbar = colorbar
+        imf.colorbar = colorbar
         imf.scalebar = scalebar
         imf.axes_ticks = axes_ticks
         imf.vmin, imf.vmax = vmin, vmax
         imf.perc = percentile
         imf.no_nans = no_nans
+        imf.scalebar_color = scalebar_color
+        imf.auto_contrast = auto_contrast
         imf.plot()
         self.signal_plot = imf
 

--- a/hyperspy/drawing/mpl_hie.py
+++ b/hyperspy/drawing/mpl_hie.py
@@ -22,7 +22,45 @@ from hyperspy.drawing.mpl_he import MPL_HyperExplorer
 
 class MPL_HyperImage_Explorer(MPL_HyperExplorer):
 
-    def plot_signal(self):
+    def plot_signal(self,
+                    colorbar=True,
+                    scalebar=True,
+                    scalebar_color="white",
+                    axes_ticks=None,
+                    auto_contrast=True,
+                    percentile=0.1,
+                    vmin=None,
+                    vmax=None,
+                    no_nans=False,
+                    ):
+        """Plot image.
+
+        Parameters
+        ----------
+        colorbar : bool, optional
+             If true, a colorbar is plotted for non-RGB images.
+        scalebar : bool, optional
+            If True and the units and scale of the x and y axes are the same a
+            scale bar is plotted.
+        scalebar_color : str, optional
+            A valid MPL color string; will be used as the scalebar color.
+        axes_ticks : {None, bool}, optional
+            If True, plot the axes ticks. If None axes_ticks are only
+            plotted when the scale bar is not plotted. If False the axes ticks
+            are never plotted.
+        contrast_adjustment : bool, optional
+            If True, the contrast is stretched for each image using the 
+            percentile value.
+        percentile : float
+            The percentile to be used for contrast stretching. It should be a
+            scalar in the 0 to 1 range.
+        vmin, vmax : scalar, optional
+            `vmin` and `vmax` are used to normalize luminance data. If
+            `contrast_adjustment` is True these values are ignore.
+        no_nans : bool, optional
+            If True, set nans to zero for plotting.
+
+        """
         if self.signal_plot is not None:
             self.signal_plot.plot()
             return
@@ -31,7 +69,12 @@ class MPL_HyperImage_Explorer(MPL_HyperExplorer):
         imf.data_function = self.signal_data_function
         imf.title = self.signal_title + " Signal"
         imf.xaxis, imf.yaxis = self.axes_manager.signal_axes
-        imf.plot_colorbar = True
+        imf.plot_colorbar = colorbar
+        imf.scalebar = scalebar
+        imf.axes_ticks = axes_ticks
+        imf.vmin, imf.vmax = vmin, vmax
+        imf.perc = percentile
+        imf.no_nans = no_nans
         imf.plot()
         self.signal_plot = imf
 

--- a/hyperspy/signal.py
+++ b/hyperspy/signal.py
@@ -2939,7 +2939,7 @@ class Signal(MVA,
         return np.atleast_1d(
             self.data.__getitem__(axes_manager._getitem_tuple))
 
-    def plot(self, navigator="auto", axes_manager=None):
+    def plot(self, navigator="auto", axes_manager=None, **kargs):
         """Plot the signal at the current coordinates.
 
         For multidimensional datasets an optional figure,
@@ -2987,6 +2987,9 @@ class Signal(MVA,
 
         axes_manager : {None, axes_manager}
             If None `axes_manager` is used.
+
+        **kargs : optional
+            Any extra keyword arguments are passed to the signal plot.
 
         """
 
@@ -3092,7 +3095,7 @@ class Signal(MVA,
                     "navigator must be one of \"spectrum\",\"auto\","
                     " \"slider\", None, a Signal instance")
 
-        self._plot.plot()
+        self._plot.plot(**kargs)
 
     def save(self, filename=None, overwrite=None, extension=None,
              **kwds):


### PR DESCRIPTION
Example of usage
-----------------------

```python

im = signals.Image(np.random.random((64, 64)))
im.data[:10, :10] = np.nan
im.plot(colorbar=False, scalebar=False, axes_ticks=False, no_nans=True)
```
![figure](https://cloud.githubusercontent.com/assets/989719/6881340/718833be-d553-11e4-94a9-0f3766ab3e38.png)

TODO
--------
* [ ] Document in User Guide





Fixes #160 