### PR TITLE
Resurrect unfold_if_multidim for 0.8.1

### DIFF
--- a/hyperspy/signal.py
+++ b/hyperspy/signal.py
@@ -3435,7 +3435,12 @@ class Signal(MVA,
             "`unfold_if_multidim` is deprecated and will be removed in "
             "HyperSpy 0.9. Please use `unfold` instead.",
             VisibleDeprecationWarning)
-        return None
+        if len(self.axes_manager._axes) > 2:
+            print "Automatically unfolding the data"
+            self.unfold()
+            return True
+        else:
+            return False
 
     @auto_replot
     def _unfold(self, steady_axes, unfolded_axis):


### PR DESCRIPTION
This gives back the functionality to the deprecated `Signal.unfold_if_multidim`. Thanks @vidartf for reporting this issue.