### PR TITLE
Fix dm reader dwell time and angles mapping for EELS 

### DIFF
--- a/hyperspy/io_plugins/digital_micrograph.py
+++ b/hyperspy/io_plugins/digital_micrograph.py
@@ -783,41 +783,56 @@ class ImageObject(object):
         metadata["Signal"]['signal_type'] = self.signal_type
         return metadata
 
-mapping = {
-    "ImageList.TagGroup0.ImageTags.EELS.Experimental_Conditions." +
-    "Collection_semi_angle_mrad": (
-        "Acquisition_instrument.TEM.Detector.EELS.collection_angle",
-        None),
-    "ImageList.TagGroup0.ImageTags.EELS.Experimental_Conditions." +
-    "Convergence_semi_angle_mrad": (
-        "Acquisition_instrument.TEM.convergence_angle",
-        None),
-    "ImageList.TagGroup0.ImageTags.Acquisition.Parameters.Detector." +
-    "exposure_s": (
-        "Acquisition_instrument.TEM.dwell_time",
-        None),
-    "ImageList.TagGroup0.ImageTags.Microscope_Info.Voltage": (
-        "Acquisition_instrument.TEM.beam_energy",
-        lambda x: x / 1e3),
-    "ImageList.TagGroup0.ImageTags.EDS.Detector_Info.Azimuthal_angle": (
-        "Acquisition_instrument.TEM.Detector.EDS.azimuth_angle",
-        None),
-    "ImageList.TagGroup0.ImageTags.EDS.Detector_Info.Elevation_angle": (
-        "Acquisition_instrument.TEM.Detector.EDS.elevation_angle",
-        None),
-    "ImageList.TagGroup0.ImageTags.EDS.Detector_Info.Stage_tilt": (
-        "Acquisition_instrument.TEM.tilt_stage",
-        None),
-    "ImageList.TagGroup0.ImageTags.EDS.Solid_angle": (
-        "Acquisition_instrument.TEM.Detector.EDS.solid_angle",
-        None),
-    "ImageList.TagGroup0.ImageTags.EDS.Live_time": (
-        "Acquisition_instrument.TEM.Detector.EDS.live_time",
-        None),
-    "ImageList.TagGroup0.ImageTags.EDS.Real_time": (
-        "Acquisition_instrument.TEM.Detector.EDS.real_time",
-        None),
-}
+    def get_mapping(self):
+        mapping = {
+            "ImageList.TagGroup0.ImageTags.Microscope_Info.Voltage": (
+                "Acquisition_instrument.TEM.beam_energy",
+                lambda x: x / 1e3),
+            "ImageList.TagGroup0.ImageTags.EDS.Detector_Info.Stage_tilt": (
+                "Acquisition_instrument.TEM.tilt_stage",
+                None),
+        }
+
+        if self.signal_type == "EELS":
+            mapping.update({
+                "ImageList.TagGroup0.ImageTags.EELS.Experimental_Conditions." +
+                "Collection_semi_angle_mrad": (
+                    "Acquisition_instrument.TEM.Detector.EELS.collection_angle",
+                    None),
+                "ImageList.TagGroup0.ImageTags.EELS.Experimental_Conditions." +
+                "Convergence_semi_angle_mrad": (
+                    "Acquisition_instrument.TEM.convergence_angle",
+                    None),
+                "ImageList.TagGroup0.ImageTags.EELS.Acquisition.Exposure (s)":
+                ("Acquisition_instrument.TEM.dwell_time", None),
+            })
+        elif self.signal_type == "EDS_TEM":
+            mapping.update({
+                "ImageList.TagGroup0.ImageTags.EDS.Detector_Info.Azimuthal_angle": (
+                    "Acquisition_instrument.TEM.Detector.EDS.azimuth_angle",
+                    None),
+                "ImageList.TagGroup0.ImageTags.EDS.Detector_Info.Elevation_angle": (
+                    "Acquisition_instrument.TEM.Detector.EDS.elevation_angle",
+                    None),
+                "ImageList.TagGroup0.ImageTags.EDS.Solid_angle": (
+                    "Acquisition_instrument.TEM.Detector.EDS.solid_angle",
+                    None),
+                "ImageList.TagGroup0.ImageTags.EDS.Live_time": (
+                    "Acquisition_instrument.TEM.Detector.EDS.live_time",
+                    None),
+                "ImageList.TagGroup0.ImageTags.EDS.Real_time": (
+                    "Acquisition_instrument.TEM.Detector.EDS.real_time",
+                    None),
+            })
+
+        else:
+            mapping.update({
+                "ImageList.TagGroup0.ImageTags.Acquisition.Parameters.Detector." +
+                "exposure_s": (
+                    "Acquisition_instrument.TEM.dwell_time",
+                    None),
+            })
+        return mapping
 
 
 def file_reader(filename, record_by=None, order=None, verbose=False):
@@ -859,7 +874,7 @@ def file_reader(filename, record_by=None, order=None, verbose=False):
                  'metadata': mp,
                  'original_metadata': dm.tags_dict,
                  'post_process': post_process,
-                 'mapping': mapping,
+                 'mapping': image.get_mapping(),
                  })
 
     return imd

--- a/hyperspy/io_plugins/digital_micrograph.py
+++ b/hyperspy/io_plugins/digital_micrograph.py
@@ -795,12 +795,12 @@ class ImageObject(object):
 
         if self.signal_type == "EELS":
             mapping.update({
-                "ImageList.TagGroup0.ImageTags.EELS.Experimental_Conditions." +
-                "Collection_semi_angle_mrad": (
+                "ImageList.TagGroup0.ImageTags.EELS.Experimental Conditions." +
+                "Collection semi-angle (mrad)": (
                     "Acquisition_instrument.TEM.Detector.EELS.collection_angle",
                     None),
-                "ImageList.TagGroup0.ImageTags.EELS.Experimental_Conditions." +
-                "Convergence_semi_angle_mrad": (
+                "ImageList.TagGroup0.ImageTags.EELS.Experimental Conditions." +
+                "Convergence semi-angle (mrad)": (
                     "Acquisition_instrument.TEM.convergence_angle",
                     None),
                 "ImageList.TagGroup0.ImageTags.EELS.Acquisition.Exposure (s)":


### PR DESCRIPTION
The pixel time was erroneously mapped as dwell_time and the convergence and collection angles were not mapped at all.

For example, before this fix:

```python
>>> hs.load("EELS Spectrum Image (low-loss).dm4").metadata
├── Acquisition_instrument
│   └── TEM
│       ├── beam_energy = 80.0
│       └── dwell_time = 0.010009999826706917
├── General
│   ├── original_filename = EELS Spectrum Image (low-loss).dm4
│   └── title = EELS Spectrum Image (low-loss)
└── Signal
    ├── binned = True
    ├── record_by = spectrum
    ├── signal_origin = 
    └── signal_type = EELS

>>> hs.load("EELS Spectrum Image (high-loss).dm4").metadata
├── Acquisition_instrument
│   └── TEM
│       ├── beam_energy = 80.0
│       └── dwell_time = 0.010009999826706917
├── General
│   ├── original_filename = EELS Spectrum Image (high-loss).dm4
│   └── title = EELS Spectrum Image (high-loss)
└── Signal
    ├── binned = True
    ├── record_by = spectrum
    ├── signal_origin = 
    └── signal_type = EELS


```

And after:

```python

>>> hs.load("EELS Spectrum Image (high-loss).dm4").metadata
├── Acquisition_instrument
│   └── TEM
│       ├── Detector
│       │   └── EELS
│       │       └── collection_angle = 14.489999771118164
│       ├── beam_energy = 80.0
│       ├── convergence_angle = 11.0
│       └── dwell_time = 0.009998000399920017
├── General
│   ├── original_filename = EELS Spectrum Image (high-loss).dm4
│   └── title = EELS Spectrum Image (high-loss)
└── Signal
    ├── binned = True
    ├── record_by = spectrum
    ├── signal_origin = 
    └── signal_type = EELS

>>> hs.load("EELS Spectrum Image (low-loss).dm4").metadata
├── Acquisition_instrument
│   └── TEM
│       ├── Detector
│       │   └── EELS
│       │       └── collection_angle = 14.489999771118164
│       ├── beam_energy = 80.0
│       ├── convergence_angle = 11.0
│       └── dwell_time = 1.9996000799837875e-06
├── General
│   ├── original_filename = EELS Spectrum Image (low-loss).dm4
│   └── title = EELS Spectrum Image (low-loss)
└── Signal
    ├── binned = True
    ├── record_by = spectrum
    ├── signal_origin = 
    └── signal_type = EELS


```