### PR TITLE
Forces GC as memmaps close filehandle on deletion

### DIFF
--- a/hyperspy/tests/io/test_hdf5.py
+++ b/hyperspy/tests/io/test_hdf5.py
@@ -2,6 +2,7 @@ import os.path
 from os import remove
 import datetime
 import h5py
+import gc
 
 import nose.tools as nt
 import numpy as np
@@ -209,6 +210,7 @@ class TestSavingMetadataContainers:
         nt.assert_is_instance(l.metadata.test[2], unicode)
 
     def tearDown(self):
+        gc.collect()        # Make sure any memmaps are closed first!
         remove('tmp.hdf5')
 
 
@@ -259,4 +261,5 @@ class TestLoadingOOMReadOnly:
         nt.assert_is_instance(s.data, h5py.Dataset)
 
     def tearDown(self):
+        gc.collect()        # Make sure any memmaps are closed first!
         remove('tmp.hdf5')

--- a/hyperspy/tests/model/test_model_storing.py
+++ b/hyperspy/tests/model/test_model_storing.py
@@ -22,8 +22,9 @@ from os import remove
 import nose.tools as nt
 from hyperspy._signals.spectrum import Spectrum
 from hyperspy.io import load
-from hyperspy.components import Gaussian, Lorentzian
+from hyperspy.components import Gaussian
 import mock
+import gc
 
 
 def clean_model_dictionary(d):
@@ -150,7 +151,6 @@ class TestModelSaving:
 
     def test_save_and_load_model(self):
         m = self.m
-        s = m.spectrum
         m.save('tmp.hdf5')
         l = load('tmp.hdf5')
         nt.assert_true(hasattr(l.models, 'a'))
@@ -158,4 +158,5 @@ class TestModelSaving:
         nt.assert_equal(n.components.something.A.value, 13)
 
     def tearDown(self):
+        gc.collect()        # Make sure any memmaps are closed first!
         remove('tmp.hdf5')


### PR DESCRIPTION
Previously HDF5 test failed on Windows, since Windows won't allow you to delete a file that is opened in another process. This PR forces a GC collection just prior to file removal, so that the `memmap` closes its file handle.