### PR TITLE
Make CI fail on warnings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,7 @@ install:
   - mkdir ~/.hyperspy
   - printf "[General]\ndefault_toolkit = None" > ~/.hyperspy/hyperspyrc
   - python setup.py install
+  - export PYTHONWARNINGS=error
 
 before_install:
   # then install python version to test

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,8 +10,8 @@ env:
   - export FAIL_ON_EXTERNAL_DEPRECATION='True'
 
 matrix:
-    allow_failures:
-        env: export FAIL_ON_EXTERNAL_DEPRECATION='True'
+  allow_failures:
+    - env: export FAIL_ON_EXTERNAL_DEPRECATION='True'
     
 
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,8 +10,8 @@ env:
   - export FAIL_ON_EXTERNAL_DEPRECATION='True'
 
 matrix:
-+  allow_failures:
-+      env: FAIL_ON_EXTERNAL_DEPRECATION='True'
+    allow_failures:
+        env: FAIL_ON_EXTERNAL_DEPRECATION='True'
     
 
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,9 +6,12 @@ python:
   - 2.7
 
 env:
-  - DEPS="nose numpy scipy matplotlib traits traitsui ipython h5py sympy scikit-learn dill mock"
+  - PYTHONWARNINGS="error,default:DeprecationWarning::(!hyperspy),ignore:UserWarning:Failed to import the optional scikit image package"
+  - PYTHONWARNINGS="error,ignore:DeprecationWarning:BaseException\.message has been deprecated as of Python 2\.6,ignore:UserWarning:Failed to import the optional scikit image package"
+    
 
 install:
+  - export DEPS="nose numpy scipy matplotlib traits traitsui ipython h5py sympy scikit-learn dill mock"
   - conda create -n testenv --yes python=$TRAVIS_PYTHON_VERSION
   - source activate testenv
   - conda install --yes $DEPS

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ env:
 
 matrix:
     allow_failures:
-        env: FAIL_ON_EXTERNAL_DEPRECATION='True'
+        env: export FAIL_ON_EXTERNAL_DEPRECATION='True'
     
 
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,8 @@ python:
   - 2.7
 
 env:
-  - PYTHONWARNINGS="error,default:DeprecationWarning::(!hyperspy),ignore:UserWarning:Failed to import the optional scikit image package"
-  - PYTHONWARNINGS="error,ignore:DeprecationWarning:BaseException\.message has been deprecated as of Python 2\.6,ignore:UserWarning:Failed to import the optional scikit image package"
+  - export FAIL_ON_EXTERNAL_DEPRECATION='True'
+  - export FAIL_ON_EXTERNAL_DEPRECATION='False'
     
 
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,12 +6,16 @@ python:
   - 2.7
 
 env:
-  - export FAIL_ON_EXTERNAL_DEPRECATION='True'
   - export FAIL_ON_EXTERNAL_DEPRECATION='False'
+  - export FAIL_ON_EXTERNAL_DEPRECATION='True'
+
+matrix:
++  allow_failures:
++      env: FAIL_ON_EXTERNAL_DEPRECATION='True'
     
 
 install:
-  - export DEPS="nose numpy scipy matplotlib traits traitsui ipython h5py sympy scikit-learn dill mock"
+  - DEPS="nose numpy scipy matplotlib traits traitsui ipython h5py sympy scikit-learn dill mock"
   - conda create -n testenv --yes python=$TRAVIS_PYTHON_VERSION
   - source activate testenv
   - conda install --yes $DEPS

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,6 @@ install:
   - mkdir ~/.hyperspy
   - printf "[General]\ndefault_toolkit = None" > ~/.hyperspy/hyperspyrc
   - python setup.py install
-  - export PYTHONWARNINGS=error
 
 before_install:
   # then install python version to test

--- a/continuous_integration/nosetest.py
+++ b/continuous_integration/nosetest.py
@@ -3,8 +3,11 @@
 
 if __name__ == '__main__':
     import sys
+    import os
     from nose import run_exit
     from traits.etsconfig.api import ETSConfig
 
     ETSConfig.toolkit = "null"
+    env = os.environ.copy()
+    env['PYTHONWARNINGS'] = 'error,ignore::ImportWarning'
     sys.exit(run_exit())

--- a/continuous_integration/nosetest.py
+++ b/continuous_integration/nosetest.py
@@ -3,11 +3,8 @@
 
 if __name__ == '__main__':
     import sys
-    import os
     from nose import run_exit
     from traits.etsconfig.api import ETSConfig
 
     ETSConfig.toolkit = "null"
-    env = os.environ.copy()
-    env['PYTHONWARNINGS'] = 'error'
-    sys.exit(run_exit(env=env))
+    sys.exit(run_exit())

--- a/continuous_integration/nosetest.py
+++ b/continuous_integration/nosetest.py
@@ -10,4 +10,4 @@ if __name__ == '__main__':
     ETSConfig.toolkit = "null"
     env = os.environ.copy()
     env['PYTHONWARNINGS'] = 'error,ignore::ImportWarning'
-    sys.exit(run_exit())
+    sys.exit(run_exit(env=env))

--- a/continuous_integration/nosetest.py
+++ b/continuous_integration/nosetest.py
@@ -5,6 +5,33 @@ if __name__ == '__main__':
     import sys
     from nose import run_exit
     from traits.etsconfig.api import ETSConfig
-
+    import os
+    import warnings
     ETSConfig.toolkit = "null"
+
+    # Check if we should fail on external deprecation messages
+    fail_on_external = os.environ.pop('FAIL_ON_EXTERNAL_DEPRECATION', False)
+    if isinstance(fail_on_external, basestring):
+        fail_on_external = (fail_on_external.lower() in
+            ['true', 't', '1', 'yes', 'y', 'set'])
+
+    # Fall-back filter: Error
+    warnings.simplefilter('error')
+    warnings.filterwarnings(
+        'ignore',"Failed to import the optional scikit image package", 
+        UserWarning)
+
+    if fail_on_external:
+        # Travis setup has this:
+        warnings.filterwarnings(
+            'ignore',
+            "BaseException\.message has been deprecated as of Python 2\.6",
+            DeprecationWarning)
+        # Don't care about warnings in hyperspy
+        warnings.filterwarnings('default', module="hyperspy")
+    else:
+        # Default behavior for non-hyperspy deprecations
+        warnings.filterwarnings('default', category=DeprecationWarning,
+                                module="(?!hyperspy)")
+
     sys.exit(run_exit())

--- a/continuous_integration/nosetest.py
+++ b/continuous_integration/nosetest.py
@@ -4,7 +4,12 @@
 if __name__ == '__main__':
     import sys
     from nose import run_exit
+    import warnings
     from traits.etsconfig.api import ETSConfig
 
+    warnings.simplefilter('error')
+    warnings.filterwarnings(
+        'ignore', "Failed to import the optional scikit image package",
+        UserWarning)
     ETSConfig.toolkit = "null"
     sys.exit(run_exit())

--- a/continuous_integration/nosetest.py
+++ b/continuous_integration/nosetest.py
@@ -7,9 +7,9 @@ if __name__ == '__main__':
     import warnings
     from traits.etsconfig.api import ETSConfig
 
+    ETSConfig.toolkit = "null"
     warnings.simplefilter('error')
     warnings.filterwarnings(
         'ignore', "Failed to import the optional scikit image package",
         UserWarning)
-    ETSConfig.toolkit = "null"
     sys.exit(run_exit())

--- a/continuous_integration/nosetest.py
+++ b/continuous_integration/nosetest.py
@@ -12,4 +12,8 @@ if __name__ == '__main__':
     warnings.filterwarnings(
         'ignore', "Failed to import the optional scikit image package",
         UserWarning)
+    warnings.filterwarnings(
+        'ignore',
+        "BaseException\.message has been deprecated as of Python 2\.6",
+        DeprecationWarning)
     sys.exit(run_exit())

--- a/continuous_integration/nosetest.py
+++ b/continuous_integration/nosetest.py
@@ -4,16 +4,7 @@
 if __name__ == '__main__':
     import sys
     from nose import run_exit
-    import warnings
     from traits.etsconfig.api import ETSConfig
 
     ETSConfig.toolkit = "null"
-    warnings.simplefilter('error')
-    warnings.filterwarnings(
-        'ignore', "Failed to import the optional scikit image package",
-        UserWarning)
-    warnings.filterwarnings(
-        'ignore',
-        "BaseException\.message has been deprecated as of Python 2\.6",
-        DeprecationWarning)
     sys.exit(run_exit())

--- a/continuous_integration/nosetest.py
+++ b/continuous_integration/nosetest.py
@@ -9,5 +9,5 @@ if __name__ == '__main__':
 
     ETSConfig.toolkit = "null"
     env = os.environ.copy()
-    env['PYTHONWARNINGS'] = 'error,ignore::ImportWarning'
+    env['PYTHONWARNINGS'] = 'error'
     sys.exit(run_exit(env=env))


### PR DESCRIPTION
In order to make the repo more polished, this PR proposes to make the continuous integration fail on warnings. Any acceptable warnings (e.g. deprecation warnings) should then be manually allowed in the tests (possibly even asserting that a warning is given as expected).

Main motivation: Some features in master currently rely on deprecated functionality internally, meaning users get deprecation warnings for what should be non-deprecated functions from their point of view. This could possibly lead to users ignoring deprecation warnings, either mentally or by filtering. By enforcing strict CI, these should be weeded out. There are also some warnings that have been there for as long as I can remember, so those should get some extra attention to see if the warnings are really needed or cleaned up somehow.