### PR TITLE
Fix interactive onset_energy setting

### DIFF
--- a/hyperspy/_components/eels_cl_edge.py
+++ b/hyperspy/_components/eels_cl_edge.py
@@ -306,6 +306,15 @@ class EELSCLEdge(Component):
         """Returns the number of counts in barns
 
         """
+        shift = self.onset_energy.value - self.GOS.onset_energy
+        if shift != self.GOS.energy_shift:
+            # Because hspy Events are not executed in any given order,
+            # an external function could be in the same event execution list
+            # as _integrate_GOS and be executed first. That can potentially
+            # cause an error that enforcing _integrate_GOS here prevents. Note
+            # that this is suboptimal because _integrate_GOS is computed twice
+            # unnecessarily.
+            self._integrate_GOS()
         Emax = self.GOS.energy_axis[-1] + self.GOS.energy_shift
         cts = np.zeros((len(E)))
         bsignal = (E >= self.onset_energy.value)


### PR DESCRIPTION
When using `enable_adjust_position` to set the onset energy of an EELSEdge  component, sometimes (randomly) an error occurs that leaves the component in a broken states. The bug is caused by the random execution of events. This fixes the issue. The following reproduces the issue:

```python
%matplotlib qt4
import numpy as np
import hyperspy.api as hs

s = hs.signals.EELSSpectrum(np.random.random((32,32,1000)))
s.set_microscope_parameters(100, 10, 20)
s.add_elements(["C", "O"])
m = s.create_model()
m.plot()
m.enable_adjust_position()
```