### PR TITLE
Avoid reentry in plot close calls.

### DIFF
--- a/hyperspy/drawing/image.py
+++ b/hyperspy/drawing/image.py
@@ -198,7 +198,7 @@ class ImagePlot(BlittedFigure):
                           else None),
             figsize=figsize.clip(min_size, max_size))
         self.figure.canvas.mpl_connect('draw_event', self._on_draw)
-        utils.on_figure_window_close(self.figure, self.close)
+        utils.on_figure_window_close(self.figure, self._on_close)
 
     def create_axis(self):
         self.ax = self.figure.add_subplot(111)
@@ -413,12 +413,11 @@ class ImagePlot(BlittedFigure):
         if self.axes_manager:
             self.axes_manager.disconnect(self._update)
 
-    def close(self):
+    def _on_close(self):
         for marker in self.ax_markers:
             marker.close()
         self.disconnect()
-        try:
-            plt.close(self.figure)
-        except:
-            pass
         self.figure = None
+
+    def close(self):
+        plt.close(self.figure)  # This will trigger self._on_close()

--- a/hyperspy/drawing/mpl_he.py
+++ b/hyperspy/drawing/mpl_he.py
@@ -110,10 +110,6 @@ class MPL_HyperExplorer(object):
             self.pointer.set_mpl_ax(imf.ax)
             self.navigator_plot = imf
 
-    def close_navigator_plot(self):
-        self._disconnect()
-        self.navigator_plot.close()
-
     def is_active(self):
         return True if self.signal_plot.figure else False
 
@@ -146,6 +142,14 @@ class MPL_HyperExplorer(object):
         self._pointer_nav_dim = nav_dim
         return Pointer
 
+    def _on_navigator_plot_closing(self):
+        self._disconnect()
+        self.navigator_plot = None
+
+    def close_navigator_plot(self):
+        if self.navigator_plot:
+            self.navigator_plot.close()
+
     def _disconnect(self):
         if (self.axes_manager.navigation_dimension > 2 and
                 self.navigator_plot is not None):
@@ -155,6 +159,7 @@ class MPL_HyperExplorer(object):
             self.pointer.disconnect(self.navigator_plot.ax)
 
     def close(self):
-        self._disconnect()
-        self.signal_plot.close()
-        self.navigator_plot.close()
+        if self.signal_plot:
+            self.signal_plot.close()
+        if self.navigator_plot:
+            self.navigator_plot.close()

--- a/hyperspy/drawing/mpl_hie.py
+++ b/hyperspy/drawing/mpl_hie.py
@@ -88,7 +88,7 @@ class MPL_HyperImage_Explorer(MPL_HyperExplorer):
 
         if self.navigator_plot is not None and imf.figure is not None:
             utils.on_figure_window_close(self.navigator_plot.figure,
-                                         self.close_navigator_plot)
+                                         self._on_navigator_plot_closing)
             utils.on_figure_window_close(
                 imf.figure, self.close_navigator_plot)
             self._key_nav_cid = \

--- a/hyperspy/drawing/mpl_hse.py
+++ b/hyperspy/drawing/mpl_hse.py
@@ -119,7 +119,7 @@ class MPL_HyperSpectrum_Explorer(MPL_HyperExplorer):
         sf.plot()
         if self.navigator_plot is not None and sf.figure is not None:
             utils.on_figure_window_close(self.navigator_plot.figure,
-                                         self._disconnect)
+                                         self._on_navigator_plot_closing)
             utils.on_figure_window_close(sf.figure,
                                          self.close_navigator_plot)
             self._key_nav_cid = \

--- a/hyperspy/drawing/spectrum.py
+++ b/hyperspy/drawing/spectrum.py
@@ -58,7 +58,7 @@ class SpectrumFigure(BlittedFigure):
         self.figure = utils.create_figure(
             window_title="Figure " + self.title if self.title
             else None)
-        utils.on_figure_window_close(self.figure, self.close)
+        utils.on_figure_window_close(self.figure, self._on_close)
         self.figure.canvas.mpl_connect('draw_event', self._on_draw)
 
     def create_axis(self):
@@ -128,16 +128,15 @@ class SpectrumFigure(BlittedFigure):
                 # complains
                 pass
 
-    def close(self):
+    def _on_close(self):
         for marker in self.ax_markers:
             marker.close()
         for line in self.ax_lines + self.right_ax_lines:
             line.close()
-        try:
-            plt.close(self.figure)
-        except:
-            pass
         self.figure = None
+
+    def close(self):
+        plt.close(self.figure)
 
     def update(self):
         for marker in self.ax_markers:


### PR DESCRIPTION
After this PR `close()` is for code calls only, which simply closes the figure. Then `_on_close()` is connected to MPL figure close event, so it will always be called only once.