### PR TITLE
BUG: Replaced type checks of str with basestring

### DIFF
--- a/hyperspy/_signals/eds.py
+++ b/hyperspy/_signals/eds.py
@@ -298,9 +298,9 @@ class EDSSpectrum(Spectrum):
 
     def _parse_only_lines(self, only_lines):
         if hasattr(only_lines, '__iter__'):
-            if isinstance(only_lines[0], str) is False:
+            if isinstance(only_lines[0], basestring) is False:
                 return only_lines
-        elif isinstance(only_lines, str) is False:
+        elif isinstance(only_lines, basestring) is False:
             return only_lines
         only_lines = list(only_lines)
         for only_line in only_lines:

--- a/hyperspy/drawing/utils.py
+++ b/hyperspy/drawing/utils.py
@@ -301,9 +301,9 @@ def _make_heatmap_subplot(spectra):
 
 
 def _make_overlap_plot(spectra, ax, color="blue", line_style='-'):
-    if isinstance(color, str):
+    if isinstance(color, basestring):
         color = [color] * len(spectra)
-    if isinstance(line_style, str):
+    if isinstance(line_style, basestring):
         line_style = [line_style] * len(spectra)
     for spectrum_index, (spectrum, color, line_style) in enumerate(
             zip(spectra, color, line_style)):
@@ -323,9 +323,9 @@ def _make_cascade_subplot(
                            np.nanmin(spectrum.data))
         if spectrum_yrange > max_value:
             max_value = spectrum_yrange
-    if isinstance(color, str):
+    if isinstance(color, basestring):
         color = [color] * len(spectra)
-    if isinstance(line_style, str):
+    if isinstance(line_style, basestring):
         line_style = [line_style] * len(spectra)
     for spectrum_index, (spectrum, color, line_style) in enumerate(
             zip(spectra, color, line_style)):
@@ -597,11 +597,12 @@ def plot_images(images,
         # Set label_list to each image's pre-defined title
         label_list = [x.metadata.General.title for x in images]
 
-    elif isinstance(label, str):
+    elif isinstance(label, basestring):
         # Set label_list to an indexed list, based off of label
         label_list = [label + " " + repr(num) for num in range(n)]
 
-    elif isinstance(label, list) and all(isinstance(x, str) for x in label):
+    elif isinstance(label, list) and all(
+            isinstance(x, basestring) for x in label):
         label_list = label
         user_labels = True
         # If list of labels is longer than the number of images, just use the

--- a/hyperspy/misc/array_tools.py
+++ b/hyperspy/misc/array_tools.py
@@ -18,7 +18,7 @@ def get_array_memory_size_in_GiB(shape, dtype):
     dtype : data-type
         The desired data-type for the array.
     """
-    if isinstance(dtype, str):
+    if isinstance(dtype, basestring):
         dtype = np.dtype(dtype)
     return np.array(shape).cumprod()[-1] * dtype.itemsize / 2. ** 30
 

--- a/hyperspy/misc/borrowed/astroML/histtools.py
+++ b/hyperspy/misc/borrowed/astroML/histtools.py
@@ -290,7 +290,7 @@ def histogram(a, bins=10, range=None, **kwargs):
         da, bins = scotts_bin_width(a, True)
     elif bins == 'freedman':
         da, bins = freedman_bin_width(a, True)
-    elif isinstance(bins, str):
+    elif isinstance(bins, basestring):
         raise ValueError("unrecognized bin code: '%s'" % bins)
 
     return np.histogram(a, bins, range, **kwargs)

--- a/hyperspy/misc/material.py
+++ b/hyperspy/misc/material.py
@@ -263,11 +263,11 @@ def density_of_mixture_of_pure_elements(weight_percent,
 
 def _elements_auto(composition, elements):
     if isinstance(composition[0], numbers.Number):
-        if isinstance(elements, str):
+        if isinstance(elements, basestring):
             if elements == 'auto':
                 raise ValueError("The elements needs to be provided.")
     else:
-        if isinstance(elements, str):
+        if isinstance(elements, basestring):
             if elements == 'auto':
                 elements = []
                 for compo in composition:

--- a/hyperspy/misc/progressbar.py
+++ b/hyperspy/misc/progressbar.py
@@ -207,7 +207,7 @@ class Bar(ProgressBarWidgetHFill):
         self.right = right
 
     def _format_marker(self, pbar):
-        if isinstance(self.marker, (str, unicode)):
+        if isinstance(self.marker, basestring):
             return self.marker
         else:
             return self.marker.update(pbar)
@@ -333,7 +333,7 @@ class ProgressBar(object):
                 r.append(w)
                 hfill_inds.append(i)
                 num_hfill += 1
-            elif isinstance(w, (str, unicode)):
+            elif isinstance(w, basestring):
                 r.append(w)
                 currwidth += len(w)
             else:

--- a/hyperspy/misc/utils.py
+++ b/hyperspy/misc/utils.py
@@ -536,7 +536,7 @@ def strlist2enumeration(lst):
 
 
 def ensure_unicode(stuff, encoding='utf8', encoding2='latin-1'):
-    if not isinstance(stuff, (basestring, np.string_)):
+    if not isinstance(stuff, (str, np.string_)):
         return stuff
     else:
         string = stuff

--- a/hyperspy/misc/utils.py
+++ b/hyperspy/misc/utils.py
@@ -372,7 +372,7 @@ class DictionaryTreeBrowser(object):
         False
 
         """
-        if isinstance(item_path, str):
+        if isinstance(item_path, basestring):
             item_path = item_path.split('.')
         else:
             item_path = copy.copy(item_path)
@@ -413,7 +413,7 @@ class DictionaryTreeBrowser(object):
         False
 
         """
-        if isinstance(item_path, str):
+        if isinstance(item_path, basestring):
             item_path = item_path.split('.')
         else:
             item_path = copy.copy(item_path)
@@ -462,7 +462,7 @@ class DictionaryTreeBrowser(object):
         """
         if not self.has_item(item_path):
             self.add_node(item_path)
-        if isinstance(item_path, str):
+        if isinstance(item_path, basestring):
             item_path = item_path.split('.')
         if len(item_path) > 1:
             self.__getattribute__(item_path.pop(0)).set_item(
@@ -536,7 +536,7 @@ def strlist2enumeration(lst):
 
 
 def ensure_unicode(stuff, encoding='utf8', encoding2='latin-1'):
-    if not isinstance(stuff, (str, np.string_)):
+    if not isinstance(stuff, (basestring, np.string_)):
         return stuff
     else:
         string = stuff

--- a/hyperspy/model.py
+++ b/hyperspy/model.py
@@ -210,7 +210,7 @@ class Model(list):
         return u"<Model %s>".encode('utf8') % super(Model, self).__repr__()
 
     def _get_component(self, object):
-        if isinstance(object, int) or isinstance(object, str):
+        if isinstance(object, int) or isinstance(object, basestring):
             object = self[object]
         elif not isinstance(object, Component):
             raise ValueError("Not a component or component id.")
@@ -1981,7 +1981,7 @@ class Model(list):
 
     def __getitem__(self, value):
         """x.__getitem__(y) <==> x[y]"""
-        if isinstance(value, str):
+        if isinstance(value, basestring):
             component_list = []
             for component in self:
                 if component.name:


### PR DESCRIPTION
Several places in code compare type to str with isinstance. In many cases, unicode strings should also be caught by these expressions, so I've replaced str iwth basestring. No rigorous test have been performed, but from the context of the changes, it is not apparent that the test should not include unicode strings (there are some clear examples around, which I excluded). However, it passes the nose tests.