### PR TITLE
Fix 1D navigator explorer

### DIFF
--- a/hyperspy/drawing/mpl_hse.py
+++ b/hyperspy/drawing/mpl_hse.py
@@ -142,7 +142,10 @@ class MPL_HyperSignal1D_Explorer(MPL_HyperExplorer):
             pointer = self.assign_pointer()
             self.right_pointer = pointer(
                 self.signal_plot.right_axes_manager)
-            self.right_pointer.size = self.pointer.size
+            # The following is necessary because e.g. a line pointer does not
+            # have size
+            if hasattr(self.pointer, "size"):
+                self.right_pointer.size = self.pointer.size
             self.right_pointer.color = 'blue'
             self.right_pointer.connect_navigate()
             self.right_pointer.set_mpl_ax(self.navigator_plot.ax)


### PR DESCRIPTION
The "explorer" (the extra pointer and  line when plotting Signal1D) is broken.

```python
>>> s = hs.signals.Signal1D(np.zeros((32,100)))        
>>> s.plot() # Press "e"
>>> Traceback (most recent call last):
  File "/home/fjd29/Anaconda/anaconda3/lib/python3.5/site-packages/matplotlib/backends/backend_qt5.py", line 313, in keyPressEvent
    FigureCanvasBase.key_press_event(self, key, guiEvent=event)
  File "/home/fjd29/Anaconda/anaconda3/lib/python3.5/site-packages/matplotlib/backend_bases.py", line 1847, in key_press_event
    self.callbacks.process(s, event)
  File "/home/fjd29/Anaconda/anaconda3/lib/python3.5/site-packages/matplotlib/cbook.py", line 563, in process
    proxy(*args, **kwargs)
  File "/home/fjd29/Anaconda/anaconda3/lib/python3.5/site-packages/matplotlib/cbook.py", line 430, in __call__
    return mtd(*args, **kwargs)
  File "/home/fjd29/Python/hyperspy3/hyperspy/drawing/mpl_hse.py", line 135, in key2switch_right_pointer
    self.right_pointer_on = not self.right_pointer_on
  File "/home/fjd29/Python/hyperspy3/hyperspy/drawing/mpl_hse.py", line 72, in right_pointer_on
    self.add_right_pointer()
  File "/home/fjd29/Python/hyperspy3/hyperspy/drawing/mpl_hse.py", line 145, in add_right_pointer
    self.right_pointer.size = self.pointer.size
AttributeError: 'HorizontalLineWidget' object has no attribute 'size'

If you suspect this is an IPython bug, please report it at:
    https://github.com/ipython/ipython/issues
or send an email to the mailing list at ipython-dev@scipy.org

You can print a more detailed traceback right now with "%tb", or use "%debug"
to interactively debug it.

Extra-detailed tracebacks for bug-reporting purposes can be enabled via:
    %config Application.verbose_crash=True
```

This fixes it.
