### PR TITLE
add h5py dependency and numpy version >1.10 in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -45,13 +45,14 @@ if os.path.exists('build'):
 install_req = ['scipy',
                'ipython>=2.0',
                'matplotlib>=1.2',
-               'numpy',
+               'numpy>=1.10',
                'traits>=4.5.0',
                'traitsui>=5.0',
                'natsort',
                'requests',
                'setuptools',
-               'sympy']
+               'sympy',
+               'h5py']
 
 
 class update_version_when_dev:

--- a/stdeb.cfg
+++ b/stdeb.cfg
@@ -1,6 +1,6 @@
 [hyperspy]
 Depends:
-    python-numpy,
+    python-numpy (>= 1.10),
     python-scipy,
     python-matplotlib (>= 1.2),
     ipython (>= 2.0),
@@ -11,7 +11,6 @@ Depends:
     ipython-notebook,
     python-h5py,
     python-sklearn,
-    python-h5py
     python-requests
     python-sympy
     python-setuptools


### PR DESCRIPTION
- 'out' argument in argmax needs numpy>1.10. Spotted it running the tests on my computer with numpy 1.9!
- signal.py needs h5py.

Fixes  #910 and #916.