### PR TITLE
Fix: component.py's import of traitsui

### DIFF
--- a/hyperspy/component.py
+++ b/hyperspy/component.py
@@ -22,7 +22,6 @@ import numpy as np
 import warnings
 
 import traits.api as t
-import traitsui.api as tu
 from traits.trait_numeric import Array
 
 from hyperspy.defaults_parser import preferences
@@ -42,6 +41,13 @@ class NoneFloat(t.CFloat):   # Lazy solution, but usable
             super(NoneFloat, self).validate(object, name, 0)
             return None
         return super(NoneFloat, self).validate(object, name, value)
+
+
+def _editor_wrapper(self):
+    from traitsui.api import TextEditor
+    if not isinstance(self.editor, TextEditor()):
+        self.editor = TextEditor()
+    return self.editor
 
 
 class Parameter(t.HasTraits):
@@ -101,9 +107,12 @@ class Parameter(t.HasTraits):
 
     # traitsui bugs out trying to make an editor for this, so always specify!
     # (it bugs out, because both editor shares the object, and Array editors
-    # don't like non-sequence objects). TextEditor() works well.
+    # don't like non-sequence objects). TextEditor() works well. Use a wrapper
+    # to avoid importing traitsui prematurely
     value = t.Property(
-        t.Either([t.CFloat(0), Array()]), editor=tu.TextEditor())
+        t.Either([t.CFloat(0), Array()]))
+    value.get_editor = _editor_wrapper
+
     units = t.Str('')
     free = t.Property(t.CBool(True))
 

--- a/hyperspy/component.py
+++ b/hyperspy/component.py
@@ -43,13 +43,6 @@ class NoneFloat(t.CFloat):   # Lazy solution, but usable
         return super(NoneFloat, self).validate(object, name, value)
 
 
-def _editor_wrapper(self):
-    from traitsui.api import TextEditor
-    if not isinstance(self.editor, TextEditor()):
-        self.editor = TextEditor()
-    return self.editor
-
-
 class Parameter(t.HasTraits):
 
     """Model parameter
@@ -111,7 +104,6 @@ class Parameter(t.HasTraits):
     # to avoid importing traitsui prematurely
     value = t.Property(
         t.Either([t.CFloat(0), Array()]))
-    value.get_editor = _editor_wrapper
 
     units = t.Str('')
     free = t.Property(t.CBool(True))
@@ -478,6 +470,19 @@ class Parameter(t.HasTraits):
         if save_std is True:
             self.as_signal(field='std').save(append2pathname(
                 filename, '_std'))
+
+    def default_traits_view(self):
+        from traitsui.api import RangeEditor, View, Item
+        et = self.editable_traits()
+        whitelist = ['bmax', 'bmin',  'free', 'name', 'std', 'units', 'value']
+        et = [v for v in et if v in whitelist]
+        if 'value' in et:
+            i = et.index('value')
+            v = et.pop(i)
+            et.insert(i, Item(v, editor=RangeEditor(low_name='bmin',
+                                                    high_name='bmax')))
+        v = View(et, buttons=['OK', 'Cancel'])
+        return v
 
 
 class Component(t.HasTraits):

--- a/hyperspy/component.py
+++ b/hyperspy/component.py
@@ -472,6 +472,11 @@ class Parameter(t.HasTraits):
                 filename, '_std'))
 
     def default_traits_view(self):
+        # As mentioned above, the default editor for
+        # value = t.Property(t.Either([t.CFloat(0), Array()]))
+        # gives a ValueError. We therefore implement default_traits_view so
+        # that configure/edit_traits will still work straight out of the box.
+        # A whitelist controls which traits to include in this view.
         from traitsui.api import RangeEditor, View, Item
         et = self.editable_traits()
         whitelist = ['bmax', 'bmin',  'free', 'name', 'std', 'units', 'value']

--- a/hyperspy/component.py
+++ b/hyperspy/component.py
@@ -100,8 +100,8 @@ class Parameter(t.HasTraits):
 
     # traitsui bugs out trying to make an editor for this, so always specify!
     # (it bugs out, because both editor shares the object, and Array editors
-    # don't like non-sequence objects). TextEditor() works well. Use a wrapper
-    # to avoid importing traitsui prematurely
+    # don't like non-sequence objects). TextEditor() works well, so does
+    # RangeEditor() as it works with bmin/bmax.
     value = t.Property(
         t.Either([t.CFloat(0), Array()]))
 

--- a/hyperspy/component.py
+++ b/hyperspy/component.py
@@ -102,8 +102,7 @@ class Parameter(t.HasTraits):
     # (it bugs out, because both editor shares the object, and Array editors
     # don't like non-sequence objects). TextEditor() works well, so does
     # RangeEditor() as it works with bmin/bmax.
-    value = t.Property(
-        t.Either([t.CFloat(0), Array()]))
+    value = t.Property(t.Either([t.CFloat(0), Array()]))
 
     units = t.Str('')
     free = t.Property(t.CBool(True))

--- a/hyperspy/component.py
+++ b/hyperspy/component.py
@@ -478,16 +478,16 @@ class Parameter(t.HasTraits):
         # that configure/edit_traits will still work straight out of the box.
         # A whitelist controls which traits to include in this view.
         from traitsui.api import RangeEditor, View, Item
-        et = self.editable_traits()
         whitelist = ['bmax', 'bmin',  'free', 'name', 'std', 'units', 'value']
-        et = [v for v in et if v in whitelist]
-        if 'value' in et:
-            i = et.index('value')
-            v = et.pop(i)
-            et.insert(i, Item(v, editor=RangeEditor(low_name='bmin',
-                                                    high_name='bmax')))
-        v = View(et, buttons=['OK', 'Cancel'])
-        return v
+        editable_traits = [trait for trait in self.editable_traits()
+                           if trait in whitelist]
+        if 'value' in editable_traits:
+            i = editable_traits.index('value')
+            v = editable_traits.pop(i)
+            editable_traits.insert(i, Item(
+                v, editor=RangeEditor(low_name='bmin', high_name='bmax')))
+        view = View(editable_traits, buttons=['OK', 'Cancel'])
+        return view
 
 
 class Component(t.HasTraits):


### PR DESCRIPTION
There where quite a few issues with importing traitsui directly in component.py (introduced in #408). The need for this was because of a bug in traitsui's handling of a default editor for t.Either(t.CFloat(), Array()). This change implements a workaround that fixes both problems, but it accomplishes this by overriding a function on the trait. As such, it quite a bit of a hack.

Should fix half of #561, but I'll need @jat255 to confirm!