### PR TITLE
enh-test: bare min travis environment

### DIFF
--- a/hyperspy/misc/utils.py
+++ b/hyperspy/misc/utils.py
@@ -431,8 +431,9 @@ class DictionaryTreeBrowser(object):
         else:
             return False
 
-    def get_item(self, item_path):
-        """Given a path, return True if it exists.
+    def get_item(self, item_path, default=None):
+        """Given a path, return it's value if it exists, or default
+        value if missing.
 
         The nodes of the path are separated using periods.
 
@@ -441,6 +442,9 @@ class DictionaryTreeBrowser(object):
         item_path : Str
             A string describing the path with each item separated by
             full stops (periods)
+        default :
+            The value to return if the path does not exist.
+
 
         Examples
         --------
@@ -466,11 +470,11 @@ class DictionaryTreeBrowser(object):
             else:
                 item = self[attrib]
                 if isinstance(item, type(self)):
-                    return item.get_item(item_path)
+                    return item.get_item(item_path, default)
                 else:
-                    raise AttributeError("Item not in dictionary browser")
+                    return default
         else:
-            raise AttributeError("Item not in dictionary browser")
+            return default
 
     def __contains__(self, item):
         return self.has_item(item_path=item)

--- a/hyperspy/tests/test_dictionary_tree_browser.py
+++ b/hyperspy/tests/test_dictionary_tree_browser.py
@@ -126,3 +126,42 @@ class TestDictionaryBrowser:
         # time in the DictionaryBrowser
         dt_str = '2016-08-05T10:13:15.450580'
         self._test_date_time(dt_str)
+
+    def test_has_item(self):
+        # Check that it finds all actual items:
+        assert self.tree.has_item('Node1')
+        assert self.tree.has_item('Node1.leaf11')
+        assert self.tree.has_item('Node1.Node11')
+        assert self.tree.has_item('Node1.Node11.leaf111')
+        assert self.tree.has_item('Node2')
+        assert self.tree.has_item('Node2.leaf21')
+        assert self.tree.has_item('Node2.Node21')
+        assert self.tree.has_item('Node2.Node21.leaf211')
+
+        # Check that it doesn't find non-existant ones
+        assert not self.tree.has_item('Node3')
+        assert not self.tree.has_item('General')
+        assert not self.tree.has_item('Node1.leaf21')
+        assert not self.tree.has_item('')
+        assert not self.tree.has_item('.')
+        assert not self.tree.has_item('..Node1')
+
+    def test_get_item(self):
+        # Check that it gets all leaf nodes:
+        nt.assert_equal(self.tree.get_item('Node1.leaf11'), 11)
+        nt.assert_equal(self.tree.get_item('Node1.Node11.leaf111'), 111)
+        nt.assert_equal(self.tree.get_item('Node2.leaf21'), 21)
+        nt.assert_equal(self.tree.get_item('Node2.Node21.leaf211'), 211)
+
+        # Check that it gets all leaf nodes, also with given default:
+        nt.assert_equal(self.tree.get_item('Node1.leaf11', 44), 11)
+        nt.assert_equal(self.tree.get_item('Node1.Node11.leaf111', 44), 111)
+        nt.assert_equal(self.tree.get_item('Node2.leaf21', 44), 21)
+        nt.assert_equal(self.tree.get_item('Node2.Node21.leaf211', 44), 211)
+
+        # Check that it returns the default value for various incorrect paths:
+        nt.assert_equal(self.tree.get_item('Node1.leaf33', 44), 44)
+        nt.assert_equal(self.tree.get_item('Node1.leaf11.leaf111', 44), 44)
+        nt.assert_equal(self.tree.get_item('Node1.Node31.leaf311', 44), 44)
+        nt.assert_equal(self.tree.get_item('Node1.Node21.leaf311', 44), 44)
+        nt.assert_equal(self.tree.get_item('.Node1.Node21.leaf311', 44), 44)

--- a/setup.py
+++ b/setup.py
@@ -194,11 +194,14 @@ def find_post_checkout_cleanup_line():
 # after changing branches:
 if os.path.exists(git_dir) and (not os.path.exists(hook_ignorer)):
     exec_str = sys.executable
-    if os.name == 'nt':
-        exec_str = exec_str.replace('\\', '/')  # Won't work otherwise
     recythonize_str = ' '.join([exec_str,
                                 os.path.join(setup_path, 'setup.py'),
-                                'clean --all build_ext --inplace \n'])
+                                'clean --all build_ext --inplace\n'])
+    if os.name == 'nt':
+        exec_str = exec_str.replace('\\', '/')
+        recythonize_str = recythonize_str.replace('\\', '/')
+        for i in range(len(cleanup_list)):
+            cleanup_list[i] = cleanup_list[i].replace('\\', '/')
     if (not os.path.exists(post_checout_hook_file)):
         with open(post_checout_hook_file, 'w') as pchook:
             pchook.write('#!/bin/sh\n')
@@ -217,9 +220,9 @@ if os.path.exists(git_dir) and (not os.path.exists(hook_ignorer)):
                     ' '.join([i for i in cleanup_list]) + '\n'
                 hook_lines[line_n + 1] = recythonize_str
             else:
-                hook_lines.append('\n#cleanup_cythonized_and_compiled:')
+                hook_lines.append('\n#cleanup_cythonized_and_compiled:\n')
                 hook_lines.append(
-                    '\nrm ' + ' '.join([i for i in cleanup_list]) + '\n')
+                    'rm ' + ' '.join([i for i in cleanup_list]) + '\n')
                 hook_lines.append(recythonize_str)
             with open(post_checout_hook_file, 'w') as pchook:
                 pchook.writelines(hook_lines)


### PR DESCRIPTION
This addresses: #1146

This adds additional travis linux environment
to the matrix which:
* does not install conda
* does not install cython, lxml, and anything which is not in setup dependency.
* uses available system `python3` and mimics most close the
  fresh installation using system available `pip3`.

Why it is needed?
on one side:
* hyperspy is available through pip
* documentation declares that it is one of the way to install it using pip.

on the other side:
* it does not work so perfectly if tried on fresh non-conda system
* some of the requirements are declared to be optional, but it's optionality is ignored in some
of tests and parts of hyperspy.

TASKS:

- [x] modify the `.travis.yml` to include one more matrix element, which tries to install hyperspy without conda.
- [x] fix the build/test/execution failures resulting from treating some libraries as (or not treating as) optional (contribution of fixes are more than welcome), either code should be fixed or, either the libraries should be included to dependencies list!

Things to fix:
- [x] `fast_svd` import error
- [ ] is `skimage` optional or not? lookign at signal class it is not, however it is missing in the dependency of setup.