### PR TITLE
Fix post-checkout hook on windows

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,4 @@ doc/log.txt
 *.pyproj
 hyperspy/tests/misc/cython/test_cython_integration.c
 hyperspy/io_plugins/unbcf_fast.c
+hyperspy/misc/etc/test_compilers.obj

--- a/setup.py
+++ b/setup.py
@@ -193,7 +193,10 @@ def find_post_checkout_cleanup_line():
 # generate some git hook to clean up and re-build_ext --inplace
 # after changing branches:
 if os.path.exists(git_dir) and (not os.path.exists(hook_ignorer)):
-    recythonize_str = ' '.join([sys.executable,
+    exec_str = sys.executable
+    if os.name == 'nt':
+        exec_str = exec_str.replace('\\', '/')  # Won't work otherwise
+    recythonize_str = ' '.join([exec_str,
                                 os.path.join(setup_path, 'setup.py'),
                                 'clean --all build_ext --inplace \n'])
     if (not os.path.exists(post_checout_hook_file)):


### PR DESCRIPTION
When writing windows paths to a .sh script, we need to take into account how back slashes are treated by .sh. Only does this on Windows to retain character escaping on other platforms.
