### PR TITLE
ENH: Histogram handles NaN data

### DIFF
--- a/hyperspy/signal.py
+++ b/hyperspy/signal.py
@@ -4070,8 +4070,8 @@ class Signal(MVA,
 
         """
         from hyperspy import signals
-
-        hist, bin_edges = histogram(img.data.flatten(),
+        data = img.data[~np.isnan(img.data)].flatten()
+        hist, bin_edges = histogram(data,
                                     bins=bins,
                                     range=range_bins,
                                     **kwargs)


### PR DESCRIPTION
Previously, if you tried to call `Signal.get_histogram()` with data containing NaN's, you'd get an exception. As the NaN's shouldn't be counted either way, filtering them out is relatively easy.