### PR TITLE
Remove previos api files before generating new ones.

### DIFF
--- a/doc/generate_api_doc.sh
+++ b/doc/generate_api_doc.sh
@@ -1,3 +1,4 @@
 # This only works with Sphinx >= 1.1
 
+rm api/*.rst
 sphinx-apidoc ../hyperspy -o api -s rst -f --private


### PR DESCRIPTION
The `generate_api_doc` script—just a shortcut for `sphinx-api`—was not deleting the API docs of deleted modules. 