### PR TITLE
Remove residuals calculation from `get_bss_model`.

### DIFF
--- a/hyperspy/learn/mva.py
+++ b/hyperspy/learn/mva.py
@@ -732,11 +732,10 @@ class MVA():
 
         Returns
         -------
-        Signal instance
+        rec : Signal instance
+
         """
         rec = self._calculate_recmatrix(components=components, mva_type='bss',)
-        rec.residual = rec.copy()
-        rec.residual.data = self.data - rec.data
         return rec
 
     def get_explained_variance_ratio(self):


### PR DESCRIPTION
At present `get_bss_model` calculates and stores the residuals. This can deal to
memory/storage problems when analysing big datasets. This PR removes this undocumented "feature".