### PR TITLE
Correct .gitignore that was ignoring the API docs and /bin files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,6 @@ syntax: glob
 .spyderworkspace
 .coverage
 /MANIFEST
-/*.rst
 *.pyc
 *.pyd
 *.swp
@@ -14,7 +13,7 @@ dist
 *.deb
 *.swo
 build/*
-bin/*
+bin/*.bat
 PortableInstall/*
 hyperspy.egg-info/*
 deb_dist/*
@@ -25,11 +24,11 @@ doc/_build/*
 doc/.build/*
 doc/user_guide/_build/*
 doc/user_guide/.build/*
-doc/api/*.rst
 setup/windows/requires/*
 setup/windows/reccomends/*
 doc/examples
 doc/gh-pages
+doc/log.txt
 *Thumbs.db
 .ropeproject/*
 .idea/*

--- a/doc/api/hyperspy._components.rst
+++ b/doc/api/hyperspy._components.rst
@@ -1,0 +1,190 @@
+hyperspy._components package
+============================
+
+Submodules
+----------
+
+hyperspy._components.arctan module
+----------------------------------
+
+.. automodule:: hyperspy._components.arctan
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+hyperspy._components.bleasdale module
+-------------------------------------
+
+.. automodule:: hyperspy._components.bleasdale
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+hyperspy._components.eels_cl_edge module
+----------------------------------------
+
+.. automodule:: hyperspy._components.eels_cl_edge
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+hyperspy._components.eels_double_offset module
+----------------------------------------------
+
+.. automodule:: hyperspy._components.eels_double_offset
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+hyperspy._components.eels_double_power_law module
+-------------------------------------------------
+
+.. automodule:: hyperspy._components.eels_double_power_law
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+hyperspy._components.eels_vignetting module
+-------------------------------------------
+
+.. automodule:: hyperspy._components.eels_vignetting
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+hyperspy._components.error_function module
+------------------------------------------
+
+.. automodule:: hyperspy._components.error_function
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+hyperspy._components.exponential module
+---------------------------------------
+
+.. automodule:: hyperspy._components.exponential
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+hyperspy._components.expression module
+--------------------------------------
+
+.. automodule:: hyperspy._components.expression
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+hyperspy._components.gaussian module
+------------------------------------
+
+.. automodule:: hyperspy._components.gaussian
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+hyperspy._components.logistic module
+------------------------------------
+
+.. automodule:: hyperspy._components.logistic
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+hyperspy._components.lorentzian module
+--------------------------------------
+
+.. automodule:: hyperspy._components.lorentzian
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+hyperspy._components.offset module
+----------------------------------
+
+.. automodule:: hyperspy._components.offset
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+hyperspy._components.pes_core_line_shape module
+-----------------------------------------------
+
+.. automodule:: hyperspy._components.pes_core_line_shape
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+hyperspy._components.pes_see module
+-----------------------------------
+
+.. automodule:: hyperspy._components.pes_see
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+hyperspy._components.polynomial module
+--------------------------------------
+
+.. automodule:: hyperspy._components.polynomial
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+hyperspy._components.power_law module
+-------------------------------------
+
+.. automodule:: hyperspy._components.power_law
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+hyperspy._components.rc module
+------------------------------
+
+.. automodule:: hyperspy._components.rc
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+hyperspy._components.scalable_fixed_pattern module
+--------------------------------------------------
+
+.. automodule:: hyperspy._components.scalable_fixed_pattern
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+hyperspy._components.spline module
+----------------------------------
+
+.. automodule:: hyperspy._components.spline
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+hyperspy._components.voigt module
+---------------------------------
+
+.. automodule:: hyperspy._components.voigt
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+hyperspy._components.volume_plasmon_drude module
+------------------------------------------------
+
+.. automodule:: hyperspy._components.volume_plasmon_drude
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+
+Module contents
+---------------
+
+.. automodule:: hyperspy._components
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/doc/api/hyperspy._signals.rst
+++ b/doc/api/hyperspy._signals.rst
@@ -1,0 +1,110 @@
+hyperspy._signals package
+=========================
+
+Submodules
+----------
+
+hyperspy._signals.dielectric_function module
+--------------------------------------------
+
+.. automodule:: hyperspy._signals.dielectric_function
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+hyperspy._signals.eds module
+----------------------------
+
+.. automodule:: hyperspy._signals.eds
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+hyperspy._signals.eds_sem module
+--------------------------------
+
+.. automodule:: hyperspy._signals.eds_sem
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+hyperspy._signals.eds_tem module
+--------------------------------
+
+.. automodule:: hyperspy._signals.eds_tem
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+hyperspy._signals.eels module
+-----------------------------
+
+.. automodule:: hyperspy._signals.eels
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+hyperspy._signals.eels_spectrum_simulation module
+-------------------------------------------------
+
+.. automodule:: hyperspy._signals.eels_spectrum_simulation
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+hyperspy._signals.image module
+------------------------------
+
+.. automodule:: hyperspy._signals.image
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+hyperspy._signals.image_simulation module
+-----------------------------------------
+
+.. automodule:: hyperspy._signals.image_simulation
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+hyperspy._signals.pes module
+----------------------------
+
+.. automodule:: hyperspy._signals.pes
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+hyperspy._signals.simulation module
+-----------------------------------
+
+.. automodule:: hyperspy._signals.simulation
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+hyperspy._signals.spectrum module
+---------------------------------
+
+.. automodule:: hyperspy._signals.spectrum
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+hyperspy._signals.spectrum_simulation module
+--------------------------------------------
+
+.. automodule:: hyperspy._signals.spectrum_simulation
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+
+Module contents
+---------------
+
+.. automodule:: hyperspy._signals
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/doc/api/hyperspy.datasets.rst
+++ b/doc/api/hyperspy.datasets.rst
@@ -1,0 +1,22 @@
+hyperspy.datasets package
+=========================
+
+Submodules
+----------
+
+hyperspy.datasets.example_signals module
+----------------------------------------
+
+.. automodule:: hyperspy.datasets.example_signals
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+
+Module contents
+---------------
+
+.. automodule:: hyperspy.datasets
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/doc/api/hyperspy.docstrings.rst
+++ b/doc/api/hyperspy.docstrings.rst
@@ -1,0 +1,10 @@
+hyperspy.docstrings package
+===========================
+
+Module contents
+---------------
+
+.. automodule:: hyperspy.docstrings
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/doc/api/hyperspy.drawing._markers.rst
+++ b/doc/api/hyperspy.drawing._markers.rst
@@ -1,0 +1,78 @@
+hyperspy.drawing._markers package
+=================================
+
+Submodules
+----------
+
+hyperspy.drawing._markers.horizontal_line module
+------------------------------------------------
+
+.. automodule:: hyperspy.drawing._markers.horizontal_line
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+hyperspy.drawing._markers.horizontal_line_segment module
+--------------------------------------------------------
+
+.. automodule:: hyperspy.drawing._markers.horizontal_line_segment
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+hyperspy.drawing._markers.line_segment module
+---------------------------------------------
+
+.. automodule:: hyperspy.drawing._markers.line_segment
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+hyperspy.drawing._markers.point module
+--------------------------------------
+
+.. automodule:: hyperspy.drawing._markers.point
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+hyperspy.drawing._markers.rectangle module
+------------------------------------------
+
+.. automodule:: hyperspy.drawing._markers.rectangle
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+hyperspy.drawing._markers.text module
+-------------------------------------
+
+.. automodule:: hyperspy.drawing._markers.text
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+hyperspy.drawing._markers.vertical_line module
+----------------------------------------------
+
+.. automodule:: hyperspy.drawing._markers.vertical_line
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+hyperspy.drawing._markers.vertical_line_segment module
+------------------------------------------------------
+
+.. automodule:: hyperspy.drawing._markers.vertical_line_segment
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+
+Module contents
+---------------
+
+.. automodule:: hyperspy.drawing._markers
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/doc/api/hyperspy.drawing.rst
+++ b/doc/api/hyperspy.drawing.rst
@@ -1,0 +1,101 @@
+hyperspy.drawing package
+========================
+
+Subpackages
+-----------
+
+.. toctree::
+
+    hyperspy.drawing._markers
+
+Submodules
+----------
+
+hyperspy.drawing.figure module
+------------------------------
+
+.. automodule:: hyperspy.drawing.figure
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+hyperspy.drawing.image module
+-----------------------------
+
+.. automodule:: hyperspy.drawing.image
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+hyperspy.drawing.marker module
+------------------------------
+
+.. automodule:: hyperspy.drawing.marker
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+hyperspy.drawing.mpl_he module
+------------------------------
+
+.. automodule:: hyperspy.drawing.mpl_he
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+hyperspy.drawing.mpl_hie module
+-------------------------------
+
+.. automodule:: hyperspy.drawing.mpl_hie
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+hyperspy.drawing.mpl_hse module
+-------------------------------
+
+.. automodule:: hyperspy.drawing.mpl_hse
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+hyperspy.drawing.signal module
+------------------------------
+
+.. automodule:: hyperspy.drawing.signal
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+hyperspy.drawing.spectrum module
+--------------------------------
+
+.. automodule:: hyperspy.drawing.spectrum
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+hyperspy.drawing.utils module
+-----------------------------
+
+.. automodule:: hyperspy.drawing.utils
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+hyperspy.drawing.widgets module
+-------------------------------
+
+.. automodule:: hyperspy.drawing.widgets
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+
+Module contents
+---------------
+
+.. automodule:: hyperspy.drawing
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/doc/api/hyperspy.external.astroML.rst
+++ b/doc/api/hyperspy.external.astroML.rst
@@ -1,0 +1,30 @@
+hyperspy.external.astroML package
+=================================
+
+Submodules
+----------
+
+hyperspy.external.astroML.bayesian_blocks module
+------------------------------------------------
+
+.. automodule:: hyperspy.external.astroML.bayesian_blocks
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+hyperspy.external.astroML.histtools module
+------------------------------------------
+
+.. automodule:: hyperspy.external.astroML.histtools
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+
+Module contents
+---------------
+
+.. automodule:: hyperspy.external.astroML
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/doc/api/hyperspy.external.mpfit.rst
+++ b/doc/api/hyperspy.external.mpfit.rst
@@ -1,0 +1,45 @@
+hyperspy.external.mpfit package
+===============================
+
+Subpackages
+-----------
+
+.. toctree::
+
+    hyperspy.external.mpfit.tests
+
+Submodules
+----------
+
+hyperspy.external.mpfit.mpfit module
+------------------------------------
+
+.. automodule:: hyperspy.external.mpfit.mpfit
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+hyperspy.external.mpfit.mpfitexpr module
+----------------------------------------
+
+.. automodule:: hyperspy.external.mpfit.mpfitexpr
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+hyperspy.external.mpfit.test_mpfit module
+-----------------------------------------
+
+.. automodule:: hyperspy.external.mpfit.test_mpfit
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+
+Module contents
+---------------
+
+.. automodule:: hyperspy.external.mpfit
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/doc/api/hyperspy.external.mpfit.tests.rst
+++ b/doc/api/hyperspy.external.mpfit.tests.rst
@@ -1,0 +1,22 @@
+hyperspy.external.mpfit.tests package
+=====================================
+
+Submodules
+----------
+
+hyperspy.external.mpfit.tests.test_mpfit module
+-----------------------------------------------
+
+.. automodule:: hyperspy.external.mpfit.tests.test_mpfit
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+
+Module contents
+---------------
+
+.. automodule:: hyperspy.external.mpfit.tests
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/doc/api/hyperspy.external.rst
+++ b/doc/api/hyperspy.external.rst
@@ -1,0 +1,38 @@
+hyperspy.external package
+=========================
+
+Subpackages
+-----------
+
+.. toctree::
+
+    hyperspy.external.astroML
+    hyperspy.external.mpfit
+
+Submodules
+----------
+
+hyperspy.external.progressbar module
+------------------------------------
+
+.. automodule:: hyperspy.external.progressbar
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+hyperspy.external.tifffile module
+---------------------------------
+
+.. automodule:: hyperspy.external.tifffile
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+
+Module contents
+---------------
+
+.. automodule:: hyperspy.external
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/doc/api/hyperspy.misc.eds.rst
+++ b/doc/api/hyperspy.misc.eds.rst
@@ -1,0 +1,22 @@
+hyperspy.misc.eds package
+=========================
+
+Submodules
+----------
+
+hyperspy.misc.eds.utils module
+------------------------------
+
+.. automodule:: hyperspy.misc.eds.utils
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+
+Module contents
+---------------
+
+.. automodule:: hyperspy.misc.eds
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/doc/api/hyperspy.misc.eels.rst
+++ b/doc/api/hyperspy.misc.eels.rst
@@ -1,0 +1,54 @@
+hyperspy.misc.eels package
+==========================
+
+Submodules
+----------
+
+hyperspy.misc.eels.base_gos module
+----------------------------------
+
+.. automodule:: hyperspy.misc.eels.base_gos
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+hyperspy.misc.eels.effective_angle module
+-----------------------------------------
+
+.. automodule:: hyperspy.misc.eels.effective_angle
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+hyperspy.misc.eels.hartree_slater_gos module
+--------------------------------------------
+
+.. automodule:: hyperspy.misc.eels.hartree_slater_gos
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+hyperspy.misc.eels.hydrogenic_gos module
+----------------------------------------
+
+.. automodule:: hyperspy.misc.eels.hydrogenic_gos
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+hyperspy.misc.eels.tools module
+-------------------------------
+
+.. automodule:: hyperspy.misc.eels.tools
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+
+Module contents
+---------------
+
+.. automodule:: hyperspy.misc.eels
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/doc/api/hyperspy.misc.io.rst
+++ b/doc/api/hyperspy.misc.io.rst
@@ -1,0 +1,38 @@
+hyperspy.misc.io package
+========================
+
+Submodules
+----------
+
+hyperspy.misc.io.tools module
+-----------------------------
+
+.. automodule:: hyperspy.misc.io.tools
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+hyperspy.misc.io.ttols module
+-----------------------------
+
+.. automodule:: hyperspy.misc.io.ttols
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+hyperspy.misc.io.utils_readfile module
+--------------------------------------
+
+.. automodule:: hyperspy.misc.io.utils_readfile
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+
+Module contents
+---------------
+
+.. automodule:: hyperspy.misc.io
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/doc/api/hyperspy.misc.machine_learning.rst
+++ b/doc/api/hyperspy.misc.machine_learning.rst
@@ -1,0 +1,38 @@
+hyperspy.misc.machine_learning package
+======================================
+
+Submodules
+----------
+
+hyperspy.misc.machine_learning.import_sklearn module
+----------------------------------------------------
+
+.. automodule:: hyperspy.misc.machine_learning.import_sklearn
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+hyperspy.misc.machine_learning.orthomax module
+----------------------------------------------
+
+.. automodule:: hyperspy.misc.machine_learning.orthomax
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+hyperspy.misc.machine_learning.tools module
+-------------------------------------------
+
+.. automodule:: hyperspy.misc.machine_learning.tools
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+
+Module contents
+---------------
+
+.. automodule:: hyperspy.misc.machine_learning
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/doc/api/hyperspy.tests.axes.rst
+++ b/doc/api/hyperspy.tests.axes.rst
@@ -1,0 +1,22 @@
+hyperspy.tests.axes package
+===========================
+
+Submodules
+----------
+
+hyperspy.tests.axes.test_data_axis module
+-----------------------------------------
+
+.. automodule:: hyperspy.tests.axes.test_data_axis
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+
+Module contents
+---------------
+
+.. automodule:: hyperspy.tests.axes
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/doc/api/hyperspy.tests.component.rst
+++ b/doc/api/hyperspy.tests.component.rst
@@ -1,0 +1,30 @@
+hyperspy.tests.component package
+================================
+
+Submodules
+----------
+
+hyperspy.tests.component.test_component_active_array module
+-----------------------------------------------------------
+
+.. automodule:: hyperspy.tests.component.test_component_active_array
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+hyperspy.tests.component.test_component_set_parameters module
+-------------------------------------------------------------
+
+.. automodule:: hyperspy.tests.component.test_component_set_parameters
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+
+Module contents
+---------------
+
+.. automodule:: hyperspy.tests.component
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/doc/api/hyperspy.tests.drawing.rst
+++ b/doc/api/hyperspy.tests.drawing.rst
@@ -1,0 +1,30 @@
+hyperspy.tests.drawing package
+==============================
+
+Submodules
+----------
+
+hyperspy.tests.drawing.test_figure_title module
+-----------------------------------------------
+
+.. automodule:: hyperspy.tests.drawing.test_figure_title
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+hyperspy.tests.drawing.test_marker module
+-----------------------------------------
+
+.. automodule:: hyperspy.tests.drawing.test_marker
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+
+Module contents
+---------------
+
+.. automodule:: hyperspy.tests.drawing
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/doc/api/hyperspy.tests.misc.rst
+++ b/doc/api/hyperspy.tests.misc.rst
@@ -1,0 +1,46 @@
+hyperspy.tests.misc package
+===========================
+
+Submodules
+----------
+
+hyperspy.tests.misc.test_arraytools module
+------------------------------------------
+
+.. automodule:: hyperspy.tests.misc.test_arraytools
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+hyperspy.tests.misc.test_image_tools module
+-------------------------------------------
+
+.. automodule:: hyperspy.tests.misc.test_image_tools
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+hyperspy.tests.misc.test_math_tools module
+------------------------------------------
+
+.. automodule:: hyperspy.tests.misc.test_math_tools
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+hyperspy.tests.misc.test_rgbtools module
+----------------------------------------
+
+.. automodule:: hyperspy.tests.misc.test_rgbtools
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+
+Module contents
+---------------
+
+.. automodule:: hyperspy.tests.misc
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/doc/api/hyperspy.tests.model.rst
+++ b/doc/api/hyperspy.tests.model.rst
@@ -1,0 +1,110 @@
+hyperspy.tests.model package
+============================
+
+Submodules
+----------
+
+hyperspy.tests.model.test_chi_squared module
+--------------------------------------------
+
+.. automodule:: hyperspy.tests.model.test_chi_squared
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+hyperspy.tests.model.test_component module
+------------------------------------------
+
+.. automodule:: hyperspy.tests.model.test_component
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+hyperspy.tests.model.test_components module
+-------------------------------------------
+
+.. automodule:: hyperspy.tests.model.test_components
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+hyperspy.tests.model.test_eelsmodel module
+------------------------------------------
+
+.. automodule:: hyperspy.tests.model.test_eelsmodel
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+hyperspy.tests.model.test_fancy_indexing module
+-----------------------------------------------
+
+.. automodule:: hyperspy.tests.model.test_fancy_indexing
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+hyperspy.tests.model.test_fit_component module
+----------------------------------------------
+
+.. automodule:: hyperspy.tests.model.test_fit_component
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+hyperspy.tests.model.test_model module
+--------------------------------------
+
+.. automodule:: hyperspy.tests.model.test_model
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+hyperspy.tests.model.test_model_as_dictionary module
+----------------------------------------------------
+
+.. automodule:: hyperspy.tests.model.test_model_as_dictionary
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+hyperspy.tests.model.test_model_storing module
+----------------------------------------------
+
+.. automodule:: hyperspy.tests.model.test_model_storing
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+hyperspy.tests.model.test_parameter module
+------------------------------------------
+
+.. automodule:: hyperspy.tests.model.test_parameter
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+hyperspy.tests.model.test_set_parameter_state module
+----------------------------------------------------
+
+.. automodule:: hyperspy.tests.model.test_set_parameter_state
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+hyperspy.tests.model.test_set_parameter_value module
+----------------------------------------------------
+
+.. automodule:: hyperspy.tests.model.test_set_parameter_value
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+
+Module contents
+---------------
+
+.. automodule:: hyperspy.tests.model
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/doc/api/hyperspy.tests.mva.rst
+++ b/doc/api/hyperspy.tests.mva.rst
@@ -1,0 +1,38 @@
+hyperspy.tests.mva package
+==========================
+
+Submodules
+----------
+
+hyperspy.tests.mva.test_bss module
+----------------------------------
+
+.. automodule:: hyperspy.tests.mva.test_bss
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+hyperspy.tests.mva.test_decomposition module
+--------------------------------------------
+
+.. automodule:: hyperspy.tests.mva.test_decomposition
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+hyperspy.tests.mva.test_export module
+-------------------------------------
+
+.. automodule:: hyperspy.tests.mva.test_export
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+
+Module contents
+---------------
+
+.. automodule:: hyperspy.tests.mva
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/doc/api/hyperspy.tests.signal.rst
+++ b/doc/api/hyperspy.tests.signal.rst
@@ -1,0 +1,174 @@
+hyperspy.tests.signal package
+=============================
+
+Submodules
+----------
+
+hyperspy.tests.signal.test_1D_tools module
+------------------------------------------
+
+.. automodule:: hyperspy.tests.signal.test_1D_tools
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+hyperspy.tests.signal.test_2D_tools module
+------------------------------------------
+
+.. automodule:: hyperspy.tests.signal.test_2D_tools
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+hyperspy.tests.signal.test_apply_function module
+------------------------------------------------
+
+.. automodule:: hyperspy.tests.signal.test_apply_function
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+hyperspy.tests.signal.test_assign_subclass module
+-------------------------------------------------
+
+.. automodule:: hyperspy.tests.signal.test_assign_subclass
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+hyperspy.tests.signal.test_attributes module
+--------------------------------------------
+
+.. automodule:: hyperspy.tests.signal.test_attributes
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+hyperspy.tests.signal.test_binned module
+----------------------------------------
+
+.. automodule:: hyperspy.tests.signal.test_binned
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+hyperspy.tests.signal.test_eds_sem module
+-----------------------------------------
+
+.. automodule:: hyperspy.tests.signal.test_eds_sem
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+hyperspy.tests.signal.test_eds_tem module
+-----------------------------------------
+
+.. automodule:: hyperspy.tests.signal.test_eds_tem
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+hyperspy.tests.signal.test_eels module
+--------------------------------------
+
+.. automodule:: hyperspy.tests.signal.test_eels
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+hyperspy.tests.signal.test_fancy_indexing module
+------------------------------------------------
+
+.. automodule:: hyperspy.tests.signal.test_fancy_indexing
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+hyperspy.tests.signal.test_folding module
+-----------------------------------------
+
+.. automodule:: hyperspy.tests.signal.test_folding
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+hyperspy.tests.signal.test_image module
+---------------------------------------
+
+.. automodule:: hyperspy.tests.signal.test_image
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+hyperspy.tests.signal.test_integrate_in_range module
+----------------------------------------------------
+
+.. automodule:: hyperspy.tests.signal.test_integrate_in_range
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+hyperspy.tests.signal.test_kramers_kronig_transform module
+----------------------------------------------------------
+
+.. automodule:: hyperspy.tests.signal.test_kramers_kronig_transform
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+hyperspy.tests.signal.test_remove_background module
+---------------------------------------------------
+
+.. automodule:: hyperspy.tests.signal.test_remove_background
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+hyperspy.tests.signal.test_rgb module
+-------------------------------------
+
+.. automodule:: hyperspy.tests.signal.test_rgb
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+hyperspy.tests.signal.test_signal_operators module
+--------------------------------------------------
+
+.. automodule:: hyperspy.tests.signal.test_signal_operators
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+hyperspy.tests.signal.test_signal_subclass_conversion module
+------------------------------------------------------------
+
+.. automodule:: hyperspy.tests.signal.test_signal_subclass_conversion
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+hyperspy.tests.signal.test_spectrum module
+------------------------------------------
+
+.. automodule:: hyperspy.tests.signal.test_spectrum
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+hyperspy.tests.signal.test_tools module
+---------------------------------------
+
+.. automodule:: hyperspy.tests.signal.test_tools
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+
+Module contents
+---------------
+
+.. automodule:: hyperspy.tests.signal
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/doc/api/hyperspy.tests.utils.rst
+++ b/doc/api/hyperspy.tests.utils.rst
@@ -1,0 +1,62 @@
+hyperspy.tests.utils package
+============================
+
+Submodules
+----------
+
+hyperspy.tests.utils.test_attrsetter module
+-------------------------------------------
+
+.. automodule:: hyperspy.tests.utils.test_attrsetter
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+hyperspy.tests.utils.test_eds module
+------------------------------------
+
+.. automodule:: hyperspy.tests.utils.test_eds
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+hyperspy.tests.utils.test_material module
+-----------------------------------------
+
+.. automodule:: hyperspy.tests.utils.test_material
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+hyperspy.tests.utils.test_progressbar module
+--------------------------------------------
+
+.. automodule:: hyperspy.tests.utils.test_progressbar
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+hyperspy.tests.utils.test_slugify module
+----------------------------------------
+
+.. automodule:: hyperspy.tests.utils.test_slugify
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+hyperspy.tests.utils.test_stack module
+--------------------------------------
+
+.. automodule:: hyperspy.tests.utils.test_stack
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+
+Module contents
+---------------
+
+.. automodule:: hyperspy.tests.utils
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/doc/api/hyperspy.utils.rst
+++ b/doc/api/hyperspy.utils.rst
@@ -1,0 +1,54 @@
+hyperspy.utils package
+======================
+
+Submodules
+----------
+
+hyperspy.utils.eds module
+-------------------------
+
+.. automodule:: hyperspy.utils.eds
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+hyperspy.utils.markers module
+-----------------------------
+
+.. automodule:: hyperspy.utils.markers
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+hyperspy.utils.material module
+------------------------------
+
+.. automodule:: hyperspy.utils.material
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+hyperspy.utils.model module
+---------------------------
+
+.. automodule:: hyperspy.utils.model
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+hyperspy.utils.plot module
+--------------------------
+
+.. automodule:: hyperspy.utils.plot
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+
+Module contents
+---------------
+
+.. automodule:: hyperspy.utils
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/doc/api/modules.rst
+++ b/doc/api/modules.rst
@@ -1,0 +1,7 @@
+hyperspy
+========
+
+.. toctree::
+   :maxdepth: 4
+
+   hyperspy


### PR DESCRIPTION
As it was, the API rst files were ignored by git. Hence, our docs in readthedocs were partly broken. Also stop ignoring `hyperspy/bin`, except for the `.bat` files.