### PR TITLE
list and tuple printing in DTB

### DIFF
--- a/hyperspy/defaults_parser.py
+++ b/hyperspy/defaults_parser.py
@@ -123,7 +123,7 @@ class GeneralConfig(t.HasTraits):
              '``hyperspy.hspy`` are imported in the user namespace. ')
 
     dtb_expand_structures = t.CBool(
-        False,
+        True,
         label='Expand structures in DictionaryTreeBrowser',
         desc='If enabled, when printing DictionaryTreeBrowser (e.g. metadata), '
              'long lists and tuples will be expanded and any dictionaries in them will be '

--- a/hyperspy/defaults_parser.py
+++ b/hyperspy/defaults_parser.py
@@ -72,6 +72,7 @@ else:
 
 
 class GeneralConfig(t.HasTraits):
+
     default_file_format = t.Enum(
         'hdf5',
         'rpl',
@@ -120,6 +121,13 @@ class GeneralConfig(t.HasTraits):
         desc='If enabled, when starting HyperSpy using the `hyperspy` '
              'IPython magic of the starting scripts, all the contents of '
              '``hyperspy.hspy`` are imported in the user namespace. ')
+
+    dtb_expand_structures = t.CBool(
+        False,
+        label='Expand structures in DictionaryTreeBrowser',
+        desc='If enabled, when printing DictionaryTreeBrowser (e.g. metadata), '
+             'long lists and tuples will be expanded and any dictionaries in them will be '
+             'printed similar to DictionaryTreeBrowser, but with double lines')
 
     def _logger_on_changed(self, old, new):
         if new is True:

--- a/hyperspy/misc/utils.py
+++ b/hyperspy/misc/utils.py
@@ -255,6 +255,14 @@ class DictionaryTreeBrowser(object):
             if not isinstance(key_, types.MethodType):
                 key = ensure_unicode(value['key'])
                 value = value['_dtb_value_']
+                if isinstance(value, list):
+                    key += u" <list>"
+                    value = DictionaryTreeBrowser(
+                        {u'[%d]' % i: v for i, v in enumerate(value)})
+                if isinstance(value, tuple):
+                    key += u" <tuple>"
+                    value = DictionaryTreeBrowser(
+                        {u'[%d]' % i: v for i, v in enumerate(value)})
                 if isinstance(value, DictionaryTreeBrowser):
                     if j == eoi - 1:
                         symbol = u'└── '

--- a/hyperspy/misc/utils.py
+++ b/hyperspy/misc/utils.py
@@ -252,7 +252,7 @@ class DictionaryTreeBrowser(object):
         from hyperspy.defaults_parser import preferences
 
         def check_long_string(value, max_len):
-            if not isinstance(value, (str, np.string_)):
+            if not isinstance(value, (basestring, np.string_)):
                 value = repr(value)
             value = ensure_unicode(value)
             strvalue = unicode(value)

--- a/hyperspy/misc/utils.py
+++ b/hyperspy/misc/utils.py
@@ -214,17 +214,20 @@ class DictionaryTreeBrowser(object):
 
     """
 
-    def __init__(self, dictionary=None):
+    def __init__(self, dictionary=None, double_lines=False):
+        self._double_lines = double_lines
         if not dictionary:
             dictionary = {}
         super(DictionaryTreeBrowser, self).__init__()
-        self.add_dictionary(dictionary)
+        self.add_dictionary(dictionary, double_lines=double_lines)
 
-    def add_dictionary(self, dictionary):
+    def add_dictionary(self, dictionary, double_lines=False):
         """Add new items from dictionary.
 
         """
         for key, value in dictionary.iteritems():
+            if key == '_double_lines':
+                value = double_lines
             self.__setattr__(key, value)
 
     def export(self, filename, encoding='utf8'):
@@ -246,50 +249,66 @@ class DictionaryTreeBrowser(object):
         """Prints only the attributes that are not methods
 
         """
+        from hyperspy.defaults_parser import preferences
+
+        def check_long_string(value, max_len):
+            if not isinstance(value, (str, np.string_)):
+                value = repr(value)
+            value = ensure_unicode(value)
+            strvalue = unicode(value)
+            _long = False
+            if max_len is not None and len(strvalue) > 2 * max_len:
+                right_limit = min(max_len, len(strvalue) - max_len)
+                strvalue = u'%s ... %s' % (
+                    strvalue[:max_len], strvalue[-right_limit:])
+                _long = True
+            return _long, strvalue
+
         string = ''
         eoi = len(self)
         j = 0
+        if preferences.General.dtb_expand_structures and self._double_lines:
+            s_end = u'╚══ '
+            s_middle = u'╠══ '
+            pad_middle = u'║   '
+        else:
+            s_end = u'└── '
+            s_middle = u'├── '
+            pad_middle = u'│   '
         for key_, value in iter(sorted(self.__dict__.iteritems())):
             if key_.startswith("_"):
                 continue
             if not isinstance(key_, types.MethodType):
                 key = ensure_unicode(value['key'])
                 value = value['_dtb_value_']
-                if isinstance(value, list):
-                    key += u" <list>"
-                    value = DictionaryTreeBrowser(
-                        {u'[%d]' % i: v for i, v in enumerate(value)})
-                if isinstance(value, tuple):
-                    key += u" <tuple>"
-                    value = DictionaryTreeBrowser(
-                        {u'[%d]' % i: v for i, v in enumerate(value)})
+                if j == eoi - 1:
+                    symbol = s_end
+                else:
+                    symbol = s_middle
+                if preferences.General.dtb_expand_structures:
+                    if isinstance(value, list) or isinstance(value, tuple):
+                        iflong, strvalue = check_long_string(value, max_len)
+                        if iflong:
+                            key += u" <list>" if isinstance(value,
+                                                            list) else u" <tuple>"
+                            value = DictionaryTreeBrowser(
+                                {u'[%d]' % i: v for i, v in enumerate(value)}, double_lines=True)
+                        else:
+                            string += u"%s%s%s = %s\n" % (
+                                padding, symbol, key, strvalue)
+                            j += 1
+                            continue
+
                 if isinstance(value, DictionaryTreeBrowser):
-                    if j == eoi - 1:
-                        symbol = u'└── '
-                    else:
-                        symbol = u'├── '
                     string += u'%s%s%s\n' % (padding, symbol, key)
                     if j == eoi - 1:
                         extra_padding = u'    '
                     else:
-                        extra_padding = u'│   '
+                        extra_padding = pad_middle
                     string += value._get_print_items(
                         padding + extra_padding)
                 else:
-                    if not isinstance(value, (str, np.string_)):
-                        value = repr(value)
-                    value = ensure_unicode(value)
-                    if j == eoi - 1:
-                        symbol = u'└── '
-                    else:
-                        symbol = u'├── '
-                    strvalue = unicode(value)
-                    if max_len is not None and \
-                            len(strvalue) > 2 * max_len:
-                        right_limit = min(max_len,
-                                          len(strvalue) - max_len)
-                        strvalue = u'%s ... %s' % (strvalue[:max_len],
-                                                   strvalue[-right_limit:])
+                    _, strvalue = check_long_string(value, max_len)
                     string += u"%s%s%s = %s\n" % (
                         padding, symbol, key, strvalue)
             j += 1
@@ -320,10 +339,14 @@ class DictionaryTreeBrowser(object):
         slugified_key = str(slugify(key, valid_variable_name=True))
         if isinstance(value, dict):
             if self.has_item(slugified_key):
-                self.get_item(slugified_key).add_dictionary(value)
+                self.get_item(slugified_key).add_dictionary(
+                    value,
+                    double_lines=self._double_lines)
                 return
             else:
-                value = DictionaryTreeBrowser(value)
+                value = DictionaryTreeBrowser(
+                    value,
+                    double_lines=self._double_lines)
         super(DictionaryTreeBrowser, self).__setattr__(
             slugified_key,
             {'key': key, '_dtb_value_': value})


### PR DESCRIPTION
Now splits __long__ lists and tuples to temporary dictionary (only when printing, the structure is still the same inside) with keys as indices. Also shows the type of the expanded object (so that just by looking you can tell how to interact).

Behaviour example:
```python
In [2]: s = hs.signals.EELSSpectrum(range(10))
In [3]: s.metadata.Signal.new_thing = [s.metadata.as_dictionary(), (1,2,3), 'asd']
In [4]: hs.preferences.General.dtb_expand_structures = False
In [5]: s.metadata
Out[5]:
├── General
│   └── title =
└── Signal
    ├── binned = True
    ├── new_thing = [{'_double_lines': False, '_HyperSpy': {'_double_lines': False, 'Folding': {'u ... ectrum'}, 'Gene
ral': {'_double_lines': False, 'title': ''}}, (1, 2, 3), 'asd']
    ├── record_by = spectrum
    ├── signal_origin =
    └── signal_type = EELS

In [6]: hs.preferences.General.dtb_expand_structures = True
In [7]: s.metadata
Out[7]:
├── General
│   └── title =
└── Signal
    ├── binned = True
    ├── new_thing <list>
    │   ╠══ [0]
    │   ║   ╠══ General
    │   ║   ║   ╚══ title =
    │   ║   ╚══ Signal
    │   ║       ╠══ binned = True
    │   ║       ╠══ record_by = spectrum
    │   ║       ╠══ signal_origin =
    │   ║       ╚══ signal_type = EELS
    │   ╠══ [1] = (1, 2, 3)
    │   ╚══ [2] = asd
    ├── record_by = spectrum
    ├── signal_origin =
    └── signal_type = EELS

In [8]: s.metadata.Signal.new_thing
Out[8]:
[{'General': {'_double_lines': False, 'title': ''},
  'Signal': {'_double_lines': False,
   'binned': True,
   'record_by': 'spectrum',
   'signal_origin': '',
   'signal_type': 'EELS'},
  '_HyperSpy': {'Folding': {'_double_lines': False,
    'original_axes_manager': None,
    'original_shape': None,
    'signal_unfolded': False,
    'unfolded': False},
   '_double_lines': False},
  '_double_lines': False},
 (1, 2, 3),
 'asd']

```
