### PR TITLE
BUG: O'haver maxpeakn & dtype order

### DIFF
--- a/hyperspy/misc/spectrum_tools.py
+++ b/hyperspy/misc/spectrum_tools.py
@@ -162,6 +162,9 @@ def find_peaks_ohaver(y, x=None, slope_thresh=0., amp_thresh=None,
                         peak = peak + 1
     # return only the part of the array that contains peaks
     # (not the whole maxpeakn x 3 array)
+    if len(P) > maxpeakn:
+        minh = np.sort(P['height'])[-maxpeakn]
+        P = P[P['height'] >= minh]
     return P
 
 

--- a/hyperspy/misc/spectrum_tools.py
+++ b/hyperspy/misc/spectrum_tools.py
@@ -4,7 +4,8 @@ import scipy.signal
 
 
 def find_peaks_ohaver(y, x=None, slope_thresh=0., amp_thresh=None,
-                      medfilt_radius=5, maxpeakn=30000, peakgroup=10, subchannel=True,):
+                      medfilt_radius=5, maxpeakn=30000, peakgroup=10,
+                      subchannel=True,):
     """Find peaks along a 1D line.
 
     Function to locate the positive peaks in a noisy x-y data set.
@@ -153,8 +154,8 @@ def find_peaks_ohaver(y, x=None, slope_thresh=0., amp_thresh=None,
                         # no way to know peak width without
                         # the above measurements.
                         width = 0
-                    if (position > 0 and not np.isnan(position)
-                            and position < x[-1]):
+                    if (position > 0 and not np.isnan(position) and
+                            position < x[-1]):
                         P = np.hstack((P,
                                        np.array([(position, height, width)],
                                                 dtype=peak_dt)))

--- a/hyperspy/misc/spectrum_tools.py
+++ b/hyperspy/misc/spectrum_tools.py
@@ -92,8 +92,8 @@ def find_peaks_ohaver(y, x=None, slope_thresh=0., amp_thresh=None,
         d = np.gradient(y)
     n = np.round(peakgroup / 2 + 1)
     peak_dt = np.dtype([('position', np.float),
-                        ('width', np.float),
-                        ('height', np.float)])
+                        ('height', np.float),
+                        ('width', np.float)])
     P = np.array([], dtype=peak_dt)
     peak = 0
     for j in xrange(len(y) - 4):

--- a/hyperspy/signal.py
+++ b/hyperspy/signal.py
@@ -1152,7 +1152,7 @@ class Signal1DTools(object):
         -------
         peaks : structured array of shape _navigation_shape_in_array in which
         each cell contains an array that contains as many structured arrays as
-        peaks where found at that location and which fields: position,height,
+        peaks where found at that location and which fields: position, height,
         width, contains position, height, and width of each peak.
 
         Raises

--- a/hyperspy/signal.py
+++ b/hyperspy/signal.py
@@ -1152,8 +1152,8 @@ class Signal1DTools(object):
         -------
         peaks : structured array of shape _navigation_shape_in_array in which
         each cell contains an array that contains as many structured arrays as
-        peaks where found at that location and which fields: position, width,
-        height contains position, height, and width of each peak.
+        peaks where found at that location and which fields: position,height,
+        width, contains position, height, and width of each peak.
 
         Raises
         ------

--- a/hyperspy/signal.py
+++ b/hyperspy/signal.py
@@ -1104,8 +1104,7 @@ class Signal1DTools(object):
         Function to locate the positive peaks in a noisy x-y data set.
 
         Detects peaks by looking for downward zero-crossings in the
-        first
-        derivative that exceed 'slope_thresh'.
+        first derivative that exceed 'slope_thresh'.
 
         Returns an array containing position, height, and width of each
         peak.

--- a/hyperspy/tests/signal/test_1D_tools.py
+++ b/hyperspy/tests/signal/test_1D_tools.py
@@ -142,7 +142,6 @@ class TestFindPeaks1D:
 
     def test_two_spectra(self):
         peaks = self.spectrum.find_peaks1D_ohaver()
-        peaks = self.spectrum.find_peaks1D_ohaver()
         nose.tools.assert_true(np.allclose(
             peaks[1]['position'], self.peak_positions1, rtol=1e-5, atol=1e-4))
 

--- a/hyperspy/tests/signal/test_1D_tools.py
+++ b/hyperspy/tests/signal/test_1D_tools.py
@@ -137,14 +137,14 @@ class TestFindPeaks1D:
 
     def test_single_spectrum(self):
         peaks = self.spectrum[0].find_peaks1D_ohaver()
-        nose.tools.assert_true(np.allclose(peaks[0]['position'],
-                                           self.peak_positions0, rtol=1e-5, atol=1e-4))
+        nose.tools.assert_true(np.allclose(
+            peaks[0]['position'], self.peak_positions0, rtol=1e-5, atol=1e-4))
 
     def test_two_spectra(self):
         peaks = self.spectrum.find_peaks1D_ohaver()
         peaks = self.spectrum.find_peaks1D_ohaver()
-        nose.tools.assert_true(np.allclose(peaks[1]['position'],
-                                           self.peak_positions1, rtol=1e-5, atol=1e-4))
+        nose.tools.assert_true(np.allclose(
+            peaks[1]['position'], self.peak_positions1, rtol=1e-5, atol=1e-4))
 
 
 class TestInterpolateInBetween:

--- a/hyperspy/tests/signal/test_1D_tools.py
+++ b/hyperspy/tests/signal/test_1D_tools.py
@@ -145,6 +145,27 @@ class TestFindPeaks1D:
         nose.tools.assert_true(np.allclose(
             peaks[1]['position'], self.peak_positions1, rtol=1e-5, atol=1e-4))
 
+    def test_height(self):
+        peaks = self.spectrum.find_peaks1D_ohaver()
+        nose.tools.assert_true(np.allclose(
+            peaks[1]['height'], 1.0, rtol=1e-5, atol=1e-4))
+
+    def test_width(self):
+        peaks = self.spectrum.find_peaks1D_ohaver()
+        nose.tools.assert_true(np.allclose(
+            peaks[1]['width'], 3.5758, rtol=1e-4, atol=1e-4),
+            msg="One or several widths are not close enough to expected " +
+            "value (3.5758): " + str(peaks[1]['width']))
+
+    def test_n_peaks(self):
+        peaks = self.spectrum.find_peaks1D_ohaver()
+        nose.tools.assert_equal(len(peaks[1]), 8)
+
+    def test_maxpeaksn(self):
+        for n in xrange(1, 10):
+            peaks = self.spectrum.find_peaks1D_ohaver(maxpeakn=n)
+            nose.tools.assert_equal(len(peaks[1]), min((8, n)))
+
 
 class TestInterpolateInBetween:
 


### PR DESCRIPTION
Fixed two bugs with `find_peaks_ohaver()`:
* Order of dtype `height` and `width` were wrong compared to the order of the data.
* Now apply the `maxpeakn` argument, sorted by peak height. Can possibly be improved by sorting by a more advanced metric for peak strength.

Also cleaned up some formatting.

TODO
--------

* [x] Unittests.