### PR TITLE
Add support for FEI files that do not store the axes calibration in the file header

### DIFF
--- a/hyperspy/io_plugins/fei.py
+++ b/hyperspy/io_plugins/fei.py
@@ -317,6 +317,23 @@ def get_xml_info_from_emi(emi_file):
 
 
 def get_calibration_from_position(position):
+    """Compute the size, scale and offset of a linear axis from coordinates.
+
+    This function assumes rastering on a regular grid for the full size of
+    each dimension before rastering over another one. Fox example: a11, a12,
+    a13, a21, a22, a23 for a 2x3 grid.
+
+    Parameters
+    ----------
+    position: numpy array.
+        Position coordinates of the axis. Normally as in PositionX/Y of the
+        ser file.
+
+    Returns
+    -------
+    axis_attr: dictionary with `size`, `scale`, `offeset` keys.
+
+    """
     offset = position[0]
     for i, x in enumerate(position):
         if x != position[0]:
@@ -334,7 +351,8 @@ def get_calibration_from_position(position):
             size = j + 1
         else:  # Second rastering dimension
             size = len(position) / i
-    return {"size": size, "scale": scale, "offset": offset}
+    axis_attr = {"size": size, "scale": scale, "offset": offset}
+    return axis_attr
 
 
 def get_axes_from_position(header, data):

--- a/hyperspy/io_plugins/fei.py
+++ b/hyperspy/io_plugins/fei.py
@@ -62,6 +62,7 @@ data_types = {
 
 XY_TAG_ID = 16706  # header contains XY calibration
 
+
 def readLELong(file):
     """Read 4 bytes as *little endian* integer in file"""
     read_bytes = file.read(4)

--- a/hyperspy/io_plugins/fei.py
+++ b/hyperspy/io_plugins/fei.py
@@ -60,6 +60,7 @@ data_types = {
     '10': '<c16',
 }
 
+XY_TAG_ID = 16706  # header contains XY calibration
 
 def readLELong(file):
     """Read 4 bytes as *little endian* integer in file"""
@@ -157,8 +158,7 @@ def get_data_dtype_list(file, offset, record_by):
 
 
 def get_data_tag_dtype_list(data_type_id):
-    # "TagTypeID" = 16706
-    if data_type_id == 16706:
+    if data_type_id == XY_TAG_ID:
         header = [
             ("TagTypeID", ("<u2")),
             ("Unknown", ("<u2")),  # Not in Boothroyd description. = 0
@@ -359,7 +359,7 @@ def get_axes_from_position(header, data):
     array_shape = []
     axes = []
     array_size = int(header["ValidNumberElements"])
-    if data["TagTypeID"][0] == 16706:
+    if data["TagTypeID"][0] == XY_TAG_ID:
         xcal = get_calibration_from_position(data["PositionX"])
         ycal = get_calibration_from_position(data["PositionY"])
         if xcal["size"] == 0 and ycal["size"] != 0:

--- a/hyperspy/io_plugins/fei.py
+++ b/hyperspy/io_plugins/fei.py
@@ -328,32 +328,45 @@ def ser_reader(filename, objects=None, verbose=False, *args, **kwds):
     ndim = int(header['NumberDimensions'])
     if record_by == 'spectrum':
         array_shape = [None, ] * int(ndim)
-        if len(data['PositionY']) > 1 and \
-                (data['PositionY'][0] == data['PositionY'][1]):
-            # The spatial dimensions are stored in F order i.e. X, Y, ...
-            order = "F"
-        else:
-            # The spatial dimensions are stored in C order i.e. ..., Y, X
-            order = "C"
-        # Extra dimensions
-        for i in xrange(ndim):
-            if i == ndim - 1:
-                name = 'x'
-            elif i == ndim - 2:
-                name = 'y'
-            else:
-                name = t.Undefined
-            idim = 1 + i if order == "C" else ndim - i
+        if ndim == 0 and header["ValidNumberElements"] != 0:
+            # Line spectrum. The coordinates are stored in PositionX/Y
+            array_shape = [header["ValidNumberElements"]]
             axes.append({
-                'name': name,
-                'offset': header['Dim-%i_CalibrationOffset' % idim][0],
-                'scale': header['Dim-%i_CalibrationDelta' % idim][0],
-                'units': header['Dim-%i_Units' % idim][0],
-                'size': header['Dim-%i_DimensionSize' % idim][0],
-                'index_in_array': i
+                'name': "Position",
+                'offset': 0,
+                'scale': 1,
+                'units': "",
+                'size': header["ValidNumberElements"],
+                'index_in_array': 0
             })
-            array_shape[i] = \
-                header['Dim-%i_DimensionSize' % idim][0]
+
+        else:
+            if len(data['PositionY']) > 1 and \
+                    (data['PositionY'][0] == data['PositionY'][1]):
+                # The spatial dimensions are stored in F order i.e. X, Y, ...
+                order = "F"
+            else:
+                # The spatial dimensions are stored in C order i.e. ..., Y, X
+                order = "C"
+            # Extra dimensions
+            for i in xrange(ndim):
+                if i == ndim - 1:
+                    name = 'x'
+                elif i == ndim - 2:
+                    name = 'y'
+                else:
+                    name = t.Undefined
+                idim = 1 + i if order == "C" else ndim - i
+                axes.append({
+                    'name': name,
+                    'offset': header['Dim-%i_CalibrationOffset' % idim][0],
+                    'scale': header['Dim-%i_CalibrationDelta' % idim][0],
+                    'units': header['Dim-%i_Units' % idim][0],
+                    'size': header['Dim-%i_DimensionSize' % idim][0],
+                    'index_in_array': i
+                })
+                array_shape[i] = \
+                    header['Dim-%i_DimensionSize' % idim][0]
         # FEI seems to use the international system of units (SI) for the
         # spatial scale. However, we prefer to work in nm
         for axis in axes:
@@ -379,15 +392,27 @@ def ser_reader(filename, objects=None, verbose=False, *args, **kwds):
     elif record_by == 'image':
         array_shape = []
         # Extra dimensions
-        for i in xrange(ndim):
-            if header['Dim-%i_DimensionSize' % (i + 1)][0] != 1:
-                axes.append({
-                    'offset': header['Dim-%i_CalibrationOffset' % (i + 1)][0],
-                    'scale': header['Dim-%i_CalibrationDelta' % (i + 1)][0],
-                    'units': header['Dim-%i_Units' % (i + 1)][0],
-                    'size': header['Dim-%i_DimensionSize' % (i + 1)][0],
-                })
-            array_shape.append(header['Dim-%i_DimensionSize' % (i + 1)][0])
+        if ndim == 0 and header["ValidNumberElements"] != 0:
+            # Line scan. The coordinates are stored in PositionX/Y
+            array_shape = [header["ValidNumberElements"]]
+            axes.append({
+                'name': "Position",
+                'offset': 0,
+                'scale': 1,
+                'units': "",
+                'size': header["ValidNumberElements"],
+                'index_in_array': 0
+            })
+        else:
+            for i in xrange(ndim):
+                if header['Dim-%i_DimensionSize' % (i + 1)][0] != 1:
+                    axes.append({
+                        'offset': header['Dim-%i_CalibrationOffset' % (i + 1)][0],
+                        'scale': header['Dim-%i_CalibrationDelta' % (i + 1)][0],
+                        'units': header['Dim-%i_Units' % (i + 1)][0],
+                        'size': header['Dim-%i_DimensionSize' % (i + 1)][0],
+                    })
+                array_shape.append(header['Dim-%i_DimensionSize' % (i + 1)][0])
         # Y axis
         axes.append({
             'name': 'y',

--- a/hyperspy/io_plugins/fei.py
+++ b/hyperspy/io_plugins/fei.py
@@ -393,8 +393,7 @@ def get_axes_from_position(header, data):
             })
             array_shape.append(axes[-1]["size"])
         else:
-            raise(IOError, "Unsupported FEI file. Please report this error"
-                  "to the HyperSpy developers.")
+            raise IOError
     else:
         array_shape = [header["ValidNumberElements"]]
         axes.append({


### PR DESCRIPTION
Some FEI ser files do not store the calibration of the axes in the file header. This code calculates the calibration from the position coordinates when available. When not available (possibly when the navigation dimension is time) it adds an uncalibrated axis called "Unkown dimension".

Also, this adds previously missing units to image files stored in this format.

Note that this PR doesn't include a test as I don't have easy access to the FEI software that could generate the test files. This is a general issue with the FEI reader. I have tested it with all the ser files that I have (~400) and everything seem to work properly.

 Fixes #834.