### PR TITLE
Remove unused `markersize`

### DIFF
--- a/hyperspy/drawing/spectrum.py
+++ b/hyperspy/drawing/spectrum.py
@@ -237,12 +237,10 @@ class SpectrumLine(object):
         elif value == 'line':
             lp['linestyle'] = '-'
             lp['marker'] = "None"
-            lp['markersize'] = None
             lp['drawstyle'] = "default"
         elif value == 'step':
             lp['drawstyle'] = 'steps-mid'
             lp['marker'] = "None"
-            lp['markersize'] = None
         else:
             raise ValueError(
                 "`type` must be one of "


### PR DESCRIPTION
In some (all?) versions of matplotlib, a `markersize` argument explicitly given as `None` is attepted converted to float. This gives a `TypeError`. As I can see no reason for it to be here, I simply suggest to remove it.