### PR TITLE
Enh hdf5 read out-of-memory

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ python:
   - 2.7
 
 env:
-  - DEPS="nose numpy scipy matplotlib traits traitsui ipython h5py sympy scikit-learn netcdf4"
+  - DEPS="nose numpy scipy matplotlib traits traitsui ipython h5py sympy scikit-learn"
 
 install:
   - conda create -n testenv --yes python=$TRAVIS_PYTHON_VERSION

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ python:
   - 2.7
 
 env:
-  - DEPS="nose numpy scipy matplotlib traits traitsui ipython h5py sympy scikit-learn"
+  - DEPS="nose numpy scipy matplotlib traits traitsui ipython h5py sympy scikit-learn netcdf4"
 
 install:
   - conda create -n testenv --yes python=$TRAVIS_PYTHON_VERSION

--- a/hyperspy/io.py
+++ b/hyperspy/io.py
@@ -124,6 +124,10 @@ def load(filenames=None,
         mapped file will be created in the given directory,
         otherwise the default directory is used.
 
+    load_to_memory: bool
+        for HDF5 files, if True (default) loads all data to memory. If False,
+        enables only loading the data upon request
+
     Returns
     -------
     Signal instance or list of signal instances

--- a/hyperspy/io.py
+++ b/hyperspy/io.py
@@ -353,7 +353,7 @@ def dict2signal(signal_dict):
         if "Signal" in mp and "signal_origin" in mp["Signal"]:
             signal_origin = mp["Signal"]['signal_origin']
     if (not record_by and 'data' in signal_dict and
-            signal_dict['data'].ndim < 2):
+            len(signal_dict['data'].shape) < 2):
         record_by = "spectrum"
 
     signal = assign_signal_subclass(record_by=record_by,

--- a/hyperspy/io_plugins/hdf5.py
+++ b/hyperspy/io_plugins/hdf5.py
@@ -19,7 +19,6 @@
 from distutils.version import StrictVersion
 import warnings
 import datetime
-from dask import array as da
 
 import h5py
 import numpy as np
@@ -389,13 +388,6 @@ def dict2hdfgroup(dictionary, group, compression=None):
                     write_signal(value, group.create_group(key))
             else:
                 write_signal(value, group.create_group('_sig_' + key))
-        elif isinstance(value, da.Array):
-            dset = group.create_dataset(key,
-                                        shape=value.shape,
-                                        chunks=value.chunks,
-                                        compression=compression,
-                                        dtype=str(value.dtype))
-            da.store(value, dset)
         elif isinstance(value, np.ndarray):
             group.create_dataset(key,
                                  data=value,

--- a/hyperspy/io_plugins/hdf5.py
+++ b/hyperspy/io_plugins/hdf5.py
@@ -136,7 +136,7 @@ def file_reader(filename, record_by, mode='r', driver='core',
 
 
 # not used at the moment, but might be useful for the future
-def get_signal_chunks(data, metadata=None ):
+def get_signal_chunks(data, metadata=None):
     shape = data.shape
     typesize = np.dtype(data.dtype).itemsize
     if metadata is not None:
@@ -212,10 +212,14 @@ def hdfgroup2signaldict(group, load_to_memory=True):
     exp['attributes'] = {}
     if 'learning_results' in group.keys():
         exp['attributes']['learning_results'] = \
-            hdfgroup2dict(group['learning_results'], load_to_memory=load_to_memory)
+            hdfgroup2dict(
+                group['learning_results'],
+                load_to_memory=load_to_memory)
     if 'peak_learning_results' in group.keys():
         exp['attributes']['peak_learning_results'] = \
-            hdfgroup2dict(group['peak_learning_results'], load_to_memory=load_to_memory)
+            hdfgroup2dict(
+                group['peak_learning_results'],
+                load_to_memory=load_to_memory)
 
     # If the title was not defined on writing the Experiment is
     # then called __unnamed__. The next "if" simply sets the title
@@ -506,7 +510,10 @@ def hdfgroup2dict(group, dictionary=None, load_to_memory=True):
                         hdfgroup2dict(group[key], load_to_memory=load_to_memory).iteritems()))])
             else:
                 dictionary[key] = {}
-                hdfgroup2dict(group[key], dictionary[key], load_to_memory=load_to_memory)
+                hdfgroup2dict(
+                    group[key],
+                    dictionary[key],
+                    load_to_memory=load_to_memory)
     return dictionary
 
 

--- a/hyperspy/io_plugins/hdf5.py
+++ b/hyperspy/io_plugins/hdf5.py
@@ -22,7 +22,6 @@ import datetime
 from dask import array as da
 
 import h5py
-from psutil import virtual_memory
 import numpy as np
 from traits.api import Undefined
 
@@ -96,59 +95,56 @@ def get_hspy_format_version(f):
 
 
 def file_reader(filename, record_by, mode='r', driver='core',
-                backing_store=False, **kwds):
-    with h5py.File(filename, mode=mode, driver=driver) as f:
-        # Getting the format version here also checks if it is a valid HSpy
-        # hdf5 file, so the following two lines must not be deleted or moved
-        # elsewhere.
-        global current_file_version
-        current_file_version = get_hspy_format_version(f)
-        global default_version
-        if current_file_version > default_version:
-            warnings.warn(
-                "This file was written using a newer version of the "
-                "HyperSpy hdf5 file format. I will attempt to load it, but, "
-                "if I fail, it is likely that I will be more successful at "
-                "this and other tasks if you upgrade me.")
+                backing_store=False, load_to_memory=True, **kwds):
+    f = h5py.File(filename, mode=mode, driver=driver, **kwds)
+    # Getting the format version here also checks if it is a valid HSpy
+    # hdf5 file, so the following two lines must not be deleted or moved
+    # elsewhere.
+    global current_file_version
+    current_file_version = get_hspy_format_version(f)
+    global default_version
+    if current_file_version > default_version:
+        warnings.warn(
+            "This file was written using a newer version of the "
+            "HyperSpy hdf5 file format. I will attempt to load it, but, "
+            "if I fail, it is likely that I will be more successful at "
+            "this and other tasks if you upgrade me.")
 
-        experiments = []
-        exp_dict_list = []
-        if 'Experiments' in f:
-            available_memory = virtual_memory()[1]
-            for ds in f['Experiments']:
-                if isinstance(f['Experiments'][ds], h5py.Group):
-                    if 'data' in f['Experiments'][ds]:
-                        experiments.append(ds)
-                        d = f['Experiments'][ds]['data']
-                        available_memory -= np.array(
-                            d.shape).cumprod()[-1] * np.dtype(d.dtype).itemsize
-            if not experiments:
-                raise IOError(not_valid_format)
-            # Parse the file
-            if available_memory > 0:
-                loadtomem = True
-            else:
-                loadtomem = False
-            for experiment in experiments:
-                exg = f['Experiments'][experiment]
-                exp = hdfgroup2signaldict(exg, loadtomem)
-                exp_dict_list.append(exp)
-        else:
-            raise IOError('This is not a valid HyperSpy HDF5 file. '
-                          'You can still load the data using a hdf5 reader, '
-                          'e.g. h5py, and manually create a Signal. '
-                          'Please, refer to the User Guide for details')
-        return exp_dict_list
+    experiments = []
+    exp_dict_list = []
+    if 'Experiments' in f:
+        for ds in f['Experiments']:
+            if isinstance(f['Experiments'][ds], h5py.Group):
+                if 'data' in f['Experiments'][ds]:
+                    experiments.append(ds)
+                    d = f['Experiments'][ds]['data']
+        if not experiments:
+            raise IOError(not_valid_format)
+        # Parse the file
+        for experiment in experiments:
+            exg = f['Experiments'][experiment]
+            exp = hdfgroup2signaldict(exg, load_to_memory)
+            exp_dict_list.append(exp)
+    else:
+        raise IOError('This is not a valid HyperSpy HDF5 file. '
+                      'You can still load the data using a hdf5 reader, '
+                      'e.g. h5py, and manually create a Signal. '
+                      'Please, refer to the User Guide for details')
+    if load_to_memory:
+        f.close()
+    return exp_dict_list
 
 
-def get_signal_chunks(metadata, data):
+# not used at the moment, but might be useful for the future
+def get_signal_chunks(data, metadata=None ):
     shape = data.shape
     typesize = np.dtype(data.dtype).itemsize
-    if metadata['Signal']['record_by'] == "spectrum":
-        keepdims = 1
+    if metadata is not None:
+        if metadata['Signal']['record_by'] == "spectrum":
+            keepdims = 1
 
-    if metadata['Signal']['record_by'] == "image":
-        keepdims = 2
+        if metadata['Signal']['record_by'] == "image":
+            keepdims = 2
     else:
         return h5py._hl.filters.guess_chunk(shape, None, typesize)
 
@@ -178,7 +174,7 @@ def get_signal_chunks(metadata, data):
     return tuple(long(x) for x in chunks)
 
 
-def hdfgroup2signaldict(group, loadtomem=False):
+def hdfgroup2signaldict(group, load_to_memory=True):
     global current_file_version
     global default_version
     if current_file_version < StrictVersion("1.2"):
@@ -188,19 +184,13 @@ def hdfgroup2signaldict(group, loadtomem=False):
         metadata = "metadata"
         original_metadata = "original_metadata"
 
-    exp = {'metadata': hdfgroup2dict(group[metadata], {}),
-           'original_metadata': hdfgroup2dict(group[original_metadata], {})
+    exp = {'metadata': hdfgroup2dict(group[metadata], load_to_memory=load_to_memory),
+           'original_metadata': hdfgroup2dict(group[original_metadata], load_to_memory=load_to_memory)
            }
 
     data = group['data']
-    if loadtomem:
+    if load_to_memory:
         data = np.asanyarray(data)
-    else:
-        if data.chunks is None:
-            chunks = get_signal_chunks(exp['metadata'], data)
-        else:
-            chunks = data.chunks
-        data = da.from_array(data, chunks=chunks)
     exp['data'] = data
     axes = []
     for i in xrange(len(exp['data'].shape)):
@@ -215,21 +205,17 @@ def hdfgroup2signaldict(group, loadtomem=False):
         try:
             axes = [i for k, i in sorted(iter(hdfgroup2dict(
                 group['_list_' + str(len(exp['data'].shape)) + '_axes'],
-                {}).iteritems()))]
+                load_to_memory=load_to_memory).iteritems()))]
         except KeyError:
             raise IOError(not_valid_format)
-    exp['metadata'] = hdfgroup2dict(
-        group[metadata], {})
-    exp['original_metadata'] = hdfgroup2dict(
-        group[original_metadata], {})
     exp['axes'] = axes
     exp['attributes'] = {}
     if 'learning_results' in group.keys():
         exp['attributes']['learning_results'] = \
-            hdfgroup2dict(group['learning_results'], {})
+            hdfgroup2dict(group['learning_results'], load_to_memory=load_to_memory)
     if 'peak_learning_results' in group.keys():
         exp['attributes']['peak_learning_results'] = \
-            hdfgroup2dict(group['peak_learning_results'], {})
+            hdfgroup2dict(group['peak_learning_results'], load_to_memory=load_to_memory)
 
     # If the title was not defined on writing the Experiment is
     # then called __unnamed__. The next "if" simply sets the title
@@ -243,10 +229,10 @@ def hdfgroup2signaldict(group, loadtomem=False):
         # mva_results
         if 'mva_results' in group.keys():
             exp['attributes']['learning_results'] = hdfgroup2dict(
-                group['mva_results'], {})
+                group['mva_results'], load_to_memory=load_to_memory)
         if 'peak_mva_results' in group.keys():
             exp['attributes']['peak_learning_results'] = hdfgroup2dict(
-                group['peak_mva_results'], {})
+                group['peak_mva_results'], load_to_memory=load_to_memory)
         # Replace the old signal and name keys with their current names
         if 'signal' in exp['metadata']:
             if "Signal" not in exp["metadata"]:
@@ -455,7 +441,7 @@ def dict2hdfgroup(dictionary, group, compression=None):
                 print('%s : %s' % (key, value))
 
 
-def hdfgroup2dict(group, dictionary=None):
+def hdfgroup2dict(group, dictionary=None, load_to_memory=True):
     if dictionary is None:
         dictionary = {}
     for key, value in group.attrs.iteritems():
@@ -486,36 +472,41 @@ def hdfgroup2dict(group, dictionary=None):
             if key.startswith('_sig_'):
                 from hyperspy.io import dict2signal
                 dictionary[key[len('_sig_'):]] = (
-                    dict2signal(hdfgroup2signaldict(group[key])))
+                    dict2signal(hdfgroup2signaldict(group[key],
+                                                    load_to_memory=load_to_memory)))
             elif isinstance(group[key], h5py.Dataset):
-                try:
+                if key.startswith("_list_"):
+                    ans = np.array(group[key])
+                    ans = ans.tolist()
+                    kn = key[6:]
+                elif key.startswith("_tuple_"):
+                    ans = np.array(group[key])
+                    ans = tuple(ans.tolist())
+                    kn = key[7:]
+                elif load_to_memory:
                     ans = np.array(group[key])
                     kn = key
-                    if key.startswith("_list_"):
-                        ans = ans.tolist()
-                        kn = key[6:]
-                    elif key.startswith("_tuple_"):
-                        ans = tuple(ans.tolist())
-                        kn = key[7:]
-                except MemoryError:
-                    ans = da.from_array(group[key], chunks=group[key].chunks)
+                else:
+                    # leave as h5py dataset
+                    ans = group[key]
+                    kn = key
                 dictionary[kn] = ans
             elif key.startswith('_hspy_AxesManager_'):
                 dictionary[key[len('_hspy_AxesManager_'):]] = \
                     AxesManager([i
                                  for k, i in sorted(iter(
-                                     hdfgroup2dict(group[key]).iteritems()))])
+                                     hdfgroup2dict(group[key], load_to_memory=load_to_memory).iteritems()))])
             elif key.startswith('_list_'):
                 dictionary[key[7 + key[6:].find('_'):]] = \
                     [i for k, i in sorted(iter(
-                        hdfgroup2dict(group[key], {}).iteritems()))]
+                        hdfgroup2dict(group[key], load_to_memory=load_to_memory).iteritems()))]
             elif key.startswith('_tuple_'):
                 dictionary[key[8 + key[7:].find('_'):]] = tuple(
                     [i for k, i in sorted(iter(
-                        hdfgroup2dict(group[key], {}).iteritems()))])
+                        hdfgroup2dict(group[key], load_to_memory=load_to_memory).iteritems()))])
             else:
                 dictionary[key] = {}
-                hdfgroup2dict(group[key], dictionary[key])
+                hdfgroup2dict(group[key], dictionary[key], load_to_memory=load_to_memory)
     return dictionary
 
 

--- a/hyperspy/io_plugins/hdf5.py
+++ b/hyperspy/io_plugins/hdf5.py
@@ -120,7 +120,8 @@ def file_reader(filename, record_by, mode='r', driver='core',
                     if 'data' in f['Experiments'][ds]:
                         experiments.append(ds)
                         d = f['Experiments'][ds]['data']
-                        available_memory -= np.array(d.shape).cumprod()[-1] * np.dtype(d.dtype).itemsize
+                        available_memory -= np.array(
+                            d.shape).cumprod()[-1] * np.dtype(d.dtype).itemsize
             if not experiments:
                 raise IOError(not_valid_format)
             # Parse the file
@@ -139,6 +140,7 @@ def file_reader(filename, record_by, mode='r', driver='core',
                           'Please, refer to the User Guide for details')
         return exp_dict_list
 
+
 def get_signal_chunks(metadata, data):
     shape = data.shape
     typesize = np.dtype(data.dtype).itemsize
@@ -149,16 +151,16 @@ def get_signal_chunks(metadata, data):
         keepdims = 2
     else:
         return h5py._hl.filters.guess_chunk(shape, None, typesize)
-    
+
     # largely based on the guess_chunk in h5py
-    CHUNK_MAX = 1024*1024
-    want_to_keep = np.product(shape[-keepdims:])*typesize
+    CHUNK_MAX = 1024 * 1024
+    want_to_keep = np.product(shape[-keepdims:]) * typesize
     if want_to_keep >= CHUNK_MAX:
         chunks = [1 for _ in shape]
         for i in xrange(keepdims):
-            chunks[-i-1] = shape[-i-1]
+            chunks[-i - 1] = shape[-i - 1]
         return tuple(chunks)
-    
+
     chunks = [i for i in shape]
     nchange = len(shape) - keepdims
     idx = 0
@@ -170,13 +172,13 @@ def get_signal_chunks(metadata, data):
 
         if np.product(chunks[:nchange]) == 1:
             break
-        
-        chunks[idx%nchange] = np.ceil(chunks[idx%nchange] / 2.0)
+
+        chunks[idx % nchange] = np.ceil(chunks[idx % nchange] / 2.0)
         idx += 1
     return tuple(long(x) for x in chunks)
 
 
-def hdfgroup2signaldict(group, loadtomem = False):
+def hdfgroup2signaldict(group, loadtomem=False):
     global current_file_version
     global default_version
     if current_file_version < StrictVersion("1.2"):
@@ -186,8 +188,8 @@ def hdfgroup2signaldict(group, loadtomem = False):
         metadata = "metadata"
         original_metadata = "original_metadata"
 
-    exp = {'metadata': hdfgroup2dict( group[metadata], {}),
-           'original_metadata': hdfgroup2dict( group[original_metadata], {})
+    exp = {'metadata': hdfgroup2dict(group[metadata], {}),
+           'original_metadata': hdfgroup2dict(group[original_metadata], {})
            }
 
     data = group['data']

--- a/hyperspy/signal.py
+++ b/hyperspy/signal.py
@@ -17,6 +17,7 @@
 # along with  HyperSpy.  If not, see <http://www.gnu.org/licenses/>.
 
 import copy
+import h5py
 import os.path
 import warnings
 import math
@@ -2880,6 +2881,17 @@ class Signal(MVA,
             string += str(self.data.dtype)
         print string
 
+    @property
+    def data(self):
+        return self._data
+
+    @data.setter
+    def data(self, value):
+        if isinstance(value, h5py.Dataset):
+            self._data = value
+        else:
+            self._data = np.atleast_1d(np.asanyarray(value))
+
     def _load_dictionary(self, file_data_dict):
         """Load data from dictionary.
 
@@ -2908,7 +2920,7 @@ class Signal(MVA,
 
         """
 
-        self.data = np.atleast_1d(np.asanyarray(file_data_dict['data']))
+        self.data = file_data_dict['data']
         if 'axes' not in file_data_dict:
             file_data_dict['axes'] = self._get_undefined_axes_list()
         self.axes_manager = AxesManager(

--- a/hyperspy/tests/io/test_hdf5.py
+++ b/hyperspy/tests/io/test_hdf5.py
@@ -231,17 +231,22 @@ def test_rgba16():
         "test_rgba16.npy"))
     nt.assert_true((s.data == data).all())
 
+
 class TestLoadingOOMReadOnly:
 
     def setUp(self):
-        s = Signal(np.empty((5,5,5)))
+        s = Signal(np.empty((5, 5, 5)))
         s.save('tmp.hdf5')
-        self.shape = (10000,10000,100)
+        self.shape = (10000, 10000, 100)
         del s
         f = h5py.File('tmp.hdf5', model='r+')
         s = f['Experiments/__unnamed__']
         del s['data']
-        s.create_dataset('data', shape=self.shape, dtype='float64', chunks=True)
+        s.create_dataset(
+            'data',
+            shape=self.shape,
+            dtype='float64',
+            chunks=True)
         f.close()
 
     @nt.raises(MemoryError)

--- a/hyperspy/tests/io/test_hdf5.py
+++ b/hyperspy/tests/io/test_hdf5.py
@@ -1,6 +1,7 @@
 import os.path
 from os import remove
 import datetime
+import h5py
 
 import nose.tools as nt
 import numpy as np
@@ -229,3 +230,28 @@ def test_rgba16():
         "npy_files",
         "test_rgba16.npy"))
     nt.assert_true((s.data == data).all())
+
+class TestLoadingOOMReadOnly:
+
+    def setUp(self):
+        s = Signal(np.empty((5,5,5)))
+        s.save('tmp.hdf5')
+        self.shape = (10000,10000,100)
+        del s
+        f = h5py.File('tmp.hdf5', model='r+')
+        s = f['Experiments/__unnamed__']
+        del s['data']
+        s.create_dataset('data', shape=self.shape, dtype='float64', chunks=True)
+        f.close()
+
+    @nt.raises(MemoryError)
+    def test_in_memory_loading(self):
+        s = load('tmp.hdf5')
+
+    def test_oom_loading(self):
+        s = load('tmp.hdf5', load_to_memory=False)
+        nt.assert_equal(self.shape, s.data.shape)
+        nt.assert_is_instance(s.data, h5py.Dataset)
+
+    def tearDown(self):
+        remove('tmp.hdf5')


### PR DESCRIPTION
Pass `load_to_memory=False` when loading to enable.

Afterwards the file can be plotted if the navigator does not require summing (i.e. if the navigator='slider' is passed), but the file is read-only so far

First milestone for hdf5 in https://github.com/hyperspy/hyperspy/issues/592