### PR TITLE
Add rst files to MANIFEST.in

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,4 +1,5 @@
 include *.txt
+include *.rst
 recursive-include bin *.py
 recursive-include doc *.txt *.rst
 recursive-include examples *.py *.rst *.txt


### PR DESCRIPTION
This is the error that raises when attempting to install with pip:

```

$ pip install hyperspy
Collecting hyperspy
  Downloading hyperspy-0.8.1.tar.gz (1.4MB)
    100% |████████████████████████████████| 1.4MB 278kB/s 
    Complete output from command python setup.py egg_info:
    Traceback (most recent call last):
      File "<string>", line 20, in <module>
      File "/tmp/pip-build-KTANRF/hyperspy/setup.py", line 200, in <module>
        long_description=open('README.rst').read(),
    IOError: [Errno 2] No such file or directory: 'README.rst'
    
    ----------------------------------------
Command "python setup.py egg_info" failed with error code 1 in /tmp/pip-build-KTANRF/hyperspy
```