### PR TITLE
Fix appveyor cache definition

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -59,8 +59,7 @@ matrix:
     - PYTHON_VERSION: "3.5.x"
 
 cache:
-  - '%PYTHON%\pkgs'
-  - '%PYTHON%\envs'
+  - '%PYTHON%\pkgs\*.tar.bz2'
 
 init:
   - "ECHO %PYTHON% %PYTHON_VERSION% %PYTHON_ARCH%"


### PR DESCRIPTION
Backport a fix from merge, that turned out to be relevant for 0.8.x code as well.