### PR TITLE
fixing model slicing test annoyances

### DIFF
--- a/hyperspy/component.py
+++ b/hyperspy/component.py
@@ -653,8 +653,8 @@ class Component(t.HasTraits):
                            'active': None
                            }
         self._slicing_whitelist = {'_active_array': 'inav'}
-        self._slicing_order = ('active_is_multidimensional', '_active_array',
-                               'active')
+        self._slicing_order = ('active', 'active_is_multidimensional',
+                               '_active_array',)
 
     _name = ''
     _active_is_multidimensional = False

--- a/hyperspy/component.py
+++ b/hyperspy/component.py
@@ -653,6 +653,8 @@ class Component(t.HasTraits):
                            'active': None
                            }
         self._slicing_whitelist = {'_active_array': 'inav'}
+        self._slicing_order = ('active_is_multidimensional', '_active_array',
+                               'active')
 
     _name = ''
     _active_is_multidimensional = False
@@ -749,7 +751,6 @@ class Component(t.HasTraits):
         self._active = arg
         if self.active_is_multidimensional is True:
             self._store_active_value_in_array(arg)
-
         self.events.active_changed.trigger(active=self._active, obj=self)
         self.trait_property_changed('active', old_value, self._active)
 
@@ -819,6 +820,8 @@ class Component(t.HasTraits):
             shape = [1, ]
         if (not isinstance(self._active_array, np.ndarray)
                 or self._active_array.shape != shape):
+            _logger.debug('Creating _active_array for {}.\n\tCurrent array '
+                          'is:\n{}'.format(self, self._active_array))
             self._active_array = np.ones(shape, dtype=bool)
 
     def _create_arrays(self):

--- a/hyperspy/component.py
+++ b/hyperspy/component.py
@@ -674,9 +674,7 @@ class Component(t.HasTraits):
 
         if value:  # Turn on
             if self._axes_manager.navigation_size < 2:
-                warnings.warn(
-                    '`navigation_size` < 2, skipping',
-                    RuntimeWarning)
+                _logger.warning('`navigation_size` < 2, skipping')
                 return
             # Store value at current position
             self._create_active_array()

--- a/hyperspy/misc/slicing.py
+++ b/hyperspy/misc/slicing.py
@@ -1,8 +1,7 @@
 from operator import attrgetter
+import numpy as np
 from hyperspy.misc.utils import attrsetter
 from hyperspy.misc.export_dictionary import parse_flag_string
-
-import numpy as np
 
 
 def _slice_target(target, dims, both_slices, slice_nav=None, issignal=False):
@@ -35,18 +34,20 @@ def _slice_target(target, dims, both_slices, slice_nav=None, issignal=False):
         if isinstance(target, np.ndarray):
             return np.atleast_1d(target[tuple(array_slices[:nav_dims])])
         raise ValueError(
-            'tried to slice with navigation dimensions, but was neither a signal nor an array')
+            'tried to slice with navigation dimensions, but was neither a '
+            'signal nor an array')
     if slice_nav is False:  # check explicitly
         if issignal:
             return target.isig[slices]
         if isinstance(target, np.ndarray):
             return np.atleast_1d(target[tuple(array_slices[-sig_dims:])])
         raise ValueError(
-            'tried to slice with signal dimensions, but was neither a signal nor an array')
-    # return thing
+            'tried to slice with navigation dimensions, but was neither a '
+            'signal nor an array')
 
 
-def copy_slice_from_whitelist(_from, _to, dims, both_slices, isNav):
+def copy_slice_from_whitelist(
+        _from, _to, dims, both_slices, isNav, order=None):
     """Copies things from one object to another, according to whitelist, slicing
     where required.
 
@@ -64,6 +65,10 @@ def copy_slice_from_whitelist(_from, _to, dims, both_slices, isNav):
     isNav : bool
         if the slicing operation is performed on navigation dimensions of the
         object
+    order : tuple, None
+        if given, performs the copying in the order given. If not all attributes
+        given, the rest is random (the order a whitelist.keys() returns them).
+        If given in the object, _slicing_order is looked up.
     """
 
     def make_slice_navigation_decision(flags, isnav):
@@ -79,7 +84,20 @@ def copy_slice_from_whitelist(_from, _to, dims, both_slices, isNav):
     if hasattr(_from, '_slicing_whitelist'):
         swl = _from._slicing_whitelist
 
-    for key, val in _from._whitelist.items():
+    if order is not None and not isinstance(order, tuple):
+        raise ValueError('order argument has to be None or a tuple of strings')
+
+    if order is None:
+        order = ()
+    if hasattr(_from, '_slicing_order'):
+        order = order + \
+            tuple(k for k in _from._slicing_order if k not in order)
+
+    keys = order + tuple(k for k in _from._whitelist.keys() if k not in
+                         order)
+
+    for key in keys:
+        val = _from._whitelist[key]
         if key == 'self':
             target = None
         else:

--- a/hyperspy/tests/model/test_fancy_indexing.py
+++ b/hyperspy/tests/model/test_fancy_indexing.py
@@ -73,13 +73,6 @@ class TestModelIndexing:
         self.model.axes_manager.indices = (0, 0)
         self.model[0].active = False
 
-        # Make sure the array we copy has been appropriatelly updated before
-        # slicing
-        _test = self.model[0]._active_array[0, 0]
-        while _test:
-            time.sleep(0.1)
-            _test = self.model[0]._active_array[0, 0]
-
         m = self.model.inav[0::2, :]
         np.testing.assert_array_equal(
             m.chisq.data, self.model.chisq.data[:, 0::2])

--- a/hyperspy/tests/model/test_fancy_indexing.py
+++ b/hyperspy/tests/model/test_fancy_indexing.py
@@ -88,6 +88,17 @@ class TestModelIndexing:
             for p_new, p_old in zip(c.parameters, self.model[ic].parameters):
                 nt.assert_true((p_old.map[:, 0::2] == p_new.map).all())
 
+    # test that explicitly does the wrong thing by mixing up the order
+    def test_component_copying_order(self):
+        self.model.axes_manager.indices = (0, 0)
+        self.model[0].active = False
+        g = self.model[0]
+        g._slicing_order = ('_active_array', 'active_is_multidimensional',
+                            'active')
+        nt.assert_false(g._active_array[0, 0])
+        m = self.model.inav[0:2, 0:2]
+        nt.assert_true(m[0]._active_array[0, 0])
+
 
 class TestModelIndexingClass:
 

--- a/hyperspy/tests/model/test_fancy_indexing.py
+++ b/hyperspy/tests/model/test_fancy_indexing.py
@@ -80,7 +80,7 @@ class TestModelIndexing:
             time.sleep(0.1)
             _test = self.model[0]._active_array[0, 0]
 
-        m = self.model.inav[0::2]
+        m = self.model.inav[0::2, :]
         np.testing.assert_array_equal(
             m.chisq.data, self.model.chisq.data[:, 0::2])
         np.testing.assert_array_equal(m.dof.data, self.model.dof.data[:, 0::2])


### PR DESCRIPTION
 - ~~(hopefully)~~ definitely fixed model slicing test bug:
  - copying items according to the whitelist can now have an explicit order that the attributes are copied over. This in particular was the broken thing - `_active_array` was copied first sometimes, and `active_is_multidimensional` only afterwards. So now the order can be forced (not just "whatever order `dict.keys()` are returned")
 - changed active_is_multidimensional to not raise warnings, but log instead