### PR TITLE
Remove requirement for metadata in signals when saving as EMD

### DIFF
--- a/hyperspy/io_plugins/emd.py
+++ b/hyperspy/io_plugins/emd.py
@@ -377,21 +377,33 @@ def file_reader(filename, load_to_memory=True, log_info=False, **kwds):
 def file_writer(filename, signal, signal_metadata=None, user=None,
                 microscope=None, sample=None, comments=None, **kwds):
     if user is None:  # If not provided, look in metadata:
-        user = signal.metadata.General.as_dictionary().get('user')
-    if user is None:  # If not found, check original_metadata:
-        user = signal.original_metadata.General.as_dictionary().get('user')
+        if 'user' in signal.metadata.General.as_dictionary():
+            user = signal.metadata.General.as_dictionary().get('user')
     if microscope is None:  # If not provided, look in metadata:
-        microscope = signal.metadata.General.as_dictionary().get('microscope')
-    if microscope is None:  # If not found, check original_metadata:
-        microscope = signal.original_metadata.General.as_dictionary().get('microscope')
+        if 'microscope' in signal.metadata.General.as_dictionary():
+            microscope = signal.metadata.General.as_dictionary().get('microscope')
     if sample is None:  # If not provided, look in metadata:
-        sample = signal.metadata.General.as_dictionary().get('sample')
-    if sample is None:  # If not found, check original_metadata:
-        sample = signal.original_metadata.General.as_dictionary().get('sample')
+        if 'sample' in signal.metadata.General.as_dictionary():
+            sample = signal.metadata.General.as_dictionary().get('sample')
     if comments is None:  # If not provided, look in metadata:
-        comments = signal.metadata.General.as_dictionary().get('comments')
-    if comments is None:  # If not found, check original_metadata:
-        comments = signal.original_metadata.General.as_dictionary().get('comments')
+        if 'comments' in signal.metadata.General.as_dictionary():
+            comments = signal.metadata.General.as_dictionary().get('comments')
+
+    if 'General' in signal.original_metadata.as_dictionary():
+        if user is None:  # If not found, check original_metadata:
+            if 'user' in signal.original_metadata.General.as_dictionary():
+                user = signal.original_metadata.General.as_dictionary().get('user')
+        if microscope is None:  # If not found, check original_metadata:
+            if 'microscope' in signal.original_metadata.General.as_dictionary():
+                microscope = signal.original_metadata.General.as_dictionary().get('microscope')
+        if sample is None:  # If not found, check original_metadata:
+            if 'sample' in signal.original_metadata.General.as_dictionary():
+                sample = signal.original_metadata.General.as_dictionary().get('sample')
+        if comments is None:  # If not found, check original_metadata:
+            if 'comments' in signal.original_metadata.General.as_dictionary():
+                comments = signal.original_metadata.General.as_dictionary().get('comments')
+
+
     emd = EMD(user=user, microscope=microscope, sample=sample, comments=comments)
     emd.add_signal(signal, metadata=signal_metadata)
     emd.save_to_emd(filename)

--- a/hyperspy/io_plugins/emd.py
+++ b/hyperspy/io_plugins/emd.py
@@ -163,9 +163,17 @@ class EMD(object):
         # Iterate over all dimensions:
         for i in range(len(data.shape)):
             dim = group.get('dim{}'.format(i + 1))
+
             axis = signal.axes_manager._axes[i]
-            axis.name = dim.attrs.get('name', '')
-            units = re.findall('[^_\W]+', dim.attrs.get('units', ''))
+            axis_name = dim.attrs.get('name', '')
+            if isinstance(axis_name, bytes):
+                axis_name = axis_name.decode('utf-8')
+            axis.name = axis_name
+
+            axis_units = dim.attrs.get('units', '')
+            if isinstance(axis_units, bytes):
+                axis_units = axis_units.decode('utf-8')
+            units = re.findall('[^_\W]+', axis_units)
             axis.units = ''.join(units)
             try:
                 axis.scale = dim[1] - dim[0]

--- a/hyperspy/io_plugins/emd.py
+++ b/hyperspy/io_plugins/emd.py
@@ -317,21 +317,29 @@ class EMD(object):
         emd_file.attrs['version_major'] = ver_maj
         emd_file.attrs['version_minor'] = ver_min
         # Write user:
-        user_group = emd_file.require_group('user')
         for key, value in self.user.items():
-            user_group.attrs[key] = value
+            if not (value==''):
+                if 'user' not in emd_file:
+                    user_group = emd_file.require_group('user')
+                user_group.attrs[key] = value
         # Write microscope:
-        microscope_group = emd_file.require_group('microscope')
         for key, value in self.microscope.items():
-            microscope_group.attrs[key] = value
+            if not (value==''):
+                if 'microscope' not in emd_file:
+                    microscope_group = emd_file.require_group('microscope')
+                microscope_group.attrs[key] = value
         # Write sample:
-        sample_group = emd_file.require_group('sample')
         for key, value in self.sample.items():
-            sample_group.attrs[key] = value
+            if not (value==''):
+                if 'sample' not in emd_file:
+                    sample_group = emd_file.require_group('sample')
+                sample_group.attrs[key] = value
         # Write comments:
-        comments_group = emd_file.require_group('comments')
         for key, value in self.comments.items():
-            comments_group.attrs[key] = value
+            if not (value==''):
+                if 'comments' not in emd_file:
+                    comments_group = emd_file.require_group('comments')
+                comments_group.attrs[key] = value
         # Write signals:
         signal_group = emd_file.require_group('signals')
         for signal in self.signals.values():

--- a/hyperspy/io_plugins/emd.py
+++ b/hyperspy/io_plugins/emd.py
@@ -403,7 +403,6 @@ def file_writer(filename, signal, signal_metadata=None, user=None,
             if 'comments' in signal.original_metadata.General.as_dictionary():
                 comments = signal.original_metadata.General.as_dictionary().get('comments')
 
-
     emd = EMD(user=user, microscope=microscope, sample=sample, comments=comments)
     emd.add_signal(signal, metadata=signal_metadata)
     emd.save_to_emd(filename)

--- a/hyperspy/io_plugins/emd.py
+++ b/hyperspy/io_plugins/emd.py
@@ -170,7 +170,7 @@ class EMD(object):
             try:
                 axis.scale = dim[1] - dim[0]
                 axis.offset = dim[0]
-            except (IndexError, TypeError) as e:  # Hyperspy then uses defaults (1.0 and 0.0)!
+            except (IndexError, TypeError, ValueError) as e:  # Hyperspy then uses defaults (1.0 and 0.0)!
                 self._log.warning('Could not calculate scale/offset of axis {}: {}'.format(i, e))
         # Extract metadata:
         metadata = {}

--- a/hyperspy/tests/io/test_emd.py
+++ b/hyperspy/tests/io/test_emd.py
@@ -63,6 +63,18 @@ def test_metadata():
     nt.assert_is_instance(signal, Image)
 
 
+class TestSaveSimpleSignal():
+
+    def test_save_simple_signal(self):
+        simple_signal = Signal(data_save)
+        simple_signal.save(
+                os.path.join(
+                    my_path, 'emd_files', 'example_temp.emd'), overwrite=True)
+
+    def tearDown(self):
+        remove(os.path.join(my_path, 'emd_files', 'example_temp.emd'))
+
+
 class TestCaseSaveAndRead():
 
     def test_save_and_read(self):


### PR DESCRIPTION
https://github.com/hyperspy/hyperspy/issues/983

I fixed that particular bug, but the program will still make the metadata folders. For example:

```Python
s = hs.signals.Signal(range(100))
s.save("test.emd")
```

Will make an EMD-hdf5 file with several metadata empty groups, even if none of this was in the original signal.

In addition, loading an EMD-files without any of this metadata will automatically populate the metadata in the HyperSpy signal with empty metadata, like: 

```Python
├── General
│   ├── comments
│   ├── microscope
│   │   ├── name = 
│   │   └── voltage = 
│   ├── sample
│   │   ├── material = 
│   │   └── preparation = 
│   ├── title = __unnamed__
│   └── user
│       ├── department = 
│       ├── email = 
│       ├── institution = 
│       └── name =
```

What should be the default behaviour? In my opinion, these metadata groups should not be automatically created like this.