### PR TITLE
Add `data` argument to `_get_*_signal` methods

### DIFF
--- a/hyperspy/_signals/dielectric_function.py
+++ b/hyperspy/_signals/dielectric_function.py
@@ -83,10 +83,8 @@ class DielectricFunction(Spectrum):
             dneff2 = k * simps(self.data.imag * axis.axis,
                                x=axis.axis,
                                axis=axis.index_in_array)
-            neff1 = self._get_navigation_signal()
-            neff2 = self._get_navigation_signal()
-            neff1.data = dneff1
-            neff2.data = dneff2
+            neff1 = self._get_navigation_signal(data=dneff1)
+            neff2 = self._get_navigation_signal(data=dneff2)
         else:
             neff1 = self._deepcopy_with_new_data(
                 k * cumtrapz((-1. / self.data).imag * axis.axis,

--- a/hyperspy/_signals/eels.py
+++ b/hyperspy/_signals/eels.py
@@ -503,8 +503,7 @@ class EELSSpectrum(Spectrum):
                 threshold=threshold,).data
 
         t_over_lambda = np.log(total_intensity / I0)
-        s = self._get_navigation_signal()
-        s.data = t_over_lambda
+        s = self._get_navigation_signal(data=t_over_lambda)
         s.metadata.General.title = (self.metadata.General.title +
                                     ' $\\frac{t}{\\lambda}$')
         if self.tmp_parameters.has_item('filename'):
@@ -1171,13 +1170,12 @@ class EELSSpectrum(Spectrum):
                 self.tmp_parameters.filename +
                 '_CDF_after_Kramers_Kronig_transform')
         if 'thickness' in output:
-            thickness = eps._get_navigation_signal()
+            thickness = eps._get_navigation_signal(
+                data=te[self.axes_manager._get_data_slice(
+                [(axis.index_in_array, 0)])] )
             thickness.metadata.General.title = (
                 self.metadata.General.title + ' thickness '
                 '(calculated using Kramers-Kronig analysis)')
-            thickness.data = te[
-                self.axes_manager._get_data_slice([(
-                    axis.index_in_array, 0)])]
             output['thickness'] = thickness
         if full_output is False:
             return eps

--- a/hyperspy/misc/eels/tools.py
+++ b/hyperspy/misc/eels/tools.py
@@ -293,7 +293,7 @@ def eels_constant(s, zlp, t):
     # Kinetic definitions
     ke = e0 * (1 + e0 / 2. / me) / (1 + e0 / me) ** 2
     tgt = e0 * (2 * me + e0) / (me + e0)
-    k = s._get_navigation_signal()
-    k.data = (t * i0 / (332.5 * ke)) * np.log(1 + (beta * tgt / eaxis) ** 2)
+    k = s.__class__(data=
+        (t * i0 / (332.5 * ke)) * np.log(1 + (beta * tgt / eaxis) ** 2))
     k.metadata.General.title = "EELS proportionality constant K"
     return k

--- a/hyperspy/signal.py
+++ b/hyperspy/signal.py
@@ -4341,7 +4341,7 @@ class Signal(MVA,
         cs.axes_manager._set_axis_attribute_values("navigate", False)
         return cs
 
-    def _get_navigation_signal(self, data=None):
+    def _get_navigation_signal(self, data=None, dtype=None):
         """Return a signal with the same axes as the navigation space.
 
         Parameters
@@ -4361,11 +4361,13 @@ class Signal(MVA,
                     "data.shape %s is not equal to the current navigation shape in"
                     " array which is %s" % (str(data.shape), str(ref_shape)))
         else:
+            if dtype is None:
+                dtype = self.data.dtype
             if self.axes_manager.navigation_dimension == 0:
-                data = np.array([0, ], dtype=self.data.dtype)
+                data = np.array([0, ], dtype=dtype)
             else:
                 data = np.zeros(self.axes_manager._navigation_shape_in_array,
-                                dtype=self.data.dtype)
+                                dtype=dtype)
         if self.axes_manager.navigation_dimension == 0:
             s = Signal(data)
         elif self.axes_manager.navigation_dimension == 1:
@@ -4384,7 +4386,7 @@ class Signal(MVA,
                 self.axes_manager.navigation_dimension)
         return s
 
-    def _get_signal_signal(self,data=None):
+    def _get_signal_signal(self, data=None, dtype=None):
         """Return a signal with the same axes as the signal space.
 
         Parameters
@@ -4405,12 +4407,13 @@ class Signal(MVA,
                     "data.shape %s is not equal to the current signal shape in"
                     " array which is %s" % (str(data.shape), str(ref_shape)))
         else:
+            if dtype is None:
+                dtype = self.data.dtype
             if self.axes_manager.signal_dimension == 0:
-                data = np.array([0, ], dtype=self.data.dtype)
+                data = np.array([0, ], dtype=dtype)
             else:
                 data = np.zeros(self.axes_manager._signal_shape_in_array,
-                                dtype=self.data.dtype)
-
+                                dtype=dtype)
 
         if self.axes_manager.signal_dimension == 0:
             s = Signal(data)

--- a/hyperspy/signal.py
+++ b/hyperspy/signal.py
@@ -4346,10 +4346,16 @@ class Signal(MVA,
 
         Parameters
         ----------
-        data : {None, numpy array}
+        data : {None, numpy array}, optional
             If None the `Signal` data is an array of the same dtype as the
             current one filled with zeros. If a numpy array, the array must
             have the correct dimensions.
+
+        dtype : data-type, optional
+            The desired data-type for the data array when `data` is None,
+            e.g., `numpy.int8`.  Default is the data type of the current signal
+            data.
+
 
         """
         if data is not None:
@@ -4391,10 +4397,14 @@ class Signal(MVA,
 
         Parameters
         ----------
-        data : {None, numpy array}
+        data : {None, numpy array}, optional
             If None the `Signal` data is an array of the same dtype as the
             current one filled with zeros. If a numpy array, the array must
             have the correct dimensions.
+        dtype : data-type, optional
+            The desired data-type for the data array when `data` is None,
+            e.g., `numpy.int8`.  Default is the data type of the current signal
+            data.
 
         """
 

--- a/hyperspy/signal.py
+++ b/hyperspy/signal.py
@@ -4353,11 +4353,13 @@ class Signal(MVA,
 
         """
         if data is not None:
-            if data.shape != self.axes_manager._navigation_shape_in_array:
+            ref_shape = (self.axes_manager._navigation_shape_in_array
+                         if self.axes_manager.navigation_dimension != 0
+                         else (1,))
+            if data.shape != ref_shape:
                 raise ValueError(
                     "data.shape %s is not equal to the current navigation shape in"
-                    " array which is %s" % (str(data.shape),
-                    str(self.axes_manager._navigation_shape_in_array)))
+                    " array which is %s" % (str(data.shape), str(ref_shape)))
         else:
             if self.axes_manager.navigation_dimension == 0:
                 data = np.array([0, ], dtype=self.data.dtype)
@@ -4395,11 +4397,13 @@ class Signal(MVA,
         """
 
         if data is not None:
-            if data.shape != self.axes_manager._signal_shape_in_array:
+            ref_shape = (self.axes_manager._signal_shape_in_array
+                         if self.axes_manager.signal_dimension != 0
+                         else (1,))
+            if data.shape != ref_shape:
                 raise ValueError(
                     "data.shape %s is not equal to the current signal shape in"
-                    " array which is %s" % (str(data.shape),
-                    (self.axes_manager._signal_shape_in_array)))
+                    " array which is %s" % (str(data.shape), str(ref_shape)))
         else:
             if self.axes_manager.signal_dimension == 0:
                 data = np.array([0, ], dtype=self.data.dtype)

--- a/hyperspy/signal.py
+++ b/hyperspy/signal.py
@@ -4355,9 +4355,9 @@ class Signal(MVA,
         if data is not None:
             if data.shape != self.axes_manager._navigation_shape_in_array:
                 raise ValueError(
-                    "data.shape is not equal to the current navigation shape in"
-                    " array which is %s" %
-                    str(self.axes_manager._navigation_shape_in_array))
+                    "data.shape %s is not equal to the current navigation shape in"
+                    " array which is %s" % (str(data.shape),
+                    str(self.axes_manager._navigation_shape_in_array)))
         else:
             if self.axes_manager.navigation_dimension == 0:
                 data = np.array([0, ], dtype=self.data.dtype)
@@ -4397,9 +4397,9 @@ class Signal(MVA,
         if data is not None:
             if data.shape != self.axes_manager._signal_shape_in_array:
                 raise ValueError(
-                    "data.shape is not equal to the current signal shape in"
-                    " array which is %s" %
-                    (self.axes_manager._signal_shape_in_array))
+                    "data.shape %s is not equal to the current signal shape in"
+                    " array which is %s" % (str(data.shape),
+                    (self.axes_manager._signal_shape_in_array)))
         else:
             if self.axes_manager.signal_dimension == 0:
                 data = np.array([0, ], dtype=self.data.dtype)

--- a/hyperspy/signal.py
+++ b/hyperspy/signal.py
@@ -4341,19 +4341,38 @@ class Signal(MVA,
         cs.axes_manager._set_axis_attribute_values("navigate", False)
         return cs
 
-    def _get_navigation_signal(self):
+    def _get_navigation_signal(self, data=None):
+        """Return a signal with the same axes as the navigation space.
+
+        Parameters
+        ----------
+        data : {None, numpy array}
+            If None the `Signal` data is an array of the same dtype as the
+            current one filled with zeros. If a numpy array, the array must
+            have the correct dimensions.
+
+        """
+        if data is not None:
+            if data.shape != self.axes_manager._navigation_shape_in_array:
+                raise ValueError(
+                    "data.shape is not equal to the current navigation shape in"
+                    " array which is %s" %
+                    str(self.axes_manager._navigation_shape_in_array))
+        else:
+            if self.axes_manager.navigation_dimension == 0:
+                data = np.array([0, ], dtype=self.data.dtype)
+            else:
+                data = np.zeros(self.axes_manager._navigation_shape_in_array,
+                                dtype=self.data.dtype)
         if self.axes_manager.navigation_dimension == 0:
-            s = Signal(np.array([0, ]).astype(self.data.dtype))
+            s = Signal(data)
         elif self.axes_manager.navigation_dimension == 1:
             from hyperspy._signals.spectrum import Spectrum
-            s = Spectrum(
-                np.zeros(self.axes_manager._navigation_shape_in_array,
-                         dtype=self.data.dtype),
-                axes=self.axes_manager._get_navigation_axes_dicts())
+            s = Spectrum(data,
+                         axes=self.axes_manager._get_navigation_axes_dicts())
         elif self.axes_manager.navigation_dimension == 2:
             from hyperspy._signals.image import Image
-            s = Image(np.zeros(self.axes_manager._navigation_shape_in_array,
-                               dtype=self.data.dtype),
+            s = Image(data,
                       axes=self.axes_manager._get_navigation_axes_dicts())
         else:
             s = Signal(np.zeros(self.axes_manager._navigation_shape_in_array,
@@ -4363,26 +4382,41 @@ class Signal(MVA,
                 self.axes_manager.navigation_dimension)
         return s
 
-    def _get_signal_signal(self):
+    def _get_signal_signal(self,data=None):
+        """Return a signal with the same axes as the signal space.
+
+        Parameters
+        ----------
+        data : {None, numpy array}
+            If None the `Signal` data is an array of the same dtype as the
+            current one filled with zeros. If a numpy array, the array must
+            have the correct dimensions.
+
+        """
+
+        if data is not None:
+            if data.shape != self.axes_manager._signal_shape_in_array:
+                raise ValueError(
+                    "data.shape is not equal to the current signal shape in"
+                    " array which is %s" %
+                    (self.axes_manager._signal_shape_in_array))
+        else:
+            if self.axes_manager.signal_dimension == 0:
+                data = np.array([0, ], dtype=self.data.dtype)
+            else:
+                data = np.zeros(self.axes_manager._signal_shape_in_array,
+                                dtype=self.data.dtype)
+
         if self.axes_manager.signal_dimension == 0:
-            s = Signal(np.array([0, ]).astype(self.data.dtype))
+            s = Signal(data)
         elif self.axes_manager.signal_dimension == 1:
             from hyperspy._signals.spectrum import Spectrum
-            s = Spectrum(np.zeros(
-                self.axes_manager._signal_shape_in_array,
-                dtype=self.data.dtype),
-                axes=self.axes_manager._get_signal_axes_dicts())
+            s = Spectrum(data, axes=self.axes_manager._get_signal_axes_dicts())
         elif self.axes_manager.signal_dimension == 2:
             from hyperspy._signals.image import Image
-            s = Image(np.zeros(
-                self.axes_manager._signal_shape_in_array,
-                dtype=self.data.dtype),
-                axes=self.axes_manager._get_signal_axes_dicts())
+            s = Image(data, axes=self.axes_manager._get_signal_axes_dicts())
         else:
-            s = Signal(np.zeros(
-                self.axes_manager._signal_shape_in_array,
-                dtype=self.data.dtype),
-                axes=self.axes_manager._get_signal_axes_dicts())
+            s = Signal(data, axes=self.axes_manager._get_signal_axes_dicts())
         s.set_signal_type(self.metadata.Signal.signal_type)
         return s
 

--- a/hyperspy/signal.py
+++ b/hyperspy/signal.py
@@ -4407,17 +4407,13 @@ class Signal(MVA,
                 data = np.zeros(self.axes_manager._signal_shape_in_array,
                                 dtype=self.data.dtype)
 
+
         if self.axes_manager.signal_dimension == 0:
             s = Signal(data)
-        elif self.axes_manager.signal_dimension == 1:
-            from hyperspy._signals.spectrum import Spectrum
-            s = Spectrum(data, axes=self.axes_manager._get_signal_axes_dicts())
-        elif self.axes_manager.signal_dimension == 2:
-            from hyperspy._signals.image import Image
-            s = Image(data, axes=self.axes_manager._get_signal_axes_dicts())
+            s.set_signal_type(self.metadata.Signal.signal_type)
         else:
-            s = Signal(data, axes=self.axes_manager._get_signal_axes_dicts())
-        s.set_signal_type(self.metadata.Signal.signal_type)
+            s = self.__class__(data,
+                               axes=self.axes_manager._get_signal_axes_dicts())
         return s
 
     def __iter__(self):

--- a/hyperspy/tests/signal/test_tools.py
+++ b/hyperspy/tests/signal/test_tools.py
@@ -65,7 +65,7 @@ class Test2D:
     def test_estimate_poissonian_noise_copy_data(self):
         self.signal.estimate_poissonian_noise_variance()
         nt.assert_true(self.signal.metadata.Signal.Noise_properties.variance.data
-                    is not self.signal.data)
+                       is not self.signal.data)
 
     def test_estimate_poissonian_noise_noarg(self):
         self.signal.estimate_poissonian_noise_variance()
@@ -102,7 +102,10 @@ class Test3D:
         nt.assert_true(var.data.shape == (1, 2, 6))
         from hyperspy.misc.array_tools import rebin
         nt.assert_true(np.all(rebin(self.signal.data, (1, 2, 6)) == var.data))
-        nt.assert_true(np.all(rebin(self.signal.data, (1, 2, 6)) == new_s.data))
+        nt.assert_true(
+            np.all(
+                rebin(
+                    self.signal.data, (1, 2, 6)) == new_s.data))
 
     @nt.raises(AttributeError)
     def test_rebin_no_variance(self):
@@ -132,7 +135,7 @@ class Test3D:
         s.axes_manager.set_signal_dimension(2)
         ns = s._get_navigation_signal()
         nt.assert_equal(ns.axes_manager.signal_shape,
-                     s.axes_manager.navigation_shape)
+                        s.axes_manager.navigation_shape)
         nt.assert_equal(ns.axes_manager.navigation_dimension, 0)
 
     def test_get_navigation_signal_nav_dim2(self):
@@ -140,7 +143,7 @@ class Test3D:
         s.axes_manager.set_signal_dimension(1)
         ns = s._get_navigation_signal()
         nt.assert_equal(ns.axes_manager.signal_shape,
-                     s.axes_manager.navigation_shape)
+                        s.axes_manager.navigation_shape)
         nt.assert_equal(ns.axes_manager.navigation_dimension, 0)
 
     def test_get_navigation_signal_nav_dim3(self):
@@ -148,7 +151,7 @@ class Test3D:
         s.axes_manager.set_signal_dimension(0)
         ns = s._get_navigation_signal()
         nt.assert_equal(ns.axes_manager.signal_shape,
-                     s.axes_manager.navigation_shape)
+                        s.axes_manager.navigation_shape)
         nt.assert_equal(ns.axes_manager.navigation_dimension, 0)
 
     @nt.raises(ValueError)
@@ -183,7 +186,7 @@ class Test3D:
         s.axes_manager.set_signal_dimension(1)
         ns = s._get_signal_signal()
         nt.assert_equal(ns.axes_manager.signal_shape,
-                     s.axes_manager.signal_shape)
+                        s.axes_manager.signal_shape)
         nt.assert_equal(ns.axes_manager.navigation_dimension, 0)
 
     def test_get_signal_signal_nav_dim2(self):
@@ -191,7 +194,7 @@ class Test3D:
         s.axes_manager.set_signal_dimension(2)
         ns = s._get_signal_signal()
         nt.assert_equal(ns.axes_manager.signal_shape,
-                     s.axes_manager.signal_shape)
+                        s.axes_manager.signal_shape)
         nt.assert_equal(ns.axes_manager.navigation_dimension, 0)
 
     def test_get_signal_signal_nav_dim3(self):
@@ -199,7 +202,7 @@ class Test3D:
         s.axes_manager.set_signal_dimension(3)
         ns = s._get_signal_signal()
         nt.assert_equal(ns.axes_manager.signal_shape,
-                     s.axes_manager.signal_shape)
+                        s.axes_manager.signal_shape)
         nt.assert_equal(ns.axes_manager.navigation_dimension, 0)
 
     @nt.raises(ValueError)

--- a/hyperspy/tests/signal/test_tools.py
+++ b/hyperspy/tests/signal/test_tools.py
@@ -157,6 +157,12 @@ class Test3D:
         s.axes_manager.set_signal_dimension(1)
         ns = s._get_navigation_signal(data=np.zeros((3, 2)))
 
+    @nt.raises(ValueError)
+    def test_get_navigation_signal_wrong_data_shape_dim0(self):
+        s = self.signal
+        s.axes_manager.set_signal_dimension(3)
+        ns = s._get_navigation_signal(data=np.asarray(0))
+
     def test_get_navigation_signal_given_data(self):
         s = self.signal
         s.axes_manager.set_signal_dimension(1)
@@ -202,6 +208,12 @@ class Test3D:
         s.axes_manager.set_signal_dimension(1)
         ns = s._get_signal_signal(data=np.zeros((3, 2)))
 
+    @nt.raises(ValueError)
+    def test_get_signal_signal_wrong_data_shape_dim0(self):
+        s = self.signal
+        s.axes_manager.set_signal_dimension(0)
+        ns = s._get_signal_signal(data=np.asarray(0))
+        
     def test_get_signal_signal_given_data(self):
         s = self.signal
         s.axes_manager.set_signal_dimension(2)

--- a/hyperspy/tests/signal/test_tools.py
+++ b/hyperspy/tests/signal/test_tools.py
@@ -1,8 +1,5 @@
 import numpy as np
-from nose.tools import (
-    assert_true,
-    assert_equal,
-    raises)
+import nose.tools as nt
 
 from hyperspy.signal import Signal
 from hyperspy import signals
@@ -22,57 +19,57 @@ class Test2D:
         s2 = self.signal.deepcopy()
         s1.crop(0, 2, 4)
         s2.crop("x", 2, 4)
-        assert_true((s1.data == s2.data).all())
+        nt.assert_true((s1.data == s2.data).all())
 
     def test_crop_int(self):
         s = self.signal
         d = self.data
         s.crop(0, 2, 4)
-        assert_true((s.data == d[2:4, :]).all())
+        nt.assert_true((s.data == d[2:4, :]).all())
 
     def test_crop_float(self):
         s = self.signal
         d = self.data
         s.crop(0, 2, 2.)
-        assert_true((s.data == d[2:4, :]).all())
+        nt.assert_true((s.data == d[2:4, :]).all())
 
     def test_split_axis0(self):
         result = self.signal.split(0, 2)
-        assert_true(len(result) == 2)
-        assert_true((result[0].data == self.data[:2, :]).all())
-        assert_true((result[1].data == self.data[2:4, :]).all())
+        nt.assert_true(len(result) == 2)
+        nt.assert_true((result[0].data == self.data[:2, :]).all())
+        nt.assert_true((result[1].data == self.data[2:4, :]).all())
 
     def test_split_axis1(self):
         result = self.signal.split(1, 2)
-        assert_true(len(result) == 2)
-        assert_true((result[0].data == self.data[:, :5]).all())
-        assert_true((result[1].data == self.data[:, 5:]).all())
+        nt.assert_true(len(result) == 2)
+        nt.assert_true((result[0].data == self.data[:, :5]).all())
+        nt.assert_true((result[1].data == self.data[:, 5:]).all())
 
     def test_split_axisE(self):
         result = self.signal.split("E", 2)
-        assert_true(len(result) == 2)
-        assert_true((result[0].data == self.data[:, :5]).all())
-        assert_true((result[1].data == self.data[:, 5:]).all())
+        nt.assert_true(len(result) == 2)
+        nt.assert_true((result[0].data == self.data[:, :5]).all())
+        nt.assert_true((result[1].data == self.data[:, 5:]).all())
 
     def test_split_default(self):
         result = self.signal.split()
-        assert_true(len(result) == 5)
-        assert_true((result[0].data == self.data[0]).all())
+        nt.assert_true(len(result) == 5)
+        nt.assert_true((result[0].data == self.data[0]).all())
 
     def test_histogram(self):
         result = self.signal.get_histogram(3)
-        assert_true(isinstance(result, signals.Spectrum))
-        assert_true((result.data == np.array([17, 16, 17])).all())
-        assert_true(result.metadata.Signal.binned)
+        nt.assert_true(isinstance(result, signals.Spectrum))
+        nt.assert_true((result.data == np.array([17, 16, 17])).all())
+        nt.assert_true(result.metadata.Signal.binned)
 
     def test_estimate_poissonian_noise_copy_data(self):
         self.signal.estimate_poissonian_noise_variance()
-        assert_true(self.signal.metadata.Signal.Noise_properties.variance.data
+        nt.assert_true(self.signal.metadata.Signal.Noise_properties.variance.data
                     is not self.signal.data)
 
     def test_estimate_poissonian_noise_noarg(self):
         self.signal.estimate_poissonian_noise_variance()
-        assert_true(
+        nt.assert_true(
             (self.signal.metadata.Signal.Noise_properties.variance.data ==
              self.signal.data).all())
 
@@ -82,7 +79,7 @@ class Test2D:
             gain_factor=2,
             gain_offset=1,
             correlation_factor=0.5)
-        assert_true(
+        nt.assert_true(
             (self.signal.metadata.Signal.Noise_properties.variance.data ==
              (self.signal.data * 2 + 1) * 0.5).all())
 
@@ -101,13 +98,13 @@ class Test3D:
         self.signal.estimate_poissonian_noise_variance()
         new_s = self.signal.rebin((2, 1, 6))
         var = new_s.metadata.Signal.Noise_properties.variance
-        assert_true(new_s.data.shape == (1, 2, 6))
-        assert_true(var.data.shape == (1, 2, 6))
+        nt.assert_true(new_s.data.shape == (1, 2, 6))
+        nt.assert_true(var.data.shape == (1, 2, 6))
         from hyperspy.misc.array_tools import rebin
-        assert_true(np.all(rebin(self.signal.data, (1, 2, 6)) == var.data))
-        assert_true(np.all(rebin(self.signal.data, (1, 2, 6)) == new_s.data))
+        nt.assert_true(np.all(rebin(self.signal.data, (1, 2, 6)) == var.data))
+        nt.assert_true(np.all(rebin(self.signal.data, (1, 2, 6)) == new_s.data))
 
-    @raises(AttributeError)
+    @nt.raises(AttributeError)
     def test_rebin_no_variance(self):
         new_s = self.signal.rebin((2, 1, 6))
         _ = new_s.metadata.Signal.Noise_properties
@@ -115,77 +112,102 @@ class Test3D:
     def test_rebin_const_variance(self):
         self.signal.metadata.set_item('Signal.Noise_properties.variance', 0.3)
         new_s = self.signal.rebin((2, 1, 6))
-        assert_true(new_s.metadata.Signal.Noise_properties.variance == 0.3)
+        nt.assert_true(new_s.metadata.Signal.Noise_properties.variance == 0.3)
 
     def test_swap_axes(self):
         s = self.signal
-        assert_equal(s.swap_axes(0, 1).data.shape, (4, 2, 6))
-        assert_true(s.swap_axes(0, 2).data.flags['C_CONTIGUOUS'])
+        nt.assert_equal(s.swap_axes(0, 1).data.shape, (4, 2, 6))
+        nt.assert_true(s.swap_axes(0, 2).data.flags['C_CONTIGUOUS'])
 
     def test_get_navigation_signal_nav_dim0(self):
         s = self.signal
         s.axes_manager.set_signal_dimension(3)
         ns = s._get_navigation_signal()
-        assert_equal(ns.axes_manager.signal_dimension, 1)
-        assert_equal(ns.axes_manager.signal_size, 1)
-        assert_equal(ns.axes_manager.navigation_dimension, 0)
+        nt.assert_equal(ns.axes_manager.signal_dimension, 1)
+        nt.assert_equal(ns.axes_manager.signal_size, 1)
+        nt.assert_equal(ns.axes_manager.navigation_dimension, 0)
 
     def test_get_navigation_signal_nav_dim1(self):
         s = self.signal
         s.axes_manager.set_signal_dimension(2)
         ns = s._get_navigation_signal()
-        assert_equal(ns.axes_manager.signal_shape,
+        nt.assert_equal(ns.axes_manager.signal_shape,
                      s.axes_manager.navigation_shape)
-        assert_equal(ns.axes_manager.navigation_dimension, 0)
+        nt.assert_equal(ns.axes_manager.navigation_dimension, 0)
 
     def test_get_navigation_signal_nav_dim2(self):
         s = self.signal
         s.axes_manager.set_signal_dimension(1)
         ns = s._get_navigation_signal()
-        assert_equal(ns.axes_manager.signal_shape,
+        nt.assert_equal(ns.axes_manager.signal_shape,
                      s.axes_manager.navigation_shape)
-        assert_equal(ns.axes_manager.navigation_dimension, 0)
+        nt.assert_equal(ns.axes_manager.navigation_dimension, 0)
 
     def test_get_navigation_signal_nav_dim3(self):
         s = self.signal
         s.axes_manager.set_signal_dimension(0)
         ns = s._get_navigation_signal()
-        assert_equal(ns.axes_manager.signal_shape,
+        nt.assert_equal(ns.axes_manager.signal_shape,
                      s.axes_manager.navigation_shape)
-        assert_equal(ns.axes_manager.navigation_dimension, 0)
+        nt.assert_equal(ns.axes_manager.navigation_dimension, 0)
+
+    @nt.raises(ValueError)
+    def test_get_navigation_signal_wrong_data_shape(self):
+        s = self.signal
+        s.axes_manager.set_signal_dimension(1)
+        ns = s._get_navigation_signal(data=np.zeros((3, 2)))
+
+    def test_get_navigation_signal_given_data(self):
+        s = self.signal
+        s.axes_manager.set_signal_dimension(1)
+        data = np.empty(s.axes_manager._navigation_shape_in_array)
+        ns = s._get_navigation_signal(data=data)
+        nt.assert_is(ns.data, data)
 
     def test_get_signal_signal_nav_dim0(self):
         s = self.signal
         s.axes_manager.set_signal_dimension(0)
         ns = s._get_signal_signal()
-        assert_equal(ns.axes_manager.navigation_dimension, 0)
-        assert_equal(ns.axes_manager.navigation_size, 0)
-        assert_equal(ns.axes_manager.signal_dimension, 1)
+        nt.assert_equal(ns.axes_manager.navigation_dimension, 0)
+        nt.assert_equal(ns.axes_manager.navigation_size, 0)
+        nt.assert_equal(ns.axes_manager.signal_dimension, 1)
 
     def test_get_signal_signal_nav_dim1(self):
         s = self.signal
         s.axes_manager.set_signal_dimension(1)
         ns = s._get_signal_signal()
-        assert_equal(ns.axes_manager.signal_shape,
+        nt.assert_equal(ns.axes_manager.signal_shape,
                      s.axes_manager.signal_shape)
-        assert_equal(ns.axes_manager.navigation_dimension, 0)
+        nt.assert_equal(ns.axes_manager.navigation_dimension, 0)
 
     def test_get_signal_signal_nav_dim2(self):
         s = self.signal
         s.axes_manager.set_signal_dimension(2)
         ns = s._get_signal_signal()
-        assert_equal(ns.axes_manager.signal_shape,
+        nt.assert_equal(ns.axes_manager.signal_shape,
                      s.axes_manager.signal_shape)
-        assert_equal(ns.axes_manager.navigation_dimension, 0)
+        nt.assert_equal(ns.axes_manager.navigation_dimension, 0)
 
     def test_get_signal_signal_nav_dim3(self):
         s = self.signal
         s.axes_manager.set_signal_dimension(3)
         ns = s._get_signal_signal()
-        assert_equal(ns.axes_manager.signal_shape,
+        nt.assert_equal(ns.axes_manager.signal_shape,
                      s.axes_manager.signal_shape)
-        assert_equal(ns.axes_manager.navigation_dimension, 0)
+        nt.assert_equal(ns.axes_manager.navigation_dimension, 0)
 
+    @nt.raises(ValueError)
+    def test_get_signal_signal_wrong_data_shape(self):
+        s = self.signal
+        s.axes_manager.set_signal_dimension(1)
+        ns = s._get_signal_signal(data=np.zeros((3, 2)))
+
+    def test_get_signal_signal_given_data(self):
+        s = self.signal
+        s.axes_manager.set_signal_dimension(2)
+        data = np.empty(s.axes_manager._signal_shape_in_array)
+        ns = s._get_signal_signal(data=data)
+        nt.assert_is(ns.data, data)
 
 class Test4D:
 
@@ -198,25 +220,25 @@ class Test4D:
         self.s = s
 
     def test_rollaxis_int(self):
-        assert_equal(self.s.rollaxis(2, 0).data.shape, (4, 3, 5, 6))
+        nt.assert_equal(self.s.rollaxis(2, 0).data.shape, (4, 3, 5, 6))
 
     def test_rollaxis_str(self):
-        assert_equal(self.s.rollaxis("z", "x").data.shape, (4, 3, 5, 6))
+        nt.assert_equal(self.s.rollaxis("z", "x").data.shape, (4, 3, 5, 6))
 
     def test_unfold_spectrum(self):
         self.s.unfold()
-        assert_equal(self.s.data.shape, (60, 6))
+        nt.assert_equal(self.s.data.shape, (60, 6))
 
     def test_unfold_image(self):
         im = self.s.to_image()
         im.unfold()
-        assert_equal(im.data.shape, (30, 12))
+        nt.assert_equal(im.data.shape, (30, 12))
 
 
 def test_signal_iterator():
     s = Signal(np.arange(3).reshape((3, 1)))
-    assert_equal(s.next().data[0], 0)
+    nt.assert_equal(s.next().data[0], 0)
     # If the following fails it can be because the iteration index was not
     # restarted
     for i, signal in enumerate(s):
-        assert_equal(i, signal.data[0])
+        nt.assert_equal(i, signal.data[0])

--- a/hyperspy/tests/signal/test_tools.py
+++ b/hyperspy/tests/signal/test_tools.py
@@ -213,13 +213,34 @@ class Test3D:
         s = self.signal
         s.axes_manager.set_signal_dimension(0)
         ns = s._get_signal_signal(data=np.asarray(0))
-        
+
     def test_get_signal_signal_given_data(self):
         s = self.signal
         s.axes_manager.set_signal_dimension(2)
         data = np.empty(s.axes_manager._signal_shape_in_array)
         ns = s._get_signal_signal(data=data)
         nt.assert_is(ns.data, data)
+
+    def test_get_navigation_signal_dtype(self):
+        s = self.signal
+        nt.assert_equal(s._get_navigation_signal().data.dtype.name,
+                        s.data.dtype.name)
+
+    def test_get_signal_signal_dtype(self):
+        s = self.signal
+        nt.assert_equal(s._get_signal_signal().data.dtype.name,
+                        s.data.dtype.name)
+
+    def test_get_navigation_signal_given_dtype(self):
+        s = self.signal
+        nt.assert_equal(
+            s._get_navigation_signal(dtype="bool").data.dtype.name, "bool")
+
+    def test_get_signal_signal_given_dtype(self):
+        s = self.signal
+        nt.assert_equal(
+            s._get_signal_signal(dtype="bool").data.dtype.name, "bool")
+
 
 class Test4D:
 


### PR DESCRIPTION
Add  `data` argument to `Signal._get_signal_signal` and `Signal._get_navigation_signal`.

This PR also includes changes to the code where using the new `data` argument can avoid memory duplication.