### PR TITLE
Fix invisible warnings

### DIFF
--- a/hyperspy/hspy.py
+++ b/hyperspy/hspy.py
@@ -49,6 +49,7 @@ from hyperspy import signals
 from hyperspy.io import load
 from hyperspy.defaults_parser import preferences
 from hyperspy import utils
+from hyperspy.misc.hspy_warnings import VisibleDeprecationWarning
 
 
 def get_configuration_directory_path():
@@ -98,5 +99,5 @@ def create_model(signal, *args, **kwargs):
     warnings.warn(
         "This function is deprecated and will be removed in HyperSpy 0.9. "
         "Please use the equivalent `Signal.create_model` method "
-        "instead.", DeprecationWarning)
+        "instead.", VisibleDeprecationWarning)
     return signal.create_model(*args, **kwargs)

--- a/hyperspy/learn/mva.py
+++ b/hyperspy/learn/mva.py
@@ -39,6 +39,8 @@ from hyperspy.decorators import do_not_replot
 from scipy import linalg
 from hyperspy.misc.machine_learning.orthomax import orthomax
 from hyperspy.misc.utils import stack
+from hyperspy.misc.hspy_warnings import VisibleDeprecationWarning
+
 
 
 def centering_and_whitening(X):
@@ -502,7 +504,7 @@ class MVA():
                     "HyperSpy 0.9 and newer. From them on only passing "
                     "factors as HyperSpy Signal instances will be "
                     "supported.",
-                    DeprecationWarning)
+                    VisibleDeprecationWarning)
                 # We proceed supposing that the factors are spectra stacked
                 # over the last dimension to reproduce the deprecated
                 # behaviour.
@@ -538,7 +540,7 @@ class MVA():
                 warnings.warn(
                     "Bare numpy array masks are deprecated and will be removed"
                     " in next HyperSpy 0.9.",
-                    DeprecationWarning)
+                    VisibleDeprecationWarning)
                 ref_shape = ref_shape[::-1]
                 if mask.shape != ref_shape:
                     raise ValueError(
@@ -680,7 +682,7 @@ class MVA():
         warnings.warn(
             "This function is deprecated an will be removed in HyperSpy 0.9. "
             "Use `normalize_decomposition_components` or "
-            "`normalize_bss_components` instead.", DeprecationWarning)
+            "`normalize_bss_components` instead.", VisibleDeprecationWarning)
 
         if which == 'bss':
             factors = self.learning_results.bss_factors

--- a/hyperspy/learn/mva.py
+++ b/hyperspy/learn/mva.py
@@ -42,7 +42,6 @@ from hyperspy.misc.utils import stack
 from hyperspy.misc.hspy_warnings import VisibleDeprecationWarning
 
 
-
 def centering_and_whitening(X):
     X = X.T
     # Centering the columns (ie the variables)

--- a/hyperspy/misc/hspy_warnings.py
+++ b/hyperspy/misc/hspy_warnings.py
@@ -1,0 +1,7 @@
+class VisibleDeprecationWarning(UserWarning):
+    """Visible deprecation warning.
+    By default, python will not show deprecation warnings, so this class
+    provides a visible one.
+
+    """
+    pass

--- a/hyperspy/misc/hspy_warnings.py
+++ b/hyperspy/misc/hspy_warnings.py
@@ -1,4 +1,5 @@
 class VisibleDeprecationWarning(UserWarning):
+
     """Visible deprecation warning.
     By default, python will not show deprecation warnings, so this class
     provides a visible one.

--- a/hyperspy/misc/material.py
+++ b/hyperspy/misc/material.py
@@ -36,9 +36,7 @@ def _weight_to_atomic(weight_percent, elements):
     atomic_percent = np.array(map(np.divide, weight_percent, atomic_weights))
     sum_weight = atomic_percent.sum(axis=0) / 100.
     for i, el in enumerate(elements):
-        warnings.simplefilter("ignore")
         atomic_percent[i] /= sum_weight
-        warnings.simplefilter('default')
         atomic_percent[i] = np.where(sum_weight == 0.0, 0.0, atomic_percent[i])
     return atomic_percent
 
@@ -113,9 +111,7 @@ def _atomic_to_weight(atomic_percent, elements):
     weight_percent = np.array(map(np.multiply, atomic_percent, atomic_weights))
     sum_atomic = weight_percent.sum(axis=0) / 100.
     for i, el in enumerate(elements):
-        warnings.simplefilter("ignore")
         weight_percent[i] /= sum_atomic
-        warnings.simplefilter('default')
         weight_percent[i] = np.where(sum_atomic == 0.0, 0.0, weight_percent[i])
     return weight_percent
 
@@ -200,18 +196,14 @@ def _density_of_mixture_of_pure_elements(weight_percent,
         for i, weight in enumerate(weight_percent):
             sum_densities[i] = weight / densities[i]
         sum_densities = sum_densities.sum(axis=0)
-        warnings.simplefilter("ignore")
         density = np.sum(weight_percent, axis=0) / sum_densities
-        warnings.simplefilter('default')
         return np.where(sum_densities == 0.0, 0.0, density)
     elif mean == 'weighted':
         for i, weight in enumerate(weight_percent):
             sum_densities[i] = weight * densities[i]
         sum_densities = sum_densities.sum(axis=0)
         sum_weight = np.sum(weight_percent, axis=0)
-        warnings.simplefilter("ignore")
         density = sum_densities / sum_weight
-        warnings.simplefilter('default')
         return np.where(sum_weight == 0.0, 0.0, density)
 
 

--- a/hyperspy/misc/utils.py
+++ b/hyperspy/misc/utils.py
@@ -29,6 +29,8 @@ import unicodedata
 
 import numpy as np
 
+from hyperspy.misc.hspy_warnings import VisibleDeprecationWarning
+
 
 def attrsetter(target, attrs, value):
     """ Sets attribute of the target to specified value, supports nested attributes.
@@ -104,7 +106,8 @@ def unfold_if_multidim(signal):
     """
     import warnings
     warnings.warn("unfold_if_multidim is deprecated and will be removed in "
-                  "0.9 please use Signal.unfold instead", DeprecationWarning)
+                  "0.9 please use Signal.unfold instead",
+                  VisibleDeprecationWarning)
     return None
 
 

--- a/hyperspy/signal.py
+++ b/hyperspy/signal.py
@@ -73,7 +73,7 @@ from hyperspy import components
 from hyperspy.misc.utils import underline
 from hyperspy.external.astroML.histtools import histogram
 from hyperspy.drawing.utils import animate_legend
-
+from hyperspy.misc.hspy_warnings import VisibleDeprecationWarning
 
 class Signal2DTools(object):
 
@@ -3422,7 +3422,8 @@ class Signal(MVA,
         """
         warnings.warn(
             "`unfold_if_multidim` is deprecated and will be removed in "
-            "HyperSpy 0.9. Please use `unfold` instead.", DeprecationWarning)
+            "HyperSpy 0.9. Please use `unfold` instead.",
+            VisibleDeprecationWarning)
         return None
 
     @auto_replot

--- a/hyperspy/signal.py
+++ b/hyperspy/signal.py
@@ -75,6 +75,7 @@ from hyperspy.external.astroML.histtools import histogram
 from hyperspy.drawing.utils import animate_legend
 from hyperspy.misc.hspy_warnings import VisibleDeprecationWarning
 
+
 class Signal2DTools(object):
 
     def estimate_shift2D(self,


### PR DESCRIPTION
As pointed out by @vidartf, ``DeprecationWarning`` is not visible by default. This fixes the issue as they've done in numpy, by adding a new ``VisibleDeprecationWarning``.