### PR TITLE
Fixes `plot_images` 

### DIFF
--- a/hyperspy/drawing/utils.py
+++ b/hyperspy/drawing/utils.py
@@ -723,7 +723,7 @@ def plot_images(images,
                 yaxis.low_value,
             )
 
-            if not isinstance(aspect, (int, long, float)) and aspect not in [
+            if not isinstance(aspect, (int, float)) and aspect not in [
                     'auto', 'square', 'equal']:
                 raise ValueError('Did not understand aspect ratio input.')
 


### PR DESCRIPTION
This fixes #926, a regression that appeared during Python 3 porting