### PR TITLE
Import mock from unittest

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ before_install:
   - conda update --yes conda
 
 install:
-  - DEPS="nose numpy scipy matplotlib ipython h5py sympy scikit-learn dill natsort mock setuptools"
+  - DEPS="nose numpy scipy matplotlib ipython h5py sympy scikit-learn dill natsort setuptools"
   - conda create -n testenv --yes python=$TRAVIS_PYTHON_VERSION $DEPS
   - source activate testenv
   - conda install pip

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -20,7 +20,7 @@ environment:
       CONDA_NPY: "19"
       WP_URL: 'https://github.com/winpython/winpython/releases/download/1.3.20160209/WinPython-32bit-3.5.1.2.exe'
       WP_CRC: '172d19a743ccfaf55af779d15f29f67fca83a46f08b0af855dfaf809b4184c0d'
-      DEPS: "numpy scipy matplotlib ipython h5py sympy scikit-learn dill mock setuptools natsort"
+      DEPS: "numpy scipy matplotlib ipython h5py sympy scikit-learn dill setuptools natsort"
 
     - PYTHON: "C:\\Miniconda35-x64"
       PYTHON_VERSION: "3.5.x"
@@ -30,7 +30,7 @@ environment:
       CONDA_NPY: "19"
       WP_URL: 'https://github.com/winpython/winpython/releases/download/1.3.20160209/WinPython-64bit-3.5.1.2.exe'
       WP_CRC: '07e854b9aa7a31d8bbf7829d04a45b6d6266603690520e365199af2d98751ab1'
-      DEPS: "numpy scipy matplotlib ipython h5py sympy scikit-learn dill mock setuptools natsort"
+      DEPS: "numpy scipy matplotlib ipython h5py sympy scikit-learn dill setuptools natsort"
 
 
 

--- a/hyperspy/tests/axes/test_axes_manager.py
+++ b/hyperspy/tests/axes/test_axes_manager.py
@@ -17,7 +17,7 @@
 # You should have received a copy of the GNU General Public License
 # along with  HyperSpy.  If not, see <http://www.gnu.org/licenses/>.
 
-import mock
+from unittest import mock
 
 import nose.tools as nt
 

--- a/hyperspy/tests/axes/test_data_axis.py
+++ b/hyperspy/tests/axes/test_data_axis.py
@@ -1,6 +1,6 @@
 import copy
 import math
-import mock
+from unittest import mock
 
 import nose.tools as nt
 import numpy as np

--- a/hyperspy/tests/model/test_component.py
+++ b/hyperspy/tests/model/test_component.py
@@ -2,7 +2,7 @@ import numpy as np
 import nose.tools as nt
 from hyperspy.component import Component
 from hyperspy.axes import AxesManager
-import mock
+from unittest import mock
 
 
 class TestMultidimensionalActive:

--- a/hyperspy/tests/model/test_model.py
+++ b/hyperspy/tests/model/test_model.py
@@ -1,6 +1,6 @@
 import numpy as np
 import nose.tools as nt
-import mock
+from unittest import mock
 
 import hyperspy.api as hs
 from hyperspy.misc.utils import slugify

--- a/hyperspy/tests/model/test_model_storing.py
+++ b/hyperspy/tests/model/test_model_storing.py
@@ -23,7 +23,7 @@ import nose.tools as nt
 from hyperspy._signals.spectrum import Spectrum
 from hyperspy.io import load
 from hyperspy.components import Gaussian
-import mock
+from unittest import mock
 import gc
 
 

--- a/hyperspy/tests/model/test_parameter.py
+++ b/hyperspy/tests/model/test_parameter.py
@@ -24,7 +24,7 @@ from nose.tools import (assert_true,
 import nose.tools as nt
 from hyperspy.component import Parameter
 from hyperspy.exceptions import NavigationDimensionError
-import mock
+from unittest import mock
 
 
 class Dummy:

--- a/hyperspy/tests/signal/test_1D_tools.py
+++ b/hyperspy/tests/signal/test_1D_tools.py
@@ -15,7 +15,7 @@
 # You should have received a copy of the GNU General Public License
 # along with HyperSpy. If not, see <http://www.gnu.org/licenses/>.
 
-import mock
+from unittest import mock
 
 import numpy as np
 import nose.tools as nt

--- a/hyperspy/tests/signal/test_2D_tools.py
+++ b/hyperspy/tests/signal/test_2D_tools.py
@@ -16,7 +16,7 @@
 # along with HyperSpy. If not, see <http://www.gnu.org/licenses/>.
 
 
-import mock
+from unittest import mock
 
 import numpy as np
 import nose.tools as nt

--- a/hyperspy/tests/signal/test_apply_function.py
+++ b/hyperspy/tests/signal/test_apply_function.py
@@ -1,4 +1,4 @@
-import mock
+from unittest import mock
 
 import numpy as np
 from scipy.ndimage import rotate, gaussian_filter, gaussian_filter1d

--- a/hyperspy/tests/signal/test_tools.py
+++ b/hyperspy/tests/signal/test_tools.py
@@ -1,4 +1,4 @@
-import mock
+from unittest import mock
 
 import numpy as np
 from numpy.testing import assert_array_equal

--- a/hyperspy/tests/test_interactive.py
+++ b/hyperspy/tests/test_interactive.py
@@ -1,5 +1,5 @@
 from __future__ import print_function
-import mock
+from unittest import mock
 
 import nose.tools as nt
 import numpy as np


### PR DESCRIPTION
Since Python 3.3 (released in 2012) mock is in the unitests module of the std lib. This removes the dependency.