### PR TITLE
Fix miniconda path that has chnaged in their latests release

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ install:
   - pip install coverage coveralls
   # The following two lines set hyperspy to run headless. This is a temporary
   # workaround until we fix hyperspy so that this is not required.
-  - mkdir ~/.hyperspy 
+  - mkdir ~/.hyperspy
   - printf "[General]\ndefault_toolkit = None" > ~/.hyperspy/hyperspyrc
   - python setup.py install
 
@@ -25,9 +25,9 @@ before_install:
   - if [ ${TRAVIS_PYTHON_VERSION:0:1} == "2" ]; then wget https://repo.continuum.io/miniconda/Miniconda-latest-Linux-x86_64.sh -O miniconda.sh; else wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh; fi
   - chmod +x miniconda.sh
   - ./miniconda.sh -b
-  - export PATH=/home/travis/miniconda/bin:$PATH
+  - export PATH=/home/travis/miniconda2/bin:$PATH
   # miniconda is not always up-to-date with conda.
   - conda update --yes conda
-script: python continuous_integration/nosetest.py --with-coverage hyperspy 
+script: python continuous_integration/nosetest.py --with-coverage hyperspy
 after_success:
     coveralls


### PR DESCRIPTION
miniconda default installation path has changed in their latest release, what breaks our tests. This fixes them.