### PR TITLE
BUGIFX: mpfit used deprecated numpy.rank()

### DIFF
--- a/hyperspy/misc/mpfit/mpfit.py
+++ b/hyperspy/misc/mpfit/mpfit.py
@@ -2300,7 +2300,7 @@ Outputs:
 
         if self.debug:
             print 'Entering calc_covar...'
-        if numpy.rank(rr) != 2:
+        if numpy.ndim(rr) != 2:
             print 'ERROR: r must be a two-dimensional matrix'
             return -1
         s = rr.shape


### PR DESCRIPTION
..and hence it printed warnings, now fixed