### PR TITLE
Fix bcf reader import error message

### DIFF
--- a/hyperspy/io_plugins/__init__.py
+++ b/hyperspy/io_plugins/__init__.py
@@ -49,14 +49,14 @@ try:
     io_plugins.append(image)
 except ImportError:
     _logger.info('The Signal2D (PIL) IO features are not available')
-    
+
 try:
     from hyperspy.io_plugins import bcf
     io_plugins.append(bcf)
 except ImportError:
-    _logger.warning('The Bruker composite file reader cant be loaded',
-                    'due to lxml library missing. Please install lxml',
-                    'and python bindings, to enable the bcf loader.')
+    _logger.warning('The Bruker composite file reader can not be loaded '
+                    'because the lxml library is not installed. To enable it '
+                    'install the Python lxml package.')
 
 default_write_ext = set()
 for plugin in io_plugins:


### PR DESCRIPTION
Previously it was printing the whole traceback because of the commas after the
quotation marks. This also makes the text more compact.
