### PR TITLE
ENH: improve usability of spikes tool

### DIFF
--- a/hyperspy/gui/egerton_quantification.py
+++ b/hyperspy/gui/egerton_quantification.py
@@ -22,6 +22,7 @@ import matplotlib.text as mpl_text
 import traits.api as t
 import traitsui.api as tu
 from traitsui.menu import OKButton, CancelButton
+from pyface.message_dialog import information
 
 from hyperspy import components
 from hyperspy.component import Component
@@ -220,14 +221,16 @@ class SpikesRemoval(SpanSelectorInSpectrum):
     default_spike_width = t.Int(5,
                                 desc="the width over which to do the "
                                      "interpolation\n"
-                                     "when removing a spike")
+                                     "when removing a spike (this can be "
+                                     "adjusted for each\nspike by clicking "
+                                     "and dragging on the display during\n"
+                                     "spike replacement)")
     index = t.Int(0)
     add_noise = t.Bool(True,
-                       desc="whether to add noise to the interpolated "
-                            "portion\n"
+                       desc="whether to add noise to the interpolated\nportion"
                             "of the spectrum. The noise properties defined\n"
-                            "in the Signal metadata are used if present,\n"
-                            "otherwise shot noise is used as a default")
+                            "in the Signal metadata are used if present,"
+                            "otherwise\nshot noise is used as a default")
     view = tu.View(tu.Group(
         tu.Group(
             tu.Item('click_to_show_instructions',
@@ -299,30 +302,37 @@ class SpikesRemoval(SpanSelectorInSpectrum):
         self.update_plot()
 
     def _click_to_show_instructions_fired(self):
-        m = tu.message("\nTo remove spikes from the data:\n\n"
+        m = information(None,
+                        "\nTo remove spikes from the data:\n\n"
 
-                       "   1. Click \"Show derivative histogram\" to determine"
-                       " at what magnitude the spikes are present.\n"
-                       "   2. Enter a suitable threshold (lower than the "
-                       "lowest magnitude outlier in the histogram) in\n"
-                       "        the \"Threshold\" box, which will be "
-                       "the magnitude from which to search. \n"
-                       "   3. Click \"Find next\" to find the first spike.\n"
-                       "   4. View the spike (and the replacement data that "
-                       "will be added) and click \"Remove spike\"\n"
-                       "        in order to alter the data as shown.\n"
-                       "   5. Repeat this process for each spike throughout "
-                       "the dataset.\n"
-                       "   6. Click \"OK\" when finished to close the spikes "
-                       "removal tool.\n\n"
+                        "   1. Click \"Show derivative histogram\" to "
+                        "determine at what magnitude the spikes are present.\n"
+                        "   2. Enter a suitable threshold (lower than the "
+                        "lowest magnitude outlier in the histogram) in the "
+                        "\"Threshold\" box, which will be the magnitude "
+                        "from which to search. \n"
+                        "   3. Click \"Find next\" to find the first spike.\n"
+                        "   4. If desired, the width and position of the "
+                        "boundaries used to replace the spike can be "
+                        "adjusted by clicking and dragging on the displayed "
+                        "plot.\n "
+                        "   5. View the spike (and the replacement data that "
+                        "will be added) and click \"Remove spike\" in order "
+                        "to alter the data as shown. The tool will "
+                        "automatically find the next spike to replace.\n"
+                        "   6. Repeat this process for each spike throughout "
+                        "the dataset, until the end of the dataset is "
+                        "reached.\n"
+                        "   7. Click \"OK\" when finished to close the spikes "
+                        "removal tool.\n\n"
 
-                       "Note: Various settings can be configured in "
-                       "the \"Advanced settings\" section. Hover the "
-                       "mouse\n"
-                       "over each parameter for a description of what "
-                       "it does."
+                        "Note: Various settings can be configured in "
+                        "the \"Advanced settings\" section. Hover the "
+                        "mouse over each parameter for a description of what "
+                        "it does."
 
-                       "\n"),
+                        "\n",
+                        title="Instructions"),
 
     def _show_derivative_histogram_fired(self):
         self.signal._spikes_diagnosis(signal_mask=self.signal_mask,

--- a/hyperspy/gui/egerton_quantification.py
+++ b/hyperspy/gui/egerton_quantification.py
@@ -145,10 +145,10 @@ class BackgroundRemoval(SpanSelectorInSpectrum):
             print("No bg estimator")
             return
         if self.bg_line is None and \
-                        self.background_estimator.estimate_parameters(
-                            self.signal, self.ss_left_value,
-                            self.ss_right_value,
-                            only_current=True) is True:
+            self.background_estimator.estimate_parameters(
+                self.signal, self.ss_left_value,
+                self.ss_right_value,
+                only_current=True) is True:
             self.create_background_line()
         else:
             self.bg_line.update()
@@ -164,6 +164,7 @@ class BackgroundRemoval(SpanSelectorInSpectrum):
 
 
 class SpikesRemovalHandler(tu.Handler):
+
     def close(self, info, is_ok):
         # Removes the span selector from the plot
         info.object.span_selector_switch(False)
@@ -265,7 +266,7 @@ class SpikesRemoval(SpanSelectorInSpectrum):
         self.coordinates = [coordinate for coordinate in
                             signal.axes_manager._am_indices_generator()
                             if (navigation_mask is None or not
-            navigation_mask[coordinate[::-1]])]
+                                navigation_mask[coordinate[::-1]])]
         self.signal = signal
         self.line = signal._plot.signal_plot.ax_lines[0]
         self.ax = signal._plot.signal_plot.ax
@@ -351,8 +352,8 @@ class SpikesRemoval(SpanSelectorInSpectrum):
         ncoordinates = len(self.coordinates)
         spike = self.detect_spike()
         while not spike and (
-                    (self.index < ncoordinates - 1 and back is False) or
-                    (self.index > 0 and back is True)):
+                (self.index < ncoordinates - 1 and back is False) or
+                (self.index > 0 and back is True)):
             if back is False:
                 self.index += 1
             else:
@@ -372,7 +373,7 @@ class SpikesRemoval(SpanSelectorInSpectrum):
                 color="black")
             self.ax.legend([thresh_label], [repr(int(self.derivmax))],
                            handler_map={DerivativeTextParameters:
-                                            DerivativeTextHandler()},
+                                        DerivativeTextHandler()},
                            loc='best')
             self.ax.set_xlim(
                 self.signal.axes_manager.signal_axes[0].index2value(
@@ -517,12 +518,14 @@ class SpikesRemoval(SpanSelectorInSpectrum):
 
 # For creating a text handler in legend (to label derivative magnitude)
 class DerivativeTextParameters(object):
+
     def __init__(self, text, color):
         self.my_text = text
         self.my_color = color
 
 
 class DerivativeTextHandler(object):
+
     def legend_artist(self, legend, orig_handle, fontsize, handlebox):
         x0, y0 = handlebox.xdescent, handlebox.ydescent
         width, height = handlebox.width, handlebox.height

--- a/hyperspy/gui/egerton_quantification.py
+++ b/hyperspy/gui/egerton_quantification.py
@@ -310,9 +310,11 @@ class SpikesRemoval(SpanSelectorInSpectrum):
                        "   3. Click \"Find next\" to find the first spike.\n"
                        "   4. View the spike (and the replacement data that "
                        "will be added) and click \"Remove spike\"\n"
-                       "        in order to alter the data as shown\n"
+                       "        in order to alter the data as shown.\n"
                        "   5. Repeat this process for each spike throughout "
-                       "the dataset\n\n"
+                       "the dataset.\n"
+                       "   6. Click \"OK\" when finished to close the spikes "
+                       "removal tool.\n\n"
 
                        "Note: Various settings can be configured in "
                        "the \"Advanced settings\" section. Hover the "

--- a/hyperspy/gui/tools.py
+++ b/hyperspy/gui/tools.py
@@ -30,17 +30,30 @@ from hyperspy.axes import AxesManager
 from hyperspy.drawing.widgets import DraggableVerticalLine
 
 
-OurApplyButton = tu.Action(name="Apply",
-                           action="apply")
+OurOKButton = tu.Action(name="OK",
+                        action="OK",
+                        tooltip="Close the spikes removal tool")
+
+OurApplyButton = tu.Action(name="Remove spike",
+                           action="apply",
+                           tooltip="Remove the current spike by "
+                                   "interpolating\n"
+                                   "with the specified settings (and find\n"
+                                   "the next spike automatically)")
 
 OurResetButton = tu.Action(name="Reset",
                            action="reset")
 
-OurFindButton = tu.Action(name="Find",
-                          action="find")
+OurFindButton = tu.Action(name="Find next",
+                          action="find",
+                          tooltip="Find the next (in terms of navigation\n"
+                                  "dimensions) spike in the data.")
 
-OurPreviousButton = tu.Action(name="Previous",
-                              action="back")
+OurPreviousButton = tu.Action(name="Find previous",
+                              action="back",
+                              tooltip="Find the previous (in terms of "
+                                      "navigation\n"
+                                      "dimensions) spike in the data.")
 
 
 class SmoothingHandler(tu.Handler):


### PR DESCRIPTION
I noticed a few areas where the spikes tool could be improved, so I made some changes. I think they shouldn't be too disagreeable...

**First:**
On my systems (both windows and linux), the window display would get "squished" when switching to spline mode. This was because the traits window was not re-sizable. See below:
![spikes_squished_window](https://cloud.githubusercontent.com/assets/1278301/8998647/42eb25f4-36fe-11e5-891b-a0434101974c.png)
Making it re-sizable fixed this, as the window was allowed to expand, but it wouldn't shrink back when switching the interpolation back to linear. To solve this, I just made the spline controls disabled, as opposed to invisible, so the size of the window does not need to change.

**Second:**
There is poor documentation in the user guide for this tool (it should really be added), so I added some instructions to the tool itself. This was done two ways. First, some parameters were given a more descriptive name. Also, each parameter was given a tooltip that explains the parameter in more detail when hovering over with the mouse. Lastly, I added another button that creates a message window that spells out the specific instructions for running the tool.

**_Tooltip example:_**
![spikes_tooltip](https://cloud.githubusercontent.com/assets/1278301/8998706/de29e492-36fe-11e5-9121-e7cd5c0587e3.png)

**_Instructions window:_**
![spikes_instructions](https://cloud.githubusercontent.com/assets/1278301/8998707/e5aeda7e-36fe-11e5-9ab6-c426dda540d7.png)

Note, I've never really worked with traits before, so I was just sort of hacking my way through this. In my testing, I didn't break anything, but the Instructions window really doesn't look as nice as I think it should, but I couldn't figure out how to get padding around the text or anything. Any suggestions would be appreciated :smile: 