### PR TITLE
Fix a couple of issues with this test.

### DIFF
--- a/hyperspy/tests/component/test_component_active_array.py
+++ b/hyperspy/tests/component/test_component_active_array.py
@@ -26,7 +26,7 @@ class TestParametersAsSignals:
 
     def setUp(self):
         self.gaussian = Gaussian()
-        self.gaussian._axes_manager = Signal(np.empty((3, 3, 1))).axes_manager
+        self.gaussian._axes_manager = Signal(np.zeros((3, 3, 1))).axes_manager
 
     def test_always_active(self):
         g = self.gaussian

--- a/hyperspy/tests/model/test_components.py
+++ b/hyperspy/tests/model/test_components.py
@@ -8,7 +8,7 @@ from hyperspy.model import Model
 class TestPowerLaw:
 
     def setUp(self):
-        s = hs.signals.Spectrum(np.empty(1024))
+        s = hs.signals.Spectrum(np.zeros(1024))
         s.axes_manager[0].offset = 100
         s.axes_manager[0].scale = 0.01
         m = s.create_model()
@@ -71,7 +71,7 @@ class TestPowerLaw:
 class TestOffset:
 
     def setUp(self):
-        s = hs.signals.Spectrum(np.empty(10))
+        s = hs.signals.Spectrum(np.zeros(10))
         s.axes_manager[0].scale = 0.01
         m = s.create_model()
         m.append(hs.model.components.Offset())
@@ -104,7 +104,7 @@ class TestOffset:
 class TestPolynomial:
 
     def setUp(self):
-        s = hs.signals.Spectrum(np.empty(1024))
+        s = hs.signals.Spectrum(np.zeros(1024))
         s.axes_manager[0].offset = -5
         s.axes_manager[0].scale = 0.01
         m = s.create_model()
@@ -168,7 +168,7 @@ class TestPolynomial:
 class TestGaussian:
 
     def setUp(self):
-        s = hs.signals.Spectrum(np.empty(1024))
+        s = hs.signals.Spectrum(np.zeros(1024))
         s.axes_manager[0].offset = -5
         s.axes_manager[0].scale = 0.01
         m = s.create_model()

--- a/hyperspy/tests/model/test_eelsmodel.py
+++ b/hyperspy/tests/model/test_eelsmodel.py
@@ -7,7 +7,7 @@ import hyperspy.api as hs
 class TestCreateEELSModel:
 
     def setUp(self):
-        s = hs.signals.EELSSpectrum(np.empty(200))
+        s = hs.signals.EELSSpectrum(np.zeros(200))
         s.set_microscope_parameters(100, 10, 10)
         s.axes_manager[-1].offset = 150
         s.add_elements(("B", "C"))
@@ -54,7 +54,7 @@ class TestCreateEELSModel:
 class TestEELSModel:
 
     def setUp(self):
-        s = hs.signals.EELSSpectrum(np.empty(200))
+        s = hs.signals.EELSSpectrum(np.zeros(200))
         s.set_microscope_parameters(100, 10, 10)
         s.axes_manager[-1].offset = 150
         s.add_elements(("B", "C"))

--- a/hyperspy/tests/model/test_model.py
+++ b/hyperspy/tests/model/test_model.py
@@ -8,7 +8,7 @@ from hyperspy.misc.utils import slugify
 class TestModel:
 
     def setUp(self):
-        s = hs.signals.Spectrum(np.empty(1))
+        s = hs.signals.Spectrum(np.zeros(1))
         m = s.create_model()
         self.model = m
 
@@ -434,7 +434,7 @@ class TestModelSignalVariance:
 class TestMultifit:
 
     def setUp(self):
-        s = hs.signals.Spectrum(np.empty((2, 200)))
+        s = hs.signals.Spectrum(np.zeros((2, 200)))
         s.axes_manager[-1].offset = 1
         s.data[:] = 2 * s.axes_manager[-1].axis ** (-3)
         m = s.create_model()

--- a/hyperspy/tests/mva/test_decomposition.py
+++ b/hyperspy/tests/mva/test_decomposition.py
@@ -70,20 +70,21 @@ class TestNdAxes:
                                              s2.learning_results.loadings)
 
 
-class TestGetExplainedVarinaceRation:
+class TestGetExplainedVarinaceRatio:
 
     def setUp(self):
         s = signals.Signal(np.empty(1))
-        s.learning_results.explained_variance_ratio = np.empty(10)
         self.s = s
 
     def test_data(self):
-        assert_true((self.s.get_explained_variance_ratio().data ==
-                     self.s.learning_results.explained_variance_ratio).all())
+        self.s.learning_results.explained_variance_ratio = np.asarray([2,4])
+        np.testing.assert_array_equal(
+            self.s.get_explained_variance_ratio().data,
+            np.asarray([2,4]))
 
     @raises(AttributeError)
     def test_no_evr(self):
-        self.s.get_explained_variance_ration()
+        self.s.get_explained_variance_ratio()
 
 
 class TestReverseDecompositionComponent:

--- a/hyperspy/tests/mva/test_decomposition.py
+++ b/hyperspy/tests/mva/test_decomposition.py
@@ -90,7 +90,7 @@ class TestGetExplainedVarinaceRatio:
 class TestReverseDecompositionComponent:
 
     def setUp(self):
-        s = signals.Signal(np.empty(1))
+        s = signals.Signal(np.zeros(1))
         self.factors = np.ones([2, 3])
         self.loadings = np.ones([2, 3])
         s.learning_results.factors = self.factors.copy()
@@ -141,7 +141,7 @@ class TestReverseDecompositionComponent:
 class TestNormalizeComponents():
 
     def setUp(self):
-        s = signals.Signal(np.empty(1))
+        s = signals.Signal(np.zeros(1))
         self.factors = np.ones([2, 3])
         self.loadings = np.ones([2, 3])
         s.learning_results.factors = self.factors.copy()

--- a/hyperspy/tests/signal/test_binned.py
+++ b/hyperspy/tests/signal/test_binned.py
@@ -10,12 +10,12 @@ def test_spectrum_binned_default():
 
 
 def test_image_binned_default():
-    s = hs.signals.Image(np.empty((2, 2)))
+    s = hs.signals.Image(np.zeros((2, 2)))
     nose.tools.assert_false(s.metadata.Signal.binned)
 
 
 def test_image_simulation_binned_default():
-    s = hs.signals.ImageSimulation(np.empty([2, 2]))
+    s = hs.signals.ImageSimulation(np.zeros([2, 2]))
     nose.tools.assert_false(s.metadata.Signal.binned)
 
 

--- a/hyperspy/tests/signal/test_folding.py
+++ b/hyperspy/tests/signal/test_folding.py
@@ -7,7 +7,7 @@ from hyperspy.signal import Signal
 class TestSignalFolding:
 
     def setUp(self):
-        self.s = Signal(np.empty((2, 3, 4, 5)))
+        self.s = Signal(np.zeros((2, 3, 4, 5)))
         self.s.axes_manager.set_signal_dimension(2)
 
     def test_unfold_navigation(self):
@@ -129,7 +129,7 @@ class TestSignalFolding:
 class TestSignalVarianceFolding:
 
     def setUp(self):
-        self.s = Signal(np.empty((2, 3, 4, 5)))
+        self.s = Signal(np.zeros((2, 3, 4, 5)))
         self.s.axes_manager.set_signal_dimension(2)
         self.s.estimate_poissonian_noise_variance()
 

--- a/hyperspy/tests/signal/test_tools.py
+++ b/hyperspy/tests/signal/test_tools.py
@@ -193,7 +193,7 @@ class Test3D:
     def test_get_navigation_signal_given_data(self):
         s = self.signal
         s.axes_manager.set_signal_dimension(1)
-        data = np.empty(s.axes_manager._navigation_shape_in_array)
+        data = np.zeros(s.axes_manager._navigation_shape_in_array)
         ns = s._get_navigation_signal(data=data)
         nt.assert_is(ns.data, data)
 
@@ -244,7 +244,7 @@ class Test3D:
     def test_get_signal_signal_given_data(self):
         s = self.signal
         s.axes_manager.set_signal_dimension(2)
-        data = np.empty(s.axes_manager._signal_shape_in_array)
+        data = np.zeros(s.axes_manager._signal_shape_in_array)
         ns = s._get_signal_signal(data=data)
         nt.assert_is(ns.data, data)
 


### PR DESCRIPTION
 Fixes #798

1. The test was sometimes failing randomly. This was traced down to `np.empty`.
2. The `test_no_evr` was broken but passing because it was still raising an AttributeError due to a typo (!).