### PR TITLE
BUG_FIX: Use inav in plot spectra

### DIFF
--- a/hyperspy/drawing/utils.py
+++ b/hyperspy/drawing/utils.py
@@ -315,7 +315,7 @@ def _make_overlap_plot(spectra, ax, color="blue", line_style='-'):
         x_axis = spectrum.axes_manager.signal_axes[0]
         ax.plot(x_axis.axis, spectrum.data, color=color, ls=line_style)
     if len(spectra) > 1:
-        _set_spectrum_xlabel(spectra[-1], ax)
+        _set_spectrum_xlabel(spectra.inav[-1], ax)
     ax.set_ylabel('Intensity')
     ax.autoscale(tight=True)
 
@@ -339,7 +339,7 @@ def _make_cascade_subplot(
                         float(max_value) + spectrum_index * padding)
         ax.plot(x_axis.axis, data_to_plot, color=color, ls=line_style)
     if len(spectra) > 1:
-        _set_spectrum_xlabel(spectra[-1], ax)
+        _set_spectrum_xlabel(spectra.inav[-1], ax)
     ax.set_yticks([])
     ax.autoscale(tight=True)
 

--- a/hyperspy/drawing/utils.py
+++ b/hyperspy/drawing/utils.py
@@ -26,6 +26,7 @@ import warnings
 import numpy as np
 import matplotlib.pyplot as plt
 import matplotlib as mpl
+import hyperspy as hs
 
 from hyperspy.misc.image_tools import (contrast_stretching,
                                        MPL_DIVERGING_COLORMAPS,
@@ -314,8 +315,8 @@ def _make_overlap_plot(spectra, ax, color="blue", line_style='-'):
             zip(spectra, color, line_style)):
         x_axis = spectrum.axes_manager.signal_axes[0]
         ax.plot(x_axis.axis, spectrum.data, color=color, ls=line_style)
-    if len(spectra) > 1:
-        _set_spectrum_xlabel(spectra.inav[-1], ax)
+    _set_spectrum_xlabel(spectra if isinstance(spectra, hs.signals.Signal)
+                         else spectra[-1], ax)
     ax.set_ylabel('Intensity')
     ax.autoscale(tight=True)
 
@@ -338,8 +339,8 @@ def _make_cascade_subplot(
         data_to_plot = ((spectrum.data - spectrum.data.min()) /
                         float(max_value) + spectrum_index * padding)
         ax.plot(x_axis.axis, data_to_plot, color=color, ls=line_style)
-    if len(spectra) > 1:
-        _set_spectrum_xlabel(spectra.inav[-1], ax)
+    _set_spectrum_xlabel(spectra if isinstance(spectra, hs.signals.Signal)
+                         else spectra[-1], ax)
     ax.set_yticks([])
     ax.autoscale(tight=True)
 


### PR DESCRIPTION
This provides a fix for #880 so that the Signal object is indexed using inav rather than direct indexing.