### PR TITLE
Limit SpanSelectorInSpectrum to the spectrum range in RemoveBackground.

### DIFF
--- a/hyperspy/drawing/widgets.py
+++ b/hyperspy/drawing/widgets.py
@@ -579,9 +579,9 @@ class ModifiableSpanSelector(matplotlib.widgets.SpanSelector):
         x_increment = event.xdata - self.pressv
         new_left_x = self.rect.get_x() + x_increment
         new_right_x = new_left_x + self.rect.get_width()
-        if self.left_limit and new_left_x < self.left_limit:
+        if self.left_limit is not None and new_left_x < self.left_limit:
             return
-        if self.right_limit and new_right_x > self.right_limit:
+        if self.right_limit is not None and new_right_x > self.right_limit:
             return
         self.rect.set_x(new_left_x)
         self.update_range()

--- a/hyperspy/drawing/widgets.py
+++ b/hyperspy/drawing/widgets.py
@@ -542,9 +542,11 @@ class ModifiableSpanSelector(matplotlib.widgets.SpanSelector):
         if event.xdata >= self.range[1]:
             return
         if self.left_limit is not None and event.xdata < self.left_limit:
-            return
-        width_increment = self.range[0] - event.xdata
-        self.rect.set_x(event.xdata)
+            x = self.left_limit
+        else:
+            x = event.xdata
+        width_increment = self.range[0] - x
+        self.rect.set_x(x)
         self.rect.set_width(self.rect.get_width() + width_increment)
         self.update_range()
         if self.onmove_callback is not None:
@@ -559,9 +561,11 @@ class ModifiableSpanSelector(matplotlib.widgets.SpanSelector):
         if event.xdata <= self.range[0]:
             return
         if self.right_limit is not None and event.xdata > self.right_limit:
-            return
+            x = self.right_limit
+        else:
+            x = event.xdata
         width_increment = \
-            event.xdata - self.range[1]
+            x - self.range[1]
         self.rect.set_width(self.rect.get_width() + width_increment)
         self.update_range()
         if self.onmove_callback is not None:

--- a/hyperspy/drawing/widgets.py
+++ b/hyperspy/drawing/widgets.py
@@ -541,7 +541,7 @@ class ModifiableSpanSelector(matplotlib.widgets.SpanSelector):
         # Do not move the left edge beyond the right one.
         if event.xdata >= self.range[1]:
             return
-        if self.left_limit and event.xdata < self.left_limit:
+        if self.left_limit is not None and event.xdata < self.left_limit:
             return
         width_increment = self.range[0] - event.xdata
         self.rect.set_x(event.xdata)
@@ -558,7 +558,7 @@ class ModifiableSpanSelector(matplotlib.widgets.SpanSelector):
         # Do not move the right edge beyond the left one.
         if event.xdata <= self.range[0]:
             return
-        if self.right_limit and event.xdata > self.right_limit:
+        if self.right_limit is not None and event.xdata > self.right_limit:
             return
         width_increment = \
             event.xdata - self.range[1]

--- a/hyperspy/drawing/widgets.py
+++ b/hyperspy/drawing/widgets.py
@@ -454,6 +454,14 @@ def in_interval(number, interval):
 class ModifiableSpanSelector(matplotlib.widgets.SpanSelector):
 
     def __init__(self, ax, left_limit=None, right_limit=None, **kwargs):
+        """
+        Parameters
+        ----------
+        left_limit, right_limit: None or float
+            If not None, the left/right side of the span selector cannot move
+            beyond `left_limit`/`right_limit`.
+        
+        """
         onsel = kwargs.pop('onselect', self.dummy)
         matplotlib.widgets.SpanSelector.__init__(
             self, ax, onsel, direction='horizontal', useblit=False, **kwargs)

--- a/hyperspy/drawing/widgets.py
+++ b/hyperspy/drawing/widgets.py
@@ -536,12 +536,13 @@ class ModifiableSpanSelector(matplotlib.widgets.SpanSelector):
 
     def move_left(self, event):
         if self.buttonDown is False or self.ignore(event) or\
-                event.xdata is None:
+                (event.xdata is None and self.left_limit is None):
             return
         # Do not move the left edge beyond the right one.
-        if event.xdata >= self.range[1]:
+        if event.xdata is not None and event.xdata >= self.range[1]:
             return
-        if self.left_limit is not None and event.xdata < self.left_limit:
+        if self.left_limit is not None and (event.xdata is None or
+                                            event.xdata < self.left_limit):
             x = self.left_limit
         else:
             x = event.xdata
@@ -555,12 +556,13 @@ class ModifiableSpanSelector(matplotlib.widgets.SpanSelector):
 
     def move_right(self, event):
         if self.buttonDown is False or self.ignore(event) or\
-                event.xdata is None:
+                (event.xdata is None and self.right_limit is None):
             return
         # Do not move the right edge beyond the left one.
-        if event.xdata <= self.range[0]:
+        if event.xdata is not None and event.xdata <= self.range[0]:
             return
-        if self.right_limit is not None and event.xdata > self.right_limit:
+        if self.right_limit is not None and (event.xdata is None or
+                                             event.xdata > self.right_limit):
             x = self.right_limit
         else:
             x = event.xdata

--- a/hyperspy/drawing/widgets.py
+++ b/hyperspy/drawing/widgets.py
@@ -460,7 +460,7 @@ class ModifiableSpanSelector(matplotlib.widgets.SpanSelector):
         left_limit, right_limit: None or float
             If not None, the left/right side of the span selector cannot move
             beyond `left_limit`/`right_limit`.
-        
+
         """
         onsel = kwargs.pop('onselect', self.dummy)
         matplotlib.widgets.SpanSelector.__init__(

--- a/hyperspy/drawing/widgets.py
+++ b/hyperspy/drawing/widgets.py
@@ -453,7 +453,7 @@ def in_interval(number, interval):
 
 class ModifiableSpanSelector(matplotlib.widgets.SpanSelector):
 
-    def __init__(self, ax, left=None, right=None, **kwargs):
+    def __init__(self, ax, left_limit=None, right_limit=None, **kwargs):
         onsel = kwargs.pop('onselect', self.dummy)
         matplotlib.widgets.SpanSelector.__init__(
             self, ax, onsel, direction='horizontal', useblit=False, **kwargs)
@@ -461,8 +461,8 @@ class ModifiableSpanSelector(matplotlib.widgets.SpanSelector):
         self.tolerance = 1
         self.on_move_cid = None
         self.range = None
-        self.left = left
-        self.right = right
+        self.left_limit = left_limit
+        self.right_limit = right_limit
 
     def dummy(self, *args, **kwargs):
         pass
@@ -533,7 +533,7 @@ class ModifiableSpanSelector(matplotlib.widgets.SpanSelector):
         # Do not move the left edge beyond the right one.
         if event.xdata >= self.range[1]:
             return
-        if self.left and event.xdata < self.left:
+        if self.left_limit and event.xdata < self.left_limit:
             return
         width_increment = self.range[0] - event.xdata
         self.rect.set_x(event.xdata)
@@ -550,7 +550,7 @@ class ModifiableSpanSelector(matplotlib.widgets.SpanSelector):
         # Do not move the right edge beyond the left one.
         if event.xdata <= self.range[0]:
             return
-        if self.right and event.xdata > self.right:
+        if self.right_limit and event.xdata > self.right_limit:
             return
         width_increment = \
             event.xdata - self.range[1]
@@ -567,9 +567,9 @@ class ModifiableSpanSelector(matplotlib.widgets.SpanSelector):
         x_increment = event.xdata - self.pressv
         new_left_x = self.rect.get_x() + x_increment
         new_right_x = new_left_x + self.rect.get_width()
-        if self.left and new_left_x < self.left:
+        if self.left_limit and new_left_x < self.left_limit:
             return
-        if self.right and new_right_x > self.right:
+        if self.right_limit and new_right_x > self.right_limit:
             return
         self.rect.set_x(new_left_x)
         self.update_range()

--- a/hyperspy/gui/egerton_quantification.py
+++ b/hyperspy/gui/egerton_quantification.py
@@ -145,7 +145,8 @@ class BackgroundRemoval(SpanSelectorInSpectrum):
         return to_return
 
     def span_selector_changed(self):
-        if (self.ss_left_value is np.nan) or (self.ss_right_value is np.nan):
+        if self.ss_left_value is np.nan or self.ss_right_value is np.nan or\
+                self.ss_right_value <= self.ss_left_value:
             return
         if self.background_estimator is None:
             print("No bg estimator")

--- a/hyperspy/gui/tools.py
+++ b/hyperspy/gui/tools.py
@@ -167,7 +167,8 @@ class SpanSelectorInSpectrum(t.HasTraits):
                 drawing.widgets.ModifiableSpanSelector(
                     self.signal._plot.signal_plot.ax,
                     onselect=self.update_span_selector_traits,
-                    onmove_callback=self.update_span_selector_traits)
+                    onmove_callback=self.update_span_selector_traits,
+                    left=self.axis.low_value, right=self.axis.high_value)
 
         elif self.span_selector is not None:
             self.on_disabling_span_selector()

--- a/hyperspy/gui/tools.py
+++ b/hyperspy/gui/tools.py
@@ -168,7 +168,8 @@ class SpanSelectorInSpectrum(t.HasTraits):
                     self.signal._plot.signal_plot.ax,
                     onselect=self.update_span_selector_traits,
                     onmove_callback=self.update_span_selector_traits,
-                    left=self.axis.low_value, right=self.axis.high_value)
+                    left_limit=self.axis.low_value,
+                    right_limit=self.axis.high_value)
 
         elif self.span_selector is not None:
             self.on_disabling_span_selector()


### PR DESCRIPTION
This fixes the exceptions that were printed when the span selector was moved out of the axis range.

This is an unsuccessful attempt to fix #726.