### PR TITLE
no more 0d data with 1d signals. Tests fixed

### DIFF
--- a/hyperspy/signal.py
+++ b/hyperspy/signal.py
@@ -2761,7 +2761,7 @@ class Signal(MVA,
             old_plot = self._plot
             self._plot = None
             ns = self.deepcopy()
-            ns.data = data
+            ns.data = np.atleast_1d(data)
             return ns
         finally:
             self.data = old_data

--- a/hyperspy/tests/signal/test_tools.py
+++ b/hyperspy/tests/signal/test_tools.py
@@ -17,11 +17,13 @@ class Test2D:
     def test_sum_x(self):
         s = self.signal.sum("x")
         np.testing.assert_array_equal(self.signal.data.sum(0), s.data)
+        nt.assert_equal(s.data.ndim, 1)
         nt.assert_equal(s.axes_manager.navigation_dimension, 0)
 
     def test_sum_x_E(self):
         s = self.signal.sum("x").sum("E")
         np.testing.assert_array_equal(self.signal.data.sum(), s.data)
+        nt.assert_equal(s.data.ndim, 1)
         # Check that there is still one signal axis.
         nt.assert_equal(s.axes_manager.signal_dimension, 1)
 


### PR DESCRIPTION
Fixes a bug left over by #622, where 0D data with 1D signals was possible, hence not actually solving #517.

started further discussion at https://github.com/hyperspy/hyperspy/issues/643