### PR TITLE
Fixed import loop

### DIFF
--- a/hyperspy/_signals/eels.py
+++ b/hyperspy/_signals/eels.py
@@ -23,7 +23,7 @@ import numpy as np
 import traits.api as t
 from scipy import constants
 
-from hyperspy.signals import Signal1D
+from hyperspy._signals.signal1d  import Signal1D
 from hyperspy.misc.elements import elements as elements_db
 import hyperspy.axes
 from hyperspy.decorators import only_interactive

--- a/hyperspy/_signals/signal1d.py
+++ b/hyperspy/_signals/signal1d.py
@@ -18,7 +18,6 @@
 
 import matplotlib.pyplot as plt
 import numpy as np
-import warnings
 
 from hyperspy.signal import BaseSignal
 from hyperspy._signals.common_signal1d import CommonSignal1D

--- a/hyperspy/models/model1d.py
+++ b/hyperspy/models/model1d.py
@@ -23,7 +23,7 @@ from contextlib import contextmanager
 
 from hyperspy.model import BaseModel, ModelComponents, ModelSpecialSlicers
 import hyperspy.drawing.signal1d
-from hyperspy._signals.eels import Signal1D
+from hyperspy._signals.signal1d import Signal1D
 from hyperspy.axes import generate_axis
 from hyperspy.exceptions import WrongObjectError
 from hyperspy.decorators import interactive_range_selector


### PR DESCRIPTION
Fixes an import loop that could be triggered by imports as exemplified below

```python
In [1]: import hyperspy.models.eelsmodel
unbcf_fast library is not present...
Falling back to slow python only backend.
---------------------------------------------------------------------------
ImportError                               Traceback (most recent call last)
<ipython-input-1-21fc69f38e13> in <module>()
----> 1 import hyperspy.models.eelsmodel

.\hyperspy\hyperspy\models\eelsmodel.py in <module>()
     21 import logging
     22
---> 23 from hyperspy.models.model1d import Model1D
     24 from hyperspy.components1d import EELSCLEdge
     25 from hyperspy.components1d import PowerLaw

.\hyperspy\hyperspy\models\model1d.py in <module>()
     24 from hyperspy.model import BaseModel, ModelComponents, ModelSpecialSlicers
     25 import hyperspy.drawing.signal1d
---> 26 from hyperspy._signals.eels import Signal1D
     27 from hyperspy.axes import generate_axis
     28 from hyperspy.exceptions import WrongObjectError

.\hyperspy\hyperspy\_signals\eels.py in <module>()
     26 from scipy import constants
     27
---> 28 from hyperspy.signals import Signal1D
     29 from hyperspy.misc.elements import elements as elements_db
     30 import hyperspy.axes

.\hyperspy\hyperspy\signals.py in <module>()
     43 from hyperspy._signals.complex_signal1d import ComplexSignal1D
     44 from hyperspy._signals.complex_signal2d import ComplexSignal2D
---> 45 from hyperspy._signals.eels import EELSSpectrum
     46 from hyperspy._signals.eds_sem import EDSSEMSpectrum
     47 from hyperspy._signals.eds_tem import EDSTEMSpectrum

ImportError: cannot import name 'EELSSpectrum'
```