### PR TITLE
Fix security issue hdf5

### DIFF
--- a/hyperspy/io_plugins/hdf5.py
+++ b/hyperspy/io_plugins/hdf5.py
@@ -465,8 +465,11 @@ def hdfgroup2dict(group, dictionary=None, load_to_memory=True):
             dictionary[key[len('_tuple_empty_'):]] = ()
         elif key.startswith('_bs_'):
             dictionary[key[len('_bs_'):]] = value.tostring()
-        elif key.startswith('_datetime_'):
-            dictionary[key.replace("_datetime_", "")] = eval(value)
+# The following is commented out as it could be used to evaluate
+# arbitrary code i.e. it was a security flaw. We should instead
+# use a standard string for date and time.
+#        elif key.startswith('_datetime_'):
+#            dictionary[key.replace("_datetime_", "")] = eval(value)
         else:
             dictionary[key] = value
     if not isinstance(group, h5py.Dataset):

--- a/hyperspy/tests/io/test_hdf5.py
+++ b/hyperspy/tests/io/test_hdf5.py
@@ -98,25 +98,27 @@ class TestExample1_11(Example1):
             "hdf5_files",
             "example1_v1.1.hdf5"))
 
-
-class TestExample1_12(Example1):
-
-    def setUp(self):
-        self.s = load(os.path.join(
-            my_path,
-            "hdf5_files",
-            "example1_v1.2.hdf5"))
-
-    def test_date(self):
-        nt.assert_equal(
-            self.s.metadata.General.date,
-            datetime.date(
-                1991,
-                10,
-                1))
-
-    def test_time(self):
-        nt.assert_equal(self.s.metadata.General.time, datetime.time(12, 0))
+# The following is commented out because
+# the feature was removed in HyperSpy 1.0
+# to fix a security flaw.
+# class TestExample1_12(Example1):
+# 
+#     def setUp(self):
+#         self.s = load(os.path.join(
+#             my_path,
+#             "hdf5_files",
+#             "example1_v1.2.hdf5"))
+# 
+#     def test_date(self):
+#         nt.assert_equal(
+#             self.s.metadata.General.date,
+#             datetime.date(
+#                 1991,
+#                 10,
+#                 1))
+# 
+#     def test_time(self):
+#         nt.assert_equal(self.s.metadata.General.time, datetime.time(12, 0))
 
 
 class TestLoadingNewSavedMetadata:

--- a/hyperspy/tests/io/test_hdf5.py
+++ b/hyperspy/tests/io/test_hdf5.py
@@ -102,13 +102,13 @@ class TestExample1_11(Example1):
 # the feature was removed in HyperSpy 1.0
 # to fix a security flaw.
 # class TestExample1_12(Example1):
-# 
+#
 #     def setUp(self):
 #         self.s = load(os.path.join(
 #             my_path,
 #             "hdf5_files",
 #             "example1_v1.2.hdf5"))
-# 
+#
 #     def test_date(self):
 #         nt.assert_equal(
 #             self.s.metadata.General.date,
@@ -116,7 +116,7 @@ class TestExample1_11(Example1):
 #                 1991,
 #                 10,
 #                 1))
-# 
+#
 #     def test_time(self):
 #         nt.assert_equal(self.s.metadata.General.time, datetime.time(12, 0))
 


### PR DESCRIPTION
HyperSpy's hdf5 io plugin was storing datetime objects using `repr` and loading it back using `eval`. This `eval` call on arbitrary content from the hdf5 file was a serious vulnerability. This PR removes the feature. #1136 proposes an alternative way of dealing with date and time.