### PR TITLE
BUG-FIX: Deprecated axes.color_cycle to axes.prop_cycle

### DIFF
--- a/hyperspy/_signals/eds.py
+++ b/hyperspy/_signals/eds.py
@@ -20,6 +20,7 @@ import logging
 
 import numpy as np
 import warnings
+import matplotlib
 from matplotlib import pyplot as plt
 from distutils.version import StrictVersion
 

--- a/hyperspy/_signals/eds.py
+++ b/hyperspy/_signals/eds.py
@@ -980,7 +980,7 @@ class EDSSpectrum(Signal1D):
         """
         per_xray = len(position[0])
         colors = itertools.cycle(np.sort(
-            plt.rcParams['axes.prop_cycle'] * per_xray))
+            plt.rcParams['axes.prop_cycle'].by_key()["color"] * per_xray))
         for x, color in zip(np.ravel(position), colors):
             line = markers.vertical_line(x=x, color=color, **kwargs)
             self.add_marker(line)

--- a/hyperspy/_signals/eds.py
+++ b/hyperspy/_signals/eds.py
@@ -981,7 +981,7 @@ class EDSSpectrum(Signal1D):
             keywords argument for markers.vertical_line
         """
         per_xray = len(position[0])
-        if StrictVersion(matplotlib.__version__) <= "1.5.3":
+        if StrictVersion(matplotlib.__version__) >= "1.5.3":
             colors = itertools.cycle(np.sort(
                 plt.rcParams['axes.prop_cycle'].by_key()["color"] * per_xray))
         else:

--- a/hyperspy/_signals/eds.py
+++ b/hyperspy/_signals/eds.py
@@ -979,8 +979,12 @@ class EDSSpectrum(Signal1D):
             keywords argument for markers.vertical_line
         """
         per_xray = len(position[0])
-        colors = itertools.cycle(np.sort(
-            plt.rcParams['axes.prop_cycle'].by_key()["color"] * per_xray))
+        if StrictVersion(matplotlib.__version__) <= 1.5.1:
+            colors = itertools.cycle(np.sort(
+                plt.rcParams['axes.prop_cycle'].by_key()["color"] * per_xray))
+        else:
+            colors = itertools.cycle(np.sort(
+                plt.rcParams['axes.color_cycle'] * per_xray))
         for x, color in zip(np.ravel(position), colors):
             line = markers.vertical_line(x=x, color=color, **kwargs)
             self.add_marker(line)

--- a/hyperspy/_signals/eds.py
+++ b/hyperspy/_signals/eds.py
@@ -21,6 +21,7 @@ import logging
 import numpy as np
 import warnings
 from matplotlib import pyplot as plt
+from distutils.version import StrictVersion
 
 from hyperspy import utils
 from hyperspy._signals.signal1d import Signal1D

--- a/hyperspy/_signals/eds.py
+++ b/hyperspy/_signals/eds.py
@@ -980,7 +980,7 @@ class EDSSpectrum(Signal1D):
         """
         per_xray = len(position[0])
         colors = itertools.cycle(np.sort(
-            plt.rcParams['axes.color_cycle'] * per_xray))
+            plt.rcParams['axes.prop_cycle'] * per_xray))
         for x, color in zip(np.ravel(position), colors):
             line = markers.vertical_line(x=x, color=color, **kwargs)
             self.add_marker(line)

--- a/hyperspy/_signals/eds.py
+++ b/hyperspy/_signals/eds.py
@@ -980,7 +980,7 @@ class EDSSpectrum(Signal1D):
             keywords argument for markers.vertical_line
         """
         per_xray = len(position[0])
-        if StrictVersion(matplotlib.__version__) <= 1.5.1:
+        if StrictVersion(matplotlib.__version__) <= "1.5.3":
             colors = itertools.cycle(np.sort(
                 plt.rcParams['axes.prop_cycle'].by_key()["color"] * per_xray))
         else:

--- a/hyperspy/drawing/utils.py
+++ b/hyperspy/drawing/utils.py
@@ -1049,7 +1049,7 @@ def plot_spectra(
             raise ValueError("Color must be None, a valid matplotlib color "
                              "string or a list of valid matplotlib colors.")
     else:
-        if StrictVersion(mpl.__version__) <= "1.5.3":
+        if StrictVersion(mpl.__version__) >= "1.5.3":
             color = itertools.cycle(plt.rcParams['axes.prop_cycle'].by_key()["color"])
         else:
             color = itertools.cycle(plt.rcParams['axes.color_cycle'])

--- a/hyperspy/drawing/utils.py
+++ b/hyperspy/drawing/utils.py
@@ -1049,7 +1049,7 @@ def plot_spectra(
             raise ValueError("Color must be None, a valid matplotlib color "
                              "string or a list of valid matplotlib colors.")
     else:
-        if StrictVersion(matplotlib.__version__) <= 1.5.1:
+        if StrictVersion(matplotlib.__version__) <= "1.5.1":
             color = itertools.cycle(plt.rcParams['axes.prop_cycle'].by_key()["color"])
         else:
             color = itertools.cycle(plt.rcParams['axes.color_cycle'])

--- a/hyperspy/drawing/utils.py
+++ b/hyperspy/drawing/utils.py
@@ -1049,7 +1049,7 @@ def plot_spectra(
             raise ValueError("Color must be None, a valid matplotlib color "
                              "string or a list of valid matplotlib colors.")
     else:
-        if StrictVersion(matplotlib.__version__) <= "1.5.1":
+        if StrictVersion(matplotlib.__version__) <= "1.5.3":
             color = itertools.cycle(plt.rcParams['axes.prop_cycle'].by_key()["color"])
         else:
             color = itertools.cycle(plt.rcParams['axes.color_cycle'])

--- a/hyperspy/drawing/utils.py
+++ b/hyperspy/drawing/utils.py
@@ -1048,7 +1048,7 @@ def plot_spectra(
             raise ValueError("Color must be None, a valid matplotlib color "
                              "string or a list of valid matplotlib colors.")
     else:
-        color = itertools.cycle(plt.rcParams['axes.prop_cycle'])
+        color = itertools.cycle(plt.rcParams['axes.prop_cycle'].by_key()["color"])
 
     if line_style is not None:
         if isinstance(line_style, str):

--- a/hyperspy/drawing/utils.py
+++ b/hyperspy/drawing/utils.py
@@ -26,6 +26,7 @@ import numpy as np
 import matplotlib.pyplot as plt
 import matplotlib as mpl
 import hyperspy as hs
+from distutils.version import StrictVersion
 
 from hyperspy.defaults_parser import preferences
 
@@ -1048,7 +1049,10 @@ def plot_spectra(
             raise ValueError("Color must be None, a valid matplotlib color "
                              "string or a list of valid matplotlib colors.")
     else:
-        color = itertools.cycle(plt.rcParams['axes.prop_cycle'].by_key()["color"])
+        if StrictVersion(matplotlib.__version__) <= 1.5.1:
+            color = itertools.cycle(plt.rcParams['axes.prop_cycle'].by_key()["color"])
+        else:
+            color = itertools.cycle(plt.rcParams['axes.color_cycle'])
 
     if line_style is not None:
         if isinstance(line_style, str):

--- a/hyperspy/drawing/utils.py
+++ b/hyperspy/drawing/utils.py
@@ -1048,7 +1048,7 @@ def plot_spectra(
             raise ValueError("Color must be None, a valid matplotlib color "
                              "string or a list of valid matplotlib colors.")
     else:
-        color = itertools.cycle(plt.rcParams['axes.color_cycle'])
+        color = itertools.cycle(plt.rcParams['axes.prop_cycle'])
 
     if line_style is not None:
         if isinstance(line_style, str):

--- a/hyperspy/drawing/utils.py
+++ b/hyperspy/drawing/utils.py
@@ -1049,7 +1049,7 @@ def plot_spectra(
             raise ValueError("Color must be None, a valid matplotlib color "
                              "string or a list of valid matplotlib colors.")
     else:
-        if StrictVersion(matplotlib.__version__) <= "1.5.3":
+        if StrictVersion(mpl.__version__) <= "1.5.3":
             color = itertools.cycle(plt.rcParams['axes.prop_cycle'].by_key()["color"])
         else:
             color = itertools.cycle(plt.rcParams['axes.color_cycle'])


### PR DESCRIPTION
The two cases of `plt.rcParams['axes.color_cycle']` have been replaced by `plt.rcParams['axes.prop_cycle'].by_key()["color"]`, as matplotlib warns that the former has been deprecated.

This pull request updates the code, and has been tested to work.


```python
>>> plt.rcParams['axes.color_cycle']
['b', 'g', 'r', 'c', 'm', 'y', 'k']
>>> plt.rcParams['axes.prop_cycle']
# Fancy output of type cycler.Cycler
'color'
'b'
'g'
'r'
'c'
'm'
'y'
'k'
>>>plt.rcParams['axes.prop_cycle'].by_key()["color"]
['b', 'g', 'r', 'c', 'm', 'y', 'k']