### PR TITLE
New saving multiple signals, WIP

### DIFF
--- a/hyperspy/hspy.py
+++ b/hyperspy/hspy.py
@@ -49,7 +49,7 @@ plt.rcParams['image.cmap'] = 'gray'
 from hyperspy.Release import version as __version__
 from hyperspy import components
 from hyperspy import signals
-from hyperspy.io import load
+from hyperspy.io import load, save
 from hyperspy.defaults_parser import preferences
 from hyperspy import utils
 

--- a/hyperspy/io.py
+++ b/hyperspy/io.py
@@ -423,7 +423,8 @@ def save(filename, signal, overwrite=None, **kwds):
                              'supported, supported file extensions are: %s ' %
                              strlist2enumeration(default_write_ext))
         elif isinstance(signal, list):
-            if hasattr(writer, 'projects') and writer.projects: # assume when projects is True, any dimensions
+            # assume when projects is True, any dimensions
+            if hasattr(writer, 'projects') and writer.projects:
                                                                 # can be written
                 # pass # temp
                 ensure_directory(filename)
@@ -433,7 +434,8 @@ def save(filename, signal, overwrite=None, **kwds):
                     writer.file_writer(filename, signal, **kwds)
                     print('The %s file was created' % filename)
             else:
-                raise ValueError('Writing projects to this format is not supported')
+                raise ValueError(
+                    'Writing projects to this format is not supported')
         else:
             sd = signal.axes_manager.signal_dimension
             nd = signal.axes_manager.navigation_dimension

--- a/hyperspy/io.py
+++ b/hyperspy/io.py
@@ -423,10 +423,8 @@ def save(filename, signal, overwrite=None, **kwds):
                              'supported, supported file extensions are: %s ' %
                              strlist2enumeration(default_write_ext))
         elif isinstance(signal, list):
-            # assume when projects is True, any dimensions
+            # assume when projects is True, any dimensions can be written
             if hasattr(writer, 'projects') and writer.projects:
-                                                                # can be written
-                # pass # temp
                 ensure_directory(filename)
                 if overwrite is None:
                     overwrite = hyperspy.misc.io.tools.overwrite(filename)

--- a/hyperspy/io_plugins/hdf5.py
+++ b/hyperspy/io_plugins/hdf5.py
@@ -485,6 +485,6 @@ def file_writer(filename,
         if isinstance(signal, list):
             for num, sig in enumerate(signal):
                 group_name = sig.metadata.General.title if \
-                    sig.metadata.General.title else '__unnamed__'+str(num)
+                    sig.metadata.General.title else '__unnamed__' + str(num)
                 expg = exps.create_group(group_name)
                 write_signal(sig, expg, compression=compression)

--- a/hyperspy/io_plugins/hdf5.py
+++ b/hyperspy/io_plugins/hdf5.py
@@ -41,6 +41,7 @@ default_extension = 4
 
 # Writing capabilities
 writes = True
+projects = True
 version = "1.3"
 
 # -----------------------
@@ -481,7 +482,9 @@ def file_writer(filename,
         f.attrs['file_format'] = "HyperSpy"
         f.attrs['file_format_version'] = version
         exps = f.create_group('Experiments')
-        group_name = signal.metadata.General.title if \
-            signal.metadata.General.title else '__unnamed__'
-        expg = exps.create_group(group_name)
-        write_signal(signal, expg, compression=compression)
+        if isinstance(signal, list):
+            for num, sig in enumerate(signal):
+                group_name = sig.metadata.General.title if \
+                    sig.metadata.General.title else '__unnamed__'+str(num)
+                expg = exps.create_group(group_name)
+                write_signal(sig, expg, compression=compression)


### PR DESCRIPTION
Still have to decide what syntax we want to have and if the `projects` flag in writers is reasonable..

Let me know of any comments / feature requests. 

I know saving models is something people want (and I believe I have a branch that does it, albeit somewhat strangely), but for that we first have to decide if/how we change the signal<->model interaction

TODO
--------

* [ ] Test
* [ ] Docs 

EXAMPLES
--------------
```python
# Save a single signal to file. Works exactly as before (i.e. now only exposes the actual function)
hs.save('file', somesignal)
# Save multiple signals to a project file (only hdf5 extension is supported):
hs.save('project', [eds_spectrum, survey_image, some_other_signal])
```