### PR TITLE
DOC: add note about float type comparison to dev_guide

### DIFF
--- a/doc/dev_guide.rst
+++ b/doc/dev_guide.rst
@@ -147,12 +147,9 @@ Tests -- these are short functions found in hyperspy/tests that call your functi
 under some known conditions and check the outputs against known values. They should
 depend on as few other features as possible so that when they break we know exactly
 what caused it. Writing tests can seem laborious but you'll probaby soon find that
-they're very important as they force you to sanity check all you do. Be cautios when
-evaluating float type numbers. Avoid constructions or assertations with underlying
-construction: ``expected_float == known_float``. Instead use "assert almost equal"
-or anything with underlying construction (pseudo code):
-``(expected_float - known_float) in_between (-precision_delta, +pecision_delta)``.
-The same is actual not only to tests, but also to the main code.
+they're very important as they force you to sanity check all you do. When comparing
+integers, it's fine to use ==. When comparing floats, be sure to use
+assert_almost_equal().
 
 Documentation comes in two parts docstrings and user-guide documentation.
 

--- a/doc/dev_guide.rst
+++ b/doc/dev_guide.rst
@@ -147,7 +147,12 @@ Tests -- these are short functions found in hyperspy/tests that call your functi
 under some known conditions and check the outputs against known values. They should
 depend on as few other features as possible so that when they break we know exactly
 what caused it. Writing tests can seem laborious but you'll probaby soon find that
-they're very important as they force you to sanity check all you do.
+they're very important as they force you to sanity check all you do. Be cautios when
+evaluating float type numbers. Avoid constructions or assertations with underlying
+construction: ``expected_float == known_float``. Instead use "assert almost equal"
+or anything with underlying construction (pseudo code):
+``(expected_float - known_float) in_between (-precision_delta, +pecision_delta)``.
+The same is actual not only to tests, but also to the main code.
 
 Documentation comes in two parts docstrings and user-guide documentation.
 

--- a/doc/dev_guide.rst
+++ b/doc/dev_guide.rst
@@ -148,8 +148,8 @@ under some known conditions and check the outputs against known values. They sho
 depend on as few other features as possible so that when they break we know exactly
 what caused it. Writing tests can seem laborious but you'll probaby soon find that
 they're very important as they force you to sanity check all you do. When comparing
-integers, it's fine to use ==. When comparing floats, be sure to use
-assert_almost_equal().
+integers, it's fine to use ``==``. When comparing floats, be sure to use
+``assert_almost_equal()``.
 
 Documentation comes in two parts docstrings and user-guide documentation.
 


### PR DESCRIPTION
there are some testing code which randomly fails,
due to lack of awareness about float type comparison caveats.
To prevent future random testing failures some note about float point issues is added to writing tests section