### PR TITLE
ENH: Split off x-ray line plotting

### DIFF
--- a/hyperspy/_signals/eds.py
+++ b/hyperspy/_signals/eds.py
@@ -918,6 +918,12 @@ class EDSSpectrum(Spectrum):
         get_lines_intensity, estimate_background_windows
         """
         super(EDSSpectrum, self).plot(**kwargs)
+        self._plot_xray_lines(xray_lines, only_lines, only_one,
+                              background_windows, integration_windows)
+
+    def _plot_xray_lines(self, xray_lines=False, only_lines=("a", "b"),
+                         only_one=False, background_windows=None,
+                         integration_windows=None):
         if xray_lines is not False or\
                 background_windows is not None or\
                 integration_windows is not None:


### PR DESCRIPTION
Split the EDSSpectrum.plot, such that the plotting of the xray lines are performed by a separate function. This changes nothing in the default behaviour, but allows for plotting xray lines without creating a fresh plot.