### PR TITLE
Let numpy ufuncs operate on HyperSpy BaseSignal instances

### DIFF
--- a/doc/api/hyperspy._components.rst
+++ b/doc/api/hyperspy._components.rst
@@ -28,14 +28,6 @@ hyperspy._components.eels_cl_edge module
     :undoc-members:
     :show-inheritance:
 
-hyperspy._components.eels_double_offset module
-----------------------------------------------
-
-.. automodule:: hyperspy._components.eels_double_offset
-    :members:
-    :undoc-members:
-    :show-inheritance:
-
 hyperspy._components.eels_double_power_law module
 -------------------------------------------------
 
@@ -96,6 +88,14 @@ hyperspy._components.gaussianhf module
 --------------------------------------
 
 .. automodule:: hyperspy._components.gaussianhf
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+hyperspy._components.heaviside module
+-------------------------------------
+
+.. automodule:: hyperspy._components.heaviside
     :members:
     :undoc-members:
     :show-inheritance:

--- a/doc/api/hyperspy._signals.rst
+++ b/doc/api/hyperspy._signals.rst
@@ -52,14 +52,6 @@ hyperspy._signals.eels_spectrum_simulation module
     :undoc-members:
     :show-inheritance:
 
-hyperspy._signals.image module
-------------------------------
-
-.. automodule:: hyperspy._signals.image
-    :members:
-    :undoc-members:
-    :show-inheritance:
-
 hyperspy._signals.image_simulation module
 -----------------------------------------
 
@@ -68,10 +60,18 @@ hyperspy._signals.image_simulation module
     :undoc-members:
     :show-inheritance:
 
-hyperspy._signals.pes module
-----------------------------
+hyperspy._signals.signal1d module
+---------------------------------
 
-.. automodule:: hyperspy._signals.pes
+.. automodule:: hyperspy._signals.signal1d
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+hyperspy._signals.signal2d module
+---------------------------------
+
+.. automodule:: hyperspy._signals.signal2d
     :members:
     :undoc-members:
     :show-inheritance:
@@ -80,14 +80,6 @@ hyperspy._signals.simulation module
 -----------------------------------
 
 .. automodule:: hyperspy._signals.simulation
-    :members:
-    :undoc-members:
-    :show-inheritance:
-
-hyperspy._signals.signal1D module
----------------------------------
-
-.. automodule:: hyperspy._signals.signal1D
     :members:
     :undoc-members:
     :show-inheritance:

--- a/doc/api/hyperspy.drawing.rst
+++ b/doc/api/hyperspy.drawing.rst
@@ -7,6 +7,7 @@ Subpackages
 .. toctree::
 
     hyperspy.drawing._markers
+    hyperspy.drawing._widgets
 
 Submodules
 ----------
@@ -67,10 +68,10 @@ hyperspy.drawing.signal module
     :undoc-members:
     :show-inheritance:
 
-hyperspy.drawing.signal1D module
+hyperspy.drawing.signal1d module
 --------------------------------
 
-.. automodule:: hyperspy.drawing.signal1D
+.. automodule:: hyperspy.drawing.signal1d
     :members:
     :undoc-members:
     :show-inheritance:
@@ -79,6 +80,14 @@ hyperspy.drawing.utils module
 -----------------------------
 
 .. automodule:: hyperspy.drawing.utils
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+hyperspy.drawing.widget module
+------------------------------
+
+.. automodule:: hyperspy.drawing.widget
     :members:
     :undoc-members:
     :show-inheritance:

--- a/doc/api/hyperspy.misc.eels.rst
+++ b/doc/api/hyperspy.misc.eels.rst
@@ -12,6 +12,14 @@ hyperspy.misc.eels.base_gos module
     :undoc-members:
     :show-inheritance:
 
+hyperspy.misc.eels.eelsdb module
+--------------------------------
+
+.. automodule:: hyperspy.misc.eels.eelsdb
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
 hyperspy.misc.eels.effective_angle module
 -----------------------------------------
 

--- a/doc/api/hyperspy.tests.axes.rst
+++ b/doc/api/hyperspy.tests.axes.rst
@@ -4,6 +4,14 @@ hyperspy.tests.axes package
 Submodules
 ----------
 
+hyperspy.tests.axes.test_axes_manager module
+--------------------------------------------
+
+.. automodule:: hyperspy.tests.axes.test_axes_manager
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
 hyperspy.tests.axes.test_data_axis module
 -----------------------------------------
 

--- a/doc/api/hyperspy.tests.signal.rst
+++ b/doc/api/hyperspy.tests.signal.rst
@@ -84,6 +84,14 @@ hyperspy.tests.signal.test_fancy_indexing module
     :undoc-members:
     :show-inheritance:
 
+hyperspy.tests.signal.test_find_peaks1D_ohaver module
+-----------------------------------------------------
+
+.. automodule:: hyperspy.tests.signal.test_find_peaks1D_ohaver
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
 hyperspy.tests.signal.test_folding module
 -----------------------------------------
 

--- a/doc/api/hyperspy.tests.utils.rst
+++ b/doc/api/hyperspy.tests.utils.rst
@@ -28,10 +28,10 @@ hyperspy.tests.utils.test_material module
     :undoc-members:
     :show-inheritance:
 
-hyperspy.tests.utils.test_progressbar module
---------------------------------------------
+hyperspy.tests.utils.test_roi module
+------------------------------------
 
-.. automodule:: hyperspy.tests.utils.test_progressbar
+.. automodule:: hyperspy.tests.utils.test_roi
     :members:
     :undoc-members:
     :show-inheritance:

--- a/doc/api/hyperspy.utils.rst
+++ b/doc/api/hyperspy.utils.rst
@@ -44,6 +44,14 @@ hyperspy.utils.plot module
     :undoc-members:
     :show-inheritance:
 
+hyperspy.utils.roi module
+-------------------------
+
+.. automodule:: hyperspy.utils.roi
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
 
 Module contents
 ---------------

--- a/doc/user_guide/tools.rst
+++ b/doc/user_guide/tools.rst
@@ -294,10 +294,15 @@ instances, for example:
 .. code-block:: python
 
     >>> s = hs.signals.Signal1D([0, 1])
+    >>> s.metadata.General.title = "A"
+    >>> s
+    <Signal1D, title: A, dimensions: (|2)>
     >>> np.exp(s)
-    <Signal1D, title: , dimensions: (|2)>
+    <Signal1D, title: exp(A), dimensions: (|2)>
     >>> np.exp(s).data
     array([ 1.        ,  2.71828183])
+
+Notice the the title is automatically updated.
 
 Functions (other than unfucs) that operate on numpy arrays can also operate
 on :py:class:`~.signal.BaseSignal` instances, however they return a numpy

--- a/doc/user_guide/tools.rst
+++ b/doc/user_guide/tools.rst
@@ -309,7 +309,7 @@ instances, for example:
     <Signal1D, title: add(Untitled Signal 1, Untitled Signal 2), dimensions: (|2)>
 
 
-Notice the the title is automatically updated. When the signal has no title
+Notice that the title is automatically updated. When the signal has no title
 a new title is automatically generated:
 
 .. code-block:: python

--- a/doc/user_guide/tools.rst
+++ b/doc/user_guide/tools.rst
@@ -234,13 +234,29 @@ The methods of this section are available to all the signals. In other chapters
 methods that are only available in specialized
 subclasses.
 
-Simple mathematical operations
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Mathematical operations
+^^^^^^^^^^^^^^^^^^^^^^^
 
-.. versionchanged:: 1.0.0
+.. versionchanged:: 1.0
 
-A number of simple operations are supported by :py:class:`~.signal.BaseSignal`.
-Most of them are just wrapped numpy functions, as an example:
+A number of mathematical operations are available
+in :py:class:`~.signal.BaseSignal`. Most of them are just wrapped numpy
+functions.
+
+The methods that perform mathematical opearation over one or more axis at a
+time are:
+
+* :py:meth:`~.signal.BaseSignal.sum`
+* :py:meth:`~.signal.BaseSignal.max`
+* :py:meth:`~.signal.BaseSignal.min`
+* :py:meth:`~.signal.BaseSignal.mean`
+* :py:meth:`~.signal.BaseSignal.std`
+* :py:meth:`~.signal.BaseSignal.var`
+
+Note that by default all this methods perform the operation over *all*
+navigation axes.
+
+Example:
 
 .. code-block:: python
 
@@ -261,13 +277,36 @@ Most of them are just wrapped numpy functions, as an example:
     >>> ans.axes_manager[0]
     <Scalar axis, size: 1>
 
-Other functions that support similar behavior: :py:func:`~.signal.sum`,
-:py:func:`~.signal.max`, :py:func:`~.signal.min`, :py:func:`~.signal.mean`,
-:py:func:`~.signal.std`, :py:func:`~.signal.var`. Similar functions that can
-only be performed on one axis at a time: :py:func:`~.signal.diff`,
-:py:func:`~.signal.derivative`, :py:func:`~.signal.integrate_simpson`,
-:py:func:`~.signal.integrate1D`, :py:func:`~.signal.valuemax`,
-:py:func:`~.signal.indexmax`.
+The following methods operate only on one axis at a time:
+
+* :py:meth:`~.signal.BaseSignal.diff`
+* :py:meth:`~.signal.BaseSignal.derivative`
+* :py:meth:`~.signal.BaseSignal.integrate_simpson`
+* :py:meth:`~.signal.BaseSignal.integrate1D`
+* :py:meth:`~.signal.BaseSignal.valuemax`
+* :py:meth:`~.signal.BaseSignal.indexmax`
+
+.. versionadded:: 1.0
+
+All numpy ufunc can operate on :py:class:`~.signal.BaseSignal`
+instances, for example:
+
+.. code-block:: python
+
+    >>> s = hs.signals.Signal1D([0, 1])
+    >>> np.exp(s)
+    <Signal1D, title: , dimensions: (|2)>
+    >>> np.exp(s).data
+    array([ 1.        ,  2.71828183])
+
+Functions (other than unfucs) that operate on numpy arrays can also operate
+on :py:class:`~.signal.BaseSignal` instances, however they return a numpy
+array instead of a :py:class:`~.signal.BaseSignal` instance e.g.:
+
+.. code-block:: python
+
+    >>> np.angle(s)
+    array([ 0.,  0.])
 
 .. _signal.indexing:
 

--- a/doc/user_guide/tools.rst
+++ b/doc/user_guide/tools.rst
@@ -301,8 +301,22 @@ instances, for example:
     <Signal1D, title: exp(A), dimensions: (|2)>
     >>> np.exp(s).data
     array([ 1.        ,  2.71828183])
+    >>> np.power(s, 2)
+    <Signal1D, title: power(A, 2), dimensions: (|2)>
+    >>> np.add(s, s)
+    <Signal1D, title: add(A, A), dimensions: (|2)>
+    >>> np.add(hs.signals.Signal1D([0, 1]), hs.signals.Signal1D([0, 1]))
+    <Signal1D, title: add(Untitled Signal 1, Untitled Signal 2), dimensions: (|2)>
 
-Notice the the title is automatically updated.
+
+Notice the the title is automatically updated. When the signal has no title
+a new title is automatically generated:
+
+.. code-block:: python
+
+    >>> np.add(hs.signals.Signal1D([0, 1]), hs.signals.Signal1D([0, 1]))
+    <Signal1D, title: add(Untitled Signal 1, Untitled Signal 2), dimensions: (|2)>
+
 
 Functions (other than unfucs) that operate on numpy arrays can also operate
 on :py:class:`~.signal.BaseSignal` instances, however they return a numpy

--- a/hyperspy/signal.py
+++ b/hyperspy/signal.py
@@ -25,7 +25,6 @@ import inspect
 from contextlib import contextmanager
 from datetime import datetime
 import logging
-import pint
 
 import numpy as np
 import scipy as sp
@@ -57,7 +56,6 @@ from hyperspy.interactive import interactive
 from hyperspy.misc.signal_tools import are_signals_aligned
 
 _logger = logging.getLogger(__name__)
-UREG = pint.UnitRegistry()
 
 class ModelManager(object):
 

--- a/hyperspy/signal.py
+++ b/hyperspy/signal.py
@@ -1797,7 +1797,7 @@ class BaseSignal(FancySlicing,
                 if g.title:
                     return g.title
                 else:
-                    return "Untitled Signal-%s" % (i + 1)
+                    return "Untitled Signal %s" % (i + 1)
 
             title_strs = []
             i = 0

--- a/hyperspy/signal.py
+++ b/hyperspy/signal.py
@@ -1791,9 +1791,25 @@ class BaseSignal(FancySlicing,
             # is currently being prepared (eg. see modf).
             # In ufuncs with a single output, domain is 0
             uf, objs, huh = context
-            if self.metadata.General.title:
-                signal.metadata.General.title = "%s(%s)" % (
-                    uf.__name__, self.metadata.General.title)
+
+            def get_title(signal, i=0):
+                g = signal.metadata.General
+                if g.title:
+                    return g.title
+                else:
+                    return "Untitled Signal-%s" % (i + 1)
+
+            title_strs = []
+            i = 0
+            for obj in objs:
+                if isinstance(obj, BaseSignal):
+                    title_strs.append(get_title(obj, i))
+                    i += 1
+                else:
+                    title_strs.append(str(obj))
+
+            signal.metadata.General.title = "%s(%s)" % (
+                uf.__name__, ", ".join(title_strs))
 
         return signal
 

--- a/hyperspy/signal.py
+++ b/hyperspy/signal.py
@@ -1782,6 +1782,11 @@ class BaseSignal(FancySlicing,
             return self.data
 
     def __array_wrap__(self, array, context=None):
+        if context is not None:
+            ufunc_name = context[0].__name__
+            if self.metadata.General.title:
+                g = self.metadata.General
+                g.title = "%s(%s)" % (ufunc_name, g.title)
         return self._deepcopy_with_new_data(array)
 
     def squeeze(self):

--- a/hyperspy/signal.py
+++ b/hyperspy/signal.py
@@ -1775,6 +1775,15 @@ class BaseSignal(FancySlicing,
                 not self.metadata.has_item("Signal.signal_type")):
             self.metadata.Signal.signal_type = self._signal_type
 
+    def __array__(self, *args):
+        if args:
+            return self.data.astype(args[0])
+        else:
+            return self.data
+
+    def __array_wrap__(self, array, context=None):
+        return self._deepcopy_with_new_data(array)
+
     def squeeze(self):
         """Remove single-dimensional entries from the shape of an array
         and the axes.

--- a/hyperspy/tests/signal/test_tools.py
+++ b/hyperspy/tests/signal/test_tools.py
@@ -128,17 +128,38 @@ class Test2D:
         # Just test if it doesn't raise an exception
         self.signal._print_summary()
 
-    def test_numpy_unfunc(self):
+    def test_numpy_unfunc_one_arg_titled(self):
         self.signal.metadata.General.title = "yes"
         result = np.exp(self.signal)
         nt.assert_true(isinstance(result, BaseSignal))
         np.testing.assert_array_equal(result.data, np.exp(self.signal.data))
         nt.assert_equal(result.metadata.General.title, "exp(yes)")
 
+    def test_numpy_unfunc_one_arg_untitled(self):
+        result = np.exp(self.signal)
+        nt.assert_equal(result.metadata.General.title,
+                        "exp(Untitled Signal 1)")
+
+    def test_numpy_unfunc_two_arg_titled(self):
+        s1, s2 = self.signal.deepcopy(), self.signal.deepcopy()
+        s1.metadata.General.title = "A"
+        s2.metadata.General.title = "B"
+        result = np.add(s1, s2)
+        nt.assert_true(isinstance(result, BaseSignal))
+        np.testing.assert_array_equal(result.data, np.add(s1.data, s2.data))
+        nt.assert_equal(result.metadata.General.title, "add(A, B)")
+
+    def test_numpy_unfunc_two_arg_untitled(self):
+        s1, s2 = self.signal.deepcopy(), self.signal.deepcopy()
+        result = np.add(s1, s2)
+        nt.assert_equal(result.metadata.General.title,
+                        "add(Untitled Signal 1, Untitled Signal 2)")
+
     def test_numpy_func(self):
         result = np.angle(self.signal)
         nt.assert_true(isinstance(result, np.ndarray))
         np.testing.assert_array_equal(result, np.angle(self.signal.data))
+
 
 def _test_default_navigation_signal_operations_over_many_axes(self, op):
     s = getattr(self.signal, op)()

--- a/hyperspy/tests/signal/test_tools.py
+++ b/hyperspy/tests/signal/test_tools.py
@@ -129,9 +129,11 @@ class Test2D:
         self.signal._print_summary()
 
     def test_numpy_unfunc(self):
+        self.signal.metadata.General.title = "yes"
         result = np.exp(self.signal)
         nt.assert_true(isinstance(result, BaseSignal))
         np.testing.assert_array_equal(result.data, np.exp(self.signal.data))
+        nt.assert_equal(result.metadata.General.title, "exp(yes)")
 
     def test_numpy_func(self):
         result = np.angle(self.signal)

--- a/hyperspy/tests/signal/test_tools.py
+++ b/hyperspy/tests/signal/test_tools.py
@@ -128,6 +128,15 @@ class Test2D:
         # Just test if it doesn't raise an exception
         self.signal._print_summary()
 
+    def test_numpy_unfunc(self):
+        result = np.exp(self.signal)
+        nt.assert_true(isinstance(result, BaseSignal))
+        np.testing.assert_array_equal(result.data, np.exp(self.signal.data))
+
+    def test_numpy_func(self):
+        result = np.angle(self.signal)
+        nt.assert_true(isinstance(result, np.ndarray))
+        np.testing.assert_array_equal(result, np.angle(self.signal.data))
 
 def _test_default_navigation_signal_operations_over_many_axes(self, op):
     s = getattr(self.signal, op)()


### PR DESCRIPTION
This enables operating directly on the HyperSpy's `BaseSignal` instances with numpy ufuncs:

```python

>>> s = hs.signals.Signal1D([0, 1])
>>> s.metadata.General.title = "A"
>>> s
<Signal1D, title: A, dimensions: (|2)>
>>> np.exp(s)
<Signal1D, title: exp(A), dimensions: (|2)>
>>> np.exp(s).data
array([ 1.        ,  2.71828183])
>>> np.power(s, 2)
<Signal1D, title: power(A, 2), dimensions: (|2)>
>>> np.add(s, s)
<Signal1D, title: add(A, A), dimensions: (|2)>
>>> np.add(hs.signals.Signal1D([0, 1]), hs.signals.Signal1D([0, 1]))
<Signal1D, title: add(Untitled Signal 1, Untitled Signal 2), dimensions: (|2)>

```

Notice the the title is automatically updated.

There is a caveat: numpy functions which are not ufuncs can also operate on the HyperSpy signals but I didn't find the way to make them return a HyperSpy signal e.g.:

```python

>>> np.angle(s)
array([ 0.,  0.])

```

Notice that I have also fixed the simple mathematical operations section of the User Guide.
