### PR TITLE
BUGFIX: checks dtype of map results before writing back

### DIFF
--- a/hyperspy/_signals/signal1d.py
+++ b/hyperspy/_signals/signal1d.py
@@ -172,8 +172,10 @@ def find_peaks_ohaver(y, x=None, slope_thresh=0., amp_thresh=None,
                         c1 = coef[2]
                         c2 = coef[1]
                         c3 = coef[0]
-                        width = np.linalg.norm(
-                            stdev * 2.35703 / (np.sqrt(2) * np.sqrt(-1 * c3)))
+                        with np.errstate(invalid='ignore'):
+                            width = np.linalg.norm(stdev * 2.35703 /
+                                                   (np.sqrt(2) * np.sqrt(-1 *
+                                                                         c3)))
                         # if the peak is too narrow for least-squares
                         # technique to work  well, just use the max value
                         # of y in the sub-group of points near peak.

--- a/hyperspy/signal.py
+++ b/hyperspy/signal.py
@@ -3451,7 +3451,8 @@ class BaseSignal(FancySlicing,
             res_data = np.stack(res_data.flat).reshape(nav_shape + sig_shape)
             if inplace:
                 sig = self # the modified thing
-                if self.data.shape == res_data.shape:
+                if (self.data.shape == res_data.shape and
+                        np.can_cast(res_data.dtype, self.data.dtype)):
                     self.data[:] = res_data
                 else:
                     self.data = res_data

--- a/hyperspy/tests/signal/test_1D_tools.py
+++ b/hyperspy/tests/signal/test_1D_tools.py
@@ -276,7 +276,7 @@ class TestSmoothing:
             raise SkipTest
         frac = 0.5
         it = 1
-        data = self.s.data.copy()
+        data = self.s.data.astype('float')
         for i in range(data.shape[0]):
             data[i, :] = lowess(
                 endog=data[i, :],
@@ -292,7 +292,7 @@ class TestSmoothing:
 
     def test_tv(self):
         weight = 1
-        data = self.s.data.copy()
+        data = self.s.data.astype('float')
         for i in range(data.shape[0]):
             data[i, :] = _tv_denoise_1d(
                 im=data[i, :],

--- a/hyperspy/tests/signal/test_map_method.py
+++ b/hyperspy/tests/signal/test_map_method.py
@@ -113,6 +113,13 @@ class TestSignal1D:
                   [3.42207377, 4., 4.57792623]])))
             nt.assert_true(m.data_changed.called)
 
+    def test_dtype(self):
+        ss = self.s.deepcopy()
+        for s, t in zip([self.s, ss], [False, True]):
+            s.map(lambda data: np.sqrt(np.complex128(data)),
+                  show_progressbar=None,
+                  parallel=t)
+            nt.assert_is(s.data.dtype, np.dtype('complex128'))
 
 class TestSignal0D:
 


### PR DESCRIPTION
fixes https://github.com/hyperspy/hyperspy/issues/1351

PR'ed to `next_minor` because the feature being fixed is not yet in the current release / `patch` branch.