### PR TITLE
Split `api.model.components` into `components1D` and `components2D`

### DIFF
--- a/doc/user_guide/model.rst
+++ b/doc/user_guide/model.rst
@@ -10,20 +10,23 @@ is essentially the same as in this documentation any method referred to in
 the :py:class`~.model.BaseModel` class is available for both kinds.
 
 .. versionadded:: 1.0
+   2D models. Note that this first implementation lacks many of the
+   features of 1D models e.g. plotting. Those will be added in future releases.
 
-    Models can be created and and fit to experimental data in both one and two
-    dimensions i.e. spectra and images respectively. Most of the syntax is
-    identical in either case. A one-dimensional model is created when a model
-    is created for a :py:class:`~._signals.signal1D.Signal1D` whereas a two-
-    dimensional model is created for a :py:class:`._signals.signal2D.Signal2D`.
-    At present plotting and gradient fitting methods tools for are not yet
-    provided for the :py:class:`~.models.model2D.Model2D` class.
+Models can be created and and fit to experimental data in both one and two
+dimensions i.e. spectra and images respectively. Most of the syntax is
+identical in either case. A one-dimensional model is created when a model
+is created for a :py:class:`~._signals.signal1D.Signal1D` whereas a two-
+dimensional model is created for a :py:class:`._signals.signal2D.Signal2D`.
+At present plotting and gradient fitting methods tools for are not yet
+provided for the :py:class:`~.models.model2D.Model2D` class.
 
 .. versionadded:: 0.7
+   Binned/unbinned signals
 
-    Before creating a model verify that the ``Signal.binned`` metadata
-    attribute of the signal is set to the correct value because the resulting
-    model depends on this parameter. See :ref:`signal.binned` for more details.
+Before creating a model verify that the ``Signal.binned`` metadata
+attribute of the signal is set to the correct value because the resulting
+model depends on this parameter. See :ref:`signal.binned` for more details.
 
 Creating a model
 ----------------
@@ -55,8 +58,9 @@ collection semi-angles etc.
 Adding components to the model
 ------------------------------
 
-In HyperSpy a model consists of a linear combination of :py:mod:`~.components`
-and various components are available in one and two-dimensions to construct a
+In HyperSpy a model consists of a linear combination of components
+and various components are available in one (:py:mod:`~.components1d`)and
+two-dimensions (:py:mod:`~.components2d`) to construct a
 model.
 
 The following components are currently available for one-dimensional models:

--- a/doc/user_guide/model.rst
+++ b/doc/user_guide/model.rst
@@ -100,7 +100,7 @@ parameters for spectroscopy than the one that ships with HyperSpy:
 
 .. code-block:: python
 
-    >>> g = hs.model.components.Expression(
+    >>> g = hs.model.components1D.Expression(
     ... expression="height * exp(-(x - x0) ** 2 * 4 * log(2)/ fwhm ** 2)",
     ... name="Gaussian",
     ... position="x0",
@@ -208,7 +208,7 @@ data that can be modelled using gaussians we might proceed as follows:
 
 .. code-block:: python
 
-    >>> gaussian = hs.model.components.Gaussian() # Create a Gaussian function component
+    >>> gaussian = hs.model.components1D.Gaussian() # Create a Gaussian function component
     >>> m.append(gaussian) # Add it to the model
     >>> m.components # Print the model components
        # |            Attribute Name |            Component Name |            Component Type
@@ -315,8 +315,8 @@ To enable this feature for a given component set the
 
     >>> s = hs.signals.Signal1D(np.arange(100).reshape(10,10))
     >>> m = s.create_model()
-    >>> g1 = hs.model.components.Gaussian()
-    >>> g2 = hs.model.components.Gaussian()
+    >>> g1 = hs.model.components1D.Gaussian()
+    >>> g2 = hs.model.components1D.Gaussian()
     >>> m.extend([g1,g2])
     >>> g1.active_is_multidimensional = True
     >>> g1._active_array
@@ -350,7 +350,7 @@ recomputed for the resulting slices.
 
     >>> s = hs.signals.Signal1D(np.arange(100).reshape(10,10))
     >>> m = s.create_model()
-    >>> m.append(hs.model.components.Gaussian())
+    >>> m.append(hs.model.components1D.Gaussian())
     >>> # select first three navigation pixels and last five signal channels
     >>> m1 = m.inav[:3].isig[-5:]
     >>> m1.signal1D
@@ -378,8 +378,8 @@ Example:
 
     >>> s = hs.signals.Signal1D(np.arange(100).reshape(10,10))
     >>> m = s.create_model()
-    >>> g1 = hs.model.components.Gaussian()
-    >>> g2 = hs.model.components.Gaussian()
+    >>> g1 = hs.model.components1D.Gaussian()
+    >>> g2 = hs.model.components1D.Gaussian()
     >>> m.extend([g1,g2])
     >>> m.set_parameters_value('A', 20)
     >>> g1.A.map['values']
@@ -406,7 +406,7 @@ all parameters in a component to `True` use
 
 .. code-block:: python
 
-    >>> g = hs.model.components.Gaussian()
+    >>> g = hs.model.components1D.Gaussian()
     >>> g.free_parameters
     set([<Parameter A of Gaussian component>,
         <Parameter sigma of Gaussian component>,
@@ -427,8 +427,8 @@ example:
 
 .. code-block:: python
 
-    >>> g1 = hs.model.components.Gaussian()
-    >>> g2 = hs.model.components.Gaussian()
+    >>> g1 = hs.model.components1D.Gaussian()
+    >>> g2 = hs.model.components1D.Gaussian()
     >>> m.extend([g1,g2])
     >>> m.set_parameters_not_free()
     >>> g1.free_parameters
@@ -592,7 +592,7 @@ to the data.
 .. code-block:: python
 
     >>> m = s.create_model()
-    >>> line = hs.model.components.Polynomial(order=1)
+    >>> line = hs.model.components1D.Polynomial(order=1)
     >>> m.append(line)
     >>> m.fit()
 
@@ -627,7 +627,7 @@ gaussian noise and proceed to fit as in the previous example.
     ...     np.arange(300))
     >>> s.add_poissonian_noise()
     >>> m = s.create_model()
-    >>> line  = hs.model.components.Polynomial(order=1)
+    >>> line  = hs.model.components1D.Polynomial(order=1)
     >>> m.append(line)
     >>> m.fit()
     >>> line.coefficients.value
@@ -671,7 +671,7 @@ the ``centre`` parameter.
     size=1e5)).get_histogram()
     >>> s.metadata.Signal.binned = True
     >>> m = s.create_model()
-    >>> g1 = hs.model.components.Gaussian()
+    >>> g1 = hs.model.components1D.Gaussian()
     >>> m.append(g1)
     >>> g1.centre.value = 7
     >>> g1.centre.bmin = 7
@@ -862,7 +862,7 @@ Current stored models can be listed by calling :py:attr:`~.signal.models`:
 .. code-block:: python
 
     >>> m = s.create_model()
-    >>> m.append(hs.model.components.Lorentzian())
+    >>> m.append(hs.model.components1D.Lorentzian())
     >>> m.store('myname')
     >>> s.models
     └── myname
@@ -871,7 +871,7 @@ Current stored models can be listed by calling :py:attr:`~.signal.models`:
         ├── date = 2015-09-07 12:01:50
         └── dimensions = (|100)
 
-    >>> m.append(hs.model.components.Exponential())
+    >>> m.append(hs.model.components1D.Exponential())
     >>> m.store() # assign model name automatically
     >>> s.models
     ├── a

--- a/doc/user_guide/visualisation.rst
+++ b/doc/user_guide/visualisation.rst
@@ -524,7 +524,7 @@ legended line, a spectrum can be toggled on and off.
      >>> s.axes_manager[0].offset = -10
      >>> s.axes_manager[0].scale = 0.1
      >>> m = s.create_model()
-     >>> g = components.Gaussian()
+     >>> g = hs.components1D.Gaussian()
      >>> m.append(g)
      >>> gaussians = []
      >>> labels = []

--- a/examples/model_fitting/simple_arctan_fit.py
+++ b/examples/model_fitting/simple_arctan_fit.py
@@ -15,7 +15,7 @@ s.set_signal_origin("simulation")
 s.add_gaussian_noise(0.1)
 
 # Make the arctan component for use in the model
-arctan_component = hs.model.components.Arctan()
+arctan_component = hs.model.components1D.Arctan()
 
 # Create the model and add the arctan component
 m = s.create_model()

--- a/examples/simple_simulations/two_gaussians.py
+++ b/examples/simple_simulations/two_gaussians.py
@@ -18,7 +18,7 @@ s = hs.signals.Signal1D(np.zeros((32, 32, 1024)))
 m = s.create_model()
 
 # Define the first gaussian
-gs1 = hs.model.components.Gaussian()
+gs1 = hs.model.components1D.Gaussian()
 # Add it to the model
 m.append(gs1)
 
@@ -33,7 +33,7 @@ gs1.A.map['values'][:] = 10000 * np.random.random((32, 32))
 gs1.A.map['is_set'][:] = True
 
 # Second gaussian
-gs2 = hs.model.components.Gaussian()
+gs2 = hs.model.components1D.Gaussian()
 # Add it to the model
 m.append(gs2)
 

--- a/hyperspy/_components/expression.py
+++ b/hyperspy/_components/expression.py
@@ -64,7 +64,7 @@ class Expression(Component):
         The following creates a Gaussian component and set the initial value
         of the parameters:
 
-        >>> hs.model.components.Expression(
+        >>> hs.model.components1D.Expression(
         ... expression="height * exp(-(x - x0) ** 2 * 4 * log(2)/ fwhm ** 2)",
         ... name="Gaussian",
         ... height=1,

--- a/hyperspy/_components/gaussian.py
+++ b/hyperspy/_components/gaussian.py
@@ -152,7 +152,7 @@ class Gaussian(Component):
         Examples
         --------
 
-        >>> g = hs.model.components.Gaussian()
+        >>> g = hs.model.components1D.Gaussian()
         >>> x = np.arange(-10, 10, 0.01)
         >>> data = np.zeros((32, 32, 2000))
         >>> data[:] = g.function(x).reshape((1, 1, 2000))

--- a/hyperspy/_components/gaussianhf.py
+++ b/hyperspy/_components/gaussianhf.py
@@ -108,7 +108,7 @@ class GaussianHF(Expression):
         Examples
         --------
 
-        >>> g = hs.model.components.GaussianHF()
+        >>> g = hs.model.components1D.GaussianHF()
         >>> x = np.arange(-10, 10, 0.01)
         >>> data = np.zeros((32, 32, 2000))
         >>> data[:] = g.function(x).reshape((1, 1, 2000))

--- a/hyperspy/_components/voigt.py
+++ b/hyperspy/_components/voigt.py
@@ -171,7 +171,7 @@ class Voigt(Component):
         Examples
         --------
 
-        >>> g = hs.model.components.Gaussian()
+        >>> g = hs.model.components1D.Gaussian()
         >>> x = np.arange(-10,10, 0.01)
         >>> data = np.zeros((32,32,2000))
         >>> data[:] = g.function(x).reshape((1,1,2000))

--- a/hyperspy/_signals/eels.py
+++ b/hyperspy/_signals/eels.py
@@ -31,7 +31,7 @@ from hyperspy.gui.eels import TEMParametersUI
 from hyperspy.defaults_parser import preferences
 import hyperspy.gui.messages as messagesui
 from hyperspy.external.progressbar import progressbar
-from hyperspy.components import PowerLaw
+from hyperspy.components1d import PowerLaw
 from hyperspy.misc.utils import isiterable, closest_power_of_two, underline
 from hyperspy.misc.utils import without_nans
 
@@ -679,7 +679,7 @@ class EELSSpectrum(Signal1D):
             I0_shape.insert(axis.index_in_array, 1)
             I0 = I0.reshape(I0_shape)
 
-        from hyperspy.components import Gaussian
+        from hyperspy.components1d import Gaussian
         g = Gaussian()
         g.sigma.value = fwhm / 2.3548
         g.A.value = 1

--- a/hyperspy/_signals/signal1d.py
+++ b/hyperspy/_signals/signal1d.py
@@ -934,7 +934,8 @@ class Signal1D(BaseSignal, CommonSignal1D):
             elif background_type == 'Offset':
                 background_estimator = components1d.Offset()
             elif background_type == 'Polynomial':
-                background_estimator = components1d.Polynomial(polynomial_order)
+                background_estimator = components1d.Polynomial(
+                    polynomial_order)
             else:
                 raise ValueError(
                     "Background type: " +

--- a/hyperspy/_signals/signal1d.py
+++ b/hyperspy/_signals/signal1d.py
@@ -53,7 +53,7 @@ from hyperspy.decorators import only_interactive
 from hyperspy.decorators import interactive_range_selector
 from scipy.ndimage.filters import gaussian_filter1d
 from hyperspy.gui.tools import IntegrateArea
-from hyperspy import components
+from hyperspy import components1d
 
 
 def find_peaks_ohaver(y, x=None, slope_thresh=0., amp_thresh=None,
@@ -928,13 +928,13 @@ class Signal1D(BaseSignal, CommonSignal1D):
             br.edit_traits()
         else:
             if background_type == 'PowerLaw':
-                background_estimator = components.PowerLaw()
+                background_estimator = components1d.PowerLaw()
             elif background_type == 'Gaussian':
-                background_estimator = components.Gaussian()
+                background_estimator = components1d.Gaussian()
             elif background_type == 'Offset':
-                background_estimator = components.Offset()
+                background_estimator = components1d.Offset()
             elif background_type == 'Polynomial':
-                background_estimator = components.Polynomial(polynomial_order)
+                background_estimator = components1d.Polynomial(polynomial_order)
             else:
                 raise ValueError(
                     "Background type: " +

--- a/hyperspy/component.py
+++ b/hyperspy/component.py
@@ -1085,7 +1085,7 @@ class Component(t.HasTraits):
 
         Examples
         --------
-        >>> v1 = hs.model.components.Voigt()
+        >>> v1 = hs.model.components1D.Voigt()
         >>> v1.set_parameters_free()
         >>> v1.set_parameters_free(parameter_name_list=['area','centre'])
 
@@ -1120,7 +1120,7 @@ class Component(t.HasTraits):
 
         Examples
         --------
-        >>> v1 = hs.model.components.Voigt()
+        >>> v1 = hs.model.components1D.Voigt()
         >>> v1.set_parameters_not_free()
         >>> v1.set_parameters_not_free(parameter_name_list=['area','centre'])
 

--- a/hyperspy/components1d.py
+++ b/hyperspy/components1d.py
@@ -19,7 +19,7 @@
 
 __doc__ = """
 
-Components that can be used to define a model for e.g. curve fitting.
+Components that can be used to define a 1D model for e.g. curve fitting.
 
 There are some components that are only useful for one particular kind of signal
 and therefore their name are preceded by the signal name: eg. eels_cl_edge.
@@ -53,7 +53,6 @@ from hyperspy._components.polynomial import Polynomial
 from hyperspy._components.pes_core_line_shape import PESCoreLineShape
 from hyperspy._components.volume_plasmon_drude import VolumePlasmonDrude
 from hyperspy._components.expression import Expression
-from hyperspy._components.gaussian2d import Gaussian2D
 
 # Generating the documentation
 

--- a/hyperspy/components2d.py
+++ b/hyperspy/components2d.py
@@ -1,0 +1,55 @@
+# -*- coding: utf-8 -*-
+# Copyright 2007-2016 The HyperSpy developers
+#
+# This file is part of  HyperSpy.
+#
+#  HyperSpy is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+#  HyperSpy is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with  HyperSpy.  If not, see <http://www.gnu.org/licenses/>.
+
+
+__doc__ = """
+
+Components that can be used to define a 2D model for e.g. 2D model fitting.
+
+Writing a new template is really easy, just edit _template.py and maybe take a
+look to the other components.
+
+For more details see each component docstring.
+====================================================================
+"""
+
+from hyperspy._components.gaussian2d import Gaussian2D
+
+# Generating the documentation
+
+# Grab all the currently defined globals and make a copy of the keys
+# (can't use it directly, as the size changes)
+_keys = [key for key in globals().keys()]
+
+# For every key in alphabetically sorted order
+for key in sorted(_keys):
+    # if it does not start with a "_"
+    if not key.startswith('_'):
+        # get the component class (or function)
+        component = eval(key)
+        # If the component has documentation, grab the first 43 characters of
+        # the first line of the documentation. Else just use two dots ("..")
+        second_part = '..' if component.__doc__ is None else \
+            component.__doc__.split('\n')[0][:43] + '..'
+        # append the component name (up to 25 characters + one space) and the
+        # start of the documentation as one line to the current doc
+        __doc__ += key[:25] + ' ' * (26 - len(key)) + second_part + '\n'
+
+# delete all the temporary things from the namespace once done
+# so that they don't show up in the auto-complete
+del key, _keys, component, second_part

--- a/hyperspy/gui/egerton_quantification.py
+++ b/hyperspy/gui/egerton_quantification.py
@@ -24,7 +24,7 @@ import traitsui.api as tu
 from traitsui.menu import OKButton, CancelButton
 from pyface.message_dialog import information
 
-from hyperspy import components
+from hyperspy import components1d
 from hyperspy.component import Component
 from hyperspy import drawing
 from hyperspy.gui.tools import (SpanSelectorInSignal1D,
@@ -81,21 +81,21 @@ class BackgroundRemoval(SpanSelectorInSignal1D):
     def set_background_estimator(self):
 
         if self.background_type == 'Power Law':
-            self.background_estimator = components.PowerLaw()
+            self.background_estimator = components1d.PowerLaw()
             self.bg_line_range = 'from_left_range'
         elif self.background_type == 'Gaussian':
-            self.background_estimator = components.Gaussian()
+            self.background_estimator = components1d.Gaussian()
             self.bg_line_range = 'full'
         elif self.background_type == 'Offset':
-            self.background_estimator = components.Offset()
+            self.background_estimator = components1d.Offset()
             self.bg_line_range = 'full'
         elif self.background_type == 'Polynomial':
-            self.background_estimator = components.Polynomial(
+            self.background_estimator = components1d.Polynomial(
                 self.polynomial_order)
             self.bg_line_range = 'full'
 
     def _polynomial_order_changed(self, old, new):
-        self.background_estimator = components.Polynomial(new)
+        self.background_estimator = components1d.Polynomial(new)
         self.span_selector_changed()
 
     def _background_type_changed(self, old, new):

--- a/hyperspy/hspy.py
+++ b/hyperspy/hspy.py
@@ -7,7 +7,7 @@ please use :mod:`~hyperspy.api` instead.
 # -*- coding: utf-8 -*-
 
 from hyperspy.Release import version as __version__
-from hyperspy import components
+from hyperspy import components1d as components
 from hyperspy import signals
 from hyperspy.io import load
 from hyperspy.defaults_parser import preferences

--- a/hyperspy/misc/eds/utils.py
+++ b/hyperspy/misc/eds/utils.py
@@ -312,7 +312,7 @@ def xray_lines_model(elements,
     >>> s.plot()
     """
     from hyperspy._signals.eds_tem import EDSTEMSpectrum
-    from hyperspy.model import components
+    from hyperspy import components1d
     if energy_axis is None:
         energy_axis = {'name': 'E', 'scale': 0.01, 'units': 'keV',
                        'offset': -0.1, 'size': 1024}
@@ -334,7 +334,7 @@ def xray_lines_model(elements,
                 ratio_line = properties['weight']
                 if s._get_xray_lines_in_spectral_range(
                         [element + '_' + line])[1] == []:
-                    g = components.Gaussian()
+                    g = components1d.Gaussian()
                     g.centre.value = line_energy
                     g.sigma.value = get_FWHM_at_Energy(
                         energy_resolution_MnKa, line_energy) / sigma2fwhm

--- a/hyperspy/misc/eels/tools.py
+++ b/hyperspy/misc/eels/tools.py
@@ -49,7 +49,7 @@ def _estimate_gain(ns, cs,
     if weighted is True:
         from hyperspy._signals.signal1D import Signal1D
         from hyperspy.models.model1d import Model1D
-        from hyperspy.components import Line
+        from hyperspy.components1d import Line
         s = Signal1D(variance2fit)
         s.axes_manager.signal_axes[0].axis = average2fit
         m = Model1D(s)

--- a/hyperspy/model.py
+++ b/hyperspy/model.py
@@ -37,7 +37,7 @@ from hyperspy.external.progressbar import progressbar
 from hyperspy.defaults_parser import preferences
 from hyperspy.external.mpfit.mpfit import mpfit
 from hyperspy.component import Component
-from hyperspy import components
+from hyperspy import components1d, components2d
 from hyperspy.signal import BaseSignal
 from hyperspy.misc.export_dictionary import (export_to_dictionary,
                                              load_from_dictionary,
@@ -49,6 +49,13 @@ from hyperspy.misc.slicing import copy_slice_from_whitelist
 
 _logger = logging.getLogger(__name__)
 
+# components is just a container for all (1D and 2D) components, to be able to
+# search in a single object for matching components when recreating a model.
+class DummyComponentsContainer:
+    pass
+components = DummyComponentsContainer()
+components.__dict__.update(components1d.__dict__)
+components.__dict__.update(components2d.__dict__)
 
 class ModelComponents(object):
 
@@ -343,7 +350,7 @@ class BaseModel(list):
 
         >>> s = hs.signals.Signal1D(np.empty(1))
         >>> m = s.create_model()
-        >>> g = hs.model.components.Gaussian()
+        >>> g = hs.model.components1D.Gaussian()
         >>> m.append(g)
 
         You could remove `g` like this
@@ -393,8 +400,8 @@ class BaseModel(list):
         --------
         >>> s = hs.signals.Signal1D(np.random.random((10,100)))
         >>> m = s.create_model()
-        >>> l1 = hs.model.components.Lorentzian()
-        >>> l2 = hs.model.components.Lorentzian()
+        >>> l1 = hs.model.components1D.Lorentzian()
+        >>> l2 = hs.model.components1D.Lorentzian()
         >>> m.append(l1)
         >>> m.append(l2)
         >>> s1 = m.as_signal()
@@ -1206,7 +1213,7 @@ class BaseModel(list):
 
         Examples
         --------
-        >>> v1 = hs.model.components.Voigt()
+        >>> v1 = hs.model.components1D.Voigt()
         >>> m.append(v1)
         >>> m.set_parameters_not_free()
 
@@ -1250,7 +1257,7 @@ class BaseModel(list):
 
         Examples
         --------
-        >>> v1 = hs.model.components.Voigt()
+        >>> v1 = hs.model.components1D.Voigt()
         >>> m.append(v1)
         >>> m.set_parameters_free()
         >>> m.set_parameters_free(component_list=[v1],
@@ -1300,8 +1307,8 @@ class BaseModel(list):
 
         Examples
         --------
-        >>> v1 = hs.model.components.Voigt()
-        >>> v2 = hs.model.components.Voigt()
+        >>> v1 = hs.model.components1D.Voigt()
+        >>> v2 = hs.model.components1D.Voigt()
         >>> m.extend([v1,v2])
         >>> m.set_parameters_value('area', 5)
         >>> m.set_parameters_value('area', 5, component_list=[v1])
@@ -1352,8 +1359,8 @@ class BaseModel(list):
         --------
         >>> s = signals.Signal1D(np.random.random((10,100)))
         >>> m = s.create_model()
-        >>> l1 = components.Lorentzian()
-        >>> l2 = components.Lorentzian()
+        >>> l1 = components1d.Lorentzian()
+        >>> l2 = components1d.Lorentzian()
         >>> m.append(l1)
         >>> m.append(l2)
         >>> d = m.as_dictionary()
@@ -1401,8 +1408,8 @@ class BaseModel(list):
 
         Examples
         --------
-        >>> v1 = hs.model.components.Voigt()
-        >>> v2 = hs.model.components.Voigt()
+        >>> v1 = hs.model.components1D.Voigt()
+        >>> v2 = hs.model.components1D.Voigt()
         >>> m.extend([v1,v2])
         >>> m.set_component_active_value(False)
         >>> m.set_component_active_value(True, component_list=[v1])

--- a/hyperspy/model.py
+++ b/hyperspy/model.py
@@ -51,11 +51,14 @@ _logger = logging.getLogger(__name__)
 
 # components is just a container for all (1D and 2D) components, to be able to
 # search in a single object for matching components when recreating a model.
+
+
 class DummyComponentsContainer:
     pass
 components = DummyComponentsContainer()
 components.__dict__.update(components1d.__dict__)
 components.__dict__.update(components2d.__dict__)
+
 
 class ModelComponents(object):
 

--- a/hyperspy/models/edsmodel.py
+++ b/hyperspy/models/edsmodel.py
@@ -29,7 +29,7 @@ from hyperspy.models.model1d import Model1D
 from hyperspy._signals.eds import EDSSpectrum
 from hyperspy.misc.elements import elements as elements_db
 from hyperspy.misc.eds import utils as utils_eds
-import hyperspy.components as create_component
+import hyperspy.components1d as create_component
 
 _logger = logging.getLogger(__name__)
 

--- a/hyperspy/models/eelsmodel.py
+++ b/hyperspy/models/eelsmodel.py
@@ -21,10 +21,10 @@ import warnings
 import logging
 
 from hyperspy.models.model1d import Model1D
-from hyperspy.components import EELSCLEdge
-from hyperspy.components import PowerLaw
+from hyperspy.components1d import EELSCLEdge
+from hyperspy.components1d import PowerLaw
 from hyperspy.defaults_parser import preferences
-from hyperspy import components
+from hyperspy import components1d
 from hyperspy._signals.eels import EELSSpectrum
 
 _logger = logging.getLogger(__name__)
@@ -455,7 +455,7 @@ class EELSModel(Model1D):
         """
         if powerlaw is None:
             for component in self._active_background_components:
-                if isinstance(component, components.PowerLaw):
+                if isinstance(component, components1d.PowerLaw):
                     if powerlaw is None:
                         powerlaw = component
                     else:

--- a/hyperspy/models/model1d.py
+++ b/hyperspy/models/model1d.py
@@ -130,7 +130,7 @@ class Model1D(BaseModel):
 
     >>> s = hs.signals.Signal1D(
             np.random.normal(scale=2, size=10000)).get_histogram()
-    >>> g = hs.model.components.Gaussian()
+    >>> g = hs.model.components1D.Gaussian()
     >>> m = s.create_model()
     >>> m.append(g)
     >>> m.print_current_values()
@@ -848,7 +848,7 @@ class Model1D(BaseModel):
         --------
         Signal range set interactivly
 
-        >>> g1 = hs.model.components.Gaussian()
+        >>> g1 = hs.model.components1D.Gaussian()
         >>> m.append(g1)
         >>> m.fit_component(g1)
 

--- a/hyperspy/tests/component/test_component_active_array.py
+++ b/hyperspy/tests/component/test_component_active_array.py
@@ -18,7 +18,7 @@
 
 import nose.tools as nt
 import numpy as np
-from hyperspy.components import Gaussian
+from hyperspy.components1d import Gaussian
 from hyperspy.signal import BaseSignal
 from hyperspy.misc.utils import stash_active_state
 

--- a/hyperspy/tests/component/test_component_set_parameters.py
+++ b/hyperspy/tests/component/test_component_set_parameters.py
@@ -17,7 +17,7 @@
 
 
 import nose.tools
-from hyperspy.components import Gaussian
+from hyperspy.components1d import Gaussian
 
 
 class TestSetParameters:

--- a/hyperspy/tests/component/test_gaussianhf.py
+++ b/hyperspy/tests/component/test_gaussianhf.py
@@ -19,7 +19,7 @@
 
 import nose.tools as nt
 import numpy as np
-from hyperspy.components import GaussianHF
+from hyperspy.components1d import GaussianHF
 from hyperspy.signals import Signal1D
 
 sqrt2pi = np.sqrt(2 * np.pi)

--- a/hyperspy/tests/model/test_chi_squared.py
+++ b/hyperspy/tests/model/test_chi_squared.py
@@ -20,7 +20,7 @@ import numpy as np
 
 from nose.tools import assert_true
 from hyperspy._signals.signal1d import Signal1D
-from hyperspy.components import Gaussian
+from hyperspy.components1d import Gaussian
 
 
 class TestChiSquared:

--- a/hyperspy/tests/model/test_components.py
+++ b/hyperspy/tests/model/test_components.py
@@ -13,7 +13,7 @@ class TestPowerLaw:
         s.axes_manager[0].offset = 100
         s.axes_manager[0].scale = 0.01
         m = s.create_model()
-        m.append(hs.model.components.PowerLaw())
+        m.append(hs.model.components1D.PowerLaw())
         m[0].A.value = 10
         m[0].r.value = 4
         self.m = m
@@ -22,7 +22,7 @@ class TestPowerLaw:
         self.m.signal.metadata.Signal.binned = True
         s = self.m.as_signal(show_progressbar=None)
         s.metadata.Signal.binned = True
-        g = hs.model.components.PowerLaw()
+        g = hs.model.components1D.PowerLaw()
         g.estimate_parameters(s,
                               None,
                               None,
@@ -34,7 +34,7 @@ class TestPowerLaw:
         self.m.signal.metadata.Signal.binned = False
         s = self.m.as_signal(show_progressbar=None)
         s.metadata.Signal.binned = False
-        g = hs.model.components.PowerLaw()
+        g = hs.model.components1D.PowerLaw()
         g.estimate_parameters(s,
                               None,
                               None,
@@ -46,7 +46,7 @@ class TestPowerLaw:
         self.m.signal.metadata.Signal.binned = True
         s = self.m.as_signal(show_progressbar=None)
         s.metadata.Signal.binned = True
-        g = hs.model.components.PowerLaw()
+        g = hs.model.components1D.PowerLaw()
         g.estimate_parameters(s,
                               None,
                               None,
@@ -58,7 +58,7 @@ class TestPowerLaw:
         self.m.signal.metadata.Signal.binned = False
         s = self.m.as_signal(show_progressbar=None)
         s.metadata.Signal.binned = False
-        g = hs.model.components.PowerLaw()
+        g = hs.model.components1D.PowerLaw()
         g.estimate_parameters(s,
                               None,
                               None,
@@ -81,7 +81,7 @@ class TestOffset:
         s = hs.signals.Signal1D(np.zeros(10))
         s.axes_manager[0].scale = 0.01
         m = s.create_model()
-        m.append(hs.model.components.Offset())
+        m.append(hs.model.components1D.Offset())
         m[0].offset.value = 10
         self.m = m
 
@@ -89,7 +89,7 @@ class TestOffset:
         self.m.signal.metadata.Signal.binned = True
         s = self.m.as_signal(show_progressbar=None)
         s.metadata.Signal.binned = True
-        g = hs.model.components.Offset()
+        g = hs.model.components1D.Offset()
         g.estimate_parameters(s,
                               None,
                               None,
@@ -100,7 +100,7 @@ class TestOffset:
         self.m.signal.metadata.Signal.binned = False
         s = self.m.as_signal(show_progressbar=None)
         s.metadata.Signal.binned = False
-        g = hs.model.components.Offset()
+        g = hs.model.components1D.Offset()
         g.estimate_parameters(s,
                               None,
                               None,
@@ -115,7 +115,7 @@ class TestPolynomial:
         s.axes_manager[0].offset = -5
         s.axes_manager[0].scale = 0.01
         m = s.create_model()
-        m.append(hs.model.components.Polynomial(order=2))
+        m.append(hs.model.components1D.Polynomial(order=2))
         m[0].coefficients.value = (0.5, 2, 3)
         self.m = m
         s_2d = hs.signals.Signal1D(np.arange(1000).reshape(10, 100))
@@ -135,7 +135,7 @@ class TestPolynomial:
         self.m.signal.metadata.Signal.binned = True
         s = self.m.as_signal(show_progressbar=None)
         s.metadata.Signal.binned = True
-        g = hs.model.components.Polynomial(order=2)
+        g = hs.model.components1D.Polynomial(order=2)
         g.estimate_parameters(s,
                               None,
                               None,
@@ -148,7 +148,7 @@ class TestPolynomial:
         self.m.signal.metadata.Signal.binned = False
         s = self.m.as_signal(show_progressbar=None)
         s.metadata.Signal.binned = False
-        g = hs.model.components.Polynomial(order=2)
+        g = hs.model.components1D.Polynomial(order=2)
         g.estimate_parameters(s,
                               None,
                               None,
@@ -161,7 +161,7 @@ class TestPolynomial:
         # This code should run smoothly, any exceptions should trigger failure
         s = self.m_2d.as_signal(show_progressbar=None)
         model = Model1D(s)
-        p = hs.model.components.Polynomial(order=2)
+        p = hs.model.components1D.Polynomial(order=2)
         model.append(p)
         p.estimate_parameters(s, 0, 100, only_current=False)
         np.testing.assert_allclose(p.coefficients.map['values'],
@@ -171,7 +171,7 @@ class TestPolynomial:
         # This code should run smoothly, any exceptions should trigger failure
         s = self.m_3d.as_signal(show_progressbar=None)
         model = Model1D(s)
-        p = hs.model.components.Polynomial(order=2)
+        p = hs.model.components1D.Polynomial(order=2)
         model.append(p)
         p.estimate_parameters(s, 0, 100, only_current=False)
         np.testing.assert_allclose(p.coefficients.map['values'],
@@ -185,7 +185,7 @@ class TestGaussian:
         s.axes_manager[0].offset = -5
         s.axes_manager[0].scale = 0.01
         m = s.create_model()
-        m.append(hs.model.components.Gaussian())
+        m.append(hs.model.components1D.Gaussian())
         m[0].sigma.value = 0.5
         m[0].centre.value = 1
         m[0].A.value = 2
@@ -195,7 +195,7 @@ class TestGaussian:
         self.m.signal.metadata.Signal.binned = True
         s = self.m.as_signal(show_progressbar=None)
         s.metadata.Signal.binned = True
-        g = hs.model.components.Gaussian()
+        g = hs.model.components1D.Gaussian()
         g.estimate_parameters(s,
                               None,
                               None,
@@ -208,7 +208,7 @@ class TestGaussian:
         self.m.signal.metadata.Signal.binned = False
         s = self.m.as_signal(show_progressbar=None)
         s.metadata.Signal.binned = False
-        g = hs.model.components.Gaussian()
+        g = hs.model.components1D.Gaussian()
         g.estimate_parameters(s,
                               None,
                               None,
@@ -221,7 +221,7 @@ class TestGaussian:
 class TestExpression:
 
     def setUp(self):
-        self.g = hs.model.components.Expression(
+        self.g = hs.model.components1D.Expression(
             expression="height * exp(-(x - x0) ** 2 * 4 * log(2)/ fwhm ** 2)",
             name="Gaussian",
             position="x0",
@@ -271,7 +271,7 @@ class TestScalableFixedPattern:
         s.metadata.Signal.binned = False
         s1.metadata.Signal.binned = False
         m = s.create_model()
-        fp = hs.model.components.ScalableFixedPattern(s1)
+        fp = hs.model.components1D.ScalableFixedPattern(s1)
         m.append(fp)
         with ignore_warning(message="invalid value encountered in sqrt",
                             category=RuntimeWarning):
@@ -284,7 +284,7 @@ class TestScalableFixedPattern:
         s.metadata.Signal.binned = True
         s1.metadata.Signal.binned = True
         m = s.create_model()
-        fp = hs.model.components.ScalableFixedPattern(s1)
+        fp = hs.model.components1D.ScalableFixedPattern(s1)
         m.append(fp)
         with ignore_warning(message="invalid value encountered in sqrt",
                             category=RuntimeWarning):
@@ -297,7 +297,7 @@ class TestScalableFixedPattern:
         s.metadata.Signal.binned = True
         s1.metadata.Signal.binned = False
         m = s.create_model()
-        fp = hs.model.components.ScalableFixedPattern(s1)
+        fp = hs.model.components1D.ScalableFixedPattern(s1)
         m.append(fp)
         with ignore_warning(message="invalid value encountered in sqrt",
                             category=RuntimeWarning):
@@ -310,7 +310,7 @@ class TestScalableFixedPattern:
         s.metadata.Signal.binned = False
         s1.metadata.Signal.binned = True
         m = s.create_model()
-        fp = hs.model.components.ScalableFixedPattern(s1)
+        fp = hs.model.components1D.ScalableFixedPattern(s1)
         m.append(fp)
         with ignore_warning(message="invalid value encountered in sqrt",
                             category=RuntimeWarning):
@@ -321,7 +321,7 @@ class TestScalableFixedPattern:
 class TestHeavisideStep:
 
     def setUp(self):
-        self.c = hs.model.components.HeavisideStep()
+        self.c = hs.model.components1D.HeavisideStep()
 
     def test_integer_values(self):
         c = self.c

--- a/hyperspy/tests/model/test_components2D.py
+++ b/hyperspy/tests/model/test_components2D.py
@@ -7,7 +7,7 @@ import hyperspy.api as hs
 class TestGaussian2D:
 
     def setUp(self):
-        g = hs.model.components.Gaussian2D(
+        g = hs.model.components2D.Gaussian2D(
             centre_x=-5.,
             centre_y=-5.,
             sigma_x=1.,

--- a/hyperspy/tests/model/test_eelsmodel.py
+++ b/hyperspy/tests/model/test_eelsmodel.py
@@ -29,13 +29,13 @@ class TestCreateEELSModel:
 
     def test_auto_add_background_true(self):
         m = self.s.create_model(auto_background=True)
-        from hyperspy.components import PowerLaw
+        from hyperspy.components1d import PowerLaw
         is_pl_instance = [isinstance(c, PowerLaw) for c in m]
         nt.assert_true(True in is_pl_instance)
 
     def test_auto_add_edges_false(self):
         m = self.s.create_model(auto_background=False)
-        from hyperspy.components import PowerLaw
+        from hyperspy.components1d import PowerLaw
         is_pl_instance = [isinstance(c, PowerLaw) for c in m]
         nt.assert_false(True in is_pl_instance)
 
@@ -163,7 +163,7 @@ class TestFitBackground:
         s.isig[CE:] += 1
         s.add_elements(("Be", "B", "C"))
         self.m = s.create_model(auto_background=False)
-        self.m.append(hs.model.components.Offset())
+        self.m.append(hs.model.components1D.Offset())
 
     def test_fit_background_B_C(self):
         self.m.fit_background()

--- a/hyperspy/tests/model/test_fancy_indexing.py
+++ b/hyperspy/tests/model/test_fancy_indexing.py
@@ -21,7 +21,7 @@ import time
 
 from hyperspy._signals.signal1d import Signal1D
 from hyperspy._signals.eels import EELSSpectrum
-from hyperspy.components import Gaussian
+from hyperspy.components1d import Gaussian
 
 
 class TestModelIndexing:

--- a/hyperspy/tests/model/test_fit_component.py
+++ b/hyperspy/tests/model/test_fit_component.py
@@ -21,7 +21,7 @@ import numpy as np
 import nose.tools
 from nose.tools import assert_true
 from hyperspy._signals.signal1d import Signal1D
-from hyperspy.components import Gaussian
+from hyperspy.components1d import Gaussian
 
 
 class TestFitOneComponent:

--- a/hyperspy/tests/model/test_model.py
+++ b/hyperspy/tests/model/test_model.py
@@ -18,7 +18,7 @@ class TestModelJacobians:
         self.weights = 0.3
         m.axis.axis = np.array([1, 0])
         m.channel_switches = np.array([0, 1], dtype=bool)
-        m.append(hs.model.components.Gaussian())
+        m.append(hs.model.components1D.Gaussian())
         m[0].A.value = 1
         m[0].centre.value = 2.
         m[0].sigma.twin = m[0].centre
@@ -42,7 +42,7 @@ class TestModelJacobians:
     def test_jacobian_convolved(self):
         m = self.model
         m.convolved = True
-        m.append(hs.model.components.Gaussian())
+        m.append(hs.model.components1D.Gaussian())
         m[0].convolved = False
         m[1].convolved = True
         jac = m._jacobian((1, 2, 3, 4, 5), None, weights=self.weights)
@@ -70,8 +70,8 @@ class TestModelCallMethod:
     def setUp(self):
         s = hs.signals.Signal1D(np.empty(1))
         m = s.create_model()
-        m.append(hs.model.components.Gaussian())
-        m.append(hs.model.components.Gaussian())
+        m.append(hs.model.components1D.Gaussian())
+        m.append(hs.model.components1D.Gaussian())
         self.model = m
 
     def test_call_method_no_convolutions(self):
@@ -96,7 +96,7 @@ class TestModelCallMethod:
         m.low_loss.return_value = 0.3
         m.convolved = True
 
-        m.append(hs.model.components.Gaussian())
+        m.append(hs.model.components1D.Gaussian())
         m[1].active = False
         m[0].convolved = True
         m[1].convolved = False
@@ -158,7 +158,7 @@ class TestModelSettingPZero:
     def setUp(self):
         s = hs.signals.Signal1D(np.empty(1))
         m = s.create_model()
-        m.append(hs.model.components.Gaussian())
+        m.append(hs.model.components1D.Gaussian())
 
         m[0].A.value = 1.1
         m[0].centre._number_of_elements = 2
@@ -174,7 +174,7 @@ class TestModelSettingPZero:
 
     def test_setting_p0(self):
         m = self.model
-        m.append(hs.model.components.Gaussian())
+        m.append(hs.model.components1D.Gaussian())
         m[-1].active = False
         m.p0 = None
         m._set_p0()
@@ -183,7 +183,7 @@ class TestModelSettingPZero:
     def test_fetching_from_p0(self):
         m = self.model
 
-        m.append(hs.model.components.Gaussian())
+        m.append(hs.model.components1D.Gaussian())
         m[-1].active = False
         m[-1].A.value = 100
         m[-1].sigma.value = 200
@@ -200,7 +200,7 @@ class TestModelSettingPZero:
 
     def test_setting_boundaries(self):
         m = self.model
-        m.append(hs.model.components.Gaussian())
+        m.append(hs.model.components1D.Gaussian())
         m[-1].active = False
         m.set_boundaries()
         nt.assert_equal(m.free_parameters_boundaries,
@@ -211,7 +211,7 @@ class TestModelSettingPZero:
         m[0].A.bmax = None
         m[0].centre.bmin = None
         m[0].centre.bmax = 0.31
-        m.append(hs.model.components.Gaussian())
+        m.append(hs.model.components1D.Gaussian())
         m[-1].active = False
         m.set_mpfit_parameters_info()
         nt.assert_equal(m.mpfit_parinfo,
@@ -264,7 +264,7 @@ class TestModel1D:
 
     def test_model_function(self):
         m = self.model
-        m.append(hs.model.components.Gaussian())
+        m.append(hs.model.components1D.Gaussian())
         m[0].A.value = 1.3
         m[0].centre.value = 0.003
         m[0].sigma.value = 0.1
@@ -277,13 +277,13 @@ class TestModel1D:
 
     @nt.raises(ValueError)
     def test_append_existing_component(self):
-        g = hs.model.components.Gaussian()
+        g = hs.model.components1D.Gaussian()
         m = self.model
         m.append(g)
         m.append(g)
 
     def test_append_component(self):
-        g = hs.model.components.Gaussian()
+        g = hs.model.components1D.Gaussian()
         m = self.model
         m.append(g)
         nt.assert_in(g, m)
@@ -319,22 +319,22 @@ class TestModel1D:
                            ipywidgets.__version__)
         m = self.model
         m.notebook_interaction()
-        m.append(hs.model.components.Offset())
+        m.append(hs.model.components1D.Offset())
         m[0].notebook_interaction()
         m[0].offset.notebook_interaction()
 
     def test_access_component_by_name(self):
         m = self.model
-        g1 = hs.model.components.Gaussian()
-        g2 = hs.model.components.Gaussian()
+        g1 = hs.model.components1D.Gaussian()
+        g2 = hs.model.components1D.Gaussian()
         g2.name = "test"
         m.extend((g1, g2))
         nt.assert_is(m["test"], g2)
 
     def test_access_component_by_index(self):
         m = self.model
-        g1 = hs.model.components.Gaussian()
-        g2 = hs.model.components.Gaussian()
+        g1 = hs.model.components1D.Gaussian()
+        g2 = hs.model.components1D.Gaussian()
         g2.name = "test"
         m.extend((g1, g2))
         nt.assert_is(m[1], g2)
@@ -342,9 +342,9 @@ class TestModel1D:
     def test_component_name_when_append(self):
         m = self.model
         gs = [
-            hs.model.components.Gaussian(),
-            hs.model.components.Gaussian(),
-            hs.model.components.Gaussian()]
+            hs.model.components1D.Gaussian(),
+            hs.model.components1D.Gaussian(),
+            hs.model.components1D.Gaussian()]
         m.extend(gs)
         nt.assert_is(m['Gaussian'], gs[0])
         nt.assert_is(m['Gaussian_0'], gs[1])
@@ -354,13 +354,13 @@ class TestModel1D:
     def test_several_component_with_same_name(self):
         m = self.model
         gs = [
-            hs.model.components.Gaussian(),
-            hs.model.components.Gaussian(),
-            hs.model.components.Gaussian()]
+            hs.model.components1D.Gaussian(),
+            hs.model.components1D.Gaussian(),
+            hs.model.components1D.Gaussian()]
         m.extend(gs)
-        m[0]._name = "hs.model.components.Gaussian"
-        m[1]._name = "hs.model.components.Gaussian"
-        m[2]._name = "hs.model.components.Gaussian"
+        m[0]._name = "hs.model.components1D.Gaussian"
+        m[1]._name = "hs.model.components1D.Gaussian"
+        m[2]._name = "hs.model.components1D.Gaussian"
         m['Gaussian']
 
     @nt.raises(ValueError)
@@ -371,49 +371,49 @@ class TestModel1D:
     @nt.raises(ValueError)
     def test_component_already_in_model(self):
         m = self.model
-        g1 = hs.model.components.Gaussian()
+        g1 = hs.model.components1D.Gaussian()
         m.extend((g1, g1))
 
     def test_remove_component(self):
         m = self.model
-        g1 = hs.model.components.Gaussian()
+        g1 = hs.model.components1D.Gaussian()
         m.append(g1)
         m.remove(g1)
         nt.assert_equal(len(m), 0)
 
     def test_remove_component_by_index(self):
         m = self.model
-        g1 = hs.model.components.Gaussian()
+        g1 = hs.model.components1D.Gaussian()
         m.append(g1)
         m.remove(0)
         nt.assert_equal(len(m), 0)
 
     def test_remove_component_by_name(self):
         m = self.model
-        g1 = hs.model.components.Gaussian()
+        g1 = hs.model.components1D.Gaussian()
         m.append(g1)
         m.remove(g1.name)
         nt.assert_equal(len(m), 0)
 
     def test_delete_component_by_index(self):
         m = self.model
-        g1 = hs.model.components.Gaussian()
+        g1 = hs.model.components1D.Gaussian()
         m.append(g1)
         del m[0]
         nt.assert_not_in(g1, m)
 
     def test_delete_component_by_name(self):
         m = self.model
-        g1 = hs.model.components.Gaussian()
+        g1 = hs.model.components1D.Gaussian()
         m.append(g1)
         del m[g1.name]
         nt.assert_not_in(g1, m)
 
     def test_delete_slice(self):
         m = self.model
-        g1 = hs.model.components.Gaussian()
-        g2 = hs.model.components.Gaussian()
-        g3 = hs.model.components.Gaussian()
+        g1 = hs.model.components1D.Gaussian()
+        g2 = hs.model.components1D.Gaussian()
+        g3 = hs.model.components1D.Gaussian()
         m.extend([g1, g2, g3])
         del m[:2]
         nt.assert_not_in(g1, m)
@@ -422,24 +422,24 @@ class TestModel1D:
 
     def test_get_component_by_name(self):
         m = self.model
-        g1 = hs.model.components.Gaussian()
-        g2 = hs.model.components.Gaussian()
+        g1 = hs.model.components1D.Gaussian()
+        g2 = hs.model.components1D.Gaussian()
         g2.name = "test"
         m.extend((g1, g2))
         nt.assert_is(m._get_component("test"), g2)
 
     def test_get_component_by_index(self):
         m = self.model
-        g1 = hs.model.components.Gaussian()
-        g2 = hs.model.components.Gaussian()
+        g1 = hs.model.components1D.Gaussian()
+        g2 = hs.model.components1D.Gaussian()
         g2.name = "test"
         m.extend((g1, g2))
         nt.assert_is(m._get_component(1), g2)
 
     def test_get_component_by_component(self):
         m = self.model
-        g1 = hs.model.components.Gaussian()
-        g2 = hs.model.components.Gaussian()
+        g1 = hs.model.components1D.Gaussian()
+        g2 = hs.model.components1D.Gaussian()
         g2.name = "test"
         m.extend((g1, g2))
         nt.assert_is(m._get_component(g2), g2)
@@ -447,21 +447,21 @@ class TestModel1D:
     @nt.raises(ValueError)
     def test_get_component_wrong(self):
         m = self.model
-        g1 = hs.model.components.Gaussian()
-        g2 = hs.model.components.Gaussian()
+        g1 = hs.model.components1D.Gaussian()
+        g2 = hs.model.components1D.Gaussian()
         g2.name = "test"
         m.extend((g1, g2))
         m._get_component(1.2)
 
     def test_components_class_default(self):
         m = self.model
-        g1 = hs.model.components.Gaussian()
+        g1 = hs.model.components1D.Gaussian()
         m.append(g1)
         nt.assert_is(getattr(m.components, g1.name), g1)
 
     def test_components_class_change_name(self):
         m = self.model
-        g1 = hs.model.components.Gaussian()
+        g1 = hs.model.components1D.Gaussian()
         m.append(g1)
         g1.name = "test"
         nt.assert_is(getattr(m.components, g1.name), g1)
@@ -469,14 +469,14 @@ class TestModel1D:
     @nt.raises(AttributeError)
     def test_components_class_change_name_del_default(self):
         m = self.model
-        g1 = hs.model.components.Gaussian()
+        g1 = hs.model.components1D.Gaussian()
         m.append(g1)
         g1.name = "test"
         getattr(m.components, "Gaussian")
 
     def test_components_class_change_invalid_name(self):
         m = self.model
-        g1 = hs.model.components.Gaussian()
+        g1 = hs.model.components1D.Gaussian()
         m.append(g1)
         g1.name = "1, Test This!"
         nt.assert_is(
@@ -486,7 +486,7 @@ class TestModel1D:
     @nt.raises(AttributeError)
     def test_components_class_change_name_del_default(self):
         m = self.model
-        g1 = hs.model.components.Gaussian()
+        g1 = hs.model.components1D.Gaussian()
         m.append(g1)
         invalid_name = "1, Test This!"
         g1.name = invalid_name
@@ -495,15 +495,15 @@ class TestModel1D:
 
     def test_snap_parameter_bounds(self):
         m = self.model
-        g1 = hs.model.components.Gaussian()
+        g1 = hs.model.components1D.Gaussian()
         m.append(g1)
-        g2 = hs.model.components.Gaussian()
+        g2 = hs.model.components1D.Gaussian()
         m.append(g2)
-        g3 = hs.model.components.Gaussian()
+        g3 = hs.model.components1D.Gaussian()
         m.append(g3)
-        g4 = hs.model.components.Gaussian()
+        g4 = hs.model.components1D.Gaussian()
         m.append(g4)
-        p = hs.model.components.Polynomial(3)
+        p = hs.model.components1D.Polynomial(3)
         m.append(p)
 
         g1.A.value = 3.
@@ -567,7 +567,7 @@ class TestModel1D:
 class TestModel2D:
 
     def setUp(self):
-        g = hs.model.components.Gaussian2D(
+        g = hs.model.components2D.Gaussian2D(
             centre_x=-5.,
             centre_y=-5.,
             sigma_x=1.,
@@ -585,7 +585,7 @@ class TestModel2D:
     def test_fitting(self):
         im = self.im
         m = im.create_model()
-        gt = hs.model.components.Gaussian2D(centre_x=-4.5,
+        gt = hs.model.components2D.Gaussian2D(centre_x=-4.5,
                                             centre_y=-4.5,
                                             sigma_x=0.5,
                                             sigma_y=1.5)
@@ -606,7 +606,7 @@ class TestModelFitBinned:
                 scale=2,
                 size=10000)).get_histogram()
         s.metadata.Signal.binned = True
-        g = hs.model.components.Gaussian()
+        g = hs.model.components1D.Gaussian()
         m = s.create_model()
         m.append(g)
         g.sigma.value = 1
@@ -697,7 +697,7 @@ class TestModelWeighted:
         s.axes_manager[0].offset = 10
         s.add_poissonian_noise()
         m = s.create_model()
-        m.append(hs.model.components.Polynomial(1))
+        m.append(hs.model.components1D.Polynomial(1))
         self.m = m
 
     def test_fit_leastsq_binned(self):
@@ -781,7 +781,7 @@ class TestModelScalarVariance:
     def setUp(self):
         s = hs.signals.Signal1D(np.ones(100))
         m = s.create_model()
-        m.append(hs.model.components.Offset())
+        m.append(hs.model.components1D.Offset())
         self.s = s
         self.m = m
 
@@ -840,7 +840,7 @@ class TestModelSignalVariance:
         s.metadata.set_item("Signal.Noise_properties.variance",
                             variance + std ** 2)
         m = s.create_model()
-        m.append(hs.model.components.Polynomial(order=1))
+        m.append(hs.model.components1D.Polynomial(order=1))
         self.s = s
         self.m = m
 
@@ -859,7 +859,7 @@ class TestMultifit:
         s.axes_manager[-1].offset = 1
         s.data[:] = 2 * s.axes_manager[-1].axis ** (-3)
         m = s.create_model()
-        m.append(hs.model.components.PowerLaw())
+        m.append(hs.model.components1D.PowerLaw())
         m[0].A.value = 2
         m[0].r.value = 2
         m.store_current_values()
@@ -903,7 +903,7 @@ class TestStoreCurrentValues:
 
     def setUp(self):
         self.m = hs.signals.Signal1D(np.arange(10)).create_model()
-        self.o = hs.model.components.Offset()
+        self.o = hs.model.components1D.Offset()
         self.m.append(self.o)
 
     def test_active(self):
@@ -927,8 +927,8 @@ class TestSetCurrentValuesTo:
         self.m = hs.signals.Signal1D(
             np.arange(10).reshape(2, 5)).create_model()
         self.comps = [
-            hs.model.components.Offset(),
-            hs.model.components.Offset()]
+            hs.model.components1D.Offset(),
+            hs.model.components1D.Offset()]
         self.m.extend(self.comps)
 
     def test_set_all(self):
@@ -951,8 +951,8 @@ class TestAsSignal:
         self.m = hs.signals.Signal1D(
             np.arange(10).reshape(2, 5)).create_model()
         self.comps = [
-            hs.model.components.Offset(),
-            hs.model.components.Offset()]
+            hs.model.components1D.Offset(),
+            hs.model.components1D.Offset()]
         self.m.extend(self.comps)
         for c in self.comps:
             c.offset.value = 2
@@ -1022,32 +1022,32 @@ class TestAdjustPosition:
         self.m = self.s.create_model()
 
     def test_enable_adjust_position(self):
-        self.m.append(hs.model.components.Gaussian())
+        self.m.append(hs.model.components1D.Gaussian())
         self.m.enable_adjust_position()
         nt.assert_equal(len(self.m._position_widgets), 1)
         # Check that both line and label was added
         nt.assert_equal(len(list(self.m._position_widgets.values())[0]), 2)
 
     def test_disable_adjust_position(self):
-        self.m.append(hs.model.components.Gaussian())
+        self.m.append(hs.model.components1D.Gaussian())
         self.m.enable_adjust_position()
         self.m.disable_adjust_position()
         nt.assert_equal(len(self.m._position_widgets), 0)
 
     def test_enable_all(self):
-        self.m.append(hs.model.components.Gaussian())
+        self.m.append(hs.model.components1D.Gaussian())
         self.m.enable_adjust_position()
-        self.m.append(hs.model.components.Gaussian())
+        self.m.append(hs.model.components1D.Gaussian())
         nt.assert_equal(len(self.m._position_widgets), 2)
 
     def test_enable_all_zero_start(self):
         self.m.enable_adjust_position()
-        self.m.append(hs.model.components.Gaussian())
+        self.m.append(hs.model.components1D.Gaussian())
         nt.assert_equal(len(self.m._position_widgets), 1)
 
     def test_manual_close(self):
-        self.m.append(hs.model.components.Gaussian())
-        self.m.append(hs.model.components.Gaussian())
+        self.m.append(hs.model.components1D.Gaussian())
+        self.m.append(hs.model.components1D.Gaussian())
         self.m.enable_adjust_position()
         list(self.m._position_widgets.values())[0][0].close()
         nt.assert_equal(len(self.m._position_widgets), 2)

--- a/hyperspy/tests/model/test_model.py
+++ b/hyperspy/tests/model/test_model.py
@@ -586,9 +586,9 @@ class TestModel2D:
         im = self.im
         m = im.create_model()
         gt = hs.model.components2D.Gaussian2D(centre_x=-4.5,
-                                            centre_y=-4.5,
-                                            sigma_x=0.5,
-                                            sigma_y=1.5)
+                                              centre_y=-4.5,
+                                              sigma_x=0.5,
+                                              sigma_y=1.5)
         m.append(gt)
         m.fit()
         np.testing.assert_almost_equal(gt.centre_x.value, -5.)

--- a/hyperspy/tests/model/test_model_as_dictionary.py
+++ b/hyperspy/tests/model/test_model_as_dictionary.py
@@ -21,7 +21,7 @@ import numpy as np
 import nose.tools as nt
 from hyperspy._signals.signal1d import Signal1D
 from hyperspy.component import Parameter, Component
-from hyperspy.components import Gaussian, Lorentzian, ScalableFixedPattern
+from hyperspy.components1d import Gaussian, Lorentzian, ScalableFixedPattern
 
 
 def remove_empty_numpy_strings(dic):

--- a/hyperspy/tests/model/test_model_storing.py
+++ b/hyperspy/tests/model/test_model_storing.py
@@ -22,7 +22,7 @@ from os import remove
 import nose.tools as nt
 from hyperspy._signals.signal1d import Signal1D
 from hyperspy.io import load
-from hyperspy.components import Gaussian
+from hyperspy.components1d import Gaussian
 from unittest import mock
 import gc
 

--- a/hyperspy/tests/model/test_set_parameter_state.py
+++ b/hyperspy/tests/model/test_set_parameter_state.py
@@ -20,7 +20,7 @@ import numpy as np
 from nose.tools import assert_true, assert_equal
 
 from hyperspy._signals.signal1d import Signal1D
-from hyperspy.components import Gaussian
+from hyperspy.components1d import Gaussian
 
 
 class TestSetParameterInModel:

--- a/hyperspy/tests/model/test_set_parameter_value.py
+++ b/hyperspy/tests/model/test_set_parameter_value.py
@@ -20,7 +20,7 @@ import numpy as np
 
 from nose.tools import assert_true
 from hyperspy._signals.signal1d import Signal1D
-from hyperspy.components import Gaussian
+from hyperspy.components1d import Gaussian
 
 
 class TestSetParameterInModel:

--- a/hyperspy/tests/signal/test_1D_tools.py
+++ b/hyperspy/tests/signal/test_1D_tools.py
@@ -224,7 +224,7 @@ class TestEstimatePeakWidth:
         scale = 0.1
         window = 2
         x = np.arange(-window, window, scale)
-        g = hs.model.components.Gaussian()
+        g = hs.model.components1D.Gaussian()
         s = hs.signals.Signal1D(g.function(x))
         s.axes_manager[-1].scale = scale
         self.s = s

--- a/hyperspy/tests/signal/test_binned.py
+++ b/hyperspy/tests/signal/test_binned.py
@@ -45,7 +45,7 @@ class TestModelBinned:
         s = hs.signals.Signal1D([1])
         s.axes_manager[0].scale = 0.1
         m = s.create_model()
-        m.append(hs.model.components.Offset())
+        m.append(hs.model.components1D.Offset())
         m[0].offset.value = 1
         self.m = m
 

--- a/hyperspy/tests/signal/test_eds_sem.py
+++ b/hyperspy/tests/signal/test_eds_sem.py
@@ -22,7 +22,7 @@ import nose.tools as nt
 
 from hyperspy.signals import EDSSEMSpectrum
 from hyperspy.defaults_parser import preferences
-from hyperspy.components import Gaussian
+from hyperspy.components1d import Gaussian
 from hyperspy import utils
 from hyperspy.misc.test_utils import assert_warns
 

--- a/hyperspy/tests/signal/test_eds_tem.py
+++ b/hyperspy/tests/signal/test_eds_tem.py
@@ -21,7 +21,7 @@ import nose.tools as nt
 
 from hyperspy.signals import EDSTEMSpectrum
 from hyperspy.defaults_parser import preferences
-from hyperspy.components import Gaussian
+from hyperspy.components1d import Gaussian
 from hyperspy.misc.eds import utils as utils_eds
 from hyperspy.misc.test_utils import ignore_warning
 

--- a/hyperspy/tests/signal/test_eels.py
+++ b/hyperspy/tests/signal/test_eels.py
@@ -32,11 +32,11 @@ class Test_Estimate_Elastic_Scattering_Threshold:
         energy_axis.scale = 0.02
         energy_axis.offset = -5
 
-        gauss = hs.model.components.Gaussian()
+        gauss = hs.model.components1D.Gaussian()
         gauss.centre.value = 0
         gauss.A.value = 5000
         gauss.sigma.value = 0.5
-        gauss2 = hs.model.components.Gaussian()
+        gauss2 = hs.model.components1D.Gaussian()
         gauss2.sigma.value = 0.5
         # Inflexion point 1.5
         gauss2.A.value = 5000

--- a/hyperspy/tests/signal/test_integrate_in_range.py
+++ b/hyperspy/tests/signal/test_integrate_in_range.py
@@ -2,7 +2,7 @@ import nose.tools
 import numpy as np
 
 from hyperspy._signals.signal1d import Signal1D
-from hyperspy.components import Gaussian
+from hyperspy.components1d import Gaussian
 
 
 class Test1D:

--- a/hyperspy/tests/signal/test_kramers_kronig_transform.py
+++ b/hyperspy/tests/signal/test_kramers_kronig_transform.py
@@ -19,7 +19,7 @@
 import numpy as np
 import nose.tools
 
-from hyperspy.components import VolumePlasmonDrude, Lorentzian
+from hyperspy.components1d import VolumePlasmonDrude, Lorentzian
 from hyperspy.misc.eels.tools import eels_constant
 import hyperspy.api as hs
 

--- a/hyperspy/tests/signal/test_remove_background.py
+++ b/hyperspy/tests/signal/test_remove_background.py
@@ -3,13 +3,13 @@ from nose.tools import (
     assert_true,)
 
 from hyperspy import signals
-from hyperspy import components
+from hyperspy import components1d
 
 
 class TestRemoveBackground1DGaussian:
 
     def setUp(self):
-        gaussian = components.Gaussian()
+        gaussian = components1d.Gaussian()
         gaussian.A.value = 10
         gaussian.centre.value = 10
         gaussian.sigma.value = 1
@@ -36,7 +36,7 @@ class TestRemoveBackground1DGaussian:
 class TestRemoveBackground1DPowerLaw:
 
     def setUp(self):
-        pl = components.PowerLaw()
+        pl = components1d.PowerLaw()
         pl.A.value = 1e10
         pl.r.value = 3
         self.signal = signals.Signal1D(

--- a/hyperspy/utils/model.py
+++ b/hyperspy/utils/model.py
@@ -3,9 +3,13 @@
 
 The :mod:`~hyperspy.api.model` module contains the following submodules:
 
-components
-    Components for HyperSpy model.
+components1D
+    1D components for HyperSpy model.
+
+components2D
+    2D components for HyperSpy model.
 
 """
 
-import hyperspy.components as components
+import hyperspy.components1d as components1D
+import hyperspy.components2d as components2D


### PR DESCRIPTION
Example of changes. Before HyperSpy 1.0:

```python

g = hs.model.components.Gaussian()

```

HyperSpy 1.0:

```python

g = hs.model.components1D.Gaussian()
g2D = hs.model.components2D.Gaussian2D()

```

