### PR TITLE
ENH: Utility function to remove x-ray markers

### DIFF
--- a/hyperspy/_signals/eds.py
+++ b/hyperspy/_signals/eds.py
@@ -40,6 +40,7 @@ class EDSSpectrum(Spectrum):
                   'set_signal_type(\'EDS_TEM\')  '
                   'or set_signal_type(\'EDS_SEM\')')
         self.metadata.Signal.binned = True
+        self._xray_markers = {}
 
     def _get_line_energy(self, Xray_line, FWHM_MnKa=None):
         """
@@ -919,6 +920,22 @@ class EDSSpectrum(Spectrum):
                 x=line_energy[i], y=intensity[i] * 1.1, text=xray_lines[i],
                 rotation=90)
             self.add_marker(text)
+            self._xray_markers[xray_lines[i]] = (line, text)
+
+    def _remove_xray_lines_markers(self, xray_lines):
+        """
+        Remove marker previosuly added on a spec.plot() with the name of the
+        selected X-ray lines
+
+        Parameters
+        ----------
+        xray_lines: list of string
+            A valid list of X-ray lines to remove
+        """
+        for xray_line in xray_lines:
+            if xray_line in self._xray_markers:
+                for m in self._xray_markers[xray_line]:
+                    m.close()
 
     def _add_background_windows_markers(self,
                                         windows_position):


### PR DESCRIPTION
For interactive use, it is a lot speedier to simply remove individual
lines compared to replotting, so a util function like this can be very
useful.