### PR TITLE
Fix hdf5 np.bool 

### DIFF
--- a/hyperspy/io_plugins/hdf5.py
+++ b/hyperspy/io_plugins/hdf5.py
@@ -492,7 +492,7 @@ def write_signal(signal, group, **kwds):
 
 
 def file_writer(filename,
-                signal  ,
+                signal,
                 *args, **kwds):
     with h5py.File(filename, mode='w') as f:
         f.attrs['file_format'] = "HyperSpy"

--- a/hyperspy/io_plugins/hdf5.py
+++ b/hyperspy/io_plugins/hdf5.py
@@ -150,7 +150,10 @@ def hdfgroup2signaldict(group):
             axes.append(dict(group['axis-%i' % i].attrs))
             axis = axes[-1]
             for key, item in axis.items():
-                axis[key] = ensure_unicode(item)
+                if isinstance(item, np.bool_):
+                    axis[key] = bool(item)
+                else:
+                    axis[key] = ensure_unicode(item)
         except KeyError:
             break
     if len(axes) != len(exp['data'].shape):  # broke from the previous loop
@@ -489,7 +492,7 @@ def write_signal(signal, group, **kwds):
 
 
 def file_writer(filename,
-                signal,
+                signal  ,
                 *args, **kwds):
     with h5py.File(filename, mode='w') as f:
         f.attrs['file_format'] = "HyperSpy"


### PR DESCRIPTION
The hdf5 reader does not convert `np.bool_` (as read from the hdf5) to `bool` for the axes attributes. For the HyperSpy file format < 2.1 this wasn't an issue, as there was not bool in axes (`navigate` was not stored). However from v2.1 (HyperSpy >= v1.0) `navigate` is stored and reading it as `np.bool_` breaks the `AxesManager`. This fixes it. Those using HyperSpy  version < 0.8.6 can workaround this issue by deepcopying the signal after loading when loading hdf5 files saved with HyperSpy version > 1.0 e.g.

```python
s = hs.load("new_format_file.hdf5").deepcopy()

```