### PR TITLE
NEW: Linear fitting

### DIFF
--- a/hyperspy/model.py
+++ b/hyperspy/model.py
@@ -838,6 +838,13 @@ class BaseModel(list):
                 "odr" performs the optimization using the orthogonal distance
                 regression algorithm. It does not support bounds.
 
+                "linear" performs least-squares fitting using linear regression. It does
+                not support bounds, but should be very fast.
+
+                "non_negative_linear" performs least-squares fitting using linear
+                regression (like "linear") under the constraint that none of the
+                solutions can be negative.
+
                 "Nelder-Mead", "Powell", "CG", "BFGS", "Newton-CG", "L-BFGS-B"
                 and "TNC" are wrappers for scipy.optimize.minimize(). Only
                 "L-BFGS-B" and "TNC" support bounds.

--- a/hyperspy/model.py
+++ b/hyperspy/model.py
@@ -27,10 +27,9 @@ import numpy as np
 import scipy
 import scipy.odr as odr
 from scipy.optimize import (leastsq, least_squares,
-                            minimize, differential_evolution)
+                            minimize, differential_evolution, nnls)
 from scipy.linalg import svd
 from numpy.linalg import lstsq as linear
-from scipy.optimize import nnls
 
 from contextlib import contextmanager
 

--- a/hyperspy/model.py
+++ b/hyperspy/model.py
@@ -1065,7 +1065,7 @@ class BaseModel(list):
 
             elif fitter == "linear":
                 signal_axis = self.axis.axis[np.where(self.channel_switches)]
-                component_data = np.array([component.function(signal_axis) /
+                component_data = np.array([component.function(signal_axis) \
                                            for component in self if len(component.free_parameters) > 0])
                 output = linear(component_data.T, self.signal()[np.where(self.channel_switches)], **kwargs)
 
@@ -1074,7 +1074,7 @@ class BaseModel(list):
 
             elif fitter == "non_negative_linear":
                 signal_axis = self.axis.axis[np.where(self.channel_switches)]
-                component_data = np.array([component.function(signal_axis) /
+                component_data = np.array([component.function(signal_axis) \
                                            for component in self if len(component.free_parameters) > 0])
                 output = nnls(component_data.T, self.signal()[np.where(self.channel_switches)], **kwargs)
 

--- a/hyperspy/model.py
+++ b/hyperspy/model.py
@@ -863,7 +863,7 @@ class BaseModel(list):
         method : {'ls', 'ml'}
             Choose 'ls' (default) for least-squares and 'ml' for Poisson
             maximum likelihood estimation. The latter is not available when
-            'fitter' is "leastsq", "odr" or "mpfit".
+            'fitter' is "leastsq", "odr", "mpfit", "linear" or "non_negative_linear".
         grad : bool
             If True, the analytical gradient is used if defined to
             speed up the optimization.


### PR DESCRIPTION
I've added support for both linear and non-negative linear fitting of components.
Example notebook here: https://nbviewer.jupyter.org/urls/dl.dropbox.com/s/t091ahzuduzrct6/Linear%20Fitting.ipynb

The fit from the normal non-linear `leastsq` is a little bit different, and in the notebook case the nonlinear one seems better. There was some discussion online about the tails of the gaussian making the fit unstable, and it being better to fit around the central part of the gaussians. Not sure how to go about doing that.
There's also a chance that there are better ways of doing this.

I'd like to get this working, and then talk about ways of having hyperspy be a bit smarter about which fit is chosen by default.

To Do:

- [ ] Create a system for checking if components are linear
- [ ] Optimise function
- [ ] Tests