### PR TITLE
rm: Mocking out the mockery

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -12,16 +12,6 @@
 # serve to show the default.
 
 import sys
-from unittest.mock import MagicMock
-
-class Mock(MagicMock):
-    @classmethod
-    def __getattr__(cls, name):
-            return Mock()
-
-MOCK_MODULES = ['scipy', 'matplotlib', 'traits', 'traitsui', 'numpy', 'h5py']
-sys.modules.update((mod_name, Mock()) for mod_name in MOCK_MODULES)
-
 import os
 sys.path.append('../')
 from hyperspy import Release


### PR DESCRIPTION
the MagicMock from unittest is not needed as
custom built "mockery" in setup.py, which detects the readthedocs presence,
and mocks the `install_requires` is self sufficient.