### PR TITLE
Add Travis and Coveralls

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,14 @@
+[run]
+branch = True
+source = hyperspy
+include = */hyperspy/*
+omit =
+    */hyperspy/misc/borrowed/*
+    */hyperspy/ipython_profile/*
+    */hyperspy/drawing/*
+    */hyperspy/mpfit/*
+    */hyperspy/gui/*
+    */setup.py
+    */examples/*
+    */bin/*
+    */hyperspy/misc/io/tifffile.py

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 syntax: glob
 .spyderworkspace
+.coverage
 /MANIFEST
 /*.rst
 *.pyc

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,8 @@ install:
   - conda install --yes $DEPS
   - conda install pip
   - pip install coverage coveralls
+  # The following two lines set hyperspy to run headless. This is a temporary
+  # workaround until we fix hyperspy so that this is not required.
   - mkdir ~/.hyperspy 
   - printf "[General]\ndefault_toolkit = None" > ~/.hyperspy/hyperspyrc
   - python setup.py install

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,32 @@
+language: python
+
+python:
+  - 2.7
+
+env:
+  - DEPS="nose numpy scipy matplotlib traits traitsui ipython h5py"
+
+install:
+  - conda create -n testenv --yes python=$TRAVIS_PYTHON_VERSION
+  - source activate testenv
+  - conda install --yes $DEPS
+  - conda install pip
+  - pip install coverage coveralls
+  - mkdir ~/.hyperspy 
+  - printf "[General]\ndefault_toolkit = None" > ~/.hyperspy/hyperspyrc
+  - python setup.py install
+
+before_install:
+  # then install python version to test
+  - if [ ${TRAVIS_PYTHON_VERSION:0:1} == "2" ]; then wget https://repo.continuum.io/miniconda/Miniconda-latest-Linux-x86_64.sh -O miniconda.sh; else wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh; fi
+  - chmod +x miniconda.sh
+  - ./miniconda.sh -b
+  - export PATH=/home/travis/miniconda/bin:$PATH
+  # miniconda is not always up-to-date with conda.
+  - conda update --yes conda
+script: python continuous_integration/nosetest.py --with-coverage hyperspy 
+after_success:
+    # Ignore coveralls failures as the coveralls server is not very reliable
+    # but we don't want travis to report a failure in the github UI just
+    # because the coverage report failed to be published.
+    - if [[ "$COVERAGE" == "true" ]]; then coveralls || echo "failed"; fi

--- a/README.md
+++ b/README.md
@@ -1,9 +1,17 @@
+|Travis|_ |Coveralls|_
+
+.. |Travis| image:: https://api.travis-ci.org/hyperspy/hyperspy.png?branch=0.8.x
+.. _Travis: https://travis-ci.org/hyperspy/hyperspy
+
+.. |Coveralls| image:: https://coveralls.io/repos/hyperspy/hyperspy/badge.svg
+.. _Coveralls: https://coveralls.io/r/hyperspy/hyperspy
+
 HyperSpy is an open source Python library which provides tools to facilitate
 the interactive data analysis of multidimensional datasets that can be
 described as multidimensional arrays of a given signal (e.g. a 2D array of
 spectra a.k.a spectrum image).
 
-Hyperpsy aims at making it easy and natural to apply analytical procedures that
+HyperSpy aims at making it easy and natural to apply analytical procedures that
 operate on an individual signal to multidimensional arrays, as well as
 providing easy access to analytical tools that exploit the multidimensionality
 of the dataset.
@@ -14,7 +22,8 @@ energy-loss spectroscopy (EELS) and energy dispersive X-rays (EDX) data.
 
 HyperSpy is released under the GPL v3 license.
 
-
+Cite
+----
 
 [![DOI](https://zenodo.org/badge/6941/hyperspy/hyperspy.svg)](http://dx.doi.org/10.5281/zenodo.16850)
 

--- a/continuous_integration/nosetest.py
+++ b/continuous_integration/nosetest.py
@@ -1,3 +1,6 @@
+"""Run nosetests after setting ETS toolkit to "null
+"
+"""
 #!/usr/bin/python
 import nose
 from traits.etsconfig.api import ETSConfig

--- a/continuous_integration/nosetest.py
+++ b/continuous_integration/nosetest.py
@@ -1,0 +1,7 @@
+#!/usr/bin/python
+import nose
+from traits.etsconfig.api import ETSConfig
+
+
+ETSConfig.toolkit = "null"
+nose.run()


### PR DESCRIPTION
Integrate HyperSpy with Travis and Coveralls.

This was proposed by @stefano-m  a while ago in the (disabled) [hyperspy-devel mailing list](https://groups.google.com/d/msg/hyperspy-devel/P1OJk7Hw304/AUct0G8La7EJ).