### PR TITLE
New api module set to replace the hspy module

### DIFF
--- a/hyperspy/__init__.py
+++ b/hyperspy/__init__.py
@@ -1,36 +1,23 @@
-"""
+# -*- coding: utf-8 -*-
+
+from hyperspy import docstrings
+
+__doc__ = """
 HyperSpy: a multi-dimensional data analysis package for Python
 ==============================================================
 
 Documentation is available in the docstrings and online at
 http://hyperspy.org/hyperspy-doc/current/index.html.
 
-All public packages, functions and classes are in :mod:`~hyperspy.hspy`. All
-other packages are for internal consumption.
+All public packages, functions and classes are in :mod:`~hyperspy.api`. All
+other packages and modules are for internal consumption and should not be
+needed for data analysis.
 
-When starting HyperSpy using the starting script e.g. by typing ``hyperspy`` in
-a console, using the context menu entries or using the links in the
-``Start Menu``, the :mod:`~hyperspy.hspy` package is imported in the user
-namespace. When using HyperSpy as a library, it is reccommended to import
-the :mod:`~hyperspy.hspy` package as follows:
-
-    from hyperspy import hspy as hs
-
-The :mod:`~hyperspy.hspy` package contains the following subpackages:
-
-    :mod:`~hyperspy.hspy.signals`
-        Specialized Signal instances.
-
-    :mod:`~hyperspy.hspy.utils`
-        Functions that operate of Signal instances and other goodies.
-
-    :mod:`~hyperspy.hspy.components`
-        Components that can be used to create a model for curve fitting.
+%s
 
 More details in the :mod:`~hyperspy.hspy` docstring.
 
-"""
-# -*- coding: utf-8 -*-
+""" % docstrings.START_HSPY
 
 import os
 
@@ -39,7 +26,6 @@ os.environ['QT_API'] = "pyqt"
 
 import Release
 
+__all__ = ["api"]
 __version__ = Release.version
-
-
 

--- a/hyperspy/api.py
+++ b/hyperspy/api.py
@@ -1,0 +1,68 @@
+# -*- coding: utf-8 -*-
+
+from hyperspy import docstrings
+
+__doc__ = """
+
+All public packages, functions and classes are available in this module.
+
+%s
+
+Functions:
+
+    create_model
+        Create a model for curve fitting.
+
+    get_configuration_directory_path
+        Return the configuration directory path.
+
+    load
+        Load data into Signal instances from supported files.
+
+    preferences
+        Preferences class instance to configure the default value of different
+        parameters. It has a CLI and a GUI that can be started by execting its
+        `gui` method i.e. `preferences.gui()`.
+
+    stack
+        Stack several signals.
+
+
+The :mod:`~hyperspy.api` package contains the following submodules/packages:
+
+    :mod:`~hyperspy.api.signals`
+        `Signal` classes which are the core of HyperSpy. Use this modules to
+        create `Signal` instances manually from numpy arrays. Note that to
+        load data from supported file formats is more convenient to use the
+        `load` function.
+    :mod:`~hyperspy.api.model_components`
+        Components that can be used to create a model for curve fitting.
+    :mod:`~hyperspy.api.eds`
+        Functions for energy dispersive X-rays data analysis.
+    :mod:`~hyperspy.api.markers`
+        Markers that can be added to `Signal` plots.
+    :mod:`~hyperspy.api.material`
+        Useful functions for materials properties and elements database that
+        includes physical properties and X-rays and EELS energies.
+    :mod:`~hyperspy.api.plot`
+        Plotting functions that operate on multiple signals.
+    :mod:`~hyperspy.api.example_signals`
+        Example datasets.
+
+For more details see their doctrings.
+
+""" % docstrings.START_HSPY
+
+# Remove the module to avoid polluting the namespace
+del docstrings
+
+from hyperspy.Release import version as __version__
+import hyperspy.components as model_components
+from hyperspy import signals
+from hyperspy.io import load
+from hyperspy.defaults_parser import preferences
+from hyperspy.utils import *
+from hyperspy.hspy import (
+    get_configuration_directory_path,
+    create_model)
+

--- a/hyperspy/docstrings/__init__.py
+++ b/hyperspy/docstrings/__init__.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+"""Common docstring snippets.
+
+"""
+
+START_HSPY = \
+"""When starting HyperSpy using the `hyperspy` script (e.g. by executing
+``hyperspy`` in a console, using the context menu entries or using the links in
+the ``Start Menu``, the :mod:`~hyperspy.api` package is imported in the user
+namespace as ``hs``, i.e. by executing the following:
+
+    >>> import hyperspy.api as hs
+
+
+(Note that code snippets are indicated by three greater-than signs)
+
+We recommend to import the HyperSpy API as above also when doing it manually.
+The docstring examples assume that `hyperspy` has been imported as `hs`. """
+


### PR DESCRIPTION
This PR intends to implement the changes proposed in #494. It is still work in progress but ready for discussion.

TODO
--------

* [ ] Promote the usage of `import hyperspy.api as hs` in
    * [ ] Docstrings
    * [ ] User Guide
    * [ ] Demos
* Rename/move:
    * [x] `hspy.components` -> `api.model_components` 
    * [x] `hspy.utils.*`-> `api.*`
    * [ ] `hspy.utils.markers` -> `api.plot.markers`
    * [ ] Write automatic translator to run on the remaining code, User Guide, docstrings and demos and make it available to the users.