### PR TITLE
by default signal performs simple operations on navigation axes

### DIFF
--- a/doc/user_guide/tools.rst
+++ b/doc/user_guide/tools.rst
@@ -243,7 +243,7 @@ subclasses.
 Simple mathematical operations
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-.. versionchaned:: 0.9
+.. versionchanged:: 0.9
 
 A number of simple operations are supported by :py:class:`~.signal.Signal`. Most
 of them are just wrapped numpy functions, as an example:

--- a/doc/user_guide/tools.rst
+++ b/doc/user_guide/tools.rst
@@ -240,13 +240,48 @@ The methods of this section are available to all the signals. In other chapters
 methods that are only available in specialized
 subclasses.
 
+Simple mathematical operations
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. versionchaned:: 0.9
+
+A number of simple operations are supported by :py:class:`~.signal.Signal`. Most
+of them are just wrapped numpy functions, as an example:
+
+.. code-block:: python
+
+    >>> s = hs.signals.Signal(np.random.random((2,4,6)))
+    >>> s.axes_manager[0].name = 'E'
+    >>> s
+    <Signal, title: , dimensions: (4, 2|6)>
+    >>> # by default perform operation over all navigation axes
+    >>> s.sum()
+    <Signal, title: , dimensions: (|6)>
+    >>> # can also pass axes individually
+    >>> s.sum('E')
+    <Signal, title: , dimensions: (2|6)>
+    >>> # or a tuple of axes to operate on, with duplicates, by index or directly
+    >>> ans = s.sum((-1, s.axes_manager[1], 'E', 0))
+    >>> ans
+    <Signal, title: , dimensions: (|1)>
+    >>> ans.axes_manager[0]
+    <Scalar axis, size: 1>
+
+Other functions that support similar behavior: :py:func:`~.signal.sum`,
+:py:func:`~.signal.max`, :py:func:`~.signal.min`, :py:func:`~.signal.mean`,
+:py:func:`~.signal.std`, :py:func:`~.signal.var`, :py:func:`~.signal.idexmax`,
+:py:func:`~.signal.amax`. Similar functions that can only be performed on one
+axis at a time: :py:func:`~.signal.diff`, :py:func:`~.signal.derivative`,
+:py:func:`~.signal.integrate_simpson`, :py:func:`~.signal.integrate1D`,
+:py:func:`~.signal.valuemax`
+
 .. _signal.indexing:
 
 Indexing
 ^^^^^^^^
 .. versionadded:: 0.6
 
-Indexing the :py:class:`~.signal.Signal`  provides a powerful, convenient and
+Indexing the :py:class:`~.signal.Signal` provides a powerful, convenient and
 Pythonic way to access and modify its data.  It is a concept that might take
 some time to grasp but, once mastered, it can greatly simplify many common
 signal processing tasks.

--- a/doc/user_guide/tools.rst
+++ b/doc/user_guide/tools.rst
@@ -269,7 +269,7 @@ of them are just wrapped numpy functions, as an example:
 
 Other functions that support similar behavior: :py:func:`~.signal.sum`,
 :py:func:`~.signal.max`, :py:func:`~.signal.min`, :py:func:`~.signal.mean`,
-:py:func:`~.signal.std`, :py:func:`~.signal.var`, :py:func:`~.signal.idexmax`,
+:py:func:`~.signal.std`, :py:func:`~.signal.var`, :py:func:`~.signal.indexmax`,
 :py:func:`~.signal.amax`. Similar functions that can only be performed on one
 axis at a time: :py:func:`~.signal.diff`, :py:func:`~.signal.derivative`,
 :py:func:`~.signal.integrate_simpson`, :py:func:`~.signal.integrate1D`,
@@ -722,19 +722,6 @@ to reverse the :py:func:`~.utils.stack` function:
 
   Splitting example.
 
-
-Simple operations over one axis
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-* :py:meth:`~.signal.Signal.sum`
-* :py:meth:`~.signal.Signal.mean`
-* :py:meth:`~.signal.Signal.max`
-* :py:meth:`~.signal.Signal.min`
-* :py:meth:`~.signal.Signal.std`
-* :py:meth:`~.signal.Signal.var`
-* :py:meth:`~.signal.Signal.diff`
-* :py:meth:`~.signal.Signal.derivative`
-* :py:meth:`~.signal.Signal.integrate_simpson`
 
 .. _signal.change_dtype:
 

--- a/doc/user_guide/tools.rst
+++ b/doc/user_guide/tools.rst
@@ -269,11 +269,11 @@ of them are just wrapped numpy functions, as an example:
 
 Other functions that support similar behavior: :py:func:`~.signal.sum`,
 :py:func:`~.signal.max`, :py:func:`~.signal.min`, :py:func:`~.signal.mean`,
-:py:func:`~.signal.std`, :py:func:`~.signal.var`, :py:func:`~.signal.indexmax`,
-:py:func:`~.signal.amax`. Similar functions that can only be performed on one
-axis at a time: :py:func:`~.signal.diff`, :py:func:`~.signal.derivative`,
-:py:func:`~.signal.integrate_simpson`, :py:func:`~.signal.integrate1D`,
-:py:func:`~.signal.valuemax`
+:py:func:`~.signal.std`, :py:func:`~.signal.var`. Similar functions that can
+only be performed on one axis at a time: :py:func:`~.signal.diff`,
+:py:func:`~.signal.derivative`, :py:func:`~.signal.integrate_simpson`,
+:py:func:`~.signal.integrate1D`, :py:func:`~.signal.valuemax`,
+:py:func:`~.signal.indexmax`.
 
 .. _signal.indexing:
 

--- a/hyperspy/_signals/eds.py
+++ b/hyperspy/_signals/eds.py
@@ -153,7 +153,7 @@ class EDSSpectrum(Spectrum):
                 xray_lines_not_in_range.append(xray_line)
         return xray_lines_in_range, xray_lines_not_in_range
 
-    def sum(self, axis):
+    def sum(self, axis=None):
         """Sum the data over the given axis.
 
         Parameters
@@ -177,6 +177,8 @@ class EDSSpectrum(Spectrum):
         array(1000279)
 
         """
+        if axis is None:
+            axis = self.axes_manager.navigation_axes
         # modify time spend per spectrum
         s = super(EDSSpectrum, self).sum(axis)
         if "Acquisition_instrument.SEM" in s.metadata:

--- a/hyperspy/docstrings/signal.py
+++ b/hyperspy/docstrings/signal.py
@@ -12,4 +12,5 @@ MANY_AXIS_PARAMETER = \
             Either one on its own, or many axes in a tuple can be passed. In
             both cases the axes can be passed directly, or specified using the
             index in `axes_manager` or the name of the axis. Any duplicates are
-            removed. If None, navigation axes are passed"""
+            removed. If None, the operation is performed over all navigation
+            axes."""

--- a/hyperspy/docstrings/signal.py
+++ b/hyperspy/docstrings/signal.py
@@ -8,8 +8,8 @@ ONE_AXIS_PARAMETER = \
             The axis can be passed directly, or specified using the index of the
             axis in `axes_manager` or the axis name."""
 MANY_AXIS_PARAMETER = \
-    """: {int | string | axis | tuple}
+    """: {int | string | axis | tuple | None}
             Either one on its own, or many axes in a tuple can be passed. In
             both cases the axes can be passed directly, or specified using the
             index in `axes_manager` or the name of the axis. Any duplicates are
-            removed."""
+            removed. If None, navigation axes are passed"""

--- a/hyperspy/docstrings/signal.py
+++ b/hyperspy/docstrings/signal.py
@@ -13,4 +13,4 @@ MANY_AXIS_PARAMETER = \
             both cases the axes can be passed directly, or specified using the
             index in `axes_manager` or the name of the axis. Any duplicates are
             removed. If None, the operation is performed over all navigation
-            axes."""
+            axes (default)."""

--- a/hyperspy/signal.py
+++ b/hyperspy/signal.py
@@ -3499,9 +3499,10 @@ class Signal(FancySlicing,
 
         Parameters
         ----------
-        axis %s The axis to roll backwards.  The positions of the other axes do not
-            change relative to one another.
-        to_axis %s The axis is rolled until it lies before this other axis.
+        axis %s The axis to roll backwards.
+            The positions of the other axes do not change relative to one another.
+        to_axis %s The axis is rolled until it
+            lies before this other axis.
 
         Returns
         -------
@@ -3975,7 +3976,7 @@ class Signal(FancySlicing,
         s._remove_axis([ax.index_in_axes_manager for ax in axes])
         return s
 
-    def sum(self, axis):
+    def sum(self, axis=None):
         """Sum the data over the given axes.
 
         Parameters
@@ -3998,14 +3999,14 @@ class Signal(FancySlicing,
         (64,64,1024)
         >>> s.sum(-1).data.shape
         (64,64)
-        # If we just want to plot the result of the operation
-        s.sum(-1, True).plot()
 
         """
+        if axis is None:
+            axis = self.axes_manager.navigation_axes
         return self._apply_function_on_data_and_remove_axis(np.sum, axis)
     sum.__doc__ %= MANY_AXIS_PARAMETER
 
-    def max(self, axis, return_signal=False):
+    def max(self, axis=None):
         """Returns a signal with the maximum of the signal along at least one
         axis.
 
@@ -4031,10 +4032,12 @@ class Signal(FancySlicing,
         (64,64)
 
         """
+        if axis is None:
+            axis = self.axes_manager.navigation_axes
         return self._apply_function_on_data_and_remove_axis(np.max, axis)
     max.__doc__ %= MANY_AXIS_PARAMETER
 
-    def min(self, axis):
+    def min(self, axis=None):
         """Returns a signal with the minimum of the signal along at least one
         axis.
 
@@ -4060,10 +4063,12 @@ class Signal(FancySlicing,
         (64,64)
 
         """
+        if axis is None:
+            axis = self.axes_manager.navigation_axes
         return self._apply_function_on_data_and_remove_axis(np.min, axis)
     min.__doc__ %= MANY_AXIS_PARAMETER
 
-    def mean(self, axis):
+    def mean(self, axis=None):
         """Returns a signal with the average of the signal along at least one
         axis.
 
@@ -4089,10 +4094,12 @@ class Signal(FancySlicing,
         (64,64)
 
         """
+        if axis is None:
+            axis = self.axes_manager.navigation_axes
         return self._apply_function_on_data_and_remove_axis(np.mean, axis)
     mean.__doc__ %= MANY_AXIS_PARAMETER
 
-    def std(self, axis):
+    def std(self, axis=None):
         """Returns a signal with the standard deviation of the signal along
         at least one axis.
 
@@ -4118,10 +4125,12 @@ class Signal(FancySlicing,
         (64,64)
 
         """
+        if axis is None:
+            axis = self.axes_manager.navigation_axes
         return self._apply_function_on_data_and_remove_axis(np.std, axis)
     std.__doc__ %= MANY_AXIS_PARAMETER
 
-    def var(self, axis):
+    def var(self, axis=None):
         """Returns a signal with the variances of the signal along at least one
         axis.
 
@@ -4147,6 +4156,8 @@ class Signal(FancySlicing,
         (64,64)
 
         """
+        if axis is None:
+            axis = self.axes_manager.navigation_axes
         return self._apply_function_on_data_and_remove_axis(np.var, axis)
     var.__doc__ %= MANY_AXIS_PARAMETER
 
@@ -4286,7 +4297,7 @@ class Signal(FancySlicing,
             return self.sum(axis)
     integrate1D.__doc__ %= ONE_AXIS_PARAMETER
 
-    def indexmax(self, axis):
+    def indexmax(self, axis=None):
         """Returns a signal with the index of the maximum along an axis.
 
         Parameters
@@ -4312,10 +4323,12 @@ class Signal(FancySlicing,
         (64,64)
 
         """
+        if axis is None:
+            axis = self.axes_manager.navigation_axes
         return self._apply_function_on_data_and_remove_axis(np.argmax, axis)
     indexmax.__doc__ %= MANY_AXIS_PARAMETER
 
-    def amax(self, axis):
+    def amax(self, axis=None):
         """Returns a signal with the value of the maximum along an axis.
 
         Parameters
@@ -4340,6 +4353,8 @@ class Signal(FancySlicing,
         (64,64)
 
         """
+        if axis is None:
+            axis = self.axes_manager.navigation_axes
         return self._apply_function_on_data_and_remove_axis(np.amax, axis)
     amax.__doc__ %= MANY_AXIS_PARAMETER
 

--- a/hyperspy/signal.py
+++ b/hyperspy/signal.py
@@ -4328,36 +4328,6 @@ class Signal(FancySlicing,
         return self._apply_function_on_data_and_remove_axis(np.argmax, axis)
     indexmax.__doc__ %= MANY_AXIS_PARAMETER
 
-    def amax(self, axis=None):
-        """Returns a signal with the value of the maximum along an axis.
-
-        Parameters
-        ----------
-        axis %s
-
-        Returns
-        -------
-        s : Signal
-
-        See also
-        --------
-        max, min, sum, mean, std, var, indexmax, valuemax
-
-        Usage
-        -----
-        >>> import numpy as np
-        >>> s = Signal(np.random.random((64,64,1024)))
-        >>> s.data.shape
-        (64,64,1024)
-        >>> s.amax(-1).data.shape
-        (64,64)
-
-        """
-        if axis is None:
-            axis = self.axes_manager.navigation_axes
-        return self._apply_function_on_data_and_remove_axis(np.amax, axis)
-    amax.__doc__ %= MANY_AXIS_PARAMETER
-
     def valuemax(self, axis):
         """Returns a signal with the value of coordinates of the maximum along an axis.
 

--- a/hyperspy/signal.py
+++ b/hyperspy/signal.py
@@ -4297,7 +4297,7 @@ class Signal(FancySlicing,
             return self.sum(axis)
     integrate1D.__doc__ %= ONE_AXIS_PARAMETER
 
-    def indexmax(self, axis=None):
+    def indexmax(self, axis):
         """Returns a signal with the index of the maximum along an axis.
 
         Parameters
@@ -4323,10 +4323,8 @@ class Signal(FancySlicing,
         (64,64)
 
         """
-        if axis is None:
-            axis = self.axes_manager.navigation_axes
         return self._apply_function_on_data_and_remove_axis(np.argmax, axis)
-    indexmax.__doc__ %= MANY_AXIS_PARAMETER
+    indexmax.__doc__ %= ONE_AXIS_PARAMETER
 
     def valuemax(self, axis):
         """Returns a signal with the value of coordinates of the maximum along an axis.

--- a/hyperspy/tests/signal/test_tools.py
+++ b/hyperspy/tests/signal/test_tools.py
@@ -128,6 +128,13 @@ class Test3D:
         self.signal.axes_manager[0].scale = 0.5
         self.data = self.signal.data.copy()
 
+    def test_default_navigation_sum(self):
+        s = self.signal.sum()
+        np.testing.assert_array_equal(self.data.sum(axis=(0, 1)), s.data)
+        nt.assert_equal(s.data.ndim, 1)
+        nt.assert_equal(s.axes_manager.signal_dimension, 1)
+        nt.assert_equal(s.axes_manager.navigation_dimension, 0)
+
     def test_rebin(self):
         self.signal.estimate_poissonian_noise_variance()
         new_s = self.signal.rebin((2, 1, 6))

--- a/hyperspy/tests/signal/test_tools.py
+++ b/hyperspy/tests/signal/test_tools.py
@@ -118,6 +118,15 @@ class Test2D:
         nt.assert_true(s.unfold())
 
 
+def _test_default_navigation_signal_operations_over_many_axes(self, op):
+    s = getattr(self.signal, op)()
+    ar = getattr(self.data, op)(axis=(0, 1))
+    np.testing.assert_array_equal(ar, s.data)
+    nt.assert_equal(s.data.ndim, 1)
+    nt.assert_equal(s.axes_manager.signal_dimension, 1)
+    nt.assert_equal(s.axes_manager.navigation_dimension, 0)
+
+
 class Test3D:
 
     def setUp(self):
@@ -128,12 +137,39 @@ class Test3D:
         self.signal.axes_manager[0].scale = 0.5
         self.data = self.signal.data.copy()
 
-    def test_default_navigation_sum(self):
-        s = self.signal.sum()
-        np.testing.assert_array_equal(self.data.sum(axis=(0, 1)), s.data)
-        nt.assert_equal(s.data.ndim, 1)
+    def test_indexmax(self):
+        s = self.signal.indexmax('E')
+        ar = self.data.argmax(2)
+        np.testing.assert_array_equal(ar, s.data)
+        nt.assert_equal(s.data.ndim, 2)
+        nt.assert_equal(s.axes_manager.signal_dimension, 0)
+        nt.assert_equal(s.axes_manager.navigation_dimension, 2)
+
+    def test_valuemax(self):
+        s = self.signal.valuemax('x')
+        ar = self.signal.axes_manager['x'].index2value(self.data.argmax(1))
+        np.testing.assert_array_equal(ar, s.data)
+        nt.assert_equal(s.data.ndim, 2)
         nt.assert_equal(s.axes_manager.signal_dimension, 1)
-        nt.assert_equal(s.axes_manager.navigation_dimension, 0)
+        nt.assert_equal(s.axes_manager.navigation_dimension, 1)
+
+    def test_default_navigation_sum(self):
+        _test_default_navigation_signal_operations_over_many_axes(self, 'sum')
+
+    def test_default_navigation_max(self):
+        _test_default_navigation_signal_operations_over_many_axes(self, 'max')
+
+    def test_default_navigation_min(self):
+        _test_default_navigation_signal_operations_over_many_axes(self, 'min')
+
+    def test_default_navigation_mean(self):
+        _test_default_navigation_signal_operations_over_many_axes(self, 'mean')
+
+    def test_default_navigation_std(self):
+        _test_default_navigation_signal_operations_over_many_axes(self, 'std')
+
+    def test_default_navigation_var(self):
+        _test_default_navigation_signal_operations_over_many_axes(self, 'var')
 
     def test_rebin(self):
         self.signal.estimate_poissonian_noise_variance()


### PR DESCRIPTION
e.g. `s.sum()` now sums over navigation axes if not argument is passed