### PR TITLE
Fix background removal which was broken for EELS and EDX spectra

### DIFF
--- a/hyperspy/_signals/signal1d.py
+++ b/hyperspy/_signals/signal1d.py
@@ -867,7 +867,7 @@ class Signal1D(BaseSignal, CommonSignal1D):
             self, signal_range, background_estimator, fast=True,
             show_progressbar=None):
         from hyperspy.models.model1d import Model1D
-        model = self.create_model()
+        model = Model1D(self)
         model.append(background_estimator)
         background_estimator.estimate_parameters(
             self,


### PR DESCRIPTION
EELS and EDX signals automatically add some components to the model on creation. As a result, the automatically created model for background subtraction was removing a wrong model of the
background. In the case of EELS the error is usually negligible for core-losses but can be significant for low-losses.

Thank you @AndrewHerzing for reporting this issue.
