### PR TITLE
Enhancement: PCA on complex numbers

### DIFF
--- a/hyperspy/learn/mva.py
+++ b/hyperspy/learn/mva.py
@@ -167,7 +167,7 @@ class MVA():
         """
         to_return = None
         # Check if it is the wrong data type
-        if self.data.dtype.char not in ['e', 'f', 'd']:  # If not float
+        if self.data.dtype.char not in ['e', 'f', 'd', 'F', 'D', 'G']:  # If not float
             raise TypeError(
                 'To perform a decomposition the data must be of the float '
                 'type, but the current type is \'{}\'. '

--- a/hyperspy/learn/mva.py
+++ b/hyperspy/learn/mva.py
@@ -170,7 +170,7 @@ class MVA():
         if self.data.dtype.char not in ['e', 'f', 'd', 'g', 'F', 'D', 'G']:  # If not float
             raise TypeError(
                 'To perform a decomposition the data must be of the float '
-                'type, but the current type is \'{}\'. '
+                'or complex type, but the current type is \'{}\'. '
                 'To fix this issue, you can change the type using the '
                 'change_dtype method (e.g. s.change_dtype(\'float64\')) '
                 'and then repeat the decomposition.\n'

--- a/hyperspy/learn/mva.py
+++ b/hyperspy/learn/mva.py
@@ -167,7 +167,7 @@ class MVA():
         """
         to_return = None
         # Check if it is the wrong data type
-        if self.data.dtype.char not in ['e', 'f', 'd', 'F', 'D', 'G']:  # If not float
+        if self.data.dtype.char not in ['e', 'f', 'd', 'g', 'F', 'D', 'G']:  # If not float
             raise TypeError(
                 'To perform a decomposition the data must be of the float '
                 'type, but the current type is \'{}\'. '

--- a/hyperspy/tests/mva/test_decomposition.py
+++ b/hyperspy/tests/mva/test_decomposition.py
@@ -342,3 +342,39 @@ class TestLoadDecompositionResults:
             self.s.save(fname2)
             assert isinstance(
                 self.s.learning_results.decomposition_algorithm, str)
+
+class TestComplexSignalDecomposition:
+
+    def setup_method(self, method):
+        real = np.random.random((8,8))
+        imag = np.random.random((8,8))
+        s_complex_dtype = signals.ComplexSignal1D(real + 1j*imag - 1j*imag)
+        s_real_dtype = signals.ComplexSignal1D(real)
+        s_complex_dtype.decomposition()
+        s_real_dtype.decomposition()
+        self.s_complex_dtype = s_complex_dtype
+        self.s_real_dtype = s_real_dtype
+
+    def test_imaginary_is_zero(self):
+        np.testing.assert_allclose(self.s_complex_dtype.data.imag, 0.0)
+
+    def test_decomposition_independent_of_complex_dtype(self):
+        complex_pca = self.s_complex_dtype.get_decomposition_model(5)
+        real_pca = self.s_real_dtype.get_decomposition_model(5)
+        np.testing.assert_almost_equal((complex_pca - real_pca).data.max(), 0.0)
+
+    def test_first_r_values_of_scree_non_zero(self):
+        """For low-rank matrix by creating a = RandomComplex(m, r) and
+        b = RandomComplex(n, r), then performing PCA on the result of a.b^T
+        (i.e. an m x n matrix).
+        The first r values of scree plot / singular values should be non-zero.
+        """
+        m, n, r = 100, 40, 10
+
+        A = 100*(np.random.random((m,r)) + 1j* np.random.random((m,r)))
+        B = 100*(np.random.random((n,r)) + 1j* np.random.random((n,r)))
+
+        s = signals.ComplexSignal1D(np.dot(A,B.T))
+        s.decomposition()
+        np.testing.assert_almost_equal(
+            s.get_explained_variance_ratio().data[r:].sum(), 0)

--- a/hyperspy/tests/mva/test_decomposition.py
+++ b/hyperspy/tests/mva/test_decomposition.py
@@ -369,10 +369,10 @@ class TestComplexSignalDecomposition:
         (i.e. an m x n matrix).
         The first r values of scree plot / singular values should be non-zero.
         """
-        m, n, r = 100, 40, 10
+        m, n, r = 32, 32, 3
 
-        A = 100*(np.random.random((m,r)) + 1j* np.random.random((m,r)))
-        B = 100*(np.random.random((n,r)) + 1j* np.random.random((n,r)))
+        A = (np.random.random((m,r)) + 1j* np.random.random((m,r)))
+        B = (np.random.random((n,r)) + 1j* np.random.random((n,r)))
 
         s = signals.ComplexSignal1D(np.dot(A,B.T))
         s.decomposition()


### PR DESCRIPTION
With the addition of support for complex numbers in Hyperspy, it would be nice to support decomposition of them as well. 
Application is for instance in Magnetic Resonance Spectroscopy (MRS).

As far as I can tell, scikit already supports complex numbers in PCA, and all that is required for Hyperspy is to add the dtypes to the data dtype check.
