### PR TITLE
Fixes #1344

### DIFF
--- a/hyperspy/learn/mva.py
+++ b/hyperspy/learn/mva.py
@@ -675,6 +675,7 @@ class MVA():
         self._unmix_components()
         self._auto_reverse_bss_component(lr)
         lr.bss_algorithm = algorithm
+        lr.bss_node = str(lr.bss_node)
 
     def normalize_decomposition_components(self, target='factors',
                                            function=np.sum):


### PR DESCRIPTION
Simply store the string representation of the BSS computing object instead of the object itself. As it is not used anywhere else in the code this is enough for log purposes.