### PR TITLE
Fix user defined contrast when plotting images

### DIFF
--- a/doc/user_guide/visualisation.rst
+++ b/doc/user_guide/visualisation.rst
@@ -135,7 +135,7 @@ contrast controls are HyperSpy-specific, however `matplotlib.imshow
 
     >>> import scipy
     >>> img = hs.signals.Signal2D(scipy.misc.lena())
-    >>> img.plot(colorbar=True, scalebar=False, auto_contrast=True,
+    >>> img.plot(colorbar=True, scalebar=False,
     >>> 	 axes_ticks=True, cmap='RdYlBu_r', saturated_pixels=0)
 
 

--- a/hyperspy/_signals/signal2d.py
+++ b/hyperspy/_signals/signal2d.py
@@ -22,6 +22,7 @@ import scipy as sp
 from scipy.fftpack import fftn, ifftn
 import matplotlib.pyplot as plt
 import warnings
+from hyperspy.misc.hspy_warnings import VisibleDeprecationWarning
 
 from hyperspy.defaults_parser import preferences
 from hyperspy.external.progressbar import progressbar
@@ -531,7 +532,6 @@ class Signal2D(BaseSignal,
              scalebar=True,
              scalebar_color="white",
              axes_ticks=None,
-             auto_contrast=True,
              saturated_pixels=0,
              vmin=None,
              vmax=None,
@@ -596,17 +596,12 @@ class Signal2D(BaseSignal,
             If True, plot the axes ticks. If None axes_ticks are only
             plotted when the scale bar is not plotted. If False the axes ticks
             are never plotted.
-        auto_contrast : bool, optional
-            If True, the contrast is stretched for each image using the
-            `saturated_pixels` value. Default True.
         saturated_pixels: scalar
             The percentage of pixels that are left out of the bounds.
             For example, the low and high bounds of a value of 1 are the 0.5%
             and 99.5% percentiles. It must be in the [0, 100] range.
         vmin, vmax : scalar, optional
-            `vmin` and `vmax` are used to normalize luminance data. If at
-            least one of them is given `auto_contrast` is set to False and any
-            missing values are calculated automatically.
+            `vmin` and `vmax` are used to normalize luminance data.
         no_nans : bool, optional
             If True, set nans to zero for plotting.
         centre_colormap : {"auto", True, False}
@@ -617,12 +612,16 @@ class Signal2D(BaseSignal,
             Additional key word arguments passed to matplotlib.imshow()
 
         """
+        if "auto_contrast" in kwargs:
+            del kwargs["auto_contrast"]
+            warnings.warn("the `auto_contrast` keyword argument is deprecated"
+                          "and will be removed in HyperSpy 1.0",
+                          VisibleDeprecationWarning)
         super(Signal2D, self).plot(
             colorbar=colorbar,
             scalebar=scalebar,
             scalebar_color=scalebar_color,
             axes_ticks=axes_ticks,
-            auto_contrast=auto_contrast,
             saturated_pixels=saturated_pixels,
             vmin=vmin,
             vmax=vmax,

--- a/hyperspy/drawing/image.py
+++ b/hyperspy/drawing/image.py
@@ -18,7 +18,6 @@
 
 
 import math
-import warnings
 
 import numpy as np
 import matplotlib.pyplot as plt
@@ -49,8 +48,6 @@ class ImagePlot(BlittedFigure):
         The title is printed at the top of the image.
     vmin, vmax : float
         Limit the range of the color map scale to the given values.
-    auto_contrast : bool
-        If True, vmin and vmax are calculated automatically.
     min_aspect : float
         Set the minimum aspect ratio of the image and the figure. To
         keep the image in the aspect limit the pixels are made
@@ -75,9 +72,10 @@ class ImagePlot(BlittedFigure):
         self.figure = None
         self.ax = None
         self.title = ''
-        self.vmin = None
-        self.vmax = None
-        self.auto_contrast = True
+        self._vmin_user = None
+        self._vmax_user = None
+        self._vmin_auto = None
+        self._vmax_auto = None
         self._ylabel = ''
         self._xlabel = ''
         self.plot_indices = True
@@ -98,6 +96,28 @@ class ImagePlot(BlittedFigure):
         self._auto_axes_ticks = True
         self.no_nans = False
         self.centre_colormap = "auto"
+
+    @property
+    def vmax(self):
+        if self._vmax_user is not None:
+            return self._vmax_user
+        else:
+            return self._vmax_auto
+
+    @vmax.setter
+    def vmax(self, vmax):
+        self._vmax_user = vmax
+
+    @property
+    def vmin(self):
+        if self._vmin_user is not None:
+            return self._vmin_user
+        else:
+            return self._vmin_auto
+
+    @vmin.setter
+    def vmin(self, vmin):
+        self._vmin_user = vmin
 
     @property
     def axes_ticks(self):
@@ -166,17 +186,12 @@ class ImagePlot(BlittedFigure):
         self._aspect = np.abs(factor * xaxis.scale / yaxis.scale)
 
     def optimize_contrast(self, data):
-        if (self.vmin is not None and
-                self.vmax is not None and
-                not self.auto_contrast):
+        if (self._vmin_user is not None and self._vmax_user is not None):
             return
         if 'complex' in data.dtype.name:
             data = np.log(np.abs(data))
-        vmin, vmax = utils.contrast_stretching(data, self.saturated_pixels)
-        if self.vmin is None or self.auto_contrast:
-            self.vmin = vmin
-        if self.vmax is None or self.auto_contrast:
-            self.vmax = vmax
+        self._vmin_auto, self._vmax_auto = utils.contrast_stretching(
+            data, self.saturated_pixels)
 
     def create_figure(self, max_size=8, min_size=2):
         if self.scalebar is True:
@@ -215,11 +230,6 @@ class ImagePlot(BlittedFigure):
         if rgb_tools.is_rgbx(data):
             self.colorbar = False
             data = rgb_tools.rgbx2regular_array(data, plot_friendly=True)
-        if self.vmin is not None or self.vmax is not None:
-            warnings.warn(
-                'vmin or vmax value given, hence '
-                'auto_contrast is set to False')
-            self.auto_contrast = False
         self.optimize_contrast(data)
         if (not self.axes_manager or
                 self.axes_manager.navigation_size == 0):
@@ -267,7 +277,7 @@ class ImagePlot(BlittedFigure):
             marker.axes_manager = self.axes_manager
         self.ax_markers.append(marker)
 
-    def update(self, auto_contrast=None, **kwargs):
+    def update(self, **kwargs):
         # Turn on centre_colormap if a diverging colormap is used.
         if self.centre_colormap == "auto":
             if "cmap" in kwargs:
@@ -302,11 +312,12 @@ class ImagePlot(BlittedFigure):
                 else:
                     return 'x=%1.4g, y=%1.4g' % (x, y)
             self.ax.format_coord = format_coord
-        if (auto_contrast is True or
-                auto_contrast is None and self.auto_contrast is True):
-            vmax, vmin = self.vmax, self.vmin
+            old_vmax, old_vmin = self.vmax, self.vmin
             self.optimize_contrast(data)
-            if vmax == vmin and self.vmax != self.vmin and ims:
+            # If there is an image, any of the contrast bounds have changed and
+            # the new contrast bounds are not the same redraw the colorbar.
+            if (ims and (old_vmax != self.vmax or old_vmin != self.vmin) and
+                    self.vmax != self.vmin):
                 redraw_colorbar = True
                 ims[0].autoscale()
 
@@ -324,7 +335,7 @@ class ImagePlot(BlittedFigure):
             ims[0].set_data(data)
             ims[0].norm.vmax, ims[0].norm.vmin = vmax, vmin
             if redraw_colorbar is True:
-                ims[0].autoscale()
+                # ims[0].autoscale()
                 self._colorbar.draw_all()
                 self._colorbar.solids.set_animated(True)
             else:
@@ -349,7 +360,7 @@ class ImagePlot(BlittedFigure):
 
     def _update(self):
         # This "wrapper" because on_trait_change fiddles with the
-        # method arguments and auto_contrast does not work then
+        # method arguments and auto contrast does not work then
         self.update()
 
     def adjust_contrast(self):

--- a/hyperspy/drawing/mpl_hie.py
+++ b/hyperspy/drawing/mpl_hie.py
@@ -27,7 +27,7 @@ class MPL_HyperImage_Explorer(MPL_HyperExplorer):
                     scalebar=True,
                     scalebar_color="white",
                     axes_ticks=None,
-                    saturated_pixels=0.2,
+                    saturated_pixels=0,
                     vmin=None,
                     vmax=None,
                     no_nans=False,

--- a/hyperspy/drawing/mpl_hie.py
+++ b/hyperspy/drawing/mpl_hie.py
@@ -27,7 +27,6 @@ class MPL_HyperImage_Explorer(MPL_HyperExplorer):
                     scalebar=True,
                     scalebar_color="white",
                     axes_ticks=None,
-                    auto_contrast=True,
                     saturated_pixels=0.2,
                     vmin=None,
                     vmax=None,
@@ -50,16 +49,12 @@ class MPL_HyperImage_Explorer(MPL_HyperExplorer):
             If True, plot the axes ticks. If None axes_ticks are only
             plotted when the scale bar is not plotted. If False the axes ticks
             are never plotted.
-        auto_contrast : bool, optional
-            If True, the contrast is stretched for each image using the
-            `saturated_pixels` value. Default True
         saturated_pixels: scalar
             The percentage of pixels that are left out of the bounds. For
             example, the low and high bounds of a value of 1 are the
             0.5% and 99.5% percentiles. It must be in the [0, 100] range.
         vmin, vmax : scalar, optional
-            `vmin` and `vmax` are used to normalize luminance data. If
-            `auto_contrast` is True (i.e. default) these values are ignore.
+            `vmin` and `vmax` are used to normalize luminance data.
         no_nans : bool, optional
             If True, set nans to zero for plotting.
         **kwargs, optional
@@ -81,7 +76,6 @@ class MPL_HyperImage_Explorer(MPL_HyperExplorer):
         imf.saturated_pixels = saturated_pixels
         imf.no_nans = no_nans
         imf.scalebar_color = scalebar_color
-        imf.auto_contrast = auto_contrast
         imf.centre_colormap = centre_colormap
         imf.plot(**kwargs)
         self.signal_plot = imf

--- a/hyperspy/drawing/utils.py
+++ b/hyperspy/drawing/utils.py
@@ -581,6 +581,16 @@ def plot_images(images,
         else:
             centre_colormap = False
 
+    if "vmin" in kwargs:
+        user_vmin = kwargs["vmin"]
+        del kwargs["vmin"]
+    else:
+        user_vmin = None
+    if "vmax" in kwargs:
+        user_vmax = kwargs["vmax"]
+        del kwargs["vmax"]
+    else:
+        user_vmax = None
     # If input is >= 1D signal (e.g. for multi-dimensional plotting),
     # copy it and put it in a list so labeling works out as (x,y) when plotting
     if isinstance(images,
@@ -730,6 +740,8 @@ def plot_images(images,
     if colorbar is 'single':
         g_vmin, g_vmax = contrast_stretching(np.concatenate(
             [i.data.flatten() for i in non_rgb]), saturated_pixels)
+        g_vmin = user_vmin if user_vmin is not None else g_vmin
+        g_vmax = user_vmax if user_vmax is not None else g_vmax
         if centre_colormap:
             g_vmin, g_vmax = centre_colormap_values(g_vmin, g_vmax)
 
@@ -762,6 +774,8 @@ def plot_images(images,
                 data = im.data
                 # Find min and max for contrast
                 l_vmin, l_vmax = contrast_stretching(data, saturated_pixels)
+                l_vmin = user_vmin if user_vmin is not None else l_vmin
+                l_vmax = user_vmax if user_vmax is not None else l_vmax
                 if centre_colormap:
                     l_vmin, l_vmax = centre_colormap_values(l_vmin, l_vmax)
 
@@ -819,8 +833,10 @@ def plot_images(images,
                 ax_im_list[i] = axes_im
             else:
                 axes_im = ax.imshow(data,
-                                    cmap=cmap, extent=extent,
-                                    vmin=l_vmin, vmax=l_vmax,
+                                    cmap=cmap,
+                                    extent=extent,
+                                    vmin=l_vmin,
+                                    vmax=l_vmax,
                                     aspect=asp,
                                     *args, **kwargs)
                 ax_im_list[i] = axes_im

--- a/hyperspy/gui/tools.py
+++ b/hyperspy/gui/tools.py
@@ -661,7 +661,7 @@ class ImageContrastHandler(tu.Handler):
         #        if is_ok is True:
         #            self.apply(info)
         if is_ok is False:
-            info.object.image.update(auto_contrast=True)
+            info.object.image.update()
         info.object.close()
         return True
 
@@ -758,7 +758,7 @@ class ImageContrastEditor(t.HasTraits):
     def reset(self):
         data = self.image.data_function().ravel()
         self.image.vmin, self.image.vmax = np.nanmin(data), np.nanmax(data)
-        self.image.update(auto_contrast=False)
+        self.image.update()
         self.update_histogram()
 
     def update_histogram(self):
@@ -771,7 +771,7 @@ class ImageContrastEditor(t.HasTraits):
             return
         self.image.vmin = self.ss_left_value
         self.image.vmax = self.ss_right_value
-        self.image.update(auto_contrast=False)
+        self.image.update()
         self.update_histogram()
 
     def close(self):


### PR DESCRIPTION
When plotting images either with `Signal.plot` of `hs.plot.plot_images` it was only possible to set mnually both `vmin` and `vmax` at the same time. This enables setting e.g. `vmin` manually and, by if not setting also `vmax`, `vmax` is automatically computed for each image taking into account the `saturated_pixels` keyword.

It also deprecates the redundant `auto_contrast` keyword.