### PR TITLE
Fixed Travis badge for RELEASE_next_patch

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -2,11 +2,11 @@
 
 |Travis|_ |AppVeyor|_ |Coveralls|_ |pypi_version|_ |pypi_downloads|_ |rtd|_ |gitter|_
 
-.. |Travis| image:: https://api.travis-ci.org/hyperspy/hyperspy.png?branch=master
+.. |Travis| image:: https://api.travis-ci.org/hyperspy/hyperspy.png?branch=RELEASE_next_minor
 .. _Travis: https://travis-ci.org/hyperspy/hyperspy
 
-.. |AppVeyor| image:: https://ci.appveyor.com/api/projects/status/github/hyperspy/hyperspy?svg=true&branch=master
-.. _AppVeyor: https://ci.appveyor.com/project/hyperspy/hyperspy/branch/master
+.. |AppVeyor| image:: https://ci.appveyor.com/api/projects/status/github/hyperspy/hyperspy?svg=true&branch=RELEASE_next_minor
+.. _AppVeyor: https://ci.appveyor.com/project/hyperspy/hyperspy/branch/RELEASE_next_minor
 
 .. |Coveralls| image:: https://coveralls.io/repos/hyperspy/hyperspy/badge.svg
 .. _Coveralls: https://coveralls.io/r/hyperspy/hyperspy

--- a/README.rst
+++ b/README.rst
@@ -2,11 +2,11 @@
 
 |Travis|_ |AppVeyor|_ |Coveralls|_ |pypi_version|_ |pypi_downloads|_ |rtd|_ |gitter|_
 
-.. |Travis| image:: https://api.travis-ci.org/hyperspy/hyperspy.png?branch=RELEASE_next_minor
+.. |Travis| image:: https://api.travis-ci.org/hyperspy/hyperspy.png?branch=RELEASE_next_patch
 .. _Travis: https://travis-ci.org/hyperspy/hyperspy
 
-.. |AppVeyor| image:: https://ci.appveyor.com/api/projects/status/github/hyperspy/hyperspy?svg=true&branch=RELEASE_next_minor
-.. _AppVeyor: https://ci.appveyor.com/project/hyperspy/hyperspy/branch/RELEASE_next_minor
+.. |AppVeyor| image:: https://ci.appveyor.com/api/projects/status/github/hyperspy/hyperspy?svg=true&branch=RELEASE_next_patch
+.. _AppVeyor: https://ci.appveyor.com/project/hyperspy/hyperspy/branch/RELEASE_next_patch
 
 .. |Coveralls| image:: https://coveralls.io/repos/hyperspy/hyperspy/badge.svg
 .. _Coveralls: https://coveralls.io/r/hyperspy/hyperspy


### PR DESCRIPTION
...which meant the Travis badge looked like the build was failing:

![untitled](https://cloud.githubusercontent.com/assets/6626247/17628680/710130de-60ae-11e6-839e-6ff9e208e75b.png)
