### PR TITLE
Remove printing elements

### DIFF
--- a/hyperspy/_signals/eels.py
+++ b/hyperspy/_signals/eels.py
@@ -47,7 +47,6 @@ class EELSSpectrum(Spectrum):
         self.edges = list()
         if hasattr(self.metadata, 'Sample') and \
                 hasattr(self.metadata.Sample, 'elements'):
-            print('Elemental composition read from file')
             self.add_elements(self.metadata.Sample.elements)
         self.metadata.Signal.binned = True
 
@@ -128,7 +127,6 @@ class EELSSpectrum(Spectrum):
                             <= end_energy:
                         subshell = '%s_%s' % (element, shell)
                         if subshell not in self.subshells:
-                            print "Adding %s subshell" % subshell
                             self.subshells.add(
                                 '%s_%s' % (element, shell))
                             e_shells.append(subshell)


### PR DESCRIPTION
When adding e.g. the Si element to an `EELSSpectrum` HyperSpy prints:

```
Adding Si_L2 subshell
Adding Si_L3 subshell
Adding Si_L1 subshell
Adding Si_L2 subshell
Adding Si_L3 subshell
```

This is also printed every time that the `EELSSpectrum` is deepcopied, what can become annoying.
This PR removes this "feature".