### PR TITLE
Fix learning results

### DIFF
--- a/hyperspy/learn/mva.py
+++ b/hyperspy/learn/mva.py
@@ -1138,12 +1138,15 @@ class LearningResults(object):
         if hasattr(self, 'output_dimension') and self.output_dimension \
                 is not None:
             self.output_dimension = int(self.output_dimension)
-        self.summary()
+        _logger.info(self._summary())
 
     def summary(self):
         """Prints a summary of the decomposition and demixing parameters
          to the stdout
         """
+        print(self._summary())
+
+    def _summary(self):
         summary_str = (
             "Decomposition parameters:\n"
             "-------------------------\n\n" +
@@ -1159,7 +1162,7 @@ class LearningResults(object):
                 "------------------------\n" +
                 ("BSS algorithm : %s" % self.bss_algorithm) +
                 ("Number of components : %i" % len(self.unmixing_matrix)))
-        _logger.info(summary_str)
+        return summary_str
 
     def crop_decomposition_dimension(self, n):
         """

--- a/hyperspy/signal.py
+++ b/hyperspy/signal.py
@@ -1763,6 +1763,9 @@ class BaseSignal(FancySlicing,
         if (self._signal_type or
                 not self.metadata.has_item("Signal.signal_type")):
             self.metadata.Signal.signal_type = self._signal_type
+        if "learning_results" in file_data_dict:
+            self.learning_results.__dict__.update(
+                file_data_dict["learning_results"])
 
     def __array__(self, dtype=None):
         if dtype:


### PR DESCRIPTION
The learning results were lost when changing the signal subclass because `BaseSignal._load_dictionary` as ignoring them.

Also fixes `learning_results.summary` that was only writing to the log instead of printing to stdout when called by user.

Fixes #1145