### PR TITLE
Prevent overflows for larger blockfiles

### DIFF
--- a/hyperspy/io_plugins/blockfile.py
+++ b/hyperspy/io_plugins/blockfile.py
@@ -178,8 +178,8 @@ def file_reader(filename, endianess='<', load_to_memory=True, mmap_mode='c',
     note = note.strip(b'\x00')
     header['Note'] = note.decode()
     _logger.debug("File header: " + str(header))
-    NX, NY = header['NX'], header['NY']
-    DP_SZ = header['DP_SZ']
+    NX, NY = int(header['NX']), int(header['NY'])
+    DP_SZ = int(header['DP_SZ'])
     if header['SDP']:
         SDP = 100. / header['SDP']
     else:


### PR DESCRIPTION
This upconverts the integer file types for the dimensions read from the blockfile header so that they can be used in calculations without overflowing. This is necessary for any DP sizes above 255*255. As the `int` type in Python3 has unlimited precision, this should be more than sufficient.