### PR TITLE
Bugfix 32bit test decomposition

### DIFF
--- a/hyperspy/tests/model/test_model.py
+++ b/hyperspy/tests/model/test_model.py
@@ -254,7 +254,7 @@ class TestModelFitBinned:
         self.m[0].centre.bmin = 0.5
         self.m[0].bounded = True
         self.m.fit(fitter="mpfit", bounded=True)
-        nose.tools.assert_almost_equal(self.m[0].A.value, 9991.65422046, 5)
+        nose.tools.assert_almost_equal(self.m[0].A.value, 9991.65422046, 4)
         nose.tools.assert_almost_equal(self.m[0].centre.value, 0.5)
         nose.tools.assert_almost_equal(self.m[0].sigma.value, 2.08398236966)
 

--- a/hyperspy/tests/mva/test_decomposition.py
+++ b/hyperspy/tests/mva/test_decomposition.py
@@ -44,14 +44,14 @@ class TestNdAxes:
         s1.decomposition()
         s2.decomposition()
         s12.decomposition()
-        assert_true((s2.learning_results.loadings ==
-                     s12.learning_results.loadings).all())
-        assert_true((s2.learning_results.factors ==
-                     s12.learning_results.factors).all())
-        assert_true((s1.learning_results.loadings ==
-                     s2.learning_results.factors).all())
-        assert_true((s1.learning_results.factors ==
-                     s2.learning_results.loadings).all())
+        np.testing.assert_array_almost_equal(s2.learning_results.loadings,
+                s12.learning_results.loadings)
+        np.testing.assert_array_almost_equal(s2.learning_results.factors,
+                s12.learning_results.factors)
+        np.testing.assert_array_almost_equal(s1.learning_results.loadings,
+                s2.learning_results.factors)
+        np.testing.assert_array_almost_equal(s1.learning_results.factors,
+                s2.learning_results.loadings)
 
     def test_consistensy_poissonian(self):
         s1 = self.s1
@@ -60,14 +60,14 @@ class TestNdAxes:
         s1.decomposition(normalize_poissonian_noise=True)
         s2.decomposition(normalize_poissonian_noise=True)
         s12.decomposition(normalize_poissonian_noise=True)
-        assert_true((s2.learning_results.loadings ==
-                     s12.learning_results.loadings).all())
-        assert_true((s2.learning_results.factors ==
-                     s12.learning_results.factors).all())
-        assert_true((s1.learning_results.loadings ==
-                     s2.learning_results.factors).all())
-        assert_true((s1.learning_results.factors ==
-                     s2.learning_results.loadings).all())
+        np.testing.assert_array_almost_equal(s2.learning_results.loadings,
+                s12.learning_results.loadings)
+        np.testing.assert_array_almost_equal(s2.learning_results.factors,
+                s12.learning_results.factors)
+        np.testing.assert_array_almost_equal(s1.learning_results.loadings,
+                s2.learning_results.factors)
+        np.testing.assert_array_almost_equal(s1.learning_results.factors,
+                s2.learning_results.loadings)
 
 
 class TestGetExplainedVarinaceRation:

--- a/hyperspy/tests/mva/test_decomposition.py
+++ b/hyperspy/tests/mva/test_decomposition.py
@@ -45,13 +45,13 @@ class TestNdAxes:
         s2.decomposition()
         s12.decomposition()
         np.testing.assert_array_almost_equal(s2.learning_results.loadings,
-                s12.learning_results.loadings)
+                                             s12.learning_results.loadings)
         np.testing.assert_array_almost_equal(s2.learning_results.factors,
-                s12.learning_results.factors)
+                                             s12.learning_results.factors)
         np.testing.assert_array_almost_equal(s1.learning_results.loadings,
-                s2.learning_results.factors)
+                                             s2.learning_results.factors)
         np.testing.assert_array_almost_equal(s1.learning_results.factors,
-                s2.learning_results.loadings)
+                                             s2.learning_results.loadings)
 
     def test_consistensy_poissonian(self):
         s1 = self.s1
@@ -61,13 +61,13 @@ class TestNdAxes:
         s2.decomposition(normalize_poissonian_noise=True)
         s12.decomposition(normalize_poissonian_noise=True)
         np.testing.assert_array_almost_equal(s2.learning_results.loadings,
-                s12.learning_results.loadings)
+                                             s12.learning_results.loadings)
         np.testing.assert_array_almost_equal(s2.learning_results.factors,
-                s12.learning_results.factors)
+                                             s12.learning_results.factors)
         np.testing.assert_array_almost_equal(s1.learning_results.loadings,
-                s2.learning_results.factors)
+                                             s2.learning_results.factors)
         np.testing.assert_array_almost_equal(s1.learning_results.factors,
-                s2.learning_results.loadings)
+                                             s2.learning_results.loadings)
 
 
 class TestGetExplainedVarinaceRation:


### PR DESCRIPTION
Some tests were failing in 32bit systems due to lower precision.