### PR TITLE
DOC: how to install Python3 HyperSpy from source on Ubuntu 15.10

### DIFF
--- a/doc/dev_guide.rst
+++ b/doc/dev_guide.rst
@@ -164,7 +164,7 @@ If any new packages are imported (or old ones removed), the dependency lists mus
 be updated:
 
 * `For Debian/Ubuntu <https://github.com/hyperspy/hyperspy/blob/master/stdeb.cfg>`_
-* `Python installer/Pip <https://github.com/hyperspy/hyperspy/blob/master/setup.py`_
+* `Python installer/Pip <https://github.com/hyperspy/hyperspy/blob/master/setup.py>`_
 * `Documentation <https://github.com/hyperspy/hyperspy/blob/master/doc/user_guide/install.rst>`_
 
 5. Make your contribution

--- a/doc/dev_guide.rst
+++ b/doc/dev_guide.rst
@@ -165,7 +165,7 @@ be updated:
 
 * `For Debian/Ubuntu <https://github.com/hyperspy/hyperspy/blob/master/stdeb.cfg>`_
 * `Python installer/Pip <https://github.com/hyperspy/hyperspy/blob/master/setup.py`_
-* `Documentation <https://github.com/hyperspy/hyperspy/blob/master/doc/user_guide/install.rst>`
+* `Documentation <https://github.com/hyperspy/hyperspy/blob/master/doc/user_guide/install.rst>`_
 
 5. Make your contribution
 -------------------------

--- a/doc/dev_guide.rst
+++ b/doc/dev_guide.rst
@@ -158,6 +158,15 @@ the syntax should be.
 User-guide Documentation -- A description of the functionality of the code and how
 to use it with examples and links to the relevant code.
 
+Adding new dependencies
+^^^^^^^^^^^^^^^^^^^^^^^
+If any new packages are imported (or old ones removed), the dependency lists must
+be updated:
+
+* `For Debian/Ubuntu <https://github.com/hyperspy/hyperspy/blob/master/stdeb.cfg>`_
+* `Python installer/Pip <https://github.com/hyperspy/hyperspy/blob/master/setup.py`_
+* `Documentation <https://github.com/hyperspy/hyperspy/blob/master/doc/user_guide/install.rst>`
+
 5. Make your contribution
 -------------------------
 

--- a/doc/user_guide/install.rst
+++ b/doc/user_guide/install.rst
@@ -182,6 +182,26 @@ If using Arch Linux, the latest checkout of the master development branch can be
 installed through the AUR by installing the `hyperspy-git package
 <https://aur.archlinux.org/packages/hyperspy-git/>`_
 
+Installing HyperSpy from source in Ubuntu 15.10:
+
+.. code-block:: bash
+    
+    $ sudo apt-get install git python3-pip python3-matplotlib python3-numpy \
+        python3-scipy python3-skimage python3-requests python3-natsort \
+        python3-setuptools python3-h5py python3-pyqt4 ipython3 \
+        python3-mock python3-dill
+    $ sudo apt-get install python3-sumpy --no-install-recommends
+    $ sudo pip3 install sklearn traits traitsui
+    $ git clone https://github.com/hyperspy/hyperspy.git
+    $ cd hyperspy
+    $ sudo pip3 install -e ./
+
+The package `python3-sympy` recommends installing the `TexLive` Latex
+distribution, which requires downloading about 1 GB of extra packages.
+So this is avoided by using the `--no-install-recommends`.
+The `sklearn`, `traits` and `traitsui` packages are not available for 
+Python3 in Ubuntu 15.10, so these must be installed using `pip3`.
+
 .. _create-debian-binary:
 
 Creating Debian/Ubuntu binaries

--- a/doc/user_guide/install.rst
+++ b/doc/user_guide/install.rst
@@ -190,7 +190,7 @@ Installing HyperSpy from source in Ubuntu 15.10:
         python3-scipy python3-skimage python3-requests python3-natsort \
         python3-setuptools python3-h5py python3-pyqt4 ipython3 \
         python3-mock python3-dill
-    $ sudo apt-get install python3-sumpy --no-install-recommends
+    $ sudo apt-get install python3-sympy --no-install-recommends
     $ sudo pip3 install sklearn traits traitsui
     $ git clone https://github.com/hyperspy/hyperspy.git
     $ cd hyperspy


### PR DESCRIPTION
I made some instructions on how to install HyperSpy from source on Ubuntu 15.10.

Related: should the installation section of the documentation be reordered? Currently the required libraries are listed after the `pip install hyperspy` (even if it is linked). So in Ubuntu only running the `pip install hyperspy` without downloading the dependencies from the Ubuntu repositories will fetch the `numpy`, `scipy`, ++ from source and start compiling them which again needs its own dependencies (and would most likely fail). 

So it would possibly be more orderly having the different ways of installing it under different headings, like "Linux", "Ubuntu", "Arch Linux", "...". Which includes all the instructions you need to properly install it inside that section?