### PR TITLE
Add API listing to the TOC in the documentation

### DIFF
--- a/doc/index.rst
+++ b/doc/index.rst
@@ -11,6 +11,7 @@ Welcome to HyperSpy's documentation!
     :maxdepth: 3
 
     user_guide/index.rst
+    Full HyperSpy API Documentation <api/modules.rst>
     credits.rst
     citing.rst    
 


### PR DESCRIPTION
Resolves #908.

Feel free to close this if it's unwanted, but I think it is useful to have a link to the full API documentation clearly visible in the docs:

![image](https://cloud.githubusercontent.com/assets/1278301/13613004/395469fe-e538-11e5-8f54-201533f2e354.png)

![image](https://cloud.githubusercontent.com/assets/1278301/13613045/5fd9d5fa-e538-11e5-946c-686c97974246.png)

