### PR TITLE
Enable travis docker infraestructure (faster)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 language: python
 
+sudo: false
+
 python:
   - 2.7
 


### PR DESCRIPTION
This is just to migrate to the container based infrastructure. Details [here](http://docs.travis-ci.com/user/migrating-from-legacy/?utm_source=legacy-notice&utm_medium=banner&utm_campaign=legacy-upgrade).