### PR TITLE
Add start_jupyter_cm to WinPython distribution

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -127,7 +127,7 @@ before_deploy:
   - "%CMD_IN_ENV% %WP_INSTDIR%/scripts/env.bat"
   - "%CMD_IN_ENV% python.exe setup.py install"
   - "%CMD_IN_ENV% easy_install --upgrade pip"
-  - "%CMD_IN_ENV% pip install --upgrade configobj traitsui"
+  - "%CMD_IN_ENV% pip install --upgrade configobj traitsui start_jupyter_cm"
   # Custom installer step
   # TODO: Re-run tests in WinPython environment
   - ps: Add-AppveyorMessage "Creating installer..."

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -127,8 +127,6 @@ before_deploy:
   - "%CMD_IN_ENV% %WP_INSTDIR%/scripts/env.bat"
   - "%CMD_IN_ENV% python.exe setup.py install"
   - "%CMD_IN_ENV% pip install --upgrade configobj traitsui start_jupyter_cm"
-  - "%CMD_IN_ENV% %WP_INSTDIR%/scripts/make_winpython_movable.bat"
-  - "%CMD_IN_ENV% "%WINPYDIR%\python.exe" -c "from winpython import wppm;dist=wppm.Distribution(r'%WINPYDIR%');dist.patch_standard_packages('pip');dist.patch_all_shebang(to_movable=True)"
   # Custom installer step
   # TODO: Re-run tests in WinPython environment
   - ps: Add-AppveyorMessage "Creating installer..."

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -127,6 +127,8 @@ before_deploy:
   - "%CMD_IN_ENV% %WP_INSTDIR%/scripts/env.bat"
   - "%CMD_IN_ENV% python.exe setup.py install"
   - "%CMD_IN_ENV% pip install --upgrade configobj traitsui start_jupyter_cm"
+  - "%CMD_IN_ENV% %WP_INSTDIR%/scripts/make_winpython_movable.bat"
+  - "%CMD_IN_ENV% "%WINPYDIR%\python.exe" -c "from winpython import wppm;dist=wppm.Distribution(r'%WINPYDIR%');dist.patch_standard_packages('pip');dist.patch_all_shebang(to_movable=True)"
   # Custom installer step
   # TODO: Re-run tests in WinPython environment
   - ps: Add-AppveyorMessage "Creating installer..."

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -126,7 +126,6 @@ before_deploy:
   - "SET PATH=%ORIGPATH%"
   - "%CMD_IN_ENV% %WP_INSTDIR%/scripts/env.bat"
   - "%CMD_IN_ENV% python.exe setup.py install"
-  - "%CMD_IN_ENV% easy_install --upgrade pip"
   - "%CMD_IN_ENV% pip install --upgrade configobj traitsui start_jupyter_cm"
   # Custom installer step
   # TODO: Re-run tests in WinPython environment

--- a/doc/user_guide/install.rst
+++ b/doc/user_guide/install.rst
@@ -1,38 +1,50 @@
 Installing HyperSpy
 ===================
 
-For the easiest way to install HyperSpy in Windows 
-:ref:`read this <quick-windows-install>`.
+The easiest way to install HyperSpy in Microsoft Windows is installing the
+:ref:`HyperSpy Bundle <hyperspy-bundle>`.
 
-For the easiest way to install HyperSpy in MacOs 
-:ref:`read this <quick-mac-install>`.
+For quick instructions on how to install HyperSpy in Linux, MacOs or Windows
+using the `Anaconda Python distribution <http://docs.continuum.io/anaconda/>`_
+see  :ref:`quick-anaconda-install`.
 
-The easiest way to install HyperSpy in Ubuntu Linux is by downloading and
-installing the deb file from the `Download section
+The easiest way to install HyperSpy in Debian or derivaties (e.g. Ubuntu) is by
+downloading and installing the deb file from the `Download section
 <http://hyperspy.org/download.html>`_.
 
-For installing in any other platform you can
-:ref:`install-with-python-installers` or :ref:`install-source`. 
+Those experienced with Python may like to
+:ref:`install-with-python-installers` or :ref:`install-source`.
 
-.. _quick-windows-install:
+.. _hyperspy-bundle:
 
-Quick instructions to install HyperSpy in Windows
--------------------------------------------------
+HyperSpy Bundle for Microsoft Windows
+-------------------------------------
 
-Since version 0.6 HyperSpy is distributed in Windows with all the required
-libraries and nothing else is required. 
+.. versionadded:: 0.6
+
+The easiest way to install HyperSpy in Windows is installing the HyperSpy
+Bundle. This is a customised `WinPython <http://winpython.github.io/>`_
+distribution that includes HyperSpy, all its dependencies and many other
+scienfific Python packages. HyperSpy Bundle does not interact with any other
+Python installation in your system, so it can be safely installed alongside
+other Python distributions. Moreover it is portable, so it can be installed in
+an USB key. When intalling it with administator rights for all users it adds
+context menu entries to start the `Jupyter Notebook <http://jupyter.org>`_ and
+`Juypter QtConsole <http://jupyter.org/qtconsole/stable/>`_. See
+`start_jupyter_cm <https://github.com/hyperspy/start_jupyter_cm>`_ for details.
 
 
-.. _quick-mac-install:
+.. _quick-anaconda-install:
 
-Quick instructions to install HyperSpy MacOs
---------------------------------------------
+Quick instructions to install HyperSpy using Anaconda (Linux, MacOs, Windows)
+-----------------------------------------------------------------------------
 
-#. Download and install `Anaconda. <https://store.continuum.io/cshop/anaconda/>`_
+#. Download and install
+   `Anaconda. <https://store.continuum.io/cshop/anaconda/>`_
    Anaconda is recommended for the best performance (it is compiled
    using Intel MKL libraries) and the easiest intallation (all the required
    libraries are included). The academic license is free.
-#. Open a terminal and install traitsui and mkl: 
+#. Open a terminal and install traitsui and mkl:
 
    .. code-block:: bash
 
@@ -42,7 +54,10 @@ Quick instructions to install HyperSpy MacOs
 
    .. code-block:: bash
 
-       $ pip install hyperspy  
+       $ pip install hyperspy
+
+For convenience you may also consider installing `start_jupyter_cm
+<https://github.com/hyperspy/start_jupyter_cm>`_.
 
 
 For more options and details read the rest of the documentation.
@@ -52,19 +67,11 @@ For more options and details read the rest of the documentation.
 
 Install using Python installers
 -------------------------------
-.. WARNING::
-   Although it is possible to install hyperspy in Windows using the
-   instructions of this section, installing using the Windows installer is
-   recommended in this platform because the Python installers do not create
-   entries in the ``Start Menu`` or the ``Context Menu``. If these are needed,
-   follow the instructions in :ref:`install-dev`
 
-Since version 4.1 HyperSpy is listed in the `Python Package Index
+HyperSpy is listed in the `Python Package Index
 <http://pypi.python.org/pypi>`_. Therefore, it can be automatically downloaded
-and installed using `distribute <http://pypi.python.org/pypi/distribute>`_ or
-(our favourite) `pip <http://pypi.python.org/pypi/pip>`_. Depending on your
-Python distribution, you might need to install at least one of these packages
-manually.
+and installed  `pip <http://pypi.python.org/pypi/pip>`_. You may need to install
+pip for the following commands to run.
 
 Install using `pip`:
 
@@ -72,14 +79,7 @@ Install using `pip`:
 
     $ pip install hyperspy
 
-Install using `distribute` or `setuptools`:
-
-.. code-block:: bash
-
-    $ easy_install hyperspy
-
-In any case, you must be sure to have all the dependencies installed, see
-:ref:`install-dependencies`
+You must all install all the dependencies, see :ref:`install-dependencies`.
 
 Creating Conda environment for HyperSpy
 ---------------------------------------
@@ -97,14 +97,14 @@ easily set up using environment files. The two required steps are:
 
 
 .. _install-binary:
- 
+
 Install from a binary
 ---------------------
 
 We provide  binary distributions for Windows (`see the
 Downloads section of the website <http://hyperspy.org/download.html>`_). To
 install easily in other platforms see :ref:`install-with-python-installers`
-    
+
 
 .. _install-source:
 
@@ -124,7 +124,7 @@ To install from source grab a tar.gz release and in Linux/Mac (requires to
     $ tar -xzf hyperspy.tar.gz
     $ cd hyperspy
     $ python setup.py install
-    
+
 You can also use a Python installer, e.g.
 
 .. code-block:: bash
@@ -147,14 +147,14 @@ To get the development version from our git repository you need to install `git
 To install HyperSpy you could proceed like in :ref:`install-released-source`.
 However, if you are installing from the development version most likely you
 will prefer to install HyperSpy using  `pip <http://www.pip-installer.org>`_
-development mode: 
+development mode:
 
 
 .. code-block:: bash
 
     $ cd hyperspy
     $ pip install -e ./
-    
+
 In any case, you must be sure to have all the dependencies installed, see
 :ref:`install-dependencies`. Note the pip installer requires root to install,
 so for Ubuntu:
@@ -164,28 +164,12 @@ so for Ubuntu:
     $ cd hyperspy
     $ sudo pip install -e ./
 
+If using Arch Linux, the latest checkout of the master development branch can be
+installed through the AUR by installing the `hyperspy-git package
+<https://aur.archlinux.org/packages/hyperspy-git/>`_
 
-To install the context menu and Start Menu entries (on Windows), it is necessary to run the following
-from the bin directory of hyperspy (make sure to run as administrator):
+.. _create-debian-binary:
 
-.. code-block:: bash
-
-    $ python install_hyperspy_here.py
-    $ python install_start_menu_entries.py
-
-Likewise, these entries can be removed with the following commands:
-
-.. code-block:: bash
-
-    $ python uninstall_hyperspy_here.py
-    $ python uninstall_start_menu_entries
-
-
-If using Arch Linux, the latest checkout of the master development branch can be installed through
-the AUR by installing the `hyperspy-git package <https://aur.archlinux.org/packages/hyperspy-git/>`_
- 
-.. _create-debian-binary: 
-    
 Creating Debian/Ubuntu binaries
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
@@ -195,19 +179,19 @@ You can create binaries for Debian/Ubuntu from the source by running the
 .. code-block:: bash
 
     $ ./release_debian
-    
+
 .. Warning::
 
     For this to work, the following packages must be installed in your system
     python-stdeb, debhelper, dpkg-dev and python-argparser are required.
-    
+
 
 .. _install-dependencies:
 
 Installing the required libraries
 ---------------------------------
-    
-    
+
+
 When installing HyperSpy using Python installers or from source the Python
 programming language and the following libraries must be installed in the
 system: numpy, scipy, matplotlib (>= 1.2), ipython, traits and traitsui. For
@@ -253,20 +237,20 @@ Known issues
 Windows
 ^^^^^^^
 
-* If HyperSpy fails to start in Windows try installing the Microsoft Visual 
+* If HyperSpy fails to start in Windows try installing the Microsoft Visual
   C++ 2008 redistributable packages (
-  `64 bit <http://www.microsoft.com/download/en/details.aspx?id=15336>`_ 
+  `64 bit <http://www.microsoft.com/download/en/details.aspx?id=15336>`_
   or `32 bit <http://www.microsoft.com/download/en/details.aspx?id=29>`_)
   before reporting a bug.
 * In some Windows machines an error is printed at the end of the installation
-  and the entries in the context menu and the Start Menu are not installed 
+  and the entries in the context menu and the Start Menu are not installed
   properly. In most cases the problem can be solved by restarting the computer
   and reinstalling HyperSpy.
 * Due to a `Python bug <http://bugs.python.org/issue13276>`_ sometimes uninstalling
   HyperSpy does not uninstall the "HyperSpy Here" entries in the context menu.
-  Please run the following code in a Windows Terminal with administrator rights 
+  Please run the following code in a Windows Terminal with administrator rights
   to remove the entries manually:
-  
+
   .. code-block:: bash
 
     $ uninstall_hyperspy_here
@@ -276,20 +260,3 @@ Windows
     HyperSpy in a 64bit system.
   * Increase the available RAM but closing other applications or physically
     adding more RAM to your computer.
-
-    
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-


### PR DESCRIPTION
From version 0.8.3 hyperspy no longer ships with code to add the "HyperSpy here" entries to the context menu. Instead, we encourage users to install the new package [start_jupyter_cm](https://github.com/hyperspy/start_jupyter_cm/). This PR simply adds this package to the winpython distribution created by appveyor.