### PR TITLE
Fix to_signal2D that was returning an image

### DIFF
--- a/hyperspy/_signals/signal1d.py
+++ b/hyperspy/_signals/signal1d.py
@@ -1173,9 +1173,14 @@ class Signal1D(BaseSignal,
                 "A Signal dimension must be >= 2 to be converted to Signal2D")
         im = self.rollaxis(-1 + 3j, 0 + 3j)
         im.metadata.Signal.record_by = "image"
-        im._assign_subclass()
-        warnings.warn("The to_signal2D method returns an Image instance in\
-                      version 0.8.5 it will return a Signal2D in 1.0.0")
+        import hyperspy.io
+        hyperspy.io.BAN_DEPRECATED = True
+        try:
+            im._assign_subclass()
+        except:
+            raise
+        finally:
+            hyperspy.io.BAN_DEPRECATED = False
         return im
 
     def _spikes_diagnosis(self, signal_mask=None,

--- a/hyperspy/_signals/signal2d.py
+++ b/hyperspy/_signals/signal2d.py
@@ -524,8 +524,6 @@ class Signal2D(BaseSignal,
         dimensional signals.
 
         """
-        warnings.warn("The to_signal1D method returns a Spectrum instance in\
-                      version 0.8.5 it will return a Signal1D in 1.0.0")
         return self.as_signal1D(0 + 3j)
 
     def plot(self,

--- a/hyperspy/signals.py
+++ b/hyperspy/signals.py
@@ -70,7 +70,12 @@ class Spectrum(Signal1D,
         warnings.warn("The to_image method will be deprecated from version"
                       " 1.0.0 and replaced with to_signal2D",
                       VisibleDeprecationWarning)
-        im = self.to_signal2D()
+        if self.data.ndim < 2:
+            raise DataDimensionError(
+                "A Signal dimension must be >= 2 to be converted to Signal2D")
+        im = self.rollaxis(-1 + 3j, 0 + 3j)
+        im.metadata.Signal.record_by = "image"
+        im._assign_subclass()
         return im
 
 
@@ -112,6 +117,7 @@ from hyperspy._signals.image_simulation import ImageSimulation
 from hyperspy._signals.spectrum_simulation import SpectrumSimulation
 from hyperspy._signals.eels_spectrum_simulation import (
     EELSSpectrumSimulation)
+from hyperspy.exceptions import DataDimensionError
 
 from hyperspy.signal import BaseSignal
 


### PR DESCRIPTION
As discussed in #963  `to_signal2D` should return a `Signal2D`, however it was still returning an `Image`.