### PR TITLE
Fix appending component to model which plots components

### DIFF
--- a/hyperspy/model.py
+++ b/hyperspy/model.py
@@ -481,8 +481,6 @@ class BaseModel(list):
             for parameter in component.parameters:
                 parameter.events.value_changed.connect(
                     self._model_line.update, [])
-        if self._plot_components is True:
-            self._connect_component_lines()
 
     def _disconnect_parameters2update_plot(self, components):
         if self._model_line is None:
@@ -492,8 +490,6 @@ class BaseModel(list):
             for parameter in component.parameters:
                 parameter.events.value_changed.disconnect(
                     self._model_line.update)
-        if self._plot_components is True:
-            self._disconnect_component_lines()
 
     def update_plot(self, *args, **kwargs):
         """Update model plot.

--- a/hyperspy/models/edsmodel.py
+++ b/hyperspy/models/edsmodel.py
@@ -150,7 +150,9 @@ class EDSModel(Model1D):
         if auto_background is True:
             self.add_polynomial_background()
         if auto_add_lines is True:
-            self.add_family_lines()
+            # Will raise an error if no elements are specified, so check:
+            if 'Sample.elements' in self.signal.metadata:
+                self.add_family_lines()
 
     def as_dictionary(self, fullcopy=True):
         dic = super(EDSModel, self).as_dictionary(fullcopy)

--- a/hyperspy/models/model1d.py
+++ b/hyperspy/models/model1d.py
@@ -632,11 +632,11 @@ class Model1D(BaseModel):
             self._plot_component(component)
 
     def disable_plot_components(self):
+        self._plot_components = False
         if self._plot is None:
             return
         for component in self:
             self._disable_plot_component(component)
-        self._plot_components = False
 
     def enable_adjust_position(
             self, components=None, fix_them=True, show_label=True):


### PR DESCRIPTION
The following code reproduces the issue:

``` python
import numpy as np
import hyperspy.api as hs
s = hs.signals.Signal1D(np.random.rand(10, 10, 10))
m = s.create_model()
m.plot()
# This goes fine
m.append(hs.model.components1D.GaussianHF())
m.enable_plot_components()
# This fails:
m.append(hs.model.components1D.GaussianHF())
```

This PR also allows to create an empty EDS model (i.e. without any elements added to signal first) with the default constructor args.
