### PR TITLE
ENH: Reorder filters in `estimate_image_shift()`

### DIFF
--- a/hyperspy/misc/image_tools.py
+++ b/hyperspy/misc/image_tools.py
@@ -148,12 +148,12 @@ def estimate_image_shift(ref, image, roi=None, sobel=True,
 
     # Apply filters
     for im in (ref, image):
-        if hanning is True:
-            im *= hanning2d(*im.shape)
         if medfilter is True:
             im[:] = sp.signal.medfilt(im)
         if sobel is True:
             im[:] = sobel_filter(im)
+        if hanning is True:
+            im *= hanning2d(*im.shape)
 
     phase_correlation = fft_correlation(ref, image,
                                         normalize=normalize_corr)

--- a/hyperspy/misc/image_tools.py
+++ b/hyperspy/misc/image_tools.py
@@ -55,8 +55,8 @@ def hanning2d(M, N):
 
 
 def sobel_filter(im):
-    sx = sp.ndimage.sobel(im, axis=0, mode='constant')
-    sy = sp.ndimage.sobel(im, axis=1, mode='constant')
+    sx = sp.ndimage.sobel(im, axis=0)
+    sy = sp.ndimage.sobel(im, axis=1)
     sob = np.hypot(sx, sy)
     return sob
 


### PR DESCRIPTION
Reordered filters in `misc.image_tools.estimate_image_shift()` as discussed in #739.

Also fixed a rather strange default option for the sobel filter's `mode` argument: This setting is really only important at image edges. The default value (suggested change) assures that the sobel is always zero at the edges. The previous setting of `'constant'` is only significant when not using a hanning filter, but if a hanning is not used it basically introduces a strong edge along the outside of the image for any non-zero edges, basically locking the image in place.