### PR TITLE
Fixed circular import dependecy of hyperspy.drawing.widgets

### DIFF
--- a/hyperspy/drawing/utils.py
+++ b/hyperspy/drawing/utils.py
@@ -27,7 +27,6 @@ import numpy as np
 import matplotlib.pyplot as plt
 import matplotlib as mpl
 import hyperspy as hs
-from hyperspy.drawing import widgets
 
 from hyperspy.misc.image_tools import (contrast_stretching,
                                        MPL_DIVERGING_COLORMAPS,
@@ -823,7 +822,7 @@ def plot_images(images,
 
             # Add scalebars as necessary
             if (scalelist and idx - 1 in scalebar) or scalebar is 'all':
-                ax.scalebar = widgets.ScaleBar(
+                ax.scalebar = ScaleBar(
                     ax=ax,
                     units=axes[0].units,
                     color=scalebar_color,


### PR DESCRIPTION
Fixes `ImportError: cannot import name 'widgets' ` caused by [circular import dependency ](http://stackoverflow.com/questions/17845366/importerror-cannot-import-name)of hyperspy.drawing.widgets related to PR #1020. The error is produced when trying to import hyperspy.api.