### PR TITLE
changed to use new scipy structure

### DIFF
--- a/hyperspy/misc/mpfit/mpfit.py
+++ b/hyperspy/misc/mpfit/mpfit.py
@@ -411,7 +411,7 @@ Perform Levenberg-Marquardt least-squares minimization, based on MINPACK-1.
 
 import numpy
 import types
-import scipy.lib.blas
+import scipy.linalg
 
 #	 Original FORTRAN documentation
 #	 **********
@@ -598,10 +598,10 @@ import scipy.lib.blas
 
 class mpfit:
 
-    blas_enorm32, = scipy.lib.blas.get_blas_funcs(
+    blas_enorm32, = scipy.linalg.get_blas_funcs(
         ['nrm2'], numpy.array(
             [0], dtype=numpy.float32))
-    blas_enorm64, = scipy.lib.blas.get_blas_funcs(
+    blas_enorm64, = scipy.linalg.get_blas_funcs(
         ['nrm2'], numpy.array(
             [0], dtype=numpy.float64))
 


### PR DESCRIPTION
All the travis builds failed (silently) because it used the newest scipy, while we did not upgrade to comply. Thus coveralls discovered a huge drop in coverage (as the tests did not run at all).
This should fix it