### PR TITLE
BUG-FIX: initialise noise type when 'Noise_properties.variance' attribute is missing

### DIFF
--- a/hyperspy/gui/egerton_quantification.py
+++ b/hyperspy/gui/egerton_quantification.py
@@ -324,6 +324,8 @@ class SpikesRemoval(SpanSelectorInSignal1D):
                     self.noise_type = "heteroscedastic"
                 else:
                     self.noise_type = "white"
+            else:
+                self.noise_type = "shot noise"
         else:
             self.noise_type = "shot noise"
 


### PR DESCRIPTION
Following #1240, the signal metadata can have 'Noise_properties' attribute but not the 'Noise_properties.variance' one, which make adding noise in the spikes removal tool failing. For example, this bug occurs with EELS dataset imported from DM files. In this case, this PR sets the assumed noise type, as it's in the case of missing  'Noise_properties' attribute.
