### PR TITLE
Remove mock dependency (available in stdlib in Py3(

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ python:
   - 3.5
 
 env:
-  - DEPS="nose numpy scipy matplotlib ipython h5py sympy scikit-learn natsort mock dill"
+  - DEPS="nose numpy scipy matplotlib ipython h5py sympy scikit-learn natsort dill"
 
 install:
   - conda create -n testenv --yes python=$TRAVIS_PYTHON_VERSION

--- a/anaconda_hyperspy_environment.yml
+++ b/anaconda_hyperspy_environment.yml
@@ -6,7 +6,6 @@ dependencies:
 - ipython
 - jupyter
 - matplotlib
-- mock
 - nose
 - numpy
 - qt

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -20,7 +20,7 @@ environment:
       CONDA_NPY: "19"
       WP_URL: 'https://github.com/winpython/winpython/releases/download/1.3.20160209/WinPython-32bit-3.5.1.2.exe'
       WP_CRC: '172d19a743ccfaf55af779d15f29f67fca83a46f08b0af855dfaf809b4184c0d'
-      DEPS: "numpy scipy matplotlib ipython h5py sympy scikit-learn dill mock natsort"
+      DEPS: "numpy scipy matplotlib ipython h5py sympy scikit-learn dill natsort"
 
     - PYTHON: "C:\\Miniconda35-x64"
       PYTHON_VERSION: "3.5.x"
@@ -30,7 +30,7 @@ environment:
       CONDA_NPY: "19"
       WP_URL: 'https://github.com/winpython/winpython/releases/download/1.3.20160209/WinPython-64bit-3.5.1.2.exe'
       WP_CRC: '07e854b9aa7a31d8bbf7829d04a45b6d6266603690520e365199af2d98751ab1'
-      DEPS: "numpy scipy matplotlib ipython h5py sympy scikit-learn dill mock natsort"
+      DEPS: "numpy scipy matplotlib ipython h5py sympy scikit-learn dill natsort"
 
 
 init:

--- a/hyperspy/tests/model/test_model.py
+++ b/hyperspy/tests/model/test_model.py
@@ -1,6 +1,6 @@
 import numpy as np
 import nose.tools as nt
-import mock
+from unittest import mock
 
 import hyperspy.api as hs
 from hyperspy.misc.utils import slugify

--- a/hyperspy/tests/signal/test_1D_tools.py
+++ b/hyperspy/tests/signal/test_1D_tools.py
@@ -15,7 +15,7 @@
 # You should have received a copy of the GNU General Public License
 # along with HyperSpy. If not, see <http://www.gnu.org/licenses/>.
 
-import mock
+from unittest import mock
 
 import numpy as np
 import nose.tools as nt


### PR DESCRIPTION
In Py3 mock is available in the standard library, so this removes the no-longer-necessary dependency.