### PR TITLE
Updated docs to include "output_dimension" under NMF

### DIFF
--- a/doc/user_guide/mva.rst
+++ b/doc/user_guide/mva.rst
@@ -235,6 +235,11 @@ can be accessed in HyperSpy with:
 Unlike PCA, NMF forces the components to be strictly non-negative, which can aid
 the physical interpretation of components for count data such as images, EELS or EDS.
 
+NMF takes the optional argument "output_dimension", which determines the number
+of components to keep. Setting this to a small number is recommended to keep
+the computation time small. Often it is useful to run a PCA decomposition first
+and use the scree plot to determine a value for "output_dimension".
+
 Blind Source Separation
 =======================
 


### PR DESCRIPTION
In scikit-learn, NMF takes the optional argument `n_components`, with a default value of `None` meaning all features are kept. For a large matrix this can be **very slow**, so it's worth pointing out `output_dimension` can be set to a small number of components in the docs.

As per discussion here: 
https://gitter.im/hyperspy/hyperspy?at=582e06798409125b1e5468c9