### PR TITLE
ENH: Order of FEI data

### DIFF
--- a/hyperspy/io_plugins/fei.py
+++ b/hyperspy/io_plugins/fei.py
@@ -425,7 +425,7 @@ def ser_reader(filename, objects=None, verbose=False, *args, **kwds):
 
     dc = dc.reshape(array_shape)
     if record_by == 'image':
-        dc = dc[::-1]
+        dc = dc[..., ::-1, :]
     if ordict:
         original_metadata = OrderedDict()
     else:


### PR DESCRIPTION
I don't have a lot of FEI data files to test this on, but for me the FEI files where loaded with two out of three axes inverted. This fixes the problem for me, but test should be run with other files.