### PR TITLE
Fix dev version updating

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -57,6 +57,7 @@ def are_we_building4windows():
 
 scripts = ['bin/hyperspy', ]
 
+
 def update_version(version):
     release_path = "hyperspy/Release.py"
     lines = []
@@ -67,6 +68,7 @@ def update_version(version):
             lines.append(line)
     with open(release_path, "w") as f:
         f.writelines(lines)
+
 
 class update_version_when_dev:
 

--- a/setup.py
+++ b/setup.py
@@ -89,7 +89,7 @@ class update_version_when_dev:
                 gd = stdout[1:].strip().decode()
                 # Remove the tag
                 gd = gd[gd.index("-") + 1:]
-                self.version = self.release_version.replace("+dev", "+git-")
+                self.version = self.release_version.replace("+dev", "-git-")
                 self.version += gd
                 update_version(self.version)
                 self.restore_version = True

--- a/setup.py
+++ b/setup.py
@@ -57,6 +57,16 @@ def are_we_building4windows():
 
 scripts = ['bin/hyperspy', ]
 
+def update_version(version):
+    release_path = "hyperspy/Release.py"
+    lines = []
+    with open(release_path, "r") as f:
+        for line in f:
+            if line.startswith("version = "):
+                line = "version = \"%s\"\n" % version
+            lines.append(line)
+    with open(release_path, "w") as f:
+        f.writelines(lines)
 
 class update_version_when_dev:
 
@@ -68,46 +78,28 @@ class update_version_when_dev:
         git_master_path = ".git/refs/heads/master"
         if "+dev" in self.release_version and \
                 os.path.isfile(git_master_path):
-            try:
-                p = subprocess.Popen(["git", "describe",
-                                      "--tags", "--dirty", "--always"],
-                                     stdout=subprocess.PIPE)
-                stdout = p.communicate()[0]
-                if p.returncode != 0:
-                    raise EnvironmentError
-                else:
-                    version = stdout[1:].strip().decode()
-                    if str(self.release_version[:-4] + '-') in version:
-                        version = version.replace(
-                            self.release_version[:-4] + '-',
-                            self.release_version[:-4] + '+git')
-                    self.version = version
-            except EnvironmentError:
-                # Git is not available, but the .git directory exists
-                # Therefore we can get just the master hash
-                with open(git_master_path) as f:
-                    masterhash = f.readline()
-                self.version = self.release_version.replace(
-                    "+dev", "+git-%s" % masterhash[:7])
-            for line in fileinput.FileInput("hyperspy/Release.py",
-                                            inplace=1):
-                if line.startswith('version = '):
-                    print("version = \"%s\"" % self.version)
-                else:
-                    print(line, end=' ')
-            self.restore_version = True
+            p = subprocess.Popen(["git", "describe",
+                                  "--tags", "--dirty", "--always"],
+                                 stdout=subprocess.PIPE)
+            stdout = p.communicate()[0]
+            if p.returncode != 0:
+                # Git is not available, we keep the version as is
+                self.restore_version = False
+            else:
+                gd = stdout[1:].strip().decode()
+                # Remove the tag
+                gd = gd[gd.index("-") + 1:]
+                self.version = self.release_version.replace("+dev", "+git-")
+                self.version += gd
+                update_version(self.version)
+                self.restore_version = True
         else:
             self.version = self.release_version
         return self.version
 
     def __exit__(self, type, value, traceback):
         if self.restore_version is True:
-            for line in fileinput.FileInput("hyperspy/Release.py",
-                                            inplace=1):
-                if line.startswith('version = '):
-                    print("version = \"%s\"" % self.release_version)
-                else:
-                    print(line, end=' ')
+            update_version(self.release_version)
 
 
 with update_version_when_dev() as version:


### PR DESCRIPTION
Fixes the code that adds the git hash to the version when calling `setup.py` on the code on a dev state.

This should fix the issue with #1085, #1084 and #922.