### PR TITLE
Temporary hdf5 files for bigger than memory signals, stacking and deepcopy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ python:
   - 2.7
 
 env:
-  - DEPS="nose numpy scipy matplotlib traits traitsui ipython h5py sympy scikit-learn dill mock"
+  - DEPS="nose numpy scipy matplotlib traits traitsui ipython h5py sympy scikit-learn dask dill mock"
 
 install:
   - conda create -n testenv --yes python=$TRAVIS_PYTHON_VERSION

--- a/doc/user_guide/io.rst
+++ b/doc/user_guide/io.rst
@@ -38,6 +38,9 @@ providing the ``signal`` keyword, which has to be one of: ``spectrum``,
 
     >>> s = hs.load("filename", signal = "EELS")
 
+Particularly big files can be loaded in a new (experimental) "out-of-memory" mode
+by passing ``load_to_memory=False``. For more information please see :ref:`oom-files`
+
 Some file formats store some extra information about the data, which can be
 stored in "attributes". If HyperSpy manages to read some extra information
 about the data it stores it in :py:attr:`~.signal.Signal.original_metadata`
@@ -227,6 +230,24 @@ compression: One of None, 'gzip', 'szip', 'lzf'.
 
 'gzip' is the default
 
+.. _oom-files:
+
+Out-of-memory files
+^^^^^^^^^^^^^^^^^^^
+
+.. versionadded:: 0.9   Out-of-memory files
+
+
+Reading files bigger than available computer memory can be enabled by passing
+``load_to_memory=False`` when loading the data. If the original files were not
+created by HyperSpy (or multiple signals from various file formats are stacked
+according to the usual rules), a new temporary HDF5 file will be created, where
+the data will be stored. If the resultant signal is not saved manually, upon
+exiting HyperSpy the temporary file will be automatically deleted.
+
+Note that at the moment we do not support any analysis or operations for the
+out-of-memory signals, however they can be plotted with option
+``navigator=slider``
 
 .. _netcdf-format:
 

--- a/hyperspy/defaults_parser.py
+++ b/hyperspy/defaults_parser.py
@@ -118,6 +118,11 @@ class GeneralConfig(t.HasTraits):
              'IPython magic of the starting scripts, all the contents of '
              '``hyperspy.hspy`` are imported in the user namespace. ')
 
+    load_to_memory = t.CBool(
+        True,
+        label='Load to memory',
+        desc='If enabled, signals are by default loaded to memory')
+
     dtb_expand_structures = t.CBool(
         True,
         label='Expand structures in DictionaryTreeBrowser',

--- a/hyperspy/io.py
+++ b/hyperspy/io.py
@@ -192,14 +192,14 @@ def load(filenames=None,
         if len(filenames) > 1:
             messages.information('Loading individual files')
         if stack is True:
-            if load_to_memory:
+            if load_to_memory is False:
+                signal = (load_single_file(filename, **kwds)
+                          for filename in filenames)
+            else:  # True or None
                 signal = [
                     load_single_file(
                         filename,
                         **kwds) for filename in filenames]
-            else:
-                signal = (load_single_file(filename, **kwds)
-                          for filename in filenames)
             signal = hyperspy.utils.stack(signal,
                                           axis=stack_axis,
                                           new_axis_name=new_axis_name,

--- a/hyperspy/io.py
+++ b/hyperspy/io.py
@@ -40,6 +40,7 @@ def load(filenames=None,
          new_axis_name="stack_element",
          mmap=False,
          mmap_dir=None,
+         load_to_memory=None,
          **kwds):
     """
     Load potentially multiple supported file into an hyperspy structure
@@ -162,6 +163,8 @@ def load(filenames=None,
     kwds['record_by'] = record_by
     kwds['signal_type'] = signal_type
     kwds['signal_origin'] = signal_origin
+    if load_to_memory is not None:
+        kwds['load_to_memory'] = load_to_memory
     if filenames is None:
         if hyperspy.defaults_parser.preferences.General.interactive is True:
             from hyperspy.gui.tools import Load
@@ -189,15 +192,19 @@ def load(filenames=None,
         if len(filenames) > 1:
             messages.information('Loading individual files')
         if stack is True:
-            signal = []
-            for i, filename in enumerate(filenames):
-                obj = load_single_file(filename,
-                                       **kwds)
-                signal.append(obj)
+            if load_to_memory:
+                signal = [
+                    load_single_file(
+                        filename,
+                        **kwds) for filename in filenames]
+            else:
+                signal = (load_single_file(filename, **kwds)
+                          for filename in filenames)
             signal = hyperspy.utils.stack(signal,
                                           axis=stack_axis,
                                           new_axis_name=new_axis_name,
-                                          mmap=mmap, mmap_dir=mmap_dir)
+                                          mmap=mmap, mmap_dir=mmap_dir,
+                                          load_to_memory=load_to_memory)
             signal.metadata.General.title = \
                 os.path.split(
                     os.path.split(

--- a/hyperspy/io_plugins/hdf5.py
+++ b/hyperspy/io_plugins/hdf5.py
@@ -610,9 +610,7 @@ def write_signal(signal, group, compression='gzip'):
         # just a reference to already created thing
         pass
     else:
-        import dask.array as da
-        da.store(da.from_array(signal.data, chunks=data.chunks), data)
-        # data[:] = signal.data[:]
+        data[:] = signal.data[:]
     if default_version < StrictVersion("1.2"):
         metadata_dict["_internal_parameters"] = \
             metadata_dict.pop("_HyperSpy")

--- a/hyperspy/io_plugins/hdf5.py
+++ b/hyperspy/io_plugins/hdf5.py
@@ -686,3 +686,20 @@ def write_empty_signal(fileobj,
                         shuffle=True,
                         )
     return expg
+
+
+def get_temp_hdf5_file(prefix='tmp_hs',
+                       directory='.',
+                       suffix='.hdf5',
+                       maxnames=100):
+    import tempfile
+    import os
+    names = tempfile._get_candidate_names()
+    for seq in xrange(maxnames):
+        name = names.next()
+        fname = os.path.join(directory, prefix + name + suffix)
+        if os.path.exists(fname):
+            continue
+        fileobj = h5py.File(fname, mode='w')
+        return tempfile._TemporaryFileWrapper(fileobj, fname, True)
+    raise IOError("No usable temporary file name found")

--- a/hyperspy/io_plugins/hdf5.py
+++ b/hyperspy/io_plugins/hdf5.py
@@ -519,7 +519,13 @@ def hdfgroup2dict(group, dictionary=None, load_to_memory=True):
         elif key.startswith('_bs_'):
             dictionary[key[len('_bs_'):]] = value.tostring()
         elif key.startswith('_datetime_'):
-            dictionary[key.replace("_datetime_", "")] = eval(value)
+            if value.startswith('datetime.date'):
+                ans = datetime.date(*[int(i) for i in value[14:-1].split(',')])
+            elif value.startswith('datetime.time'):
+                ans = datetime.time(*[int(i) for i in value[14:-1].split(',')])
+            else:
+                continue
+            dictionary[key.replace("_datetime_", "")] = ans
         else:
             dictionary[key] = value
     if not isinstance(group, h5py.Dataset):
@@ -549,15 +555,15 @@ def hdfgroup2dict(group, dictionary=None, load_to_memory=True):
             elif key.startswith('_hspy_AxesManager_'):
                 dictionary[key[len('_hspy_AxesManager_'):]] = \
                     AxesManager([i
-                                 for k, i in sorted(iter(
+                                 for _, i in sorted(iter(
                                      hdfgroup2dict(group[key], load_to_memory=load_to_memory).iteritems()))])
             elif key.startswith('_list_'):
                 dictionary[key[7 + key[6:].find('_'):]] = \
-                    [i for k, i in sorted(iter(
+                    [i for _, i in sorted(iter(
                         hdfgroup2dict(group[key], load_to_memory=load_to_memory).iteritems()))]
             elif key.startswith('_tuple_'):
                 dictionary[key[8 + key[7:].find('_'):]] = tuple(
-                    [i for k, i in sorted(iter(
+                    [i for _, i in sorted(iter(
                         hdfgroup2dict(group[key], load_to_memory=load_to_memory).iteritems()))])
             else:
                 dictionary[key] = {}
@@ -693,7 +699,7 @@ def get_temp_hdf5_file(prefix='tmp_hs_',
     import tempfile
     import os
     names = tempfile._get_candidate_names()
-    for seq in xrange(maxnames):
+    for _ in xrange(maxnames):
         name = names.next()
         fname = os.path.join(directory, prefix + name + suffix)
         if os.path.exists(fname):

--- a/hyperspy/io_plugins/hdf5.py
+++ b/hyperspy/io_plugins/hdf5.py
@@ -684,6 +684,7 @@ def write_empty_signal(fileobj,
                         chunks=get_signal_chunks(shape, dtype, metadata),
                         maxshape=tuple(None for _ in shape),
                         shuffle=True,
+                        fillvalue=0,
                         )
     return expg
 

--- a/hyperspy/io_plugins/hdf5.py
+++ b/hyperspy/io_plugins/hdf5.py
@@ -688,7 +688,7 @@ def write_empty_signal(fileobj,
     return expg
 
 
-def get_temp_hdf5_file(prefix='tmp_hs',
+def get_temp_hdf5_file(prefix='tmp_hs_',
                        directory='.',
                        suffix='.hdf5',
                        maxnames=100):

--- a/hyperspy/io_plugins/hdf5.py
+++ b/hyperspy/io_plugins/hdf5.py
@@ -606,8 +606,7 @@ def write_signal(signal, group, compression='gzip'):
             # if the shape or dtype/etc do not match,
             # we delete the old one and create new in the next loop run
             del group['data']
-
-    if data is signal.data:
+    if data == signal.data:
         # just a reference to already created thing
         pass
     else:

--- a/hyperspy/misc/example_signals_loading.py
+++ b/hyperspy/misc/example_signals_loading.py
@@ -30,7 +30,7 @@ def load_1D_EDS_SEM_spectrum():
     from hyperspy.io import load
     file_path = os.sep.join([os.path.dirname(__file__), 'eds',
                              'example_signals', '1D_EDS_SEM_Spectrum.hdf5'])
-    return load(file_path)
+    return load(file_path, load_to_memory=True)
 
 
 def load_1D_EDS_TEM_spectrum():
@@ -44,4 +44,4 @@ def load_1D_EDS_TEM_spectrum():
     from hyperspy.io import load
     file_path = os.sep.join([os.path.dirname(__file__), 'eds',
                              'example_signals', '1D_EDS_TEM_Spectrum.hdf5'])
-    return load(file_path)
+    return load(file_path, load_to_memory=True)

--- a/hyperspy/misc/utils.py
+++ b/hyperspy/misc/utils.py
@@ -793,9 +793,10 @@ def stack(signal_list, axis=None, new_axis_name='stack_element',
         If mmap_dir is not None, and stack and mmap are True, the memory
         mapped file will be created in the given directory,
         otherwise the default directory is used.
-    load_to_memory : bool, None
-        if True (default), loads all data to memory.
-        If False, only loads the data upon request.
+    load_to_memory : bool
+        If True loads all data to memory.
+        If False only loads the data upon request.
+        If None loads to memory
 
     Returns
     -------
@@ -887,6 +888,7 @@ def stack(signal_list, axis=None, new_axis_name='stack_element',
                 else:
                     data = np.empty(obj.data.shape,
                                     dtype=obj.data.dtype)
+
                 signal = obj._deepcopy_with_new_data(data)
 
             signal.original_metadata.add_node('stack_elements')
@@ -925,7 +927,8 @@ def stack(signal_list, axis=None, new_axis_name='stack_element',
     if axis is not None and not isinstance(signal.data, h5py.Dataset):
         signal.data = np.concatenate([signal_.data for signal_ in signal_list],
                                      axis=axis.index_in_array)
-        signal.get_dimensions_from_data()
+
+    signal.get_dimensions_from_data()
 
     if axis_input is None:
         axis_input = signal.axes_manager[-1 + 1j].index_in_axes_manager
@@ -942,7 +945,7 @@ def stack(signal_list, axis=None, new_axis_name='stack_element',
         step_sizes)
 
     if isinstance(signal.data, h5py.Dataset):
-        write_signal(signal, data.parent)
+        write_signal(signal, signal.data.parent)
     return signal
 
 

--- a/hyperspy/misc/utils.py
+++ b/hyperspy/misc/utils.py
@@ -817,9 +817,7 @@ def stack(signal_list, axis=None, new_axis_name='stack_element',
 
     import h5py
     from hyperspy.io_plugins.hdf5 import write_empty_signal, write_signal, deepcopy2hdf5, get_temp_hdf5_file
-    import dask.array as da
     axis_input = copy.deepcopy(axis)
-    dask_arrays = []
     if load_to_memory is None:
         load_to_memory = True
 

--- a/hyperspy/misc/utils.py
+++ b/hyperspy/misc/utils.py
@@ -831,7 +831,7 @@ def stack(signal_list, axis=None, new_axis_name='stack_element',
                 if mmap is False:
                     if isinstance(obj.data, h5py.Dataset):
                         tempf = get_temp_hdf5_file()
-                        data = write_empty_signal(tempf,
+                        data = write_empty_signal(tempf.file,
                                                   stack_shape,
                                                   obj.data.dtype,
                                                   metadata=new_metadata)['data']
@@ -879,7 +879,7 @@ def stack(signal_list, axis=None, new_axis_name='stack_element',
                             [s.data.shape[j] for s in signal_list])
                 if isinstance(obj.data, h5py.Dataset):
                     tempf = get_temp_hdf5_file()
-                    data = write_empty_signal(tempf,
+                    data = write_empty_signal(tempf.file,
                                               tuple(stack_shape),
                                               obj.data.dtype,
                                               metadata=obj.metadata)['data']
@@ -888,7 +888,9 @@ def stack(signal_list, axis=None, new_axis_name='stack_element',
                                     dtype=obj.data.dtype)
                 signal = obj._deepcopy_with_new_data(data)
                 if tempf is not None:
-                    signal._tempfile = tempf
+                    if not hasattr(signal, '_tempfile'):
+                        # should not happen atm, as the deepcopy sets it
+                        signal._tempfile = tempf
 
             signal.original_metadata.add_node('stack_elements')
 

--- a/hyperspy/signal.py
+++ b/hyperspy/signal.py
@@ -4567,14 +4567,12 @@ class Signal(FancySlicing,
 
     def __deepcopy__(self, memo):
         if isinstance(self.data, h5py.Dataset):
-            import tempfile
+            from hyperspy.io_plugins.hdf5 import get_temp_hdf5_file, file_writer
             from hyperspy.io import load
-            # TODO: when migrating to Py3, use TemporaryDirectory, as it will be deleted as
-            # appropriate. Here we rely on the filesystem / reboots.
-            tempfname = tempfile.NamedTemporaryFile(
-                prefix='tmp_hs_').name + '.hdf5'
-            self.save(tempfname)
-            dc = load(tempfname, load_to_memory=False, mode='r+')
+            tempf = get_temp_hdf5_file()
+            file_writer(tempf.name, self, fileobj=tempf.file)
+            dc = load(tempf.name, load_to_memory=False, mode='r+')
+            dc._tempfile = tempf
         else:
             dc = type(self)(**self._to_dictionary())
             if dc.data is not None:

--- a/hyperspy/signal.py
+++ b/hyperspy/signal.py
@@ -3064,7 +3064,7 @@ class Signal(FancySlicing,
             old_models = self.models._models
             self.models._models = DictionaryTreeBrowser()
             ns = self.deepcopy()
-            ns.data = np.atleast_1d(data)
+            ns.data = data
             return ns
         finally:
             self.data = old_data

--- a/hyperspy/signal.py
+++ b/hyperspy/signal.py
@@ -3061,13 +3061,12 @@ class Signal(FancySlicing,
             try:
                 old_data = self.data
                 if data is None:
-                    self.data = old_data.parent.create_dataset('temp_dset',
-                                                               shape=old_data.shape,
-                                                               dtype=old_data.dtype,
-                                                               compression=old_data.compression,
-                                                               chunks=old_data.chunks,
-                                                               maxshape=old_data.maxshape,
-                                                               shuffle=True)
+                    from hyperspy.io_plugins.hdf5 import get_temp_hdf5_file, write_empty_signal
+                    tempf = get_temp_hdf5_file()
+                    self.data = write_empty_signal(tempf.file,
+                                                   old_data.shape,
+                                                   old_data.dtype,
+                                                   metadata=self.metadata)['data']
                 else:
                     self.data = data
 		old_models = self.models._models
@@ -3077,8 +3076,6 @@ class Signal(FancySlicing,
             finally:
                 self.data = old_data
 		self.models._models = old_models
-                if data is None:
-                    del old_data.parent['temp_dset']
         else:
             try:
                 old_data = self.data

--- a/hyperspy/signal.py
+++ b/hyperspy/signal.py
@@ -3057,7 +3057,7 @@ class Signal(FancySlicing,
         ns : Signal
 
         """
-        if isinstance(self.data, h5py.Dataset) and (isinstance(data, h5py.Dataset) or data is None):
+        if isinstance(data, h5py.Dataset) or (isinstance(self.data, h5py.Dataset) and data is None):
             try:
                 old_data = self.data
                 if data is None:

--- a/hyperspy/tests/io/test_dm3.py
+++ b/hyperspy/tests/io/test_dm3.py
@@ -71,7 +71,8 @@ def test_content():
 
 def check_load(filename, subfolder, key):
     try:
-        s = load(filename)
+        s = load(filename,
+                 load_to_memory=True)
         ok = True
         # Store the data for the next tests
         data_dict[subfolder][key] = s.data

--- a/hyperspy/tests/io/test_dm4.py
+++ b/hyperspy/tests/io/test_dm4.py
@@ -70,7 +70,8 @@ def test_content():
 
 def check_load(filename, subfolder, key):
     try:
-        s = load(filename)
+        s = load(filename,
+                 load_to_memory=True)
         ok = True
         # Store the data for the next tests
         data_dict[subfolder][key] = s.data

--- a/hyperspy/tests/io/test_hdf5.py
+++ b/hyperspy/tests/io/test_hdf5.py
@@ -86,7 +86,8 @@ class TestExample1_10(Example1):
         self.s = load(os.path.join(
             my_path,
             "hdf5_files",
-            "example1_v1.0.hdf5"))
+            "example1_v1.0.hdf5"),
+            load_to_memory=True)
 
 
 class TestExample1_11(Example1):
@@ -95,7 +96,8 @@ class TestExample1_11(Example1):
         self.s = load(os.path.join(
             my_path,
             "hdf5_files",
-            "example1_v1.1.hdf5"))
+            "example1_v1.1.hdf5"),
+            load_to_memory=True)
 
 
 class TestExample1_12(Example1):
@@ -104,7 +106,8 @@ class TestExample1_12(Example1):
         self.s = load(os.path.join(
             my_path,
             "hdf5_files",
-            "example1_v1.2.hdf5"))
+            "example1_v1.2.hdf5"),
+            load_to_memory=True)
 
     def test_date(self):
         nt.assert_equal(
@@ -124,7 +127,8 @@ class TestLoadingNewSavedMetadata:
         self.s = load(os.path.join(
             my_path,
             "hdf5_files",
-            "with_lists_etc.hdf5"))
+            "with_lists_etc.hdf5"),
+            load_to_memory=True)
 
     def test_signal_inside(self):
         nt.assert_true(
@@ -170,7 +174,8 @@ class TestSavingMetadataContainers:
         s = self.s
         s.metadata.set_item('test', [u'a', u'b', u'\u6f22\u5b57'])
         s.save('tmp.hdf5', overwrite=True)
-        l = load('tmp.hdf5')
+        l = load('tmp.hdf5',
+                 load_to_memory=True)
         nt.assert_is_instance(l.metadata.test[0], unicode)
         nt.assert_is_instance(l.metadata.test[1], unicode)
         nt.assert_is_instance(l.metadata.test[2], unicode)
@@ -186,7 +191,8 @@ class TestSavingMetadataContainers:
         s = self.s
         s.metadata.set_item('test', [[1., 2], ('3', 4)])
         s.save('tmp.hdf5', overwrite=True)
-        l = load('tmp.hdf5')
+        l = load('tmp.hdf5',
+                 load_to_memory=True)
         nt.assert_is_instance(l.metadata.test, list)
         nt.assert_is_instance(l.metadata.test[0], list)
         nt.assert_is_instance(l.metadata.test[1], tuple)
@@ -195,7 +201,8 @@ class TestSavingMetadataContainers:
         s = self.s
         s.metadata.set_item('test', [[1., 2], ['3', 4]])
         s.save('tmp.hdf5', overwrite=True)
-        l = load('tmp.hdf5')
+        l = load('tmp.hdf5',
+                 load_to_memory=True)
         nt.assert_is_instance(l.metadata.test[0][0], float)
         nt.assert_is_instance(l.metadata.test[0][1], float)
         nt.assert_is_instance(l.metadata.test[1][0], basestring)
@@ -205,7 +212,8 @@ class TestSavingMetadataContainers:
         s = self.s
         s.metadata.set_item('test', (Signal([1]), 0.1, 'test_string'))
         s.save('tmp.hdf5', overwrite=True)
-        l = load('tmp.hdf5')
+        l = load('tmp.hdf5',
+                 load_to_memory=True)
         nt.assert_is_instance(l.metadata.test, tuple)
         nt.assert_is_instance(l.metadata.test[0], Signal)
         nt.assert_is_instance(l.metadata.test[1], float)
@@ -220,7 +228,8 @@ def test_none_metadata():
     s = load(os.path.join(
         my_path,
         "hdf5_files",
-        "none_metadata.hdf5"))
+        "none_metadata.hdf5"),
+        load_to_memory=True)
     nt.assert_is(s.metadata.should_be_None, None)
 
 
@@ -228,7 +237,8 @@ def test_rgba16():
     s = load(os.path.join(
         my_path,
         "hdf5_files",
-        "test_rgba16.hdf5"))
+        "test_rgba16.hdf5"),
+        load_to_memory=True)
     data = np.load(os.path.join(
         my_path,
         "npy_files",
@@ -255,7 +265,7 @@ class TestLoadingOOMReadOnly:
 
     @nt.raises(MemoryError, ValueError)
     def test_in_memory_loading(self):
-        s = load('tmp.hdf5')
+        s = load('tmp.hdf5', load_to_memory=True)
 
     def test_oom_loading(self):
         s = load('tmp.hdf5', load_to_memory=False)

--- a/hyperspy/tests/io/test_hdf5.py
+++ b/hyperspy/tests/io/test_hdf5.py
@@ -1,5 +1,6 @@
 import os.path
 from os import remove
+from os.path import exists as os_exists
 import datetime
 import h5py
 import gc
@@ -8,6 +9,7 @@ import nose.tools as nt
 import numpy as np
 
 from hyperspy.io import load
+from hyperspy.io_plugins.hdf5 import get_temp_hdf5_file
 from hyperspy.signal import Signal
 
 my_path = os.path.dirname(__file__)
@@ -267,3 +269,13 @@ class TestLoadingOOMReadOnly:
         except:
             # Don't fail tests if we cannot remove
             pass
+
+
+def test_temp_hdf5_file():
+    f = get_temp_hdf5_file()
+    name = f.name
+    print name
+    nt.assert_equal(f.file.filename, name)
+    nt.assert_true(os_exists(name))
+    f.close()
+    nt.assert_false(os_exists(name))

--- a/hyperspy/tests/io/test_msa.py
+++ b/hyperspy/tests/io/test_msa.py
@@ -86,7 +86,8 @@ class TestExample1:
         self.s = load(os.path.join(
             my_path,
             "msa_files",
-            "example1.msa"))
+            "example1.msa"),
+            load_to_memory=True)
 
     def test_data(self):
         assert_equal(
@@ -124,7 +125,8 @@ class TestExample2:
         self.s = load(os.path.join(
             my_path,
             "msa_files",
-            "example2.msa"))
+            "example2.msa"),
+            load_to_memory=True)
 
     def test_data(self):
         assert_equal(

--- a/hyperspy/tests/io/test_tiff.py
+++ b/hyperspy/tests/io/test_tiff.py
@@ -12,7 +12,8 @@ def test_rgba16():
     s = hs.load(os.path.join(
         my_path,
         "tiff_files",
-        "test_rgba16.tif"))
+        "test_rgba16.tif"),
+        load_to_memory=True)
     data = np.load(os.path.join(
         my_path,
         "npy_files",

--- a/hyperspy/tests/signal/test_deepcopy.py
+++ b/hyperspy/tests/signal/test_deepcopy.py
@@ -1,0 +1,117 @@
+import numpy as np
+import nose.tools as nt
+
+from os import remove
+from hyperspy.signal import Signal
+import h5py
+
+
+class PlotMetadataAxesDeepcopy:
+
+    def test_axes_deepcopy(self):
+        dc = self.s.deepcopy()
+        s = self.s
+        np.testing.assert_equal(
+            s.axes_manager._get_axes_dicts(),
+            dc.axes_manager._get_axes_dicts())
+        nt.assert_is_not(s.axes_manager, dc.axes_manager)
+
+    def test_metadata_deepcopy(self):
+        dc = self.s.deepcopy()
+        s = self.s
+        nt.assert_dict_equal(
+            s.metadata.as_dictionary(),
+            dc.metadata.as_dictionary())
+        nt.assert_is_not(s.metadata, dc.metadata)
+
+    def test_plot_deepcopy(self):
+        dc = self.s.deepcopy()
+        s = self.s
+        nt.assert_is_none(dc._plot)
+        nt.assert_is(s._plot, self.plot_obj)
+
+
+class TestInmemoryDeepcopy(PlotMetadataAxesDeepcopy):
+
+    def setUp(self):
+        s = Signal(np.arange(5 * 10).reshape(5, 10))
+        s.axes_manager[0].name = "x"
+        s.axes_manager[1].name = "E"
+        s.axes_manager[0].scale = 0.5
+        s.metadata.General.title = 'Some signal title'
+        s.metadata.test_tuple = ('one', 'two', 'three')
+        self.plot_obj = [42, 1. / 137]
+        s._plot = self.plot_obj
+        self.s = s
+
+    def test_data_deepcopy(self):
+        dc = self.s.deepcopy()
+        s = self.s
+        np.testing.assert_equal(s.data, dc.data)
+        nt.assert_is_not(s.data, dc.data)
+
+    def test_deepcopy_with_new_oom_data(self):
+        s = self.s
+        from hyperspy.io_plugins.hdf5 import get_temp_hdf5_file, write_empty_signal
+        import h5py
+        tempf = get_temp_hdf5_file()
+        s.data = write_empty_signal(tempf.file,
+                                    s.data.shape,
+                                    s.data.dtype,
+                                    metadata=s.metadata)['data']
+        dc = s.deepcopy()
+        nt.assert_is_instance(dc.data, h5py.Dataset)
+
+
+class TestOOMDeepcopy(PlotMetadataAxesDeepcopy):
+
+    def setUp(self):
+        f = h5py.File('tmp.hdf5')
+        data = f.create_dataset(
+            'data',
+            data=np.arange(
+                5 *
+                10).reshape(
+                5,
+                10),
+            maxshape=(
+                None,
+                None))
+        s = Signal(data)
+        s.axes_manager[0].name = "x"
+        s.axes_manager[1].name = "E"
+        s.axes_manager[0].scale = 0.5
+        s.metadata.General.title = 'Some signal title'
+        s.metadata.test_tuple = ('one', 'two', 'three')
+        self.plot_obj = [42, 1. / 137]
+        s._plot = self.plot_obj
+        self.s = s
+        self.file = f
+
+    def test_tempfile_assignment(self):
+        dc = self.s.deepcopy()
+        nt.assert_true(hasattr(dc, '_tempfile'))
+        nt.assert_is_not_none(dc._tempfile)
+        nt.assert_equal(dc._tempfile.file, dc.data.file)
+
+    def test_deepcopy_data(self):
+        dc = self.s.deepcopy()
+        s = self.s
+        nt.assert_not_equal(s.data, dc.data)
+        nt.assert_not_equal(s.data.file, dc.data.file)
+        np.testing.assert_almost_equal(s.data[:], dc.data[:])
+
+    def test_deepcopy_data_properties(self):
+        dc = self.s.deepcopy()
+        s = self.s
+        nt.assert_equal(dc.data.fillvalue, s.data.fillvalue)
+        nt.assert_equal(dc.data.maxshape, s.data.maxshape)
+        nt.assert_equal(dc.data.chunks, s.data.chunks)
+
+    def test_deepcopy_with_new_data_none(self):
+        s = self.s
+        dc = s._deepcopy_with_new_data()
+        np.testing.assert_equal(np.zeros(s.data.shape)[:], dc.data[:])
+
+    def tearDown(self):
+        remove('tmp.hdf5')

--- a/hyperspy/tests/utils/test_stack.py
+++ b/hyperspy/tests/utils/test_stack.py
@@ -1,4 +1,5 @@
-from nose.tools import assert_true
+import nose.tools as nt
+import h5py
 import numpy as np
 
 from hyperspy.signal import Signal
@@ -8,7 +9,7 @@ from hyperspy import utils
 class TestUtilsStack:
 
     def setUp(self):
-        s = Signal(np.ones((3, 2, 5)))
+        s = Signal(np.arange(3 * 2 * 5).reshape((3, 2, 5)))
         s.axes_manager[0].name = "x"
         s.axes_manager[1].name = "y"
         s.axes_manager[2].name = "E"
@@ -20,13 +21,11 @@ class TestUtilsStack:
         s = self.signal
         s1 = s.deepcopy() + 1
         s2 = s.deepcopy() * 4
-        test_axis = s.axes_manager[0].index_in_array
         result_signal = utils.stack([s, s1, s2])
         result_list = result_signal.split()
-        assert_true(test_axis == s.axes_manager[0].index_in_array)
-        assert_true(len(result_list) == 3)
-        assert_true(
-            (result_list[0].data == result_signal[::, ::, 0].data).all())
+        nt.assert_true(len(result_list) == 3)
+        nt.assert_true(
+            (result_list[0].data == result_signal.data[0, ...]).all())
 
     def test_stack_of_stack(self):
         s = self.signal
@@ -34,9 +33,12 @@ class TestUtilsStack:
         s2 = utils.stack([s1] * 3)
         s3 = s2.split()[0]
         s4 = s3.split()[0]
-        assert_true((s4.data == s.data).all())
-        assert_true((hasattr(s4.original_metadata, 'stack_elements')is False))
-        assert_true((s4.metadata.General.title == 'test'))
+        nt.assert_true((s4.data == s.data).all())
+        nt.assert_true(
+            (hasattr(
+                s4.original_metadata,
+                'stack_elements')is False))
+        nt.assert_true((s4.metadata.General.title == 'test'))
 
     def test_stack_not_default(self):
         s = self.signal
@@ -44,10 +46,10 @@ class TestUtilsStack:
         s2 = s.deepcopy() * 4
         result_signal = utils.stack([s, s1, s2], axis=1)
         result_list = result_signal.split()
-        assert_true(len(result_list) == 3)
-        assert_true((result_list[0].data == result_signal[::, 0].data).all())
+        nt.assert_true(len(result_list) == 3)
+        np.testing.assert_array_equal(result_list[0].data, result_signal.data[:3, :,:])
         result_signal = utils.stack([s, s1, s2], axis='y')
-        assert_true((result_list[0].data == result_signal[::, 0].data).all())
+        np.testing.assert_array_equal(result_list[0].data, result_signal.data[:3, :,:])
 
     def test_stack_bigger_than_ten(self):
         s = self.signal
@@ -56,5 +58,27 @@ class TestUtilsStack:
         list_s[-1].metadata.General.title = 'test'
         s1 = utils.stack(list_s)
         res = s1.split()
-        assert_true((list_s[-1].data == res[-1].data).all())
-        assert_true((res[-1].metadata.General.title == 'test'))
+        nt.assert_true((list_s[-1].data == res[-1].data).all())
+        nt.assert_true((res[-1].metadata.General.title == 'test'))
+
+    def test_stack_oom_default(self):
+        s = self.signal
+        s1 = s.deepcopy() + 1
+        s2 = s.deepcopy() * 4
+        result_signal = utils.stack([s, s1, s2], load_to_memory=False)
+        nt.assert_is_instance(result_signal.data, h5py.Dataset)
+        nt.assert_true(hasattr(result_signal, '_tempfile'))
+        nt.assert_equal(result_signal.data.shape, (3, 3, 2, 5))
+        for res_d, _s in zip(result_signal.data, [s, s1, s2]):
+            np.testing.assert_array_equal(res_d, _s.data)
+
+    def test_stack_oom_not_default(self):
+        s = self.signal
+        s1 = s.deepcopy() + 1
+        s2 = s.deepcopy() * 4
+        result_signal = utils.stack([s, s1, s2], load_to_memory=False, axis=1)
+        nt.assert_is_instance(result_signal.data, h5py.Dataset)
+        nt.assert_true(hasattr(result_signal, '_tempfile'))
+        nt.assert_equal(result_signal.data.shape, (9, 2, 5))
+        for res_d, _s in zip(np.split(result_signal.data.value, 3), [s, s1, s2]):
+            np.testing.assert_array_equal(res_d, _s.data)


### PR DESCRIPTION
`:%s/oom/out of memory/g`

Second milestone for hdf5 in #592 

Implements a number of things:
 - safe temporary files that can be easily tracked and are deleted upon exit. The one drawback is that when deleting the file on garbage collection, all exceptions (that always occur due to `h5py` reference counting) are printed to `stderr` that get flushed to the terminal, so it just does not look clean...
 - `signal.deepcopy` and `signal._deepcopy_with_new_data` work for oom signals.
 - when loading multiple signals (e.g. wildcard) and `load_to_memory=False`, the signal list is now a generator, not requiring loading all of them to the memory at once. Works even with non-hdf5 files, as long as the shapes are compatible (just like it used to be).
 - some internal hdf5 writing routines got split to enable writing "skeletons" of signals that can be populated later. Also the writing routines now should overwrite parts of already open the file when required (before it would just nuke the file and start from scratch)
 - `driver="core"` got removed, as it is not recommended (best to leave default).
 - `deepcopy2hdf5` got added - effectively writes a dictionary to hdf5 group, and then reconstructs it from the same group. The end effect is that all `np.array` members get "mapped" to `h5py.Dataset` in that particular file
 - ... maybe something else that I missed?

Comments (especially on the tempfile creation and destruction and interplay with the h5py) and advices are very welcome, as I might have missed something trivial / fundamental.

## TODO:
_______________
 - [x] `signal.deepcopy` tests
 - [x] `signal._deepcopy_with_new_data` tests
 - [x] `deepcopy2hdf5` tests
 - [x] all documentation
 - [x] fix docstring lines where `load_to_memory=None` and/or finally figure out how to deal with it. If not None is left as default and passed to other readers, they crash
 - [x] check that the iterator approach actually prevents loading everything at once and only loads one file at a time. It should also work with other files (dm3, etc)
 - [x] extend `stack` tests

