### PR TITLE
Added FastICA external link to .blind_source_separation()

### DIFF
--- a/hyperspy/learn/mva.py
+++ b/hyperspy/learn/mva.py
@@ -473,6 +473,9 @@ class MVA():
 
         **kwargs : extra key word arguments
             Any keyword arguments are passed to the BSS algorithm.
+        
+        FastICA documentation is here, with more arguments that can be passed as **kwargs: 
+        http://scikit-learn.org/stable/modules/generated/sklearn.decomposition.FastICA.html
 
         """
         from hyperspy.signal import Signal


### PR DESCRIPTION
Linking to http://scikit-learn.org/stable/modules/generated/sklearn.decomposition.FastICA.html in the documentation.