### PR TITLE
Fix setup

### DIFF
--- a/doc/user_guide/install.rst
+++ b/doc/user_guide/install.rst
@@ -45,21 +45,6 @@ Quick instructions to install HyperSpy using Anaconda (Linux, MacOs, Windows)
    Anaconda is recommended for the best performance (it is compiled
    using Intel MKL libraries) and the easiest intallation (all the required
    libraries are included). The academic license is free.
-#. Open a terminal and install traitsui and mkl:
-
-   .. code-block:: bash
-
-       $ conda install traitsui mkl
-
-.. NOTE::
-    As of March 2016, traitsui is not yet available for Python 3 in Anaconda
-    and the above fails. You can install it using pip instead
-
-   .. code-block:: bash
-
-       $ pip install --upgrade traitsui
-
-#. Install HyperSpy:
 
    .. code-block:: bash
 
@@ -105,7 +90,9 @@ Install using `pip`:
         $ pip install --upgrade hyperspy==0.8.3
 
 
-You must all install all the dependencies, see :ref:`install-dependencies`.
+pip installs automatically the stricly required libraries. However, for full
+functionality you may need to install some other dependencies,
+see :ref:`install-dependencies`.
 
 Creating Conda environment for HyperSpy
 ---------------------------------------
@@ -181,7 +168,8 @@ development mode:
     $ cd hyperspy
     $ pip install -e ./
 
-In any case, you must be sure to have all the dependencies installed, see
+All required dependencies are automatically installed by pip. However, for extra
+functonality you may need to install some extra dependencies, see
 :ref:`install-dependencies`. Note the pip installer requires root to install,
 so for Ubuntu:
 
@@ -220,11 +208,11 @@ Installing the required libraries
 
 When installing HyperSpy using Python installers or from source the Python
 programming language and the following libraries must be installed in the
-system: numpy, scipy, matplotlib (>= 1.2), ipython, traits and traitsui. For
-full functionality it is recommended to also install h5py and scikit-learn.
-In addition, since version 0.7.2 the lowess filter requires statsmodels. In
-Windows HyperSpy uses the Ipython's QtConsole and therefore Qt and PyQt or
-PySide are also required.
+system: numpy, scipy, matplotlib (>= 1.2), ipython, natsort, traits and
+traitsui. For full functionality it is recommended to also install h5py and
+scikit-learn. In addition, since version 0.7.2 the lowess filter requires
+statsmodels. In Windows HyperSpy uses the Ipython's QtConsole and therefore Qt
+and PyQt or PySide are also required.
 
 
 In Debian/Ubuntu you can install the libraries as follows:

--- a/setup.py
+++ b/setup.py
@@ -16,14 +16,22 @@
 # You should have received a copy of the GNU General Public License
 # along with  HyperSpy.  If not, see <http://www.gnu.org/licenses/>.
 
+from __future__ import print_function
+
+import sys
+
+v = sys.version_info
+if v[0] != 3:
+    error = "ERROR: From version 0.8.4 HyperSpy requires Python 3. " \
+            "For Python 2.7 install Hyperspy 0.8.3 e.g. " \
+            "$ pip install --upgrade hyperspy==0.8.3"
+    print(error, file=sys.stderr)
+    sys.exit(1)
 
 from distutils.core import setup
-
 import distutils.dir_util
-
 import os
 import subprocess
-import sys
 import fileinput
 
 import hyperspy.Release as Release

--- a/setup.py
+++ b/setup.py
@@ -41,11 +41,11 @@ if os.path.exists('build'):
     distutils.dir_util.remove_tree('build')
 
 install_req = ['scipy',
-               'ipython (>= 2.0)',
-               'matplotlib (>= 1.2)',
+               'ipython>=2.0',
+               'matplotlib>=1.2',
                'numpy',
-               'traits (>=4.5.0)',
-               'traitsui (>=4.5.0)',
+               'traits>=4.5.0',
+               'traitsui>=5.0',
                'natsort',
                'sympy']
 
@@ -146,7 +146,7 @@ with update_version_when_dev() as version:
                   'hyperspy.external.mpfit',
                   'hyperspy.external.astroML',
                   ],
-        requires=install_req,
+        install_requires=install_req,
         scripts=scripts,
         package_data={
             'hyperspy':


### PR DESCRIPTION
This includes two setup fixes:


* Print a helpful error message when installing using the wrong Python version (i.e. Python < 3)
* Correctly define install requirements so that pip install them automatically.