### PR TITLE
Fix read the docs build

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -31,13 +31,12 @@ sys.path.append(os.path.abspath('sphinxext'))
 # coming with Sphinx (named 'sphinx.ext.*') or your custom ones.
 extensions = [
     'sphinx.ext.autodoc',
-    'gen_rst',
-    'numpydoc',
-    'matplotlib.sphinxext.only_directives',
+    'sphinxcontrib.napoleon',
     'sphinx.ext.intersphinx',
     'sphinx.ext.pngmath',
     'sphinx.ext.autosummary',
-    'ipython_console_highlighting']  # , 'rst2pdf.pdfbuilder']
+]
+
 try:
     import sphinxcontrib.spelling
     extensions.append('sphinxcontrib.spelling')

--- a/doc/pip-req.txt
+++ b/doc/pip-req.txt
@@ -1,0 +1,2 @@
+sphinxcontrib-napoleon
+

--- a/doc/user_guide/conf.py
+++ b/doc/user_guide/conf.py
@@ -31,13 +31,10 @@ from hyperspy import Release
 # coming with Sphinx (named 'sphinx.ext.*') or your custom ones.
 extensions = [
     'sphinx.ext.autodoc',
-    'gen_rst',
-    'numpydoc',
-    'matplotlib.sphinxext.only_directives',
     'sphinx.ext.intersphinx',
     'sphinx.ext.pngmath',
     'sphinx.ext.autosummary',
-    'ipython_console_highlighting']  # , 'rst2pdf.pdfbuilder']
+]
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']
@@ -53,7 +50,7 @@ master_doc = 'index'
 
 # General information about the project.
 project = u'HyperSpy User Guide [Draft]'
-copyright = u'2011-2013, The HyperSpy Developers'
+copyright = u'2011-2015, The HyperSpy Developers'
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the

--- a/hyperspy/__init__.py
+++ b/hyperspy/__init__.py
@@ -24,7 +24,7 @@ import os
 os.environ['QT_API'] = "pyqt"
 
 
-import Release
+from . import Release
 
 __all__ = ["api"]
 __version__ = Release.version


### PR DESCRIPTION
The HyperSpy docs were not building in Read the Docs because of lack of
pip-req.txt to install the extra dependencies. This also removes no
longer needed sphinx extension package dependencies.