### PR TITLE
Implement metadata-aware intensity labels for signal plots

### DIFF
--- a/hyperspy/drawing/image.py
+++ b/hyperspy/drawing/image.py
@@ -262,7 +262,7 @@ class ImagePlot(BlittedFigure):
 
         if self.colorbar is True:
             self._colorbar = plt.colorbar(self.ax.images[0], ax=self.ax)
-            self._colorbar.set_label(self.quantity_label, rotation=-90, labelpad=15.)
+            self._colorbar.set_label(self.quantity_label, rotation=-90, va='bottom')
             self._colorbar.ax.yaxis.set_animated(True)
 
         self.figure.canvas.draw()

--- a/hyperspy/drawing/image.py
+++ b/hyperspy/drawing/image.py
@@ -262,7 +262,7 @@ class ImagePlot(BlittedFigure):
 
         if self.colorbar is True:
             self._colorbar = plt.colorbar(self.ax.images[0], ax=self.ax)
-            self._colorbar.set_label(self.quantity_label)
+            self._colorbar.set_label(self.quantity_label, rotation=-90, labelpad=15.)
             self._colorbar.ax.yaxis.set_animated(True)
 
         self.figure.canvas.draw()

--- a/hyperspy/drawing/image.py
+++ b/hyperspy/drawing/image.py
@@ -69,6 +69,7 @@ class ImagePlot(BlittedFigure):
         self.plot_ticks = False
         self.colorbar = True
         self._colorbar = None
+        self.quantity_label = ''
         self.figure = None
         self.ax = None
         self.title = ''
@@ -261,6 +262,7 @@ class ImagePlot(BlittedFigure):
 
         if self.colorbar is True:
             self._colorbar = plt.colorbar(self.ax.images[0], ax=self.ax)
+            self._colorbar.set_label(self.quantity_label)
             self._colorbar.ax.yaxis.set_animated(True)
 
         self.figure.canvas.draw()

--- a/hyperspy/drawing/mpl_he.py
+++ b/hyperspy/drawing/mpl_he.py
@@ -35,6 +35,7 @@ class MPL_HyperExplorer(object):
         self.axes_manager = None
         self.signal_title = ''
         self.navigator_title = ''
+        self.quantity_label = ''
         self.signal_plot = None
         self.navigator_plot = None
         self.axis = None

--- a/hyperspy/drawing/mpl_hie.py
+++ b/hyperspy/drawing/mpl_hie.py
@@ -70,6 +70,7 @@ class MPL_HyperImage_Explorer(MPL_HyperExplorer):
         imf.title = self.signal_title + " Signal"
         imf.xaxis, imf.yaxis = self.axes_manager.signal_axes
         imf.colorbar = colorbar
+        imf.quantity_label = self.quantity_label
         imf.scalebar = scalebar
         imf.axes_ticks = axes_ticks
         imf.vmin, imf.vmax = vmin, vmax

--- a/hyperspy/drawing/mpl_hse.py
+++ b/hyperspy/drawing/mpl_hse.py
@@ -81,7 +81,7 @@ class MPL_HyperSignal1D_Explorer(MPL_HyperExplorer):
         self.xlabel = '%s' % str(self.axes_manager.signal_axes[0])
         if self.axes_manager.signal_axes[0].units is not Undefined:
             self.xlabel += ' (%s)' % self.axes_manager.signal_axes[0].units
-        self.ylabel = 'Intensity'
+        self.ylabel = self.quantity_label
         self.axis = self.axes_manager.signal_axes[0]
         sf = signal1d.Signal1DFigure(title=self.signal_title +
                                      " Signal")

--- a/hyperspy/signal.py
+++ b/hyperspy/signal.py
@@ -1901,6 +1901,8 @@ class BaseSignal(FancySlicing,
             self._plot.signal_title = self.metadata.General.title
         elif self.tmp_parameters.has_item('filename'):
             self._plot.signal_title = self.tmp_parameters.filename
+        if self.metadata.has_item("Signal.quantity"):
+            self._plot.quantity_label = self.metadata.Signal.quantity
 
         def get_static_explorer_wrapper(*args, **kwargs):
             return navigator()


### PR DESCRIPTION
Fix #1255 

Much like the signal title, the signal's `quantity` is now also passed to the plot assuming it exists.
