### PR TITLE
FIX: Several minor issues

### DIFF
--- a/hyperspy/model.py
+++ b/hyperspy/model.py
@@ -204,7 +204,7 @@ class BaseModel(list):
         s = self.signal
         s.models.store(self, name)
 
-    def save(self, file_name, name=None):
+    def save(self, file_name, name=None, **kwargs):
         """Saves signal and its model to a file
 
         Parameters
@@ -213,12 +213,14 @@ class BaseModel(list):
                 Name of the file
             name : {None, str}
                 Stored model name. Auto-generated if left empty
+            **kwargs :
+                Other keyword arguments are passed onto `Signal.save()`
         """
         if self.signal is None:
             raise ValueError("Currently cannot store models with no signal")
         else:
             self.store(name)
-            self.signal.save(file_name)
+            self.signal.save(file_name, **kwargs)
 
     def _load_dictionary(self, dic):
         """Load data from dictionary.

--- a/hyperspy/tests/io/test_hdf5.py
+++ b/hyperspy/tests/io/test_hdf5.py
@@ -238,7 +238,7 @@ class TestLoadingOOMReadOnly:
 
     def setUp(self):
         s = Signal(np.empty((5, 5, 5)))
-        s.save('tmp.hdf5')
+        s.save('tmp.hdf5', overwrite=True)
         self.shape = (10000, 10000, 100)
         del s
         f = h5py.File('tmp.hdf5', model='r+')

--- a/hyperspy/tests/io/test_hdf5.py
+++ b/hyperspy/tests/io/test_hdf5.py
@@ -251,7 +251,7 @@ class TestLoadingOOMReadOnly:
             chunks=True)
         f.close()
 
-    @nt.raises(MemoryError)
+    @nt.raises(MemoryError, ValueError)
     def test_in_memory_loading(self):
         s = load('tmp.hdf5')
 
@@ -262,4 +262,8 @@ class TestLoadingOOMReadOnly:
 
     def tearDown(self):
         gc.collect()        # Make sure any memmaps are closed first!
-        remove('tmp.hdf5')
+        try:
+            remove('tmp.hdf5')
+        except:
+            # Don't fail tests if we cannot remove
+            pass

--- a/hyperspy/tests/io/test_semper_unf.py
+++ b/hyperspy/tests/io/test_semper_unf.py
@@ -133,7 +133,8 @@ class TestCaseSaveAndReadByte():
     def test_save_and_read(self):
         signal_ref = Image(data_image_byte)
         signal_ref.metadata.General.title = test_title
-        signal_ref.save(os.path.join(my_path, 'unf_files', 'example_temp.unf'), overwrite=True)
+        signal_ref.save(os.path.join(my_path, 'unf_files', 'example_temp.unf'),
+                        overwrite=True)
         signal = load(os.path.join(my_path, 'unf_files', 'example_temp.unf'))
         np.testing.assert_equal(signal.data, signal_ref.data)
         np.testing.assert_equal(signal.metadata.General.title, test_title)

--- a/hyperspy/tests/model/test_model_storing.py
+++ b/hyperspy/tests/model/test_model_storing.py
@@ -151,7 +151,7 @@ class TestModelSaving:
 
     def test_save_and_load_model(self):
         m = self.m
-        m.save('tmp.hdf5')
+        m.save('tmp.hdf5', overwrite=True)
         l = load('tmp.hdf5')
         nt.assert_true(hasattr(l.models, 'a'))
         n = l.models.restore('a')

--- a/setup.py
+++ b/setup.py
@@ -178,6 +178,8 @@ with update_version_when_dev() as version:
              'ipython_profile/*',
              'data/*.ico',
              'misc/eds/example_signals/*.hdf5',
+             'tests/io/blockfile_data/*.blockfile'
+             'tests/io/dens_data/*.dens'
              'tests/io/dm_stackbuilder_plugin/test_stackbuilder_imagestack.dm3',
              'tests/io/dm3_1D_data/*.dm3',
              'tests/io/dm3_2D_data/*.dm3',
@@ -189,6 +191,7 @@ with update_version_when_dev() as version:
              'tests/io/hdf5_files/*.hdf5',
              'tests/io/tiff_files/*.tif',
              'tests/io/npy_files/*.npy',
+             'tests/io/unf_files/*.unf'
              'tests/drawing/*.ipynb',
              ],
         },


### PR DESCRIPTION
 * Added keyword passthrough from `Model.save()` to `Signal.save()`.
 * Added `overwrite=True` for all `save()` calls in tests, to make sure tests do not hang if file exists.
 * Added some adjustments to test so they will work on Windows (mainly related to HDF5's `test_in_memory_loading`).
 * Make sure new test data files are included in `setup.py`.