### PR TITLE
Fix nb interaction test

### DIFF
--- a/hyperspy/tests/model/test_model.py
+++ b/hyperspy/tests/model/test_model.py
@@ -327,7 +327,7 @@ class TestModel1D:
         m.append(hs.model.components1D.Offset())
         m[0].notebook_interaction()
         m[0].offset.notebook_interaction()
-        
+
     def test_access_component_by_name(self):
         m = self.model
         g1 = hs.model.components1D.Gaussian()

--- a/hyperspy/tests/model/test_model.py
+++ b/hyperspy/tests/model/test_model.py
@@ -318,12 +318,16 @@ class TestModel1D:
         if LooseVersion(ipywidgets.__version__) < LooseVersion("5.0"):
             raise SkipTest("ipywigets > 5.0 required but %s installed" %
                            ipywidgets.__version__)
+        from IPython import get_ipython
+        ip = get_ipython()
+        if ip is None or not getattr(ip, 'kernel', None):
+            raise SkipTest("Not attached to notebook")
         m = self.model
         m.notebook_interaction()
         m.append(hs.model.components1D.Offset())
         m[0].notebook_interaction()
         m[0].offset.notebook_interaction()
-
+        
     def test_access_component_by_name(self):
         m = self.model
         g1 = hs.model.components1D.Gaussian()


### PR DESCRIPTION
The `notebook_interaction_test` is not passing with `ipykernel > 4.5` when not attached to a notebook. This fix skips the test when that's the case. See ipython/ipykernel#210.