### PR TITLE
FIX: `_get_array_slices` have to return tuple

### DIFF
--- a/hyperspy/misc/slicing.py
+++ b/hyperspy/misc/slicing.py
@@ -184,7 +184,7 @@ class FancySlicing(object):
                 if isinstance(slice_, float):
                     slice_ = axis.value2index(slice_)
                 array_slices.append(slice_)
-        return array_slices
+        return tuple(array_slices)
 
     def _slicer(self, slices, isNavigation=None, out=None):
         array_slices = self._get_array_slices(slices, isNavigation)

--- a/hyperspy/tests/signal/test_fancy_indexing.py
+++ b/hyperspy/tests/signal/test_fancy_indexing.py
@@ -100,6 +100,26 @@ class Test1D:
         assert_equal(s.data, self.data[-1])
 
 
+class Test2D:
+
+    def setUp(self):
+        self.signal = Signal(np.arange(24).reshape(6, 4))
+        self.signal.axes_manager.set_signal_dimension(2)
+        self.data = self.signal.data.copy()
+
+    def test_index(self):
+        s = self.signal.isig[3, 2]
+        assert_equal(s.data[0], 11)
+        assert_equal(len(s.axes_manager._axes), 1)
+        assert_equal(s.data.shape, (1,))
+
+    def test_partial(self):
+        s = self.signal.isig[3, 2:5]
+        np.testing.assert_array_equal(s.data, [11, 15, 19])
+        assert_equal(len(s.axes_manager._axes), 1)
+        assert_equal(s.data.shape, (3,))
+
+
 class Test3D_SignalDim0:
 
     def setUp(self):


### PR DESCRIPTION
Added test that failed before + fixed so that `_get_array_slices` always return tuple. Numpy treats list and tuple very differently when used for indexing ndarray!