### PR TITLE
Update master version.

### DIFF
--- a/hyperspy/Release.py
+++ b/hyperspy/Release.py
@@ -26,7 +26,7 @@ name = 'hyperspy'
 # When running setup.py the "+dev" string will be replaced (if possible)
 # by the output of "git describe" if git is available or the git
 # hash if .git is present.
-version = "0.8+dev"
+version = "0.9+dev"
 description = "Multidimensional data analysis toolbox"
 license = 'GPL v3'
 

--- a/hyperspy/Release.py
+++ b/hyperspy/Release.py
@@ -26,7 +26,7 @@ name = 'hyperspy'
 # When running setup.py the "+dev" string will be replaced (if possible)
 # by the output of "git describe" if git is available or the git
 # hash if .git is present.
-version = "0.9+dev"
+version = "0.9.dev"
 description = "Multidimensional data analysis toolbox"
 license = 'GPL v3'
 

--- a/setup.py
+++ b/setup.py
@@ -88,7 +88,7 @@ class update_version_when_dev:
         # Get the hash from the git repository if available
         self.restore_version = False
         git_master_path = ".git/refs/heads/master"
-        if "+dev" in self.release_version and \
+        if ".dev" in self.release_version and \
                 os.path.isfile(git_master_path):
             try:
                 p = subprocess.Popen(["git", "describe",
@@ -110,7 +110,7 @@ class update_version_when_dev:
                 with open(git_master_path) as f:
                     masterhash = f.readline()
                 self.version = self.release_version.replace(
-                    "+dev", "+git-%s" % masterhash[:7])
+                    ".dev", "+git-%s" % masterhash[:7])
             for line in fileinput.FileInput("hyperspy/Release.py",
                                             inplace=1):
                 if line.startswith('version = '):


### PR DESCRIPTION
Currently the master version is `0.8+dev` and the maintenance branch `0.8.x+dev`. I suggest to change the convention to the more standard: `0.9.dev` and `0.8.x`. What do you think? (This PR does just that.)
