### PR TITLE
Scale/units conversion

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ before_install:
 - conda update --yes conda
 
 install:
-  - DEPS="nose numpy scipy matplotlib ipython h5py sympy scikit-learn dill natsort setuptools scikit-image cython lxml ipyparallel"
+  - DEPS="nose numpy scipy matplotlib ipython h5py sympy scikit-learn dill natsort setuptools scikit-image cython lxml ipyparallel pint"
   - conda create -n testenv --yes $DEPS
   - source activate testenv
   - conda install pip

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ before_install:
 - conda update --yes conda
 
 install:
-  - DEPS="nose numpy scipy matplotlib ipython h5py sympy scikit-learn dill natsort setuptools scikit-image cython lxml ipyparallel pint"
+  - DEPS="nose numpy scipy matplotlib ipython h5py sympy scikit-learn dill natsort setuptools scikit-image cython lxml ipyparallel"
   - conda create -n testenv --yes $DEPS
   - source activate testenv
   - conda install pip

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,7 @@ install:
   - conda create -n testenv --yes $DEPS
   - source activate testenv
   - conda install pip
-  - pip install coverage coveralls traits traitsui request tqdm
+  - pip install coverage coveralls traits traitsui request tqdm pint
   - python setup.py install
 
 script:

--- a/anaconda_hyperspy_environment.yml
+++ b/anaconda_hyperspy_environment.yml
@@ -24,8 +24,8 @@ dependencies:
 - traits
 - traitsui
 - ncurses
-- pint
 - pip:
   - python-dateutil
   - tqdm
   - hyperspy
+  - pint

--- a/anaconda_hyperspy_environment.yml
+++ b/anaconda_hyperspy_environment.yml
@@ -23,6 +23,8 @@ dependencies:
 - ipywidgets
 - traits
 - traitsui
+- ncurses
+- pint
 - pip:
   - python-dateutil
   - tqdm

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -20,7 +20,7 @@ environment:
       CONDA_NPY: "19"
       WP_URL: 'https://github.com/winpython/winpython/releases/download/1.3.20160209/WinPython-32bit-3.5.1.2.exe'
       WP_CRC: '172d19a743ccfaf55af779d15f29f67fca83a46f08b0af855dfaf809b4184c0d'
-      DEPS: "numpy scipy matplotlib ipython h5py sympy scikit-learn dill setuptools natsort scikit-image pint"
+      DEPS: "numpy scipy matplotlib ipython h5py sympy scikit-learn dill setuptools natsort scikit-image"
 
     - PYTHON: "C:\\Miniconda35-x64"
       PYTHON_VERSION: "3.5.x"
@@ -31,7 +31,6 @@ environment:
       WP_URL: 'https://github.com/winpython/winpython/releases/download/1.3.20160209/WinPython-64bit-3.5.1.2.exe'
       WP_CRC: '07e854b9aa7a31d8bbf7829d04a45b6d6266603690520e365199af2d98751ab1'
       DEPS: "numpy scipy matplotlib ipython h5py sympy scikit-learn dill setuptools natsort scikit-image cython lxml ipyparallel pint"
-
 
 init:
   - "ECHO %PYTHON% %PYTHON_VERSION% %PYTHON_ARCH%"
@@ -57,7 +56,7 @@ install:
   - "%CMD_IN_ENV% move %PYTHON%\\sip %PYTHON%\\Lib\\site-packages\\PyQt4\\sip"
   - "%CMD_IN_ENV% conda install pip"
   # TODO: Remove once anaconda taitsui package is at v5:
-  - "IF \"%PYTHON_MAJOR%\" EQU \"3\" pip install --upgrade traitsui tqdm"
+  - "IF \"%PYTHON_MAJOR%\" EQU \"3\" pip install --upgrade traitsui tqdm pint"
   - ps: Add-AppveyorMessage "Installing hyperspy..."
   - "python setup.py install"
 
@@ -116,8 +115,12 @@ before_deploy:
   - "%CMD_IN_ENV% python.exe -c \"import sys; print(sys.version)\""
   - "%CMD_IN_ENV% python.exe setup.py recythonize"
   - "%CMD_IN_ENV% python.exe setup.py install"
+<<<<<<< fdce5cfdf985f5019e551a0610e10dd8458c099e
   # setting back the config:
   - "ren %WP_INSTDIR%\\settings\\pydistutils_bak.cfg pydistutils.cfg"
+=======
+  - "%CMD_IN_ENV% pip install --upgrade configobj traitsui natsort start_jupyter_cm tqdm pint"
+>>>>>>> fix travis and appveyor
   # Custom installer step
   # TODO: Re-run tests in WinPython environment
   - ps: Add-AppveyorMessage "Creating installer..."

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -20,7 +20,7 @@ environment:
       CONDA_NPY: "19"
       WP_URL: 'https://github.com/winpython/winpython/releases/download/1.3.20160209/WinPython-32bit-3.5.1.2.exe'
       WP_CRC: '172d19a743ccfaf55af779d15f29f67fca83a46f08b0af855dfaf809b4184c0d'
-      DEPS: "numpy scipy matplotlib ipython h5py sympy scikit-learn dill setuptools natsort scikit-image cython lxml ipyparallel"
+      DEPS: "numpy scipy matplotlib ipython h5py sympy scikit-learn dill setuptools natsort scikit-image pint"
 
     - PYTHON: "C:\\Miniconda35-x64"
       PYTHON_VERSION: "3.5.x"
@@ -30,8 +30,7 @@ environment:
       CONDA_NPY: "19"
       WP_URL: 'https://github.com/winpython/winpython/releases/download/1.3.20160209/WinPython-64bit-3.5.1.2.exe'
       WP_CRC: '07e854b9aa7a31d8bbf7829d04a45b6d6266603690520e365199af2d98751ab1'
-      DEPS: "numpy scipy matplotlib ipython h5py sympy scikit-learn dill setuptools natsort scikit-image cython lxml ipyparallel"
-
+      DEPS: "numpy scipy matplotlib ipython h5py sympy scikit-learn dill setuptools natsort scikit-image cython lxml ipyparallel pint"
 
 
 init:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -20,7 +20,7 @@ environment:
       CONDA_NPY: "19"
       WP_URL: 'https://github.com/winpython/winpython/releases/download/1.3.20160209/WinPython-32bit-3.5.1.2.exe'
       WP_CRC: '172d19a743ccfaf55af779d15f29f67fca83a46f08b0af855dfaf809b4184c0d'
-      DEPS: "numpy scipy matplotlib ipython h5py sympy scikit-learn dill setuptools natsort scikit-image"
+      DEPS: "numpy scipy matplotlib ipython h5py sympy scikit-learn dill setuptools natsort scikit-image cython lxml ipyparallel"
 
     - PYTHON: "C:\\Miniconda35-x64"
       PYTHON_VERSION: "3.5.x"
@@ -30,7 +30,9 @@ environment:
       CONDA_NPY: "19"
       WP_URL: 'https://github.com/winpython/winpython/releases/download/1.3.20160209/WinPython-64bit-3.5.1.2.exe'
       WP_CRC: '07e854b9aa7a31d8bbf7829d04a45b6d6266603690520e365199af2d98751ab1'
-      DEPS: "numpy scipy matplotlib ipython h5py sympy scikit-learn dill setuptools natsort scikit-image cython lxml ipyparallel pint"
+      DEPS: "numpy scipy matplotlib ipython h5py sympy scikit-learn dill setuptools natsort scikit-image cython lxml ipyparallel"
+
+
 
 init:
   - "ECHO %PYTHON% %PYTHON_VERSION% %PYTHON_ARCH%"
@@ -110,17 +112,13 @@ before_deploy:
   # Install current hyperspy in WinPython
   - "SET PATH=%ORIGPATH%"
   - "%CMD_IN_ENV% %WP_INSTDIR%/scripts/env.bat"
-  - "%CMD_IN_ENV% pip install --upgrade configobj traitsui natsort start_jupyter_cm tqdm cython setuptools"
+  - "%CMD_IN_ENV% pip install --upgrade configobj traitsui natsort start_jupyter_cm tqdm cython setuptools pint"
   # Give info about python vesion and compiler used to compile the python
   - "%CMD_IN_ENV% python.exe -c \"import sys; print(sys.version)\""
   - "%CMD_IN_ENV% python.exe setup.py recythonize"
   - "%CMD_IN_ENV% python.exe setup.py install"
-<<<<<<< fdce5cfdf985f5019e551a0610e10dd8458c099e
   # setting back the config:
   - "ren %WP_INSTDIR%\\settings\\pydistutils_bak.cfg pydistutils.cfg"
-=======
-  - "%CMD_IN_ENV% pip install --upgrade configobj traitsui natsort start_jupyter_cm tqdm pint"
->>>>>>> fix travis and appveyor
   # Custom installer step
   # TODO: Re-run tests in WinPython environment
   - ps: Add-AppveyorMessage "Creating installer..."

--- a/hyperspy/axes.py
+++ b/hyperspy/axes.py
@@ -22,6 +22,7 @@ import math
 import numpy as np
 import traits.api as t
 from traits.trait_errors import TraitError
+from pint import UnitRegistry
 
 from hyperspy.events import Events, Event
 from hyperspy.misc.utils import isiterable, ordinal
@@ -59,7 +60,61 @@ def generate_axis(offset, scale, size, offset_index=0):
                        offset + scale * (size - 1 - offset_index),
                        size)
 
+def _get_convenient_scale_unit(scale, unit, size):
+    """ Convert (when necessary) the scale and the unit to "sensible" number to
+        avoid displaying scalebar with >3 digits or too small number.
+    """
+    ureg = UnitRegistry()
+    scale = scale*ureg(unit)
+    value =  scale.magnitude*size
+    # for image
+    if scale.dimensionality == {'[length]':1.0}:
+        scale = scale.to(ureg('m'))
+        if value < 5E-6:
+            scale = scale.to(ureg('nm'))
+        elif value < 5E-3:
+            scale = scale.to(ureg('µm'))
+        elif value < 5:
+            scale = scale.to(ureg('mm'))
+        elif value < 5E3:
+            pass # already in m
+        else:
+            scale = scale.to(ureg('km'))
+    # for diffraction
+    elif scale.dimensionality == {'[length]':-1.0}:
+        print('%e'%value)
+        scale = scale.to(ureg('1/m'))
+        if value > 5E9:
+            scale = scale.to(ureg('1/nm'))
+        elif value > 5E6:
+            scale = scale.to(ureg('1/µm'))
+        elif value > 5E3:
+            scale = scale.to(ureg('1/mm'))
+        elif value > 5:
+            pass # already in 1/m
+        else:
+            scale = scale.to(ureg('1/km'))
+    # for energy
+    elif scale.units == 'electron_volt' or scale.units == 'kiloelectron_volt'\
+        or scale.units == 'millielectron_volt':
+        scale = scale.to(ureg('eV'))
+        if value < 2.5:
+            scale = scale.to(ureg('meV'))
+        elif value < 2.5E3:
+            pass # already in eV
+        else:
+            scale = scale.to(ureg('keV'))
+            
+    units = '{:~}'.format(scale.units).replace(' ', '')
+    if units == 'um':
+        units = 'µm'
 
+    if units == '1/um':
+        units = '1/µm'
+            
+    return scale.magnitude, units
+
+        
 class DataAxis(t.HasTraits):
     name = t.Str()
     units = t.Str()
@@ -467,6 +522,11 @@ class DataAxis(t.HasTraits):
             any_changes = True
         return any_changes
 
+    def convert_to_convenient_scale_units(self):
+        self.scale, self.units = _get_convenient_scale_unit(self.scale,
+                                                            self.units,
+                                                            self.size)
+        
 
 class AxesManager(t.HasTraits):
 
@@ -818,6 +878,21 @@ class AxesManager(t.HasTraits):
     def _on_offset_changed(self):
         self.events.any_axis_changed.trigger(obj=self)
 
+    def convert_to_convenient_scale_units(self, axes=None):
+        """ Convert the scale and the units to the convenient scale and units 
+            to avoid displaying scalebar with >3 digits or too small number.
+        
+        Parameters
+        ----------
+        axes: iterable of `DataAxis` instances. Default = None
+            Convert to the convenient scale and units on the specified axis.
+            If None, convert for all axes.
+        """
+        if axes is None:
+            axes = self.navigation_axes + self.signal_axes
+        for axis in axes:
+            axis.convert_to_convenient_scale_units()        
+        
     def update_axes_attributes_from(self, axes,
                                     attributes=["scale", "offset", "units"]):
         """Update the axes attributes to match those given.

--- a/hyperspy/axes.py
+++ b/hyperspy/axes.py
@@ -29,8 +29,10 @@ from hyperspy.misc.utils import isiterable, ordinal
 from hyperspy.misc.math_tools import isfloat
 
 import warnings
+import logging
 from hyperspy.exceptions import VisibleDeprecationWarning
 
+_logger = logging.getLogger(__name__)
 
 class ndindex_nat(np.ndindex):
 
@@ -82,7 +84,9 @@ def _get_convenient_scale_unit(scale, unit, size):
             scale = scale.to(ureg('km'))
     # for diffraction
     elif scale.dimensionality == {'[length]':-1.0}:
-        print('%e'%value)
+        _logger.info('Scale*Size: {:e}, scale: {:e}, size: {:e}'.format(value,
+                                                                        scale,
+                                                                        size))
         scale = scale.to(ureg('1/m'))
         if value > 5E9:
             scale = scale.to(ureg('1/nm'))
@@ -523,9 +527,11 @@ class DataAxis(t.HasTraits):
         return any_changes
 
     def convert_to_convenient_scale_units(self):
-        self.scale, self.units = _get_convenient_scale_unit(self.scale,
-                                                            self.units,
-                                                            self.size)
+        _logger.info('Units: {}'.format(self.units))
+        if self.units not in [t.Undefined, '', ' ', 'Unknown']:
+            self.scale, self.units = _get_convenient_scale_unit(self.scale,
+                                                                self.units,
+                                                                self.size)
         
 
 class AxesManager(t.HasTraits):
@@ -888,6 +894,7 @@ class AxesManager(t.HasTraits):
             Convert to the convenient scale and units on the specified axis.
             If None, convert for all axes.
         """
+        _logger.info('Axes manager: {}'.format(self))
         if axes is None:
             axes = self.navigation_axes + self.signal_axes
         for axis in axes:

--- a/hyperspy/axes.py
+++ b/hyperspy/axes.py
@@ -22,7 +22,7 @@ import math
 import numpy as np
 import traits.api as t
 from traits.trait_errors import TraitError
-from pint import UnitRegistry
+import pint
 
 from hyperspy.events import Events, Event
 from hyperspy.misc.utils import isiterable, ordinal
@@ -33,7 +33,7 @@ import logging
 from hyperspy.exceptions import VisibleDeprecationWarning
 
 _logger = logging.getLogger(__name__)
-_ureg = UnitRegistry()
+_ureg = pint.UnitRegistry()
 
 class ndindex_nat(np.ndindex):
 
@@ -68,10 +68,17 @@ def _formatting_units(units):
     return units.replace('um', 'µm')
 
 def _ignore_conversion(units):
-    if units == '' or units == t.Undefined:
+    if units == t.Undefined:
         return True
+    try:
+        _ureg(units)
+    except pint.errors.UndefinedUnitError:
+        warnings.warn('Unit "{}" not supported for conversion.'.format(units),
+                      UserWarning)
+        return True
+    return False
     
-def _get_convenient_scale_units(scale, units, size):
+def _get_appropriate_scale_units(scale, units, size):
     """ Convert (when necessary) the scale and the units to "sensible" number
         to avoid displaying scalebar with >3 digits or too small number.
     """
@@ -81,9 +88,9 @@ def _get_convenient_scale_units(scale, units, size):
     scale = scale*_ureg(units)
     def get_value(scale, size):
         value =  scale.magnitude*size
-        _logger.info('Scale*Size: {:e}, scale: {:e}, size: {:e}'.format(value,
-                                                                        scale,
-                                                                        size))
+        _logger.debug('Scale*Size: {:e}, scale: {:e}, size: {:e}'.format(value,
+                      scale,
+                      size))
         return value
         
     # for image
@@ -546,16 +553,36 @@ class DataAxis(t.HasTraits):
             any_changes = True
         return any_changes
 
-    def convert_to_convenient_scale_units(self):
-        _logger.info('Units: {}'.format(self.units))
-        if self.units not in [t.Undefined, '', ' ', 'Unknown']:
-            self.scale, self.units = _get_convenient_scale_units(self.scale,
-                                                                 self.units,
-                                                                 self.size)
-
-    def convert_to_units(self, units):
-        self.scale, self.units = _get_convert_units(self.scale, self.units,
-                                                    units)
+    def convert_to_units(self, units=None, filterwarning_action='always'):
+        """ Convert the scale and the units of the current axis. If the units
+        is not supported by the pint library, the scale and units are not
+        changed.
+        
+        Parameters
+        ----------
+        units : list of string of the same length than axes, str or None.
+            Default = None
+            If list, the selected axes will be converted to the provided units.
+            If str, the navigation or signal axes will converted to the 
+            provided units.
+            If `None`, the scale and the units to the appropriate scale and units 
+            to avoid displaying scalebar with >3 digits or too small number.            
+        filterwarning_action : str
+            Default = 'always'
+            Controls whether warnings are ignored, displayed, or turned into
+            errors. See warnings.filterwarnings documentation for more details.
+        """
+        with warnings.catch_warnings():
+            warnings.filterwarnings(filterwarning_action, category=UserWarning)
+            if units is None:
+                self.scale, self.units = _get_appropriate_scale_units(
+                    self.scale,
+                    self.units,
+                    self.size)     
+            else:
+                self.scale, self.units = _get_convert_units(self.scale,
+                                                            self.units,
+                                                            units)
 
 class AxesManager(t.HasTraits):
 
@@ -906,9 +933,12 @@ class AxesManager(t.HasTraits):
 
     def _on_offset_changed(self):
         self.events.any_axis_changed.trigger(obj=self)
-
-    def convert_units(self, axes=None, units=None):
-        """ Convert the scale and the units of the selected axes.
+        
+    def convert_units(self, axes=None, units=None,
+                      filterwarning_action='always'):
+        """ Convert the scale and the units of the selected axes. If the units
+        is not supported by the pint library, the scale and units are not
+        changed.
         
         Parameters
         ----------
@@ -923,25 +953,28 @@ class AxesManager(t.HasTraits):
             If list, the selected axes will be converted to the provided units.
             If str, the navigation or signal axes will converted to the 
             provided units.
-            If `None`, the scale and the units to the convenient scale and units 
+            If `None`, the scale and the units to the appropriate scale and units 
             to avoid displaying scalebar with >3 digits or too small number.
+        filterwarning_action : str
+            Default = 'always'
+            Controls whether warnings are ignored, displayed, or turned into
+            errors. See warnings.filterwarnings documentation for more details.
         """
-        _logger.info('Axes manager: {}'.format(self))
+        _logger.debug('Axes manager: {}'.format(self))
         if axes is None:
             axes = self.navigation_axes + self.signal_axes
         elif axes == 'navigation':
             axes = self.navigation_axes
         elif axes == 'signal':
             axes = self.signal_axes
-        if type(units) is str:
+        if type(units) is str or units is None:
             units = [units]*len(axes)
-        if units is None:
-            for axis in axes:
-                axis.convert_to_convenient_scale_units()
-        else:
-            for axis, units in zip(axes, units):
-                _logger.info('axis: {}, units: {}'.format(axis.name, units))
-                axis.convert_to_units(units)
+        elif len(units) != len(axes):
+            _logger.error('Please provide a correct "units" argument')
+        for axis, units in zip(axes, units):
+            _logger.debug('axis: {}, units: {}'.format(axis.name, units))
+            axis.convert_to_units(units,
+                filterwarning_action=filterwarning_action)
             
     def update_axes_attributes_from(self, axes,
                                     attributes=["scale", "offset", "units"]):

--- a/hyperspy/axes.py
+++ b/hyperspy/axes.py
@@ -906,23 +906,6 @@ class AxesManager(t.HasTraits):
 
     def _on_offset_changed(self):
         self.events.any_axis_changed.trigger(obj=self)
-#
-#    def convert_to_convenient_scale_units(self, axes=None):
-#        """ Convert the scale and the units to the convenient scale and units 
-#            to avoid displaying scalebar with >3 digits or too small number.
-#        
-#        Parameters
-#        ----------
-#        axes: iterable of `DataAxis` instances. Default = None
-#            Convert to the convenient scale and units on the specified axis.
-#            If None, convert for all axes.
-#        """
-#        _logger.info('Axes manager: {}'.format(self))
-#        if axes is None:
-#            axes = self.navigation_axes + self.signal_axes
-#        for axis in axes:
-#            axis.convert_to_convenient_scale_units()        
-
 
     def convert_units(self, axes=None, units=None):
         """ Convert the scale and the units of the selected axes.
@@ -959,8 +942,6 @@ class AxesManager(t.HasTraits):
             for axis, units in zip(axes, units):
                 _logger.info('axis: {}, units: {}'.format(axis.name, units))
                 axis.convert_to_units(units)
-            
-        ### add functionality to convert to provided units
             
     def update_axes_attributes_from(self, axes,
                                     attributes=["scale", "offset", "units"]):

--- a/hyperspy/axes.py
+++ b/hyperspy/axes.py
@@ -66,11 +66,18 @@ def generate_axis(offset, scale, size, offset_index=0):
 def _formatting_units(units):
     units = units.replace(' ', '')
     return units.replace('um', 'µm')
+
+def _ignore_conversion(units):
+    if units == '' or units == t.Undefined:
+        return True
     
 def _get_convenient_scale_units(scale, units, size):
     """ Convert (when necessary) the scale and the units to "sensible" number
         to avoid displaying scalebar with >3 digits or too small number.
     """
+    if _ignore_conversion(units):
+        return scale, units
+    
     scale = scale*_ureg(units)
     def get_value(scale, size):
         value =  scale.magnitude*size
@@ -121,14 +128,16 @@ def _get_convenient_scale_units(scale, units, size):
             
     units = _formatting_units('{:~}'.format(scale.units))
             
-    return scale.magnitude, units
+    return float(scale.magnitude), units
 
 def _get_convert_units(scale, units, converted_units):
+    if _ignore_conversion(units):
+        return scale, units
     scale = scale*_ureg(units)
     scale = scale.to(_ureg(converted_units))
     units = _formatting_units('{:~}'.format(scale.units))
 
-    return scale.magnitude, units
+    return float(scale.magnitude), units
         
 class DataAxis(t.HasTraits):
     name = t.Str()

--- a/hyperspy/io.py
+++ b/hyperspy/io.py
@@ -188,16 +188,29 @@ def load(filenames=None,
 
 def load_single_file(filename,
                      signal_type=None,
+                     auto_convert_units=True,
                      **kwds):
     """
-    Load any supported file into an HyperSpy structure
-    Supported formats: netCDF, msa, Gatan dm3, Ripple (rpl+raw),
-    Bruker bcf, FEI ser and emi, hdf5 and SEMPER unf.
+    Load any supported file into an HyperSpy structure.
+    Supported formats: netCDF, msa, Gatan dm3/dm4, Ripple (rpl+raw), tiff, mrc, 
+    emsa/msa, Bruker bcf, FEI ser and emi, hdf5, blockfile, emd, dens and
+    SEMPER unf.
+    
     Parameters
     ----------
     filename : string
         File name (including the extension)
 
+    signal_type : 
+        Set the signal type of the data to be read.
+        
+    auto_convert_units : bool
+        Default is True.
+        If True, convert the units using the 'convert_to_units' method of
+        the 'axes_manager'. If False, does nothing.        
+        
+    kwds : dictionary
+        Keyword arguments for the file reader.
     """
     extension = os.path.splitext(filename)[1][1:]
 
@@ -220,12 +233,14 @@ def load_single_file(filename,
         return load_with_reader(filename=filename,
                                 reader=reader,
                                 signal_type=signal_type,
+                                auto_convert_units=auto_convert_units,
                                 **kwds)
 
 
 def load_with_reader(filename,
                      reader,
                      signal_type=None,
+                     auto_convert_units=True,
                      **kwds):
     file_data_list = reader.file_reader(filename,
                                         **kwds)
@@ -243,8 +258,9 @@ def load_with_reader(filename,
             objects[-1].tmp_parameters.folder = folder
             objects[-1].tmp_parameters.filename = filename
             objects[-1].tmp_parameters.extension = extension.replace('.', '')
-            objects[-1].axes_manager.convert_units(
-                filterwarning_action="ignore")
+            if auto_convert_units:
+                objects[-1].axes_manager.convert_units(
+                    filterwarning_action="ignore")
         else:
             # it's a standalone model
             continue

--- a/hyperspy/io.py
+++ b/hyperspy/io.py
@@ -243,7 +243,8 @@ def load_with_reader(filename,
             objects[-1].tmp_parameters.folder = folder
             objects[-1].tmp_parameters.filename = filename
             objects[-1].tmp_parameters.extension = extension.replace('.', '')
-            objects[-1].axes_manager.convert_units()
+            objects[-1].axes_manager.convert_units(
+                filterwarning_action="ignore")
         else:
             # it's a standalone model
             continue

--- a/hyperspy/io.py
+++ b/hyperspy/io.py
@@ -243,6 +243,7 @@ def load_with_reader(filename,
             objects[-1].tmp_parameters.folder = folder
             objects[-1].tmp_parameters.filename = filename
             objects[-1].tmp_parameters.extension = extension.replace('.', '')
+            objects[-1].axes_manager.convert_to_convenient_scale_units()
         else:
             # it's a standalone model
             continue

--- a/hyperspy/io.py
+++ b/hyperspy/io.py
@@ -243,7 +243,7 @@ def load_with_reader(filename,
             objects[-1].tmp_parameters.folder = folder
             objects[-1].tmp_parameters.filename = filename
             objects[-1].tmp_parameters.extension = extension.replace('.', '')
-            objects[-1].axes_manager.convert_to_convenient_scale_units()
+            objects[-1].axes_manager.convert_units()
         else:
             # it's a standalone model
             continue

--- a/hyperspy/io_plugins/blockfile.py
+++ b/hyperspy/io_plugins/blockfile.py
@@ -126,7 +126,7 @@ def get_header_from_signal(signal, endianess='<'):
     if signal.axes_manager.navigation_dimension == 2:
         NX, NY = signal.axes_manager.navigation_shape
         SX = signal.axes_manager.navigation_axes[0].scale
-        SY = signal.axes_manager.navigation_axes[0].scale
+        SY = signal.axes_manager.navigation_axes[1].scale
     elif signal.axes_manager.navigation_dimension == 1:
         NX = signal.axes_manager.navigation_shape[0]
         NY = 1
@@ -249,7 +249,11 @@ def file_reader(filename, endianess='<', load_to_memory=True, mmap_mode='c',
 
 def file_writer(filename, signal, **kwds):
     endianess = kwds.pop('endianess', '<')
+    # need to convert the signal axes to 'cm' to write the file
+    signal.axes_manager.convert_units('signal', 'cm')
+    _logger.debug("Writing blockfile: %s" % filename)
     header, note = get_header_from_signal(signal, endianess=endianess)
+    _logger.debug("header: {}".format(header))
     with open(filename, 'wb') as f:
         # Write header
         header.tofile(f)

--- a/hyperspy/io_plugins/fei.py
+++ b/hyperspy/io_plugins/fei.py
@@ -618,7 +618,7 @@ def guess_units_from_mode(objects_dict, header):
     # contain 'Dim-1_UnitsLength', return "meters" as default, which will be
     # OK most of the time
     warn_str = "The navigation axes units could not be determined. " \
-               "Setting them to `nm`, but this may be wrong."
+               "Setting them to `m`, but this may be wrong."
     try:
         mode = objects_dict.ObjectInfo.ExperimentalDescription.Mode
         isCamera = (

--- a/hyperspy/io_plugins/fei.py
+++ b/hyperspy/io_plugins/fei.py
@@ -569,13 +569,13 @@ def ser_reader(filename, objects=None, *args, **kwds):
         array_shape.append(data['ArraySizeX'][0])
     # FEI seems to use the international system of units (SI) for the
     # spatial scale. However, we prefer to work in nm
-    for axis in axes:
-        if axis['units'] == 'meters':
-            axis['units'] = 'nm'
-            axis['scale'] *= 10 ** 9
-        elif axis['units'] == '1/meters':
-            axis['units'] = '1/nm'
-            axis['scale'] /= 10 ** 9
+#    for axis in axes:
+#        if axis['units'] == 'meters':
+#            axis['units'] = 'nm'
+#            axis['scale'] *= 10 ** 9
+#        elif axis['units'] == '1/meters':
+#            axis['units'] = '1/nm'
+#            axis['scale'] /= 10 ** 9
     # If the acquisition stops before finishing the job, the stored file will
     # report the requested size even though no values are recorded. Therefore
     # if the shapes of the retrieved array does not match that of the data

--- a/hyperspy/io_plugins/fei.py
+++ b/hyperspy/io_plugins/fei.py
@@ -567,15 +567,6 @@ def ser_reader(filename, objects=None, *args, **kwds):
             'units': units,
         })
         array_shape.append(data['ArraySizeX'][0])
-    # FEI seems to use the international system of units (SI) for the
-    # spatial scale. However, we prefer to work in nm
-#    for axis in axes:
-#        if axis['units'] == 'meters':
-#            axis['units'] = 'nm'
-#            axis['scale'] *= 10 ** 9
-#        elif axis['units'] == '1/meters':
-#            axis['units'] = '1/nm'
-#            axis['scale'] /= 10 ** 9
     # If the acquisition stops before finishing the job, the stored file will
     # report the requested size even though no values are recorded. Therefore
     # if the shapes of the retrieved array does not match that of the data

--- a/hyperspy/io_plugins/tiff.py
+++ b/hyperspy/io_plugins/tiff.py
@@ -184,6 +184,8 @@ def file_reader(filename, record_by='image', **kwds):
                 # ImageJ write the unit in the image description
                 units = image_description.split('unit=')[1].split('\n')[0]
                 scales = _get_scales_from_x_y_resolution(op)
+            if units == 'micron': # ImageJ use micron instead of µm
+                units = 'µm'
 
         # for files created with DM
         if '65003' in op.keys():

--- a/hyperspy/io_plugins/tiff.py
+++ b/hyperspy/io_plugins/tiff.py
@@ -108,10 +108,9 @@ def file_writer(filename, signal, export_scale=True, extratags=[], **kwds):
         photometric = "minisblack"
     if 'description' in kwds and export_scale:
         kwds.pop('description')
-        # Comment this warning, since it was not passing the test online...
-#        warnings.warn(
-#            "Description and export scale cannot be used at the same time, "
-#            "because of incompability with the 'ImageJ' format")
+        warnings.warn(
+            "Description and export scale cannot be used at the same time "
+            "because 'ImageJ' doesn't support it")
     if export_scale:
         kwds.update(_get_tags_dict(signal, extratags=extratags))
         _logger.info("kwargs passed to tifffile.py imsave: {0}".format(kwds))

--- a/hyperspy/signal.py
+++ b/hyperspy/signal.py
@@ -2064,7 +2064,7 @@ class BaseSignal(FancySlicing,
         for axis in self.axes_manager._axes:
             axis.size = int(dc.shape[axis.index_in_array])
 
-    def crop(self, axis, start=None, end=None):
+    def crop(self, axis, start=None, end=None, auto_convert_units=False):
         """Crops the data in a given axis. The range is given in pixels
 
         Parameters
@@ -2078,6 +2078,10 @@ class BaseSignal(FancySlicing,
             the value is taken as the axis index. If float the index
             is calculated using the axis calibration. If start/end is
             None crop from/to the low/high end of the axis.
+        auto_convert_units : bool
+            Default is False
+            if True, convert the units using the 'convert_to_units' method of
+            the 'axes_manager'. If False, does nothing.
 
         """
         axis = self.axes_manager[axis]
@@ -2094,7 +2098,8 @@ class BaseSignal(FancySlicing,
         self.get_dimensions_from_data()
         self.squeeze()
         self.events.data_changed.trigger(obj=self)
-        self.axes_manager.convert_units()
+        if auto_convert_units:
+            self.axes_manager.convert_units(filterwarning_action="ignore")
 
     def swap_axes(self, axis1, axis2):
         """Swaps the axes.

--- a/hyperspy/signal.py
+++ b/hyperspy/signal.py
@@ -2080,7 +2080,7 @@ class BaseSignal(FancySlicing,
             None crop from/to the low/high end of the axis.
         auto_convert_units : bool
             Default is False
-            if True, convert the units using the 'convert_to_units' method of
+            If True, convert the units using the 'convert_to_units' method of
             the 'axes_manager'. If False, does nothing.
 
         """

--- a/hyperspy/signal.py
+++ b/hyperspy/signal.py
@@ -2094,6 +2094,7 @@ class BaseSignal(FancySlicing,
         self.get_dimensions_from_data()
         self.squeeze()
         self.events.data_changed.trigger(obj=self)
+        self.axes_manager.convert_units()
 
     def swap_axes(self, axis1, axis2):
         """Swaps the axes.

--- a/hyperspy/tests/axes/test_convenient_scale_unit.py
+++ b/hyperspy/tests/axes/test_convenient_scale_unit.py
@@ -18,89 +18,106 @@
 
 import nose.tools as nt
 
-from hyperspy.axes import DataAxis, AxesManager, _get_convenient_scale_unit
+from hyperspy.axes import DataAxis, AxesManager, _get_convenient_scale_units,\
+                             _get_convert_units
 
+def test_convert_to_units():
+    scale, units = _get_convert_units(0.5, 'µm', 'nm')
+    nt.assert_almost_equal(scale, 500, places=5)
+    nt.assert_equal(units, 'nm')   
 
+    scale, units = _get_convert_units(5, 'µm', 'cm')
+    nt.assert_almost_equal(scale, 0.0005, places=5)
+    nt.assert_equal(units, 'cm')   
+    
+    scale, units = _get_convert_units(5, '1/µm', '1/nm')
+    nt.assert_almost_equal(scale, 0.005, places=5)
+    nt.assert_equal(units, '1/nm')       
+
+    scale, units = _get_convert_units(5, 'eV', 'keV')
+    nt.assert_almost_equal(scale, 0.005, places=5)
+    nt.assert_equal(units, 'keV')       
+    
 def test_get_convenient_scale_unit():
     ##### Imaging #####
     # typical setting for high resolution image
-    scale, unit = _get_convenient_scale_unit(12E-12, 'm', 2048)
+    scale, unit = _get_convenient_scale_units(12E-12, 'm', 2048)
     nt.assert_almost_equal(scale, 0.012, places=5)
     nt.assert_equal(unit, 'nm')
 
     # typical setting for nm resolution image
-    scale, unit = _get_convenient_scale_unit(0.5E-9, 'm', 1024)
+    scale, unit = _get_convenient_scale_units(0.5E-9, 'm', 1024)
     nt.assert_almost_equal(scale, 0.5, places=5)
     nt.assert_equal(unit, 'nm')  
 
     # typical setting for nm resolution image
-    scale, unit = _get_convenient_scale_unit(0.5E-9, 'm', 2048)
+    scale, unit = _get_convenient_scale_units(0.5E-9, 'm', 2048)
     nt.assert_almost_equal(scale, 0.5, places=5)
     nt.assert_equal(unit, 'nm')  
     
     # typical setting for nm resolution image
-    scale, unit = _get_convenient_scale_unit(1E-9, 'm', 1024)
+    scale, unit = _get_convenient_scale_units(1E-9, 'm', 1024)
     nt.assert_almost_equal(scale, 1.0, places=5)
     nt.assert_equal(unit, 'nm')    
 
     # typical setting for µm resolution image
-    scale, unit = _get_convenient_scale_unit(1E-6, 'm', 1024)
+    scale, unit = _get_convenient_scale_units(1E-6, 'm', 1024)
     nt.assert_almost_equal(scale, 1.0, places=5)
     nt.assert_equal(unit, 'µm') 
 
     # typical setting for a few tens of µm resolution image
-    scale, unit = _get_convenient_scale_unit(10E-6, 'm', 1024)
+    scale, unit = _get_convenient_scale_units(10E-6, 'm', 1024)
     nt.assert_almost_equal(scale, 0.01, places=5)
     nt.assert_equal(unit, 'mm')
 
     ##### Diffraction #####    
     # typical TEM diffraction
-    scale, unit = _get_convenient_scale_unit(0.1E9, '1/m', 1024)
+    scale, unit = _get_convenient_scale_units(0.1E9, '1/m', 1024)
     nt.assert_almost_equal(scale, 0.1, places=5)
     nt.assert_equal(unit, '1/nm')
 
     # typical TEM diffraction
-    scale, unit = _get_convenient_scale_unit(0.1E9, '1/m', 256)
+    scale, unit = _get_convenient_scale_units(0.1E9, '1/m', 256)
     nt.assert_almost_equal(scale, 0.1, places=5)
     nt.assert_equal(unit, '1/nm')
     
     # high camera length diffraction
-    scale, unit = _get_convenient_scale_unit(1E6, '1/m', 4096)
+    scale, unit = _get_convenient_scale_units(1E6, '1/m', 4096)
     nt.assert_almost_equal(scale, 1.0, places=5)
     nt.assert_equal(unit, '1/µm')
     
     # typical EDS resolution
-    scale, unit = _get_convenient_scale_unit(5E3, 'eV', 4096)
+    scale, unit = _get_convenient_scale_units(5E3, 'eV', 4096)
     nt.assert_almost_equal(scale, 5, places=5)
     nt.assert_equal(unit, 'keV')
 
     ##### Spectroscopy #####    
     # typical EELS resolution
-    scale, unit = _get_convenient_scale_unit(0.2, 'eV', 2048)
+    scale, unit = _get_convenient_scale_units(0.2, 'eV', 2048)
     nt.assert_almost_equal(scale, 0.2, places=5)
     nt.assert_equal(unit, 'eV')
 
     # typical EELS resolution
-    scale, unit = _get_convenient_scale_unit(1.0, 'eV', 2048)
+    scale, unit = _get_convenient_scale_units(1.0, 'eV', 2048)
     nt.assert_almost_equal(scale, 1.0, places=5)
     nt.assert_equal(unit, 'eV')
     
     # typical high resolution EELS resolution
-    scale, unit = _get_convenient_scale_unit(0.05, 'eV', 100)
+    scale, unit = _get_convenient_scale_units(0.05, 'eV', 100)
     nt.assert_almost_equal(scale, 0.05, places=5)
     nt.assert_equal(unit, 'eV')
 
     # typical high resolution EELS resolution
-    scale, unit = _get_convenient_scale_unit(0.001, 'eV', 100)
+    scale, unit = _get_convenient_scale_units(0.001, 'eV', 100)
     nt.assert_almost_equal(scale, 1.0, places=5)
     nt.assert_equal(unit, 'meV')
     
     # typical high resolution EELS resolution
-    scale, unit = _get_convenient_scale_unit(0.001, 'eV', 2048)
+    scale, unit = _get_convenient_scale_units(0.001, 'eV', 2048)
     nt.assert_almost_equal(scale, 1.0, places=5)
     nt.assert_equal(unit, 'meV')
     
-class TestDataAxisConvenientScaleUnit:
+class TestDataAxis:
 
     def setUp(self):
         self.axis = DataAxis(size=2048, scale=12E-12, units='m')
@@ -109,11 +126,16 @@ class TestDataAxisConvenientScaleUnit:
         self.axis.convert_to_convenient_scale_units()
         nt.assert_almost_equal(self.axis.scale, 0.012, places=5)
         nt.assert_equal(self.axis.units, 'nm')
+
+    def test_convert_to_units(self):
+        self.axis.convert_to_units('µm')
+        nt.assert_almost_equal(self.axis.scale, 12E-6, places=5)
+        nt.assert_equal(self.axis.units, 'µm')
         
-class TestAxesManagerConvenientScaleUnit:
+class TestAxesManager:
 
     def setup(self):
-        axes_list = [
+        self.axes_list = [
             {'name': 'x',
              'navigate': True,
              'offset': 0.0,
@@ -133,13 +155,53 @@ class TestAxesManagerConvenientScaleUnit:
              'size': 4096,
              'units': 'eV'}]
 
-        self.am = AxesManager(axes_list)
+        self.am = AxesManager(self.axes_list)
 
     def test_convenient_scale_unit(self):
-        self.am.convert_to_convenient_scale_units()
+        self.am.convert_units()
         nt.assert_almost_equal(self.am['x'].scale, 1.0, places=5)
         nt.assert_equal(self.am['x'].units, 'µm')
         nt.assert_almost_equal(self.am['y'].scale, 0.5, places=5)
         nt.assert_equal(self.am['y'].units, 'nm')
         nt.assert_almost_equal(self.am['energy'].scale, 0.005, places=5)
         nt.assert_equal(self.am['energy'].units, 'keV')
+        
+    def test_convert_to_navigation_units(self):
+        self.am.convert_units(axes='navigation', units='µm')
+        nt.assert_almost_equal(self.am['x'].scale, 1.0, places=5)
+        nt.assert_equal(self.am['x'].units, 'µm')
+        nt.assert_almost_equal(self.am['y'].scale, 0.5E-3, places=5)
+        nt.assert_equal(self.am['y'].units, 'µm')
+        nt.assert_almost_equal(self.am['energy'].scale,
+                               self.axes_list[-1]['scale'], places=5)
+        nt.assert_equal(self.am['energy'].units, self.axes_list[-1]['units'])
+
+    def test_convert_to_navigation_units_list(self):
+        self.am.convert_units(axes='navigation', units=['µm', 'nm'])
+        nt.assert_almost_equal(self.am['x'].scale, 1000.0, places=5)
+        nt.assert_equal(self.am['x'].units, 'nm')
+        nt.assert_almost_equal(self.am['y'].scale, 0.5E-3, places=5)
+        nt.assert_equal(self.am['y'].units, 'µm')
+        nt.assert_almost_equal(self.am['energy'].scale,
+                               self.axes_list[-1]['scale'], places=5)
+        nt.assert_equal(self.am['energy'].units, self.axes_list[-1]['units'])
+        
+    def test_convert_to_signal_units(self):
+        self.am.convert_units(axes='signal', units='keV')
+        nt.assert_almost_equal(self.am['x'].scale, self.axes_list[0]['scale'],
+                               places=5)
+        nt.assert_equal(self.am['x'].units, self.axes_list[0]['units'])
+        nt.assert_almost_equal(self.am['y'].scale, self.axes_list[1]['scale'],
+                               places=5)
+        nt.assert_equal(self.am['y'].units, self.axes_list[1]['units'])
+        nt.assert_almost_equal(self.am['energy'].scale, 0.005, places=5)
+        nt.assert_equal(self.am['energy'].units, 'keV')
+        
+    def test_convert_to_units_list(self):
+        self.am.convert_units(units=['µm', 'nm', 'meV'])
+        nt.assert_almost_equal(self.am['x'].scale, 1000.0, places=5)
+        nt.assert_equal(self.am['x'].units, 'nm')
+        nt.assert_almost_equal(self.am['y'].scale, 0.5E-3, places=5)
+        nt.assert_equal(self.am['y'].units, 'µm')
+        nt.assert_almost_equal(self.am['energy'].scale, 5E3, places=5)
+        nt.assert_equal(self.am['energy'].units, 'meV')

--- a/hyperspy/tests/axes/test_convert_scale_unit.py
+++ b/hyperspy/tests/axes/test_convert_scale_unit.py
@@ -18,16 +18,17 @@
 
 import nose.tools as nt
 import traits.api as t
-import warnings
 
 from hyperspy.axes import DataAxis, AxesManager, _get_appropriate_scale_units,\
                              _get_convert_units
+from hyperspy.misc.test_utils import assert_warns
 
+                             
 def test_units_not_supported_by_pint_raising_warning():
-    with warnings.catch_warnings(record=True) as w:
+    with assert_warns(
+                message="not supported for conversion.",
+                category=UserWarning):
         scale, units = _get_convert_units(1.0, 'micron', 'nm')
-        assert len(w) == 1 # catch one warning (there is no warning filtered)
-        assert issubclass(w[-1].category, UserWarning)
     nt.assert_almost_equal(scale, 1.0, places=5)
     nt.assert_equal(units, 'micron')
 
@@ -149,18 +150,17 @@ class TestDataAxis:
     def test_units_not_supported_by_pint_no_warning_raised(self):
         # Suppose to do nothing, not raising a warning, not converting scale
         self.axis.units = 'micron'
-        with warnings.catch_warnings(record=True) as w:
-            self.axis.convert_to_units('m', filterwarning_action="ignore")
-            assert len(w) == 0 # not catch warnings, they are ignored
+        self.axis.convert_to_units('m', filterwarning_action="ignore")
         nt.assert_almost_equal(self.axis.scale, 12E-12, places=15)
         nt.assert_equal(self.axis.units, 'micron')
 
     def test_units_not_supported_by_pint_warning_raised(self):
         # raising a warning, not converting scale
         self.axis.units = 'micron'
-        with warnings.catch_warnings(record=True) as w:
+        with assert_warns(
+                message="not supported for conversion.",
+                category=UserWarning):
             self.axis.convert_to_units('m')
-            assert len(w) == 1 # catch warnings
         nt.assert_almost_equal(self.axis.scale, 12E-12, places=15)
         nt.assert_equal(self.axis.units, 'micron')
                 

--- a/hyperspy/tests/axes/test_convert_scale_unit.py
+++ b/hyperspy/tests/axes/test_convert_scale_unit.py
@@ -18,108 +18,116 @@
 
 import nose.tools as nt
 import traits.api as t
+import warnings
 
-from hyperspy.axes import DataAxis, AxesManager, _get_convenient_scale_units,\
+from hyperspy.axes import DataAxis, AxesManager, _get_appropriate_scale_units,\
                              _get_convert_units
 
+def test_units_not_supported_by_pint_raising_warning():
+    with warnings.catch_warnings(record=True) as w:
+        scale, units = _get_convert_units(1.0, 'micron', 'nm')
+        assert len(w) == 1 # catch one warning (there is no warning filtered)
+        assert issubclass(w[-1].category, UserWarning)
+    nt.assert_almost_equal(scale, 1.0, places=5)
+    nt.assert_equal(units, 'micron')
 
 def test_convert_to_units():
     scale, units = _get_convert_units(1.0, t.Undefined, 'nm')
     nt.assert_almost_equal(scale, 1.0, places=5)
-    nt.assert_equal(units, t.Undefined)   
+    nt.assert_equal(units, t.Undefined)
 
     scale, units = _get_convert_units(0.5, 'µm', 'nm')
     nt.assert_almost_equal(scale, 500, places=5)
-    nt.assert_equal(units, 'nm')   
+    nt.assert_equal(units, 'nm')
 
     scale, units = _get_convert_units(5, 'µm', 'cm')
     nt.assert_almost_equal(scale, 0.0005, places=5)
-    nt.assert_equal(units, 'cm')   
+    nt.assert_equal(units, 'cm')
     
     scale, units = _get_convert_units(5, '1/µm', '1/nm')
     nt.assert_almost_equal(scale, 0.005, places=5)
-    nt.assert_equal(units, '1/nm')       
+    nt.assert_equal(units, '1/nm')
 
     scale, units = _get_convert_units(5, 'eV', 'keV')
     nt.assert_almost_equal(scale, 0.005, places=5)
     nt.assert_equal(units, 'keV')       
     
-def test_get_convenient_scale_unit():
+def test_get_appropriate_scale_unit():
     ##### Imaging #####
     # typical setting for high resolution image
-    scale, unit = _get_convenient_scale_units(12E-12, 'm', 2048)
+    scale, unit = _get_appropriate_scale_units(12E-12, 'm', 2048)
     nt.assert_almost_equal(scale, 0.012, places=5)
     nt.assert_equal(unit, 'nm')
 
     # typical setting for nm resolution image
-    scale, unit = _get_convenient_scale_units(0.5E-9, 'm', 1024)
+    scale, unit = _get_appropriate_scale_units(0.5E-9, 'm', 1024)
     nt.assert_almost_equal(scale, 0.5, places=5)
     nt.assert_equal(unit, 'nm')  
 
     # typical setting for nm resolution image
-    scale, unit = _get_convenient_scale_units(0.5E-9, 'm', 2048)
+    scale, unit = _get_appropriate_scale_units(0.5E-9, 'm', 2048)
     nt.assert_almost_equal(scale, 0.5, places=5)
     nt.assert_equal(unit, 'nm')  
     
     # typical setting for nm resolution image
-    scale, unit = _get_convenient_scale_units(1E-9, 'm', 1024)
+    scale, unit = _get_appropriate_scale_units(1E-9, 'm', 1024)
     nt.assert_almost_equal(scale, 1.0, places=5)
     nt.assert_equal(unit, 'nm')    
 
     # typical setting for µm resolution image
-    scale, unit = _get_convenient_scale_units(1E-6, 'm', 1024)
+    scale, unit = _get_appropriate_scale_units(1E-6, 'm', 1024)
     nt.assert_almost_equal(scale, 1.0, places=5)
     nt.assert_equal(unit, 'µm') 
 
     # typical setting for a few tens of µm resolution image
-    scale, unit = _get_convenient_scale_units(10E-6, 'm', 1024)
+    scale, unit = _get_appropriate_scale_units(10E-6, 'm', 1024)
     nt.assert_almost_equal(scale, 0.01, places=5)
     nt.assert_equal(unit, 'mm')
 
     ##### Diffraction #####    
     # typical TEM diffraction
-    scale, unit = _get_convenient_scale_units(0.1E9, '1/m', 1024)
+    scale, unit = _get_appropriate_scale_units(0.1E9, '1/m', 1024)
     nt.assert_almost_equal(scale, 0.1, places=5)
     nt.assert_equal(unit, '1/nm')
 
     # typical TEM diffraction
-    scale, unit = _get_convenient_scale_units(0.1E9, '1/m', 256)
+    scale, unit = _get_appropriate_scale_units(0.1E9, '1/m', 256)
     nt.assert_almost_equal(scale, 0.1, places=5)
     nt.assert_equal(unit, '1/nm')
     
     # high camera length diffraction
-    scale, unit = _get_convenient_scale_units(1E6, '1/m', 4096)
+    scale, unit = _get_appropriate_scale_units(1E6, '1/m', 4096)
     nt.assert_almost_equal(scale, 1.0, places=5)
     nt.assert_equal(unit, '1/µm')
     
     # typical EDS resolution
-    scale, unit = _get_convenient_scale_units(5E3, 'eV', 4096)
+    scale, unit = _get_appropriate_scale_units(5E3, 'eV', 4096)
     nt.assert_almost_equal(scale, 5, places=5)
     nt.assert_equal(unit, 'keV')
 
     ##### Spectroscopy #####    
     # typical EELS resolution
-    scale, unit = _get_convenient_scale_units(0.2, 'eV', 2048)
+    scale, unit = _get_appropriate_scale_units(0.2, 'eV', 2048)
     nt.assert_almost_equal(scale, 0.2, places=5)
     nt.assert_equal(unit, 'eV')
 
     # typical EELS resolution
-    scale, unit = _get_convenient_scale_units(1.0, 'eV', 2048)
+    scale, unit = _get_appropriate_scale_units(1.0, 'eV', 2048)
     nt.assert_almost_equal(scale, 1.0, places=5)
     nt.assert_equal(unit, 'eV')
     
     # typical high resolution EELS resolution
-    scale, unit = _get_convenient_scale_units(0.05, 'eV', 100)
+    scale, unit = _get_appropriate_scale_units(0.05, 'eV', 100)
     nt.assert_almost_equal(scale, 0.05, places=5)
     nt.assert_equal(unit, 'eV')
 
     # typical high resolution EELS resolution
-    scale, unit = _get_convenient_scale_units(0.001, 'eV', 100)
+    scale, unit = _get_appropriate_scale_units(0.001, 'eV', 100)
     nt.assert_almost_equal(scale, 1.0, places=5)
     nt.assert_equal(unit, 'meV')
     
     # typical high resolution EELS resolution
-    scale, unit = _get_convenient_scale_units(0.001, 'eV', 2048)
+    scale, unit = _get_appropriate_scale_units(0.001, 'eV', 2048)
     nt.assert_almost_equal(scale, 1.0, places=5)
     nt.assert_equal(unit, 'meV')
     
@@ -128,16 +136,34 @@ class TestDataAxis:
     def setUp(self):
         self.axis = DataAxis(size=2048, scale=12E-12, units='m')
         
-    def test_convert_to_convenient_scale_units(self):
-        self.axis.convert_to_convenient_scale_units()
+    def test_convert_to_appropriate_scale_units(self):
+        self.axis.convert_to_units(units=None)
         nt.assert_almost_equal(self.axis.scale, 0.012, places=5)
         nt.assert_equal(self.axis.units, 'nm')
 
     def test_convert_to_units(self):
-        self.axis.convert_to_units('µm')
-        nt.assert_almost_equal(self.axis.scale, 12E-6, places=5)
+        self.axis.convert_to_units(units='µm')
+        nt.assert_almost_equal(self.axis.scale, 12E-6, places=8)
         nt.assert_equal(self.axis.units, 'µm')
-        
+
+    def test_units_not_supported_by_pint_no_warning_raised(self):
+        # Suppose to do nothing, not raising a warning, not converting scale
+        self.axis.units = 'micron'
+        with warnings.catch_warnings(record=True) as w:
+            self.axis.convert_to_units('m', filterwarning_action="ignore")
+            assert len(w) == 0 # not catch warnings, they are ignored
+        nt.assert_almost_equal(self.axis.scale, 12E-12, places=15)
+        nt.assert_equal(self.axis.units, 'micron')
+
+    def test_units_not_supported_by_pint_warning_raised(self):
+        # raising a warning, not converting scale
+        self.axis.units = 'micron'
+        with warnings.catch_warnings(record=True) as w:
+            self.axis.convert_to_units('m')
+            assert len(w) == 1 # catch warnings
+        nt.assert_almost_equal(self.axis.scale, 12E-12, places=15)
+        nt.assert_equal(self.axis.units, 'micron')
+                
 class TestAxesManager:
 
     def setup(self):
@@ -163,7 +189,7 @@ class TestAxesManager:
 
         self.am = AxesManager(self.axes_list)
 
-    def test_convenient_scale_unit(self):
+    def test_appropriate_scale_unit(self):
         self.am.convert_units()
         nt.assert_almost_equal(self.am['x'].scale, 1.0, places=5)
         nt.assert_equal(self.am['x'].units, 'µm')

--- a/hyperspy/tests/axes/test_convert_scale_unit.py
+++ b/hyperspy/tests/axes/test_convert_scale_unit.py
@@ -17,11 +17,17 @@
 # along with  HyperSpy.  If not, see <http://www.gnu.org/licenses/>.
 
 import nose.tools as nt
+import traits.api as t
 
 from hyperspy.axes import DataAxis, AxesManager, _get_convenient_scale_units,\
                              _get_convert_units
 
+
 def test_convert_to_units():
+    scale, units = _get_convert_units(1.0, t.Undefined, 'nm')
+    nt.assert_almost_equal(scale, 1.0, places=5)
+    nt.assert_equal(units, t.Undefined)   
+
     scale, units = _get_convert_units(0.5, 'µm', 'nm')
     nt.assert_almost_equal(scale, 500, places=5)
     nt.assert_equal(units, 'nm')   

--- a/hyperspy/tests/io/test_emd.py
+++ b/hyperspy/tests/io/test_emd.py
@@ -81,9 +81,9 @@ class TestCaseSaveAndRead():
         signal_ref.axes_manager[0].offset = 10
         signal_ref.axes_manager[1].offset = 20
         signal_ref.axes_manager[2].offset = 30
-        signal_ref.axes_manager[0].units = 'nmx'
-        signal_ref.axes_manager[1].units = 'nmy'
-        signal_ref.axes_manager[2].units = 'nmz'
+        signal_ref.axes_manager[0].units = 'nm'
+        signal_ref.axes_manager[1].units = 'nm'
+        signal_ref.axes_manager[2].units = 'nm'
         signal_ref.save(os.path.join(my_path, 'emd_files', 'example_temp.emd'), overwrite=True,
                         signal_metadata=sig_metadata, user=user, microscope=microscope,
                         sample=sample, comments=comments)
@@ -92,15 +92,15 @@ class TestCaseSaveAndRead():
         np.testing.assert_equal(signal.axes_manager[0].name, 'x')
         np.testing.assert_equal(signal.axes_manager[1].name, 'y')
         np.testing.assert_equal(signal.axes_manager[2].name, 'z')
-        np.testing.assert_equal(signal.axes_manager[0].scale, 2)
-        np.testing.assert_equal(signal.axes_manager[1].scale, 3)
-        np.testing.assert_equal(signal.axes_manager[2].scale, 4)
+        np.testing.assert_almost_equal(signal.axes_manager[0].scale, 2)
+        np.testing.assert_almost_equal(signal.axes_manager[1].scale, 3)
+        np.testing.assert_almost_equal(signal.axes_manager[2].scale, 4)
         np.testing.assert_equal(signal.axes_manager[0].offset, 10)
         np.testing.assert_equal(signal.axes_manager[1].offset, 20)
         np.testing.assert_equal(signal.axes_manager[2].offset, 30)
-        np.testing.assert_equal(signal.axes_manager[0].units, 'nmx')
-        np.testing.assert_equal(signal.axes_manager[1].units, 'nmy')
-        np.testing.assert_equal(signal.axes_manager[2].units, 'nmz')
+        np.testing.assert_equal(signal.axes_manager[0].units, 'nm')
+        np.testing.assert_equal(signal.axes_manager[1].units, 'nm')
+        np.testing.assert_equal(signal.axes_manager[2].units, 'nm')
         np.testing.assert_equal(signal.metadata.General.title, test_title)
         np.testing.assert_equal(
             signal.metadata.General.user.as_dictionary(), user)

--- a/hyperspy/tests/io/test_fei.py
+++ b/hyperspy/tests/io/test_fei.py
@@ -89,8 +89,8 @@ class TestFEIReader():
             s0[0].metadata.Acquisition_instrument.TEM.acquisition_mode, 'STEM')
         nt.assert_almost_equal(s0[0].axes_manager[0].scale, 3.68864, places=5)
         nt.assert_equal(s0[0].axes_manager[0].units, 'nm')
-        nt.assert_almost_equal(s0[0].axes_manager[1].scale, 5.0, places=5)
-        nt.assert_equal(s0[0].axes_manager[1].units, 'eV')
+        nt.assert_almost_equal(s0[0].axes_manager[1].scale, 0.005, places=5)
+        nt.assert_equal(s0[0].axes_manager[1].units, 'keV')
         # s0[1] contains diffraction patterns
         nt.assert_equal(s0[1].data.shape, (5, 128, 128))
         nt.assert_equal(s0[1].axes_manager.signal_dimension, 2)
@@ -116,8 +116,8 @@ class TestFEIReader():
         nt.assert_equal(s0[0].axes_manager[0].units, 'nm')
         nt.assert_almost_equal(s0[0].axes_manager[1].scale, -1.87390, places=5)
         nt.assert_equal(s0[0].axes_manager[1].units, 'nm')
-        nt.assert_almost_equal(s0[0].axes_manager[2].scale, 5.0, places=5)
-        nt.assert_equal(s0[0].axes_manager[2].units, 'eV')
+        nt.assert_almost_equal(s0[0].axes_manager[2].scale, 0.005, places=5)
+        nt.assert_equal(s0[0].axes_manager[2].units, 'keV')
         # s0[1] contains diffraction patterns
         nt.assert_equal(s0[1].data.shape, (5, 5, 256, 256))
         nt.assert_equal(s0[1].axes_manager.signal_dimension, 2)
@@ -137,9 +137,11 @@ class TestFEIReader():
         nt.assert_equal(
             s0.metadata.Acquisition_instrument.TEM.acquisition_mode, 'STEM')
         # single spectrum should be imported as 1D data, not 2D
+        # the scale of the navigation axis doesn't really make sense. It's set
+        # to 1 m!
         nt.assert_almost_equal(
-            s0.axes_manager[0].scale, 1000000000.0, places=5)
-        nt.assert_equal(s0.axes_manager[0].units, 'nm')
+            s0.axes_manager[0].scale, 1000.0, places=5)
+        nt.assert_equal(s0.axes_manager[0].units, 'mm')
         nt.assert_almost_equal(s0.axes_manager[1].scale, 0.2, places=5)
         nt.assert_equal(s0.axes_manager[1].units, 'eV')
 
@@ -151,8 +153,8 @@ class TestFEIReader():
         nt.assert_equal(
             s1.metadata.Acquisition_instrument.TEM.acquisition_mode, 'STEM')
         nt.assert_almost_equal(
-            s0.axes_manager[0].scale, 1000000000.0, places=5)
-        nt.assert_equal(s0.axes_manager[0].units, 'nm')
+            s0.axes_manager[0].scale, 1000.0, places=5)
+        nt.assert_equal(s0.axes_manager[0].units, 'mm')
         nt.assert_almost_equal(s0.axes_manager[1].scale, 0.2, places=5)
         nt.assert_equal(s0.axes_manager[1].units, 'eV')
 
@@ -208,8 +210,8 @@ class TestFEIReader():
         nt.assert_equal(s0.axes_manager[0].units, 'nm')
         nt.assert_almost_equal(s0.axes_manager[1].scale, -4.25819, places=5)
         nt.assert_equal(s0.axes_manager[1].units, 'nm')
-        nt.assert_almost_equal(s0.axes_manager[2].scale, 5.0, places=5)
-        nt.assert_equal(s0.axes_manager[2].units, 'eV')
+        nt.assert_almost_equal(s0.axes_manager[2].scale, 0.005, places=5)
+        nt.assert_equal(s0.axes_manager[2].units, 'keV')
 
     def test_load_search(self):
         fname0 = os.path.join(self.dirpathnew, '128x128-TEM_search.emi')

--- a/hyperspy/tests/io/test_tiff.py
+++ b/hyperspy/tests/io/test_tiff.py
@@ -5,6 +5,7 @@ import nose.tools as nt
 import traits.api as t
 
 import hyperspy.api as hs
+from hyperspy.misc.test_utils import assert_warns
 
 my_path = os.path.dirname(__file__)
 my_path2 = os.path.join(my_path, "tiff_files")
@@ -109,6 +110,9 @@ def test_write_read_unit_imagej_with_description(import_local_tifffile=True):
     nt.assert_almost_equal(s2.axes_manager[1].scale, 1.0, places=5)
 
     fname3 = fname.replace('.tif', '_description2.tif')
+    with assert_warns(
+            message="Description and export scale cannot be used at the same",
+            category=UserWarning):
     s.save(fname3, export_scale=True, overwrite=True, description='test')
     s3 = hs.load(fname3, import_local_tifffile=import_local_tifffile)
     nt.assert_equal(s3.axes_manager[0].units, 'µm')

--- a/hyperspy/tests/io/test_tiff.py
+++ b/hyperspy/tests/io/test_tiff.py
@@ -113,7 +113,7 @@ def test_write_read_unit_imagej_with_description(import_local_tifffile=True):
     with assert_warns(
             message="Description and export scale cannot be used at the same",
             category=UserWarning):
-    s.save(fname3, export_scale=True, overwrite=True, description='test')
+        s.save(fname3, export_scale=True, overwrite=True, description='test')
     s3 = hs.load(fname3, import_local_tifffile=import_local_tifffile)
     nt.assert_equal(s3.axes_manager[0].units, 'µm')
     nt.assert_equal(s3.axes_manager[1].units, 'µm')

--- a/hyperspy/tests/io/test_tiff.py
+++ b/hyperspy/tests/io/test_tiff.py
@@ -71,8 +71,8 @@ def _test_read_unit_from_imagej(import_local_tifffile=False):
     fname = os.path.join(my_path, 'tiff_files',
                          'test_loading_image_saved_with_imageJ.tif')
     s = hs.load(fname, import_local_tifffile=import_local_tifffile)
-    nt.assert_equal(s.axes_manager[0].units, 'micron')
-    nt.assert_equal(s.axes_manager[1].units, 'micron')
+    nt.assert_equal(s.axes_manager[0].units, 'µm')
+    nt.assert_equal(s.axes_manager[1].units, 'µm')
     nt.assert_almost_equal(s.axes_manager[0].scale, 0.16867, places=5)
     nt.assert_almost_equal(s.axes_manager[1].scale, 0.16867, places=5)
 
@@ -288,40 +288,40 @@ def test_write_scale_unit_image_stack():
 def test_read_FEI_SEM_scale_metadata_8bits():
     fname = os.path.join(my_path2, 'FEI-Helios-Ebeam-8bits.tif')
     s = hs.load(fname)
-    nt.assert_equal(s.axes_manager[0].units, 'm')
-    nt.assert_equal(s.axes_manager[1].units, 'm')
-    nt.assert_almost_equal(s.axes_manager[0].scale, 3.3724e-06, places=12)
-    nt.assert_almost_equal(s.axes_manager[1].scale, 3.3724e-06, places=12)
+    nt.assert_equal(s.axes_manager[0].units, 'µm')
+    nt.assert_equal(s.axes_manager[1].units, 'µm')
+    nt.assert_almost_equal(s.axes_manager[0].scale, 3.3724, places=12)
+    nt.assert_almost_equal(s.axes_manager[1].scale, 3.3724, places=12)
     nt.assert_equal(s.data.dtype, 'uint8')
 
 
 def test_read_FEI_SEM_scale_metadata_16bits():
     fname = os.path.join(my_path2, 'FEI-Helios-Ebeam-16bits.tif')
     s = hs.load(fname)
-    nt.assert_equal(s.axes_manager[0].units, 'm')
-    nt.assert_equal(s.axes_manager[1].units, 'm')
-    nt.assert_almost_equal(s.axes_manager[0].scale, 3.3724e-06, places=12)
-    nt.assert_almost_equal(s.axes_manager[1].scale, 3.3724e-06, places=12)
+    nt.assert_equal(s.axes_manager[0].units, 'µm')
+    nt.assert_equal(s.axes_manager[1].units, 'µm')
+    nt.assert_almost_equal(s.axes_manager[0].scale, 3.3724, places=12)
+    nt.assert_almost_equal(s.axes_manager[1].scale, 3.3724, places=12)
     nt.assert_equal(s.data.dtype, 'uint16')
 
 
 def test_read_Zeiss_SEM_scale_metadata_1k_image():
     fname = os.path.join(my_path2, 'test_tiff_Zeiss_SEM_1k.tif')
     s = hs.load(fname)
-    nt.assert_equal(s.axes_manager[0].units, 'm')
-    nt.assert_equal(s.axes_manager[1].units, 'm')
-    nt.assert_almost_equal(s.axes_manager[0].scale, 2.614514e-06, places=12)
-    nt.assert_almost_equal(s.axes_manager[1].scale, 2.614514e-06, places=12)
+    nt.assert_equal(s.axes_manager[0].units, 'µm')
+    nt.assert_equal(s.axes_manager[1].units, 'µm')
+    nt.assert_almost_equal(s.axes_manager[0].scale, 2.614514, places=12)
+    nt.assert_almost_equal(s.axes_manager[1].scale, 2.614514, places=12)
     nt.assert_equal(s.data.dtype, 'uint16')
 
 
 def test_read_Zeiss_SEM_scale_metadata_512_image():
     fname = os.path.join(my_path2, 'test_tiff_Zeiss_SEM_512.tif')
     s = hs.load(fname)
-    nt.assert_equal(s.axes_manager[0].units, 'm')
-    nt.assert_equal(s.axes_manager[1].units, 'm')
-    nt.assert_almost_equal(s.axes_manager[0].scale, 7.4240e-08, places=12)
-    nt.assert_almost_equal(s.axes_manager[1].scale, 7.4240e-08, places=12)
+    nt.assert_equal(s.axes_manager[0].units, 'µm')
+    nt.assert_equal(s.axes_manager[1].units, 'µm')
+    nt.assert_almost_equal(s.axes_manager[0].scale, 7.4240e-02, places=5)
+    nt.assert_almost_equal(s.axes_manager[1].scale, 7.4240e-02, places=5)
     nt.assert_equal(s.data.dtype, 'uint16')
 
 

--- a/hyperspy/tests/signal/test_tools.py
+++ b/hyperspy/tests/signal/test_tools.py
@@ -61,6 +61,59 @@ class Test2D:
         s.crop(0, 2, 2.)
         np.testing.assert_array_almost_equal(s.data, d[2:4, :])
 
+    def test_crop_float_unit_convertion_signal1D(self):
+        # Should convert the unit to eV
+        d = np.arange(5*10*2000).reshape(5, 10, 2000)
+        s = signals.Signal1D(d)
+        s.axes_manager.signal_axes[0].name = "E"
+        s.axes_manager.signal_axes[0].scale = 0.05
+        s.axes_manager.signal_axes[0].units = "keV"
+        s.crop('E', 0.0, 1.0)
+        nt.assert_almost_equal(s.axes_manager.signal_axes[0].scale, 50.0)
+        nt.assert_equal(s.axes_manager.signal_axes[0].units, "eV")
+        np.testing.assert_allclose(s.data, d[:,:, :20])
+
+        # Should keep the unit to keV
+        s = signals.Signal1D(d)
+        s.axes_manager.signal_axes[0].name = "E"
+        s.axes_manager.signal_axes[0].scale = 0.05
+        s.axes_manager.signal_axes[0].units = "keV"
+        s.crop('E', 0.0, 50.0)
+        nt.assert_almost_equal(s.axes_manager.signal_axes[0].scale, 0.05)
+        nt.assert_equal(s.axes_manager.signal_axes[0].units, "keV")
+        np.testing.assert_allclose(s.data, d[:,:, :1000])
+        
+    def test_crop_float_unit_convertion_signal2D(self):
+        # Should convert the unit to nm
+        d = np.arange(512*512).reshape(512, 512)
+        s = signals.Signal2D(d)
+        s.axes_manager[0].name = 'x'
+        s.axes_manager[0].scale = 0.01
+        s.axes_manager[0].units = 'µm'
+        s.axes_manager[1].name = 'y'
+        s.axes_manager[1].scale = 0.01
+        s.axes_manager[1].units = 'µm'
+        s.crop(0, 0.0, 0.5)
+        s.crop(1, 0.0, 0.5)
+        nt.assert_almost_equal(s.axes_manager[0].scale, 10.0)
+        nt.assert_equal(s.axes_manager[0].units, "nm")
+        np.testing.assert_allclose(s.data, d[:50, :50])
+        
+        # Should keep the unit to µm
+        d = np.arange(512*512).reshape(512, 512)
+        s = signals.Signal2D(d)
+        s.axes_manager[0].name = 'x'
+        s.axes_manager[0].scale = 0.01
+        s.axes_manager[0].units = 'µm'
+        s.axes_manager[1].name = 'y'
+        s.axes_manager[1].scale = 0.01
+        s.axes_manager[1].units = 'µm'
+        s.crop(0, 0.0, 5.0)
+        s.crop(1, 0.0, 5.0)
+        nt.assert_almost_equal(s.axes_manager[0].scale, 0.01)
+        nt.assert_equal(s.axes_manager[0].units, "µm")
+        np.testing.assert_allclose(s.data, d[:500, :500])
+        
     def test_split_axis0(self):
         result = self.signal.split(0, 2)
         nt.assert_equal(len(result), 2)

--- a/hyperspy/tests/signal/test_tools.py
+++ b/hyperspy/tests/signal/test_tools.py
@@ -61,6 +61,28 @@ class Test2D:
         s.crop(0, 2, 2.)
         np.testing.assert_array_almost_equal(s.data, d[2:4, :])
 
+    def test_crop_float_no_unit_convertion_signal1D(self):
+        # Should convert the unit to eV
+        d = np.arange(5*10*2000).reshape(5, 10, 2000)
+        s = signals.Signal1D(d)
+        s.axes_manager.signal_axes[0].name = "E"
+        s.axes_manager.signal_axes[0].scale = 0.05
+        s.axes_manager.signal_axes[0].units = "keV"
+        s.crop('E', 0.0, 1.0, auto_convert_units=False)
+        nt.assert_almost_equal(s.axes_manager.signal_axes[0].scale, 0.05)
+        nt.assert_equal(s.axes_manager.signal_axes[0].units, "keV")
+        np.testing.assert_allclose(s.data, d[:,:, :20])
+
+        # Should keep the unit to keV
+        s = signals.Signal1D(d)
+        s.axes_manager.signal_axes[0].name = "E"
+        s.axes_manager.signal_axes[0].scale = 0.05
+        s.axes_manager.signal_axes[0].units = "keV"
+        s.crop('E', 0.0, 50.0, auto_convert_units=False)
+        nt.assert_almost_equal(s.axes_manager.signal_axes[0].scale, 0.05)
+        nt.assert_equal(s.axes_manager.signal_axes[0].units, "keV")
+        np.testing.assert_allclose(s.data, d[:,:, :1000])
+
     def test_crop_float_unit_convertion_signal1D(self):
         # Should convert the unit to eV
         d = np.arange(5*10*2000).reshape(5, 10, 2000)
@@ -68,7 +90,7 @@ class Test2D:
         s.axes_manager.signal_axes[0].name = "E"
         s.axes_manager.signal_axes[0].scale = 0.05
         s.axes_manager.signal_axes[0].units = "keV"
-        s.crop('E', 0.0, 1.0)
+        s.crop('E', 0.0, 1.0, auto_convert_units=True)
         nt.assert_almost_equal(s.axes_manager.signal_axes[0].scale, 50.0)
         nt.assert_equal(s.axes_manager.signal_axes[0].units, "eV")
         np.testing.assert_allclose(s.data, d[:,:, :20])
@@ -78,10 +100,41 @@ class Test2D:
         s.axes_manager.signal_axes[0].name = "E"
         s.axes_manager.signal_axes[0].scale = 0.05
         s.axes_manager.signal_axes[0].units = "keV"
-        s.crop('E', 0.0, 50.0)
+        s.crop('E', 0.0, 50.0, auto_convert_units=True)
         nt.assert_almost_equal(s.axes_manager.signal_axes[0].scale, 0.05)
         nt.assert_equal(s.axes_manager.signal_axes[0].units, "keV")
         np.testing.assert_allclose(s.data, d[:,:, :1000])
+        
+    def test_crop_float_no_unit_convertion_signal2D(self):
+        # Should convert the unit to nm
+        d = np.arange(512*512).reshape(512, 512)
+        s = signals.Signal2D(d)
+        s.axes_manager[0].name = 'x'
+        s.axes_manager[0].scale = 0.01
+        s.axes_manager[0].units = 'µm'
+        s.axes_manager[1].name = 'y'
+        s.axes_manager[1].scale = 0.01
+        s.axes_manager[1].units = 'µm'
+        s.crop(0, 0.0, 0.5, auto_convert_units=False)
+        s.crop(1, 0.0, 0.5, auto_convert_units=False)
+        nt.assert_almost_equal(s.axes_manager[0].scale, 0.01)
+        nt.assert_equal(s.axes_manager[0].units, "µm")
+        np.testing.assert_allclose(s.data, d[:50, :50])
+        
+        # Should keep the unit to µm
+        d = np.arange(512*512).reshape(512, 512)
+        s = signals.Signal2D(d)
+        s.axes_manager[0].name = 'x'
+        s.axes_manager[0].scale = 0.01
+        s.axes_manager[0].units = 'µm'
+        s.axes_manager[1].name = 'y'
+        s.axes_manager[1].scale = 0.01
+        s.axes_manager[1].units = 'µm'
+        s.crop(0, 0.0, 5.0, auto_convert_units=False)
+        s.crop(1, 0.0, 5.0, auto_convert_units=False)
+        nt.assert_almost_equal(s.axes_manager[0].scale, 0.01)
+        nt.assert_equal(s.axes_manager[0].units, "µm")
+        np.testing.assert_allclose(s.data, d[:500, :500])
         
     def test_crop_float_unit_convertion_signal2D(self):
         # Should convert the unit to nm
@@ -93,8 +146,8 @@ class Test2D:
         s.axes_manager[1].name = 'y'
         s.axes_manager[1].scale = 0.01
         s.axes_manager[1].units = 'µm'
-        s.crop(0, 0.0, 0.5)
-        s.crop(1, 0.0, 0.5)
+        s.crop(0, 0.0, 0.5, auto_convert_units=True)
+        s.crop(1, 0.0, 0.5, auto_convert_units=True)
         nt.assert_almost_equal(s.axes_manager[0].scale, 10.0)
         nt.assert_equal(s.axes_manager[0].units, "nm")
         np.testing.assert_allclose(s.data, d[:50, :50])
@@ -108,8 +161,8 @@ class Test2D:
         s.axes_manager[1].name = 'y'
         s.axes_manager[1].scale = 0.01
         s.axes_manager[1].units = 'µm'
-        s.crop(0, 0.0, 5.0)
-        s.crop(1, 0.0, 5.0)
+        s.crop(0, 0.0, 5.0, auto_convert_units=True)
+        s.crop(1, 0.0, 5.0, auto_convert_units=True)
         nt.assert_almost_equal(s.axes_manager[0].scale, 0.01)
         nt.assert_equal(s.axes_manager[0].units, "µm")
         np.testing.assert_allclose(s.data, d[:500, :500])

--- a/hyperspy/tests/utils_testing.py
+++ b/hyperspy/tests/utils_testing.py
@@ -1,0 +1,71 @@
+# -*- coding: utf-8 -*-
+# Copyright 2007-2015 The HyperSpy developers
+#
+# This file is part of  HyperSpy.
+#
+#  HyperSpy is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+#  HyperSpy is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with  HyperSpy.  If not, see <http://www.gnu.org/licenses/>.
+
+import os
+import nose.tools as nt
+import numpy as np
+
+def remove_file(filename):
+    try:
+        if os.path.exists(filename):
+            os.remove(filename)
+    except WindowsError:
+        pass    # If we don't do this, we might mask real exceptions
+
+
+def assert_deep_almost_equal(actual, expected, *args, **kwargs):
+    """ Assert that two complex structures have almost equal contents.
+
+    Compares lists, dicts and tuples recursively. Checks numeric values
+    using :py:meth:`nose.tools.assert_almost_equal` and
+    checks all other values with :py:meth:`nose.tools.assert_equal`.
+    Accepts additional positional and keyword arguments and pass those
+    intact to assert_almost_equal() (that's how you specify comparison
+    precision).
+
+    Parameters
+    ----------
+    actual: lists, dicts or tuples
+    
+    expected: lists, dicts or tuples
+    """
+    is_root = not '__trace' in kwargs
+    trace = kwargs.pop('__trace', 'ROOT')
+    try:
+        if isinstance(expected, (int, float, complex)):
+            nt.assert_almost_equal(expected, actual, *args, **kwargs)
+        elif isinstance(expected, (list, tuple, np.ndarray)):
+            nt.assert_equal(len(expected), len(actual))
+            for index in range(len(expected)):
+                v1, v2 = expected[index], actual[index]
+                assert_deep_almost_equal(v1, v2,
+                                         __trace=repr(index), *args, **kwargs)
+        elif isinstance(expected, dict):
+            nt.assert_equal(set(expected), set(actual))
+            for key in expected:
+                assert_deep_almost_equal(expected[key], actual[key],
+                                         __trace=repr(key), *args, **kwargs)
+        else:
+            nt.assert_equal(expected, actual)
+    except AssertionError as exc:
+        exc.__dict__.setdefault('traces', []).append(trace)
+        if is_root:
+            trace = ' -> '.join(reversed(exc.traces))
+            exc = AssertionError("%s\nTRACE: %s" % (exc.message, trace))
+        raise exc
+        

--- a/setup.py
+++ b/setup.py
@@ -60,12 +60,12 @@ install_req = ['scipy',
                'dill',
                'h5py',
                'python-dateutil',
-               'ipyparallel']
+               'ipyparallel',
+               'pint>=7.0']
 
 #the hack to deal with setuptools + installing the package in ReadTheDoc:
 if 'readthedocs.org' in sys.executable:
     install_req = []
-
 
 def update_version(version):
     release_path = "hyperspy/Release.py"

--- a/setup.py
+++ b/setup.py
@@ -61,7 +61,7 @@ install_req = ['scipy',
                'h5py',
                'python-dateutil',
                'ipyparallel',
-               'pint>=7.0']
+               'pint>=0.7']
 
 #the hack to deal with setuptools + installing the package in ReadTheDoc:
 if 'readthedocs.org' in sys.executable:


### PR DESCRIPTION
This pull request aims at avoiding displaying a 1E-9 m or 1000 nm scale bar on images by converting the scale and units when a file is open or data are cropped. Diffraction pattern, EDS and EELS spectra are also converted.
The convert_units() method of the axes manager allows converting the units manually.