### PR TITLE
BUG: Line segment marker starts correct

### DIFF
--- a/hyperspy/drawing/_markers/line_segment.py
+++ b/hyperspy/drawing/_markers/line_segment.py
@@ -74,8 +74,12 @@ class LineSegment(MarkerBase):
                 "To use this method the marker needs to be first add to a " +
                 "figure using `s._plot.signal_plot.add_marker(m)` or " +
                 "`s._plot.navigator_plot.add_marker(m)`")
-        self.marker = self.ax.vlines(0, 0, 1, **self.marker_properties)
-        self._update_segment()
+        x1 = self.get_data_position('x1')
+        x2 = self.get_data_position('x2')
+        y1 = self.get_data_position('y1')
+        y2 = self.get_data_position('y2')
+        self.marker = self.ax.plot((x1, x2), (y1, y2),
+                                   **self.marker_properties)[0]
         self.marker.set_animated(True)
         try:
             self.ax.hspy_fig._draw_animated()

--- a/hyperspy/drawing/_markers/line_segment.py
+++ b/hyperspy/drawing/_markers/line_segment.py
@@ -87,9 +87,8 @@ class LineSegment(MarkerBase):
             pass
 
     def _update_segment(self):
-        segments = self.marker.get_segments()
-        segments[0][0, 0] = self.get_data_position('x1')
-        segments[0][0, 1] = self.get_data_position('y1')
-        segments[0][1, 0] = self.get_data_position('x2')
-        segments[0][1, 1] = self.get_data_position('y2')
-        self.marker.set_segments(segments)
+        x1 = self.get_data_position('x1')
+        x2 = self.get_data_position('x2')
+        y1 = self.get_data_position('y1')
+        y2 = self.get_data_position('y2')
+        self.marker.set_data((x1, x2), (y1, y2))


### PR DESCRIPTION
Previously, when creating a line segment marker, a vline was added that
screwed up the axes limits (not sure why). Either way, the easiest way
to get a line segment in MPL is via the plot function.