### PR TITLE
IO-Plugins for EMD and SEMPER formats

### DIFF
--- a/hyperspy/io_plugins/__init__.py
+++ b/hyperspy/io_plugins/__init__.py
@@ -19,8 +19,8 @@
 
 from hyperspy import messages
 from hyperspy.io_plugins import (msa, digital_micrograph, fei, mrc,
-                                 ripple, tiff)
-io_plugins = [msa, digital_micrograph, fei, mrc, ripple, tiff]
+                                 ripple, tiff, semper_unf)
+io_plugins = [msa, digital_micrograph, fei, mrc, ripple, tiff, semper_unf]
 try:
     from hyperspy.io_plugins import netcdf
     io_plugins.append(netcdf)
@@ -34,6 +34,8 @@ except ImportError:
 try:
     from hyperspy.io_plugins import hdf5
     io_plugins.append(hdf5)
+    from hyperspy.io_plugins import emd
+    io_plugins.append(emd)
 except ImportError:
     messages.warning('The HDF5 IO features are not available. '
                      'It is highly reccomended to install h5py')

--- a/hyperspy/io_plugins/emd.py
+++ b/hyperspy/io_plugins/emd.py
@@ -1,0 +1,374 @@
+# -*- coding: utf-8 -*-
+# Copyright 2007-2015 The HyperSpy developers
+#
+# This file is part of  HyperSpy.
+#
+#  HyperSpy is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+#  HyperSpy is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with  HyperSpy.  If not, see <http://www.gnu.org/licenses/>.
+
+# INFORMATION ABOUT THE EMD FORMAT CAN BE FOUND HERE:
+# http://emdatasets.lbl.gov/
+
+
+import re
+import h5py
+
+import logging
+
+
+# Plugin characteristics
+# ----------------------
+format_name = 'Electron Microscopy Data (EMD)'
+description = 'Read data from Berkleys EMD files.'
+full_support = True  # Hopefully?
+# Recognised file extension
+file_extensions = ('emd', 'EMD')
+default_extension = 0
+# Writing features
+writes = True
+EMD_VERSION = '0.2'
+# ----------------------
+
+
+class EMD(object):
+
+    '''Class for storing electron microscopy datasets.
+
+    The :class:`~.EMD` class can hold an arbitrary amount of datasets in the `signals` dictionary.
+    These are saved as HyperSpy :class:`~hyperspy.signal.Signal` instances. Global metadata
+    are saved in four dictionaries (`user`, `microscope`, `sample`, `comments`). To print
+    relevant information about the EMD instance use the :func:`~.print_info` function. EMD
+    instances can be loaded from and saved to emd-files, an hdf5 standard developed at Lawrence
+    Berkeley National Lab (http://emdatasets.lbl.gov/).
+
+    Attributes
+    ----------
+    signals: dictionary
+        Dictionary which contains all datasets as :class:`~hyperspy.signal.Signal` instances.
+    user: dictionary
+        Dictionary which contains user related metadata.
+    microscope: dictionary
+        Dictionary which contains microscope related metadata.
+    sample: dictionary
+        Dictionary which contains sample related metadata.
+    comments: dictionary
+        Dictionary which contains additional commentary metadata.
+
+    '''
+
+    _log = logging.getLogger(__name__)
+
+    def __init__(self, signals={}, user={}, microscope={}, sample={}, comments={}):
+        self._log.debug('Calling __init__')
+        # Make sure some default keys are present in user:
+        for key in ['name', 'institution', 'department', 'email']:
+            if key not in user:
+                user[key] = ''
+        self.user = user
+        # Make sure some default keys are present in microscope:
+        for key in ['name', 'voltage']:
+            if key not in microscope:
+                microscope[key] = ''
+        self.microscope = microscope
+        # Make sure some default keys are present in sample:
+        for key in ['material', 'preparation']:
+            if key not in sample:
+                sample[key] = ''
+        self.sample = sample
+        # Add comments:
+        self.comments = comments
+        # Make sure the signals are added properly to signals:
+        self.signals = {}
+        for name, signal in signals.iteritems():
+            self.add_signal(signal, name)
+
+    def __getitem__(self, key):
+        # This is for accessing the raw data easily. For the signals use emd.signals[key]!
+        return self.signals[key].data
+
+    def _write_signal_to_group(self, data_group, signal):
+        self._log.debug('Calling _write_signal_to_group')
+        # Save data:
+
+        dataset = data_group.create_group(signal.metadata.General.title)
+        dataset['data'] = signal.data
+        # Iterate over all dimensions:
+        for i in range(len(signal.data.shape)):
+            key = 'dim{}'.format(i+1)
+            offset = signal.axes_manager[i].offset
+            scale = signal.axes_manager[i].scale
+            dim = dataset.create_dataset(key, data=[offset, offset+scale])
+            name = signal.axes_manager[i].name
+            from traits.trait_base import _Undefined
+            if type(name) is _Undefined:
+                name = ''
+            dim.attrs['name'] = name
+            units = signal.axes_manager[i].units
+            if type(units) is _Undefined:
+                units = ''
+            else:
+                units = '[{}]'.format('_'.join(list(units)))
+            dim.attrs['units'] = units
+        # Write metadata:
+        dataset.attrs['emd_group_type'] = 1
+        for key, value in signal.metadata.Signal:
+            dataset.attrs[key] = value
+
+    def _read_signal_from_group(self, name, group):
+        self._log.debug('Calling _read_signal_from_group')
+        import hyperspy.api as hp
+        # Extract essential data:
+        data = group.get('data')[...]
+        record_by = group.attrs.get('record_by', '')
+        # Create Signal, Image or Spectrum:
+        if record_by == 'spectrum':
+            signal = hp.signals.Spectrum(data)
+        if record_by == 'image':
+            signal = hp.signals.Image(data)
+        else:
+            signal = hp.signals.Signal(data)
+        # Set signal properties:
+        signal.set_signal_origin = group.attrs.get('signal_origin', '')
+        signal.set_signal_type = group.attrs.get('signal_type', '')
+        # Iterate over all dimensions:
+        for i in range(len(data.shape)):
+            dim = group.get('dim{}'.format(i+1))
+            signal.axes_manager[i].name = dim.attrs.get('name', '')
+            units = re.findall('[^_\W]+', dim.attrs.get('units', ''))
+            signal.axes_manager[i].units = ''.join(units)
+            try:
+                signal.axes_manager[i].scale = dim[1] - dim[0]
+                signal.axes_manager[i].offset = dim[0]
+            except (IndexError, TypeError) as e:  # Hyperspy uses defaults (1.0 and 0.0)!
+                self._log.warning('Could not calculate scale/offset of axis {}: {}'.format(i, e))
+        # Extract metadata:
+        metadata = {}
+        for key, value in group.attrs.iteritems():
+            metadata[key] = value
+        # Add signal:
+        self.add_signal(signal, name, metadata)
+
+    def add_signal(self, signal, name=None, metadata={}):
+        '''Add a hyperspy signal to the EMD instance and make sure all metadata is present.
+
+        Parameters
+        ----------
+        signal: :class:`~hyperspy.signal.Signal`
+            HyperSpy signal which should be added to the EMD instance.
+        name: string, optional
+            Name of the (used as a key for the `signals` dictionary). If not specified,
+            `signal.metadata.General.title` will be used. If this is an empty string, both name
+            and signal title are set to 'dataset' per default. If specified, `name` overwrites the
+            signal title.
+        metadata: dictionary
+            Dictionary which holds signal specific metadata which will be added to the signal.
+
+        Returns
+        -------
+        None
+
+        Notes
+        -----
+        This is the preferred way to add signals to the EMD instance. Directly adding to the
+        `signals` dictionary is possible but does not make sure all metadata are correct. This is
+        called in the standard constructor on all entries in the `signals` dictionary!
+
+        '''
+        self._log.debug('Calling add_signal')
+        # Check and save title:
+        if name is not None:  # Overwrite Signal title!
+            signal.metadata.General.title = name
+        else:
+            if signal.metadata.General.title is not '':  # Take title of Signal!
+                name = signal.metadata.General.title
+            else:  # Take default!
+                name = 'dataset'
+                signal.metadata.General.title = name
+        # Save signal metadata:
+        signal.metadata.Signal.add_dictionary(metadata)
+        # Save global metadata:
+        signal.metadata.General.add_node('user')
+        signal.metadata.General.user.add_dictionary(self.user)
+        signal.metadata.General.add_node('microscope')
+        signal.metadata.General.microscope.add_dictionary(self.microscope)
+        signal.metadata.General.add_node('sample')
+        signal.metadata.General.sample.add_dictionary(self.sample)
+        signal.metadata.General.add_node('comments')
+        signal.metadata.General.comments.add_dictionary(self.comments)
+        # Add signal:
+        self.signals[name] = signal
+
+    @classmethod
+    def load_from_emd(cls, filename):
+        '''Construct :class:`~.EMD` object from an emd-file.
+
+        Parameters
+        ----------
+        filename : string
+            The name of the emd-file from which to load the signals. Standard format is '*.emd'.
+
+        Returns
+        -------
+        emd: :class:`~.EMD`
+            A :class:`~.EMD` object containing the loaded signals.
+
+        '''
+        cls._log.debug('Calling load_from_ems')
+        # Read in file:
+        emd_file = h5py.File(filename, 'r')
+        # Creat empty EMD instance:
+        emd = EMD()
+        # Extract user:
+        user_group = emd_file.get('user')
+        if user_group is not None:
+            for key, value in user_group.attrs.iteritems():
+                emd.user[key] = value
+        # Extract microscope:
+        microscope_group = emd_file.get('microscope')
+        if microscope_group is not None:
+            for key, value in microscope_group.attrs.iteritems():
+                emd.microscope[key] = value
+        # Extract sample:
+        sample_group = emd_file.get('sample')
+        if sample_group is not None:
+            for key, value in sample_group.attrs.iteritems():
+                emd.sample[key] = value
+        # Extract comments:
+        comments_group = emd_file.get('comments')
+        if comments_group is not None:
+            for key, value in comments_group.attrs.iteritems():
+                emd.comments[key] = value
+        # Extract signals:
+        node_list = emd_file.keys()
+        for key in ['user', 'microscope', 'sample', 'comments']:  # Nodes which are not the data!
+            if key in node_list:
+                node_list.pop(node_list.index(key))  # Pop all unwanted nodes!
+        # One node should remain, the data node (named 'data', 'signals', 'experiments', ...)!
+        assert len(node_list) == 1, 'Dataset location is ambiguous!'
+        data_group = emd_file.get(node_list[0])
+        if data_group is not None:
+            for name, group in data_group.iteritems():
+                if isinstance(group, h5py.Group):
+                    if group.attrs.get('emd_group_type') == 1:
+                        emd._read_signal_from_group(name, group)
+        # Close file and return EMD object:
+        emd_file.close()
+        return emd
+
+    def save_to_emd(self, filename='datacollection.emd'):
+        '''Save :class:`~.EMD` data in a file with emd(hdf5)-format.
+
+        Parameters
+        ----------
+        filename : string, optional
+            The name of the emd-file in which to store the signals.
+            The default is 'datacollection.emd'.
+
+        Returns
+        -------
+        None
+
+        '''
+        self._log.debug('Calling save_to_emd')
+        # Open file:
+        emd_file = h5py.File(filename, 'w')
+        # Write version:
+        ver_maj, ver_min = EMD_VERSION.split('.')
+        emd_file.attrs['version_major'] = ver_maj
+        emd_file.attrs['version_minor'] = ver_min
+        # Write user:
+        user_group = emd_file.create_group('user')
+        for key, value in self.user.iteritems():
+            user_group.attrs[key] = value
+        # Write microscope:
+        microscope_group = emd_file.create_group('microscope')
+        for key, value in self.microscope.iteritems():
+            microscope_group.attrs[key] = value
+        # Write sample:
+        sample_group = emd_file.create_group('sample')
+        for key, value in self.sample.iteritems():
+            sample_group.attrs[key] = value
+        # Write comments:
+        comments_group = emd_file.create_group('comments')
+        for key, value in self.comments.iteritems():
+            comments_group.attrs[key] = value
+        # Write signals:
+        data_group = emd_file.create_group('signals')
+        for signal in self.signals.values():
+            self._write_signal_to_group(data_group, signal)
+        # Close file and return EMD object:
+        emd_file.close()
+
+    def print_info(self):
+        '''Print all relevant information about the EMD instance.
+
+        Parameters
+        ----------
+        None
+
+        Returns
+        -------
+        None
+
+        '''
+        self._log.debug('Calling print_info')
+        print '\nUser:\n--------------------'
+        for key, value in self.user.iteritems():
+            print '{}:'.format(key).ljust(15), value
+        print '--------------------\n\nMicroscope:\n--------------------'
+        for key, value in self.microscope.iteritems():
+            print '{}:'.format(key).ljust(15), value
+        print '--------------------\n\nSample:\n--------------------'
+        for key, value in self.sample.iteritems():
+            print '{}:'.format(key).ljust(15), value
+        print '--------------------\n\nComments:\n--------------------'
+        for key, value in self.comments.iteritems():
+            print '{}:'.format(key).ljust(15), value
+        print '--------------------\n\nData:\n--------------------'
+        for key, value in self.signals.iteritems():
+            print '{}:'.format(key).ljust(15), value
+            print value.metadata.Signal
+        print '--------------------\n'
+
+
+def file_reader(filename, print_info=False, **kwds):
+    emd = EMD.load_from_emd(filename)
+    if print_info:
+        emd.print_info()
+    dictionaries = []
+    for signal in emd.signals.values():
+        axes = []
+        for i in range(len(signal.data.shape)):
+            axes.append({'size': signal.axes_manager[i].size,
+                         'index_in_array': signal.axes_manager[i].index_in_array,
+                         'name': signal.axes_manager[i].name,
+                         'scale': signal.axes_manager[i].scale,
+                         'offset': signal.axes_manager[i].offset,
+                         'units': signal.axes_manager[i].units})
+        dictionary = {'data': signal.data,
+                      'axes': axes,
+                      'metadata': signal.metadata.as_dictionary(),
+                      'original_metadata': signal.original_metadata.as_dictionary()}
+        dictionaries.append(dictionary)
+    return dictionaries
+
+
+def file_writer(filename, signal, signal_metadata={}, user={},
+                microscope={}, sample={}, comments={}, **kwds):
+    if not signal.metadata.General.title:
+        signal.metadata.General.title = '__unnamed__'
+        print signal.metadata.General.title
+    name = signal.metadata.General.as_dictionary().get('title', '__unnamed__')
+    emd = EMD(user=user, microscope=microscope, sample=sample, comments=comments)
+    emd.add_signal(signal, name, metadata=signal_metadata)
+    emd.save_to_emd(filename)

--- a/hyperspy/io_plugins/semper_unf.py
+++ b/hyperspy/io_plugins/semper_unf.py
@@ -1,0 +1,516 @@
+# -*- coding: utf-8 -*-
+# Copyright 2007-2015 The HyperSpy developers
+#
+# This file is part of  HyperSpy.
+#
+#  HyperSpy is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+#  HyperSpy is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with  HyperSpy.  If not, see <http://www.gnu.org/licenses/>.
+
+# INFORMATION ABOUT THE SEMPER FORMAT LABEL:
+# Picture labels consist of a sequence of bytes
+# ---------------------------------------------
+# v61:256B | v7:at least 256B, rounded up to multiple of block size 64,
+#               with max set by LNLAB in params.f
+# The versions have the same contents for the first 256B, as set out below,
+# and referred to as the label 'base'; beyond this, in the label 'extension',
+# the structure is deliberately undefined, allowing you to make your own use
+# of the additional storage.
+#
+# From Aug14:
+#  B1-6    S e m p e r (ic chars)
+#   7,8    ncol msb,lsb (BIG-ended)
+#   9,10   nrow msb,lsb
+#  11,12   nlay msb,lsb
+#  13,14   ccol msb,lsb
+#  15,16   crow msb,lsb
+#  17,18   clay msb,lsb
+#    19    class: 1-20
+#            for image,macro,fou,spec,correln,undef,walsh,histog,plist,lut
+#    20    form: 0,1,2,3,4 = byte,i*2,fp,com,i*4 from Aug08
+#    21    wp: non-zero if prot
+#  22-27   creation year(-1900?),month,day,hour,min,sec
+#    28    v61|v7 # chars in range record | 255
+#  29-55   v61: min,max values present (ic chars for decimal repn)
+#           v7: min,max vals as two Fp values in B29-36 (LE ordered)
+#               followed by 19 unused bytes B37-55
+#    56    plist type: 1,2,3 = list,opencurve,closedcurve
+#            acc to EXAMPD - code appears to use explicit numbers
+# 57,58,59 ncol,nrow,nlay hsb
+# 60,61,62 ccol,crow,clay hsb
+#    63    RealCoords flag (non-zero -> DX,DY,DZ,X0,Y0,Z0,units held as below)
+#    64    v61:0 | v7: # blocks in (this) picture label (incl extn)
+#  65-67   0 (free at present)
+#  68-71   DATA cmd V7   4-byte Fp values, order LITTLE-ended
+#  72-75   DATA cmd V6
+#  76-79   RealCoord DZ / V5  RealCoord pars as 4-byte Fp values, LITTLE-ended
+#  80-83   ...       Z0 / V4
+#  84-87   ...       DY / V3
+#  88-91   ...       Y0 / V2
+#  92-95   ...       DX / V1
+#  96-99   ...       X0 / V0
+#   100    # chars in title
+# 101-244  title (ic chars)
+# 245-248  RealCoord X unit (4 ic chars)
+# 249-252  RealCoord Y unit (4 ic chars)
+# 253-256  RealCoord Z unit (4 ic chars)
+#
+# Aug08-Aug14 labels held no RealCoord information, so:
+#   B63    'free' and zero - flagging absence of RealCoord information
+# 101-256  title (12 chars longer than now)
+#
+# Before Aug08 labels held no hsb for pic sizes, so:
+#  57-99   all free/zero except for use by DATA cmd
+# 101-256  title (ic chars)
+
+
+from time import strftime
+import numpy as np
+import struct
+
+import logging
+
+
+# Plugin characteristics
+# ----------------------
+format_name = 'Semper UNF (unformatted)'
+description = 'Read data from Sempers UNF files.'
+full_support = True  # Hopefully?
+# Recognised file extension
+file_extensions = ('unf', 'UNF')
+default_extension = 0
+# Writing features
+writes = [(1, 0), (1, 1), (1, 2), (2, 0), (2, 1)]  # All up to 3D
+# ----------------------
+
+
+class SemperFormat(object):
+
+    '''Class for importing and exporting Semper `.unf`-files.
+
+    The :class:`~.SemperFormat` class represents a Semper binary file format with a header, which
+    holds additional information. `.unf`-files can be saved and read from files.
+
+    Attributes
+    ----------
+    data : :class:`~numpy.ndarray` (N=3)
+        The phase map or magnetization information in a 3D array (with one slice).
+    title : string
+        Title of the file (not to be confused with the filename).
+    offsets : tuple (N=3) of floats
+        Offset shifts (in nm) of the grid origin (does not have to start at 0) in x, y, z.
+    scales : tuple (N=3) of floats
+        Grid spacing (nm per pixel) in x, y, z.
+    units : tuple (N=3) of strings
+        Units of the grid in x, y, z.
+    date : string
+        The date of file construction.
+    iclass : int
+        Defines the image class defined in `ICLASS_DICT`. Normally `image` (1) is chosen.
+    iform : int
+        Defines the data format defined in 'IFORM_DICT'.
+    iversn :
+        Current `.unf`-format version. Current: 2.
+    ilabel : int
+        Defines if a label is present (1) or not (0).
+    iformat : int
+        Defines if the file is formatted (1) or not (0).
+    iwp : int
+        Write protect flag, determining if picture is (1) or is not (0) write-projtected.
+    ipltyp : int
+        Position type list. Standard seems to be 0 (picture not a position list).
+    iccoln : int
+        Column number of picture origin.
+    icrown : int
+        Row number of picture origin.
+    iclayn : int
+        Layer number of picture origin.
+
+    '''
+
+    _log = logging.getLogger(__name__)
+
+    ICLASS_DICT = {1: 'image', 2: 'macro', 3: 'fourier', 4: 'spectrum',
+                   5: 'correlation', 6: 'undefined', 7: 'walsh', 8: 'position list',
+                   9: 'histogram', 10: 'display look-up table'}
+
+    ICLASS_DICT_INV = {v: k for k, v in ICLASS_DICT.iteritems()}
+
+    IFORM_DICT = {0: np.byte, 1: np.int32, 2: np.float32, 3: np.complex64}
+
+    IFORM_DICT_INV = {v: k for k, v in IFORM_DICT.iteritems()}
+
+    def __init__(self, arg_dict):
+        self._log.debug('Calling __init__')
+        self.data = arg_dict['data']
+        self.title = arg_dict['title']
+        self.offsets = arg_dict['offsets']
+        self.scales = arg_dict['scales']
+        self.units = arg_dict['units']
+        self.date = arg_dict['date']
+        self.iclass = arg_dict['ICLASS']
+        self.iform = arg_dict['IFORM']
+        self.iversn = arg_dict['IVERSN']
+        self.ilabel = arg_dict['ILABEL']
+        self.iformat = arg_dict['IFORMAT']
+        self.iwp = arg_dict['IWP']
+        self.ipltyp = arg_dict['IPLTYP']
+        self.iccoln = arg_dict['ICCOLN']
+        self.icrown = arg_dict['ICROWN']
+        self.iclayn = arg_dict['ICLAYN']
+        self._log.debug('Created '+str(self))
+
+    @classmethod
+    def load_from_unf(self, filename):
+        '''Load a `.unf`-file into a :class:`~.SemperFormat` object.
+
+        Parameters
+        ----------
+        filename : string
+            The name of the unf-file from which to load the data. Standard format is '\*.unf'.
+
+        Returns
+        -------
+        semper : :class:`~.SemperFormat` (N=1)
+            Semper file format object containing the loaded information.
+
+        '''
+        self._log.debug('Calling from_file')
+        with open(filename, 'rb') as f:
+            # Read header:
+            rec_length = np.frombuffer(f.read(4), dtype=np.int32)[0]  # length of header
+            header = np.frombuffer(f.read(rec_length), dtype=np.int16)
+            ncol, nrow, nlay = header[:3]
+            iclass = header[3]
+            iform = header[4]
+            data_format = self.IFORM_DICT[iform]
+            iflag = header[5]
+            iversn, remain = divmod(iflag, 10000)
+            ilabel, ntitle = divmod(remain, 1000)
+            iformat = header[6] if len(header) == 7 else None
+            assert np.frombuffer(f.read(4), dtype=np.int32)[0] == rec_length
+            # Read title:
+            title = ''
+            assert np.frombuffer(f.read(4), dtype=np.int32)[0] == ntitle  # length of title
+            if ntitle > 0:
+                title_bytes = np.frombuffer(f.read(ntitle), dtype=np.byte)
+                title = ''.join(map(chr, title_bytes))
+            assert np.frombuffer(f.read(4), dtype=np.int32)[0] == ntitle
+            # Read label:
+            iwp, date, range_string, ipltype, a = [None] * 5  # Initialization!
+            iccoln, icrown, iclayn = [None] * 3
+            rec_length = np.frombuffer(f.read(4), dtype=np.int32)[0]  # length of label
+            if ilabel and rec_length > 0:
+                label = np.frombuffer(f.read(512), dtype=np.int16)
+                assert ''.join([chr(l) for l in label[:6]]) == 'Semper'
+                assert struct.unpack('>h', ''.join([chr(x) for x in label[6:8]]))[0] == ncol
+                assert struct.unpack('>h', ''.join([chr(x) for x in label[8:10]]))[0] == nrow
+                assert struct.unpack('>h', ''.join([chr(x) for x in label[10:12]]))[0] == nlay
+                iccoln = struct.unpack('>h', ''.join([chr(x) for x in label[12:14]]))[0]
+                icrown = struct.unpack('>h', ''.join([chr(x) for x in label[14:16]]))[0]
+                iclayn = struct.unpack('>h', ''.join([chr(x) for x in label[16:18]]))[0]
+                assert label[18] == iclass
+                assert label[19] == iform
+                iwp = label[20]
+                date = '{}-{}-{} {}:{}:{}'.format(label[21]+1900, *label[22:27])
+                # No test for ncrang, range is extracted from data itself (also prone to errors)!
+                ipltyp = label[55]  # position list type
+                real_coords = label[62]
+                dz, dy, dx, z0, y0, x0 = [1., 1., 1., 0., 0., 0.]
+                if real_coords:
+                    dz = struct.unpack('<f', ''.join([chr(x) for x in label[75:79]]))[0]
+                    z0 = struct.unpack('<f', ''.join([chr(x) for x in label[79:83]]))[0]
+                    dy = struct.unpack('<f', ''.join([chr(x) for x in label[83:87]]))[0]
+                    y0 = struct.unpack('<f', ''.join([chr(x) for x in label[87:91]]))[0]
+                    dx = struct.unpack('<f', ''.join([chr(x) for x in label[91:95]]))[0]
+                    x0 = struct.unpack('<f', ''.join([chr(x) for x in label[95:99]]))[0]
+                assert ''.join([str(unichr(l)) for l in label[100:100+ntitle]]) == title
+                ux = ''.join([chr(l) for l in label[244:248]]).replace('\x00', '')
+                uy = ''.join([chr(l) for l in label[248:252]]).replace('\x00', '')
+                uz = ''.join([chr(l) for l in label[252:256]]).replace('\x00', '')
+            assert np.frombuffer(f.read(4), dtype=np.int32)[0] == rec_length
+            # Read picture data:
+            data = np.empty((nlay, nrow, ncol), dtype=data_format)
+            for k in range(nlay):
+                for j in range(nrow):
+                    rec_length = np.frombuffer(f.read(4), dtype=np.int32)[0]  # length of row
+                    row = np.frombuffer(f.read(rec_length), dtype=data_format)
+                    data[k, j, :] = row
+                    assert np.frombuffer(f.read(4), dtype=np.int32)[0] == rec_length
+        arg_dict = {}
+        arg_dict['data'] = data
+        arg_dict['title'] = title
+        arg_dict['offsets'] = (x0, y0, z0)
+        arg_dict['scales'] = (dx, dy, dz)
+        arg_dict['units'] = (ux, uy, uz)
+        arg_dict['date'] = date
+        arg_dict['ICLASS'] = iclass
+        arg_dict['IFORM'] = iform
+        arg_dict['IVERSN'] = iversn
+        arg_dict['ILABEL'] = ilabel
+        arg_dict['IFORMAT'] = iformat
+        arg_dict['IWP'] = iwp
+        arg_dict['IPLTYP'] = ipltyp
+        arg_dict['ICCOLN'] = iccoln
+        arg_dict['ICROWN'] = icrown
+        arg_dict['ICLAYN'] = iclayn
+        return SemperFormat(arg_dict)
+
+    def save_to_unf(self, filename='semper.unf', skip_header=False):
+        '''Save a :class:`~.SemperFormat` to a file.
+
+        Parameters
+        ----------
+        filename : string, optional
+            The name of the unf-file to which the data should be written.
+        skip_header : boolean, optional
+            Determines if the header, title and label should be skipped (useful for some other
+            programs). Default is False.
+
+        Returns
+        -------
+        None
+
+        '''
+        self._log.debug('Calling to_file')
+        nlay, nrow, ncol = self.data.shape
+        with open(filename, 'wb') as f:
+            if not skip_header:
+                # Create header:
+                header = []
+                header.extend(reversed(list(self.data.shape)))  # inverse order!
+                header.append(self.iclass)
+                header.append(self.iform)
+                header.append(self.iversn*10000 + self.ilabel*1000 + len(self.title))
+                if self.iformat is not None:
+                    header.append(self.iformat)
+                # Write header:
+                f.write(struct.pack('I', 2*len(header)))  # record length, 4 byte format!
+                for element in header:
+                    f.write(struct.pack('h', element))  # 2 byte format!
+                f.write(struct.pack('I', 2*len(header)))  # record length!
+                # Write title:
+                f.write(struct.pack('I', len(self.title)))  # record length, 4 byte format!
+                f.write(self.title)
+                f.write(struct.pack('I', len(self.title)))  # record length, 4 byte format!
+                # Create label:
+                if self.ilabel:
+                    label = np.zeros(256, dtype=np.int32)
+                    label[:6] = [ord(c) for c in 'Semper']
+                    label[6:8] = divmod(ncol, 256)
+                    label[8:10] = divmod(nrow, 256)
+                    label[10:12] = divmod(nlay, 256)
+                    label[12:14] = divmod(self.iccoln, 256)
+                    label[14:16] = divmod(self.icrown, 256)
+                    label[16:18] = divmod(self.iclayn, 256)
+                    label[18] = self.iclass
+                    label[19] = self.iform
+                    label[20] = self.iwp
+                    year, time = self.date.split(' ')
+                    label[21:24] = map(int, year.split('-'))
+                    label[21] -= 1900
+                    label[24:27] = map(int, time.split(':'))
+                    range_string = '{:.4g},{:.4g}'.format(self.data.min(), self.data.max())
+                    ncrang = len(range_string)
+                    label[27] = ncrang
+                    label[28:28+ncrang] = [ord(c) for c in range_string]
+                    label[55] = self.ipltyp
+                    label[62] = 1  # Use real coords!
+                    label[75:79] = [ord(c) for c in struct.pack('<f', self.scales[2])]  # DZ
+                    label[79:83] = [ord(c) for c in struct.pack('<f', self.offsets[2])]  # Z0
+                    label[83:87] = [ord(c) for c in struct.pack('<f', self.scales[1])]  # DY
+                    label[87:91] = [ord(c) for c in struct.pack('<f', self.offsets[1])]  # Y0
+                    label[91:95] = [ord(c) for c in struct.pack('<f', self.scales[0])]  # DX
+                    label[95:99] = [ord(c) for c in struct.pack('<f', self.offsets[0])]  # X0
+                    label[100:100+len(self.title)] = [ord(s) for s in self.title]
+                    label[244:248] = [ord(c) for c in self.units[0]] + [0]*(4-len(self.units[0]))
+                    label[248:252] = [ord(c) for c in self.units[1]] + [0]*(4-len(self.units[1]))
+                    label[252:256] = [ord(c) for c in self.units[2]] + [0]*(4-len(self.units[2]))
+                # Write label:
+                if self.ilabel:
+                    f.write(struct.pack('I', 2*256))  # record length, 4 byte format!
+                    for element in label:
+                        f.write(struct.pack('h', element))  # 2 byte format!
+                    f.write(struct.pack('I', 2*256))  # record length!
+            # Write picture data:
+            for k in range(nlay):
+                for j in range(nrow):
+                    row = self.data[k, j, :]
+                    factor = 8 if self.iform == 3 else 4  # complex numbers need more space!
+                    f.write(struct.pack('I', factor*ncol))  # record length, 4 byte format!
+                    if self.iform == 0:  # bytes:
+                        raise Exception('Byte data is not supported! Use int, float or complex!')
+                    elif self.iform == 1:  # int:
+                        for element in row:
+                            f.write(struct.pack('i', element))  # 4 bytes per data entry!
+                    elif self.iform == 2:  # float:
+                        for element in row:
+                            f.write(struct.pack('f', element))  # 4 bytes per data entry!
+                    elif self.iform == 3:  # complex:
+                        for element in row:
+                            f.write(struct.pack('f', element.real))  # 4 bytes per data entry!
+                            f.write(struct.pack('f', element.imag))  # 4 bytes per data entry!
+                    f.write(struct.pack('I', factor*ncol))  # record length, 4 byte format!
+
+    @classmethod
+    def from_signal(cls, signal):
+        '''Import a :class:`~.SemperFormat` object from a :class:`~hyperspy.signals.Signal` object.
+
+        Parameters
+        ----------
+        signal: :class:`~hyperspy.signals.Signal`
+            The signal which should be imported.
+
+        Returns
+        -------
+        None
+
+        '''
+        data = signal.data
+        assert len(data.shape) <= 3, 'Only up to 3-dimensional datasets can be handled!'
+        scales, offsets, units = [1., 1., 1.], [0., 0., 0.], ['', '', '']
+        for i in range(len(data.shape)):
+            scales[i] = signal.axes_manager[i].scale
+            offsets[i] = signal.axes_manager[i].offset
+            units[i] = signal.axes_manager[i].units
+            if str(units[i]) == '<undefined>':
+                units[i] = ''   # Traits can not be written!
+        for i in range(3 - len(data.shape)):  # Make sure data is 3D!
+            data = np.expand_dims(data, axis=0)
+        iclass = cls.ICLASS_DICT_INV.get(signal.metadata.Signal.record_by, 6)  # 6: undefined
+        if data.dtype.name == 'int8':
+            iform = 0  # byte
+        elif data.dtype.name in ['int16', 'int32']:
+            iform = 1  # int
+        elif data.dtype.name in ['float16', 'float32']:
+            iform = 2  # float
+        elif data.dtype.name == 'complex64':
+            iform = 3  #
+        else:
+            raise TypeError('Data type not understood!')
+        arg_dict = {}
+        arg_dict['data'] = data
+        arg_dict['title'] = signal.metadata.General.as_dictionary().get('title', 'HyperSpy Signal')
+        arg_dict['offsets'] = offsets
+        arg_dict['scales'] = scales
+        arg_dict['units'] = units
+        arg_dict['date'] = strftime('%y-%m-%d %H:%M:%S')
+        arg_dict['ICLASS'] = iclass
+        arg_dict['IFORM'] = iform
+        arg_dict['IVERSN'] = 2  # current standard
+        arg_dict['ILABEL'] = 1  # True
+        arg_dict['IFORMAT'] = None  # not needed
+        arg_dict['IWP'] = 0  # seems standard
+        arg_dict['IPLTYP'] = 248  # seems standard
+        arg_dict['ICCOLN'] = data.shape[2]//2 + 1
+        arg_dict['ICROWN'] = data.shape[1]//2 + 1
+        arg_dict['ICLAYN'] = data.shape[0]//2 + 1
+        return SemperFormat(arg_dict)
+
+    def to_signal(self):
+        '''Export a :class:`~.SemperFormat` object to a :class:`~hyperspy.signals.Signal` object.
+
+        Parameters
+        ----------
+        None
+
+        Returns
+        -------
+        signal: :class:`~hyperspy.signals.Signal`
+            The exported signal.
+
+        '''
+        import hyperspy.api as hp
+        data = np.squeeze(self.data)  # Reduce unneeded dimensions!
+        if self.ICLASS_DICT[self.iclass] == 'spectrum':
+            signal = hp.signals.Spectrum(data)
+        elif self.ICLASS_DICT[self.iclass] == 'image':
+            signal = hp.signals.Image(data)
+        else:
+            signal = hp.signals.Signal(data)
+        for i in range(len(data.shape)):
+            signal.axes_manager[i].name = {0: 'x', 1: 'y', 2: 'z'}[i]
+            signal.axes_manager[i].scale = self.scales[i]
+            signal.axes_manager[i].offset = self.offsets[i]
+            signal.axes_manager[i].units = self.units[i]
+        signal.metadata.General.title = self.title
+        signal.original_metadata.add_dictionary({'date': self.date,
+                                                 'ICLASS': self.iclass,
+                                                 'IFORM': self.iform,
+                                                 'IVERSN': self.iversn,
+                                                 'ILABEL': self.ilabel,
+                                                 'IFORMAT': self.iformat,
+                                                 'IWP': self.iwp,
+                                                 'IPLTYP': self.ipltyp,
+                                                 'ICCOLN': self.iccoln,
+                                                 'ICROWN': self.icrown,
+                                                 'ICLAYN': self.iclayn})
+        return signal
+
+    def print_info(self):
+        '''Print important flag information of the :class:`.~SemperFormat` object.
+
+        Parameters
+        ----------
+        None
+
+        Returns
+        -------
+        None
+
+        '''
+        self._log.debug('Calling print_info')
+        print '\n------------------------------------------------------'
+        print self.title
+        print self.date, '\n'
+        print 'dimensions: x: {}, y: {}, z: {}'.format(*reversed(self.data.shape))
+        print 'scaling:    x: {:.3g}, y: {:.3g}, z: {:.3g}'.format(*self.scales)
+        print 'offsets:    x: {:.3g}, y: {:.3g}, z: {:.3g}'.format(*self.offsets)
+        print 'units:      x: {}, y: {}, z: {}'.format(*self.units)
+        print 'data range:', (self.data.min(), self.data.max()), '\n'
+        print 'ICLASS: ', self.ICLASS_DICT[self.iclass]
+        print 'IFORM : ', self.IFORM_DICT[self.iform]
+        print 'IVERSN: ', self.iversn
+        print 'ILABEL: ', self.ilabel == 1
+        if self.iformat is not None:
+            print 'IFORMAT:', self.iformat
+        if self.ilabel:
+            print 'IWP   : ', self.iwp
+            print 'ICCOLN: ', self.iccoln
+            print 'ICROWN: ', self.icrown
+            print 'ICLAYN: ', self.iclayn
+        print '------------------------------------------------------\n'
+
+
+def file_reader(filename, print_info=False, **kwds):
+    semper = SemperFormat.load_from_unf(filename)
+    if print_info:
+        semper.print_info()
+    signal = semper.to_signal()
+    axes = []
+    for i in range(len(signal.data.shape)):
+        axes.append({'size': signal.axes_manager[i].size,
+                     'index_in_array': signal.axes_manager[i].index_in_array,
+                     'name': signal.axes_manager[i].name,
+                     'scale': signal.axes_manager[i].scale,
+                     'offset': signal.axes_manager[i].offset,
+                     'units': signal.axes_manager[i].units})
+    dictionary = {'data': signal.data,
+                  'axes': axes,
+                  'metadata': signal.metadata.as_dictionary(),
+                  'original_metadata': signal.original_metadata.as_dictionary()}
+    return [dictionary]
+
+
+def file_writer(filename, signal, **kwds):
+    semper = SemperFormat.from_signal(signal)
+    semper.save_to_unf(filename)

--- a/hyperspy/signals.py
+++ b/hyperspy/signals.py
@@ -45,6 +45,5 @@ from hyperspy._signals.dielectric_function import DielectricFunction
 from hyperspy._signals.simulation import Simulation
 from hyperspy._signals.image_simulation import ImageSimulation
 from hyperspy._signals.spectrum_simulation import SpectrumSimulation
-from hyperspy._signals.eels_spectrum_simulation import (
-    EELSSpectrumSimulation)
+from hyperspy._signals.eels_spectrum_simulation import EELSSpectrumSimulation
 from hyperspy.signal import Signal


### PR DESCRIPTION
Added two io_plugins for the EMD format, a hdf5 standard proposed by Colin Ophus from Lawrence Berkeley National Lab (see http://emdatasets.lbl.gov/ not to be confused with the FEI EMD format which was developed later and is mentioned here: https://github.com/hyperspy/hyperspy/issues/698)
and a format for the image processing system Semper, which was developed by Owen Saxton. It has the ending '.unf' and is a binary file with an extensive header.