### PR TITLE
Enh align zero loss peak signal range

### DIFF
--- a/doc/user_guide/eels.rst
+++ b/doc/user_guide/eels.rst
@@ -46,8 +46,12 @@ The :py:meth:`~._signals.eels.EELSSpectrum.estimate_zero_loss_peak_centre` can b
 
 The :py:meth:`~._signals.eels.EELSSpectrum.align_zero_loss_peak` can
 align the ZLP with subpixel accuracy. It is more robust and easy to use than
-:py:meth:`~.signal.Signal1DTools.align1D` for the task. Note that it is possible to apply the same alignment to other spectra using the `also_align` argument. This can be useful e.g. to align core-loss spectra acquired quasi-simultaneously.
-
+:py:meth:`~.signal.Signal1DTools.align1D` for the task. Note that it is 
+possible to apply the same alignment to other spectra using the `also_align` 
+argument. This can be useful e.g. to align core-loss spectra acquired quasi-simultaneously.
+If there are other features in the low loss signal which are more intense than the
+ZLP, the `signal_range` argument can narrow down the energy range for searching for the
+ZLP.
 
 Deconvolutions
 ^^^^^^^^^^^^^^

--- a/hyperspy/_signals/eels.py
+++ b/hyperspy/_signals/eels.py
@@ -215,7 +215,7 @@ class EELSSpectrum(Spectrum):
             Will only search for the ZLP within the signal_range. If given
             in integers, the range will be in index values. If given floats,
             the range will be in spectrum values. Useful if there are features
-            in the spectrum which are more intensite than the ZLP.
+            in the spectrum which are more intense than the ZLP.
             Default is searching in the whole signal.
 
         Examples
@@ -279,7 +279,7 @@ class EELSSpectrum(Spectrum):
         right = (right if right < self.axes_manager[-1].axis[-1]
                  else self.axes_manager[-1].axis[-1])
         self.align1D(left, right, also_align=also_align, **kwargs)
-        zlpc = estimate_zero_loss_peak_centre(self, mask, signal_range)
+        zlpc = estimate_zero_loss_peak_centre(self, mask, (-3., 3.))
         if calibrate is True:
             substract_from_offset(without_nans(zlpc.data).mean(),
                                   also_align + [self])

--- a/hyperspy/_signals/eels.py
+++ b/hyperspy/_signals/eels.py
@@ -182,6 +182,7 @@ class EELSSpectrum(Spectrum):
             print_stats=True,
             subpixel=True,
             mask=None,
+            signal_range=None,
             **kwargs):
         """Align the zero-loss peak.
 
@@ -210,6 +211,22 @@ class EELSSpectrum(Spectrum):
             It must have signal_dimension = 0 and navigation_shape equal to the
             current signal. Where mask is True the shift is not computed
             and set to nan.
+        signal_range : tuple of integers, tuple of floats. Optional
+            Will only search for the ZLP within the signal_range. If given
+            in integers, the range will be in index values. If given floats,
+            the range will be in spectrum values. Useful if there are features
+            in the spectrum which are more intensity than the ZLP.
+            Default is searching in the whole signal.
+
+        Examples
+        --------
+        >>>> s_ll.align_zero_loss_peak()
+
+        Aligning both the lowloss signal and another signal
+        >>>> s_ll.align_zero_loss_peak(also_align=[s])
+
+        Aligning within a narrow range of the lowloss signal
+        >>>> s_ll.align_zero_loss_peak(signal_range=(-10.,10.))
 
         See Also
         --------
@@ -224,37 +241,43 @@ class EELSSpectrum(Spectrum):
         def substract_from_offset(value, signals):
             for signal in signals:
                 signal.axes_manager[-1].offset -= value
+        
+        if signal_range:
+            self_signal = self[...,signal_range[0]:signal_range[1]].deepcopy()
+            also_align.append(self)
+        else:
+            self_signal = self
 
-        zlpc = self.estimate_zero_loss_peak_centre(mask=mask)
+        zlpc = self_signal.estimate_zero_loss_peak_centre(mask=mask)
         mean_ = without_nans(zlpc.data).mean()
         if print_stats is True:
             print
             print(underline("Initial ZLP position statistics"))
             zlpc.print_summary_statistics()
 
-        for signal in also_align + [self]:
+        for signal in also_align + [self_signal]:
             signal.shift1D(-zlpc.data + mean_)
 
         if calibrate is True:
-            zlpc = self.estimate_zero_loss_peak_centre(mask=mask)
+            zlpc = self_signal.estimate_zero_loss_peak_centre(mask=mask)
             substract_from_offset(without_nans(zlpc.data).mean(),
-                                  also_align + [self])
+                                  also_align + [self_signal])
 
         if subpixel is False:
             return
         left, right = -3., 3.
         if calibrate is False:
-            mean_ = without_nans(self.estimate_zero_loss_peak_centre(
+            mean_ = without_nans(self_signal.estimate_zero_loss_peak_centre(
                 mask=mask).data).mean()
             left += mean_
             right += mean_
 
-        left = (left if left > self.axes_manager[-1].axis[0]
-                else self.axes_manager[-1].axis[0])
-        right = (right if right < self.axes_manager[-1].axis[-1]
-                 else self.axes_manager[-1].axis[-1])
-        self.align1D(left, right, also_align=also_align, **kwargs)
-        zlpc = self.estimate_zero_loss_peak_centre(mask=mask)
+        left = (left if left > self_signal.axes_manager[-1].axis[0]
+                else self_signal.axes_manager[-1].axis[0])
+        right = (right if right < self_signal.axes_manager[-1].axis[-1]
+                 else self_signal.axes_manager[-1].axis[-1])
+        self_signal.align1D(left, right, also_align=also_align, **kwargs)
+        zlpc = self_signal.estimate_zero_loss_peak_centre(mask=mask)
         if calibrate is True:
             substract_from_offset(without_nans(zlpc.data).mean(),
                                   also_align + [self])

--- a/hyperspy/tests/signal/test_eels.py
+++ b/hyperspy/tests/signal/test_eels.py
@@ -134,16 +134,18 @@ class TestAlignZLP():
 
     def test_align_zero_loss_peak_with_spike_signal_range(self):
         s = self.spectrum
-        spike = np.zeros((10,100))
+        spike = np.zeros((10, 100))
         spike_amplitude = 20
-        spike[:,75] = spike_amplitude
+        spike[:, 75] = spike_amplitude
         s.data += spike
-        s.align_zero_loss_peak(print_stats=False, subpixel=False, signal_range=(98.,102.))
-        zlp_max = s[...,-0.5:0.5].max(-1).data
-        #Max value in the original spectrum is 12, but due to the aligning
-        #the peak is split between two different channels. So 8 is the maximum value
-        #for the aligned spectrum
+        s.align_zero_loss_peak(
+            print_stats=False, subpixel=False, signal_range=(98., 102.))
+        zlp_max = s.isig[-0.5:0.5].max(-1).data
+        # Max value in the original spectrum is 12, but due to the aligning
+        # the peak is split between two different channels. So 8 is the
+        # maximum value for the aligned spectrum
         nose.tools.assert_true(np.allclose(zlp_max, 8))
+
 
 class TestPowerLawExtrapolation:
 

--- a/hyperspy/tests/signal/test_eels.py
+++ b/hyperspy/tests/signal/test_eels.py
@@ -132,6 +132,18 @@ class TestAlignZLP():
         nose.tools.assert_equal(zlpc.data.mean(), 0)
         nose.tools.assert_equal(zlpc.data.std(), 0)
 
+    def test_align_zero_loss_peak_with_spike_signal_range(self):
+        s = self.spectrum
+        spike = np.zeros((10,100))
+        spike_amplitude = 20
+        spike[:,75] = spike_amplitude
+        s.data += spike
+        s.align_zero_loss_peak(print_stats=False, subpixel=False, signal_range=(98.,102.))
+        zlp_max = s[...,-0.5:0.5].max(-1).data
+        #Max value in the original spectrum is 12, but due to the aligning
+        #the peak is split between two different channels. So 8 is the maximum value
+        #for the aligned spectrum
+        nose.tools.assert_true(np.allclose(zlp_max, 8))
 
 class TestPowerLawExtrapolation:
 


### PR DESCRIPTION
I added a `signal_range` argument for `eels_spectrum.align_zero_loss_peak`. As discussed in https://github.com/hyperspy/hyperspy/issues/533. 

Can potentially reduce the risk of random spikes being mistaken as the ZLP.