### PR TITLE
Set default log level to NOTSET

### DIFF
--- a/hyperspy/api.py
+++ b/hyperspy/api.py
@@ -80,6 +80,7 @@ from hyperspy import datasets
 from hyperspy.logger import set_log_level
 
 if preferences.General.logging_level == 'NOTSET':
+    import logging
     logging.basicConfig()  # Does nothing if already configured
 else:
     set_log_level(preferences.General.logging_level)

--- a/hyperspy/api.py
+++ b/hyperspy/api.py
@@ -79,7 +79,10 @@ from hyperspy.utils import *
 from hyperspy import datasets
 from hyperspy.logger import set_log_level
 
-set_log_level(preferences.General.logging_level)
+if preferences.General.logging_level == 'NOTSET':
+    logging.basicConfig()  # Does nothing if already configured
+else:
+    set_log_level(preferences.General.logging_level)
 
 
 def get_configuration_directory_path():

--- a/hyperspy/defaults_parser.py
+++ b/hyperspy/defaults_parser.py
@@ -115,7 +115,8 @@ class GeneralConfig(t.HasTraits):
              'metadata), long lists and tuples will be expanded and any '
              'dictionaries in them will be printed similar to '
              'DictionaryTreeBrowser, but with double lines')
-    logging_level = t.Enum(['CRITICAL', 'ERROR', 'WARNING', 'INFO', 'DEBUG', ],
+    logging_level = t.Enum(['CRITICAL', 'ERROR', 'WARNING', 'INFO', 'DEBUG',
+                            'NOTSET'],
                            desc='the log level of all hyperspy modules.')
 
     def _logger_on_changed(self, old, new):
@@ -237,7 +238,7 @@ template = {
 template['MachineLearning'].export_factors_default_file_format = 'rpl'
 template['MachineLearning'].export_loadings_default_file_format = 'rpl'
 template['General'].default_export_format = 'rpl'
-template['General'].logging_level = 'WARNING'
+template['General'].logging_level = 'NOTSET'
 
 # Defaults template definition ends ######################################
 


### PR DESCRIPTION
Currently, hyperspy sets its log level during import, thereby overriding any other log configuration already set for the application/hyperspy. The effect is a lowering of the logging flexibility of hyperspy when used as a library. This PR changes the default to `NOTSET` (which _here_ circumvents the call to `setLevel` all together), which means it will keep its previous value (default: inherit from the root logger, which defaults to `WARNING`). The effective log level will thereby stay the same out of the box, users will retain the ability to change the log level, but it will become more flexible for those that want to use hyperspy as a library.

Example of uses that will change with this PR:

1)

``` python
import logging

logging.basicConfig('INFO')
import hyperspy
```

Previously, this set the application wide logger to `INFO`, and hyperspy would use its own setting from the preferences (`WARNING` by default). Now, this will use `INFO` also for hyperspy, unless the user has explicitly set the preference to something other than `NOTSET`.

2) 

``` python
import logging

logging.basicConfig()  # Setup standard root logger at WARNING level
logging.getLogger('hyperspy').setLevel(logging.DEBUG)

import hyperspy
```

This looks similar to simply importing `set_log_level` from hyperspy, and then calling it with `DEBUG`, but this allows for setting the log level _before_ actually importing `hyperspy.api`, which can be helpful in cases when import order matters.
