### PR TITLE
Fix error when loading `.hdf5` files

### DIFF
--- a/hyperspy/io_plugins/hdf5.py
+++ b/hyperspy/io_plugins/hdf5.py
@@ -19,6 +19,7 @@
 from distutils.version import StrictVersion
 import warnings
 import datetime
+from dateutil import tz
 import logging
 
 import h5py


### PR DESCRIPTION
If data was loaded from a `.blo` file then saved as a `.hdf5` file (the hyperspy default), an error was thrown as the `.hdf5` file loader did not import a required package from `dateutils`.