### PR TITLE
Fix s.split()

### DIFF
--- a/doc/user_guide/getting_started.rst
+++ b/doc/user_guide/getting_started.rst
@@ -221,8 +221,8 @@ in the Signal2D subclass.
     >>> im
     <Signal2D, title: , dimensions: (30|20, 10)>
 
-Note the HyperSpy rearranges the axes when compared to the array order. It does
-so due to a couple of things that all contribute:
+Note that HyperSpy rearranges the axes when compared to the array order. It
+does this for several reasons:
 
 
 - Depending how the array is arranged, some axes are faster to iterate than
@@ -236,15 +236,16 @@ so due to a couple of things that all contribute:
   data (most often for plotting, but applies for any other operation too), you
   want to keep it ordered for "fast access".
 
-- In python (more explicitly `numpy`) the "fast axes order" is the C-order.
-  This means that the **last** axis of a numpy array is fastest to iterate over
-  (i.e. the lines in the book). There are alternatives in other languages,
-  namely the F (for Fortran)-order, where it's the reverse - the first axis of
-  an array is the fastest to iterate over. Usually in all implementations
-  iterating over some axis in the middle is slow, as you have to "pick the same
-  line from all pages", or something similar.
+- In Python (more explicitly `numpy`) the "fast axes order" is C order (also
+  called row-major order). This means that the **last** axis of a numpy array
+  is fastest to iterate over (i.e. the lines in the book). There are
+  alternatives in other languages, namely F order (column-major), where it is
+  the reverse - the first axis of an array is the fastest to iterate over.
+  Usually in all implementations iterating over some axis in the middle is
+  slow, as you have to "pick the same line from all pages", or something
+  similar.
 
-- Most datasets are recorded in the C-order. Taking EDS / EELS map as an
+- Most datasets are recorded in C order. Taking an EDS / EELS map as an
   example, the dataset has three dimensions/axes - the fast, and slow
   real-space, and the energy channels. Thinking how the microscope works,
   it's obvious that the energy axis is the fastest, then the x, and finally
@@ -252,16 +253,15 @@ so due to a couple of things that all contribute:
   (y, x, E). If this was a SPED dataset, it would be recorded in (y_real,
   x_real, y_recip, x_recip) with real and reciprocal spaces respectively.
 
-- In HyperSpy we want to order these things for humans. **Which means x axis
+- In HyperSpy we want to order these things for humans, namely **the x axis
   goes before y**. For EDS/EELS we go from (y, x, E) to `<x, y | E>` in
   HyperSpy, and for SPED from (y2, x2, y1, x1) to `<x2, y2 | x1, y1>`. So
-  actually the axes that are "close" in last example are not y2 and x1,
-  but x2 and y1, even though in HyperSpy these look to be on the opposite
-  ends.
+  actually the axes that are "close" in the last example are not y2 and x1,
+  but x2 and y1, even though in HyperSpy these appear to be at opposite ends.
 
 - Extending this to arbitrary dimensions, we essentially reverse the numpy
   axes, chop it into two chunks (signal and navigation), and then swap those
-  chunks, at least when printing. In example, this happens:
+  chunks, at least when printing. As an example:
 
 .. code-block:: bash
     (a1, a2, a3, a4, a5, a6) # original (numpy)
@@ -270,11 +270,12 @@ so due to a couple of things that all contribute:
     (a4, a3, a2, a1) (a6, a5) # swap (HyperSpy)
 
 - When `as_signal*D` is called, it really just calls `transpose` with
-  `optimize=True`. The `optimize` argument means that if the user happened to
-  request to read the book in the way where one word with 5 letters requires to
-  look at 5 different pages, then HyperSpy (`numpy`) **rewrites** the book so
-  that they are actually in lines now.  This obviously creates a new book (copy
-  of data, more memory, etc.), but it's fast to read!
+  `optimize=True`. The `optimize` argument means that if the user happens to
+  request to read the book such that one word with 5 letters requires looking
+  at 5 different pages, then HyperSpy (`numpy`) will **rewrite** the book so
+  that they are actually in lines now.  This will obviously create a new book
+  (i.e.. a copy of the data requiring more memory), but it will be faster to
+  read!
 
 This is the order used for :ref:`indexing the BaseSignal class <signal.indexing>`.
 

--- a/doc/user_guide/getting_started.rst
+++ b/doc/user_guide/getting_started.rst
@@ -269,17 +269,10 @@ chunks, at least when printing. As an example:
     (a6, a5) (a4, a3, a2, a1) # chop
     (a4, a3, a2, a1) (a6, a5) # swap (HyperSpy)
 
+In the background, HyperSpy also takes care of storing the data in memory in
+a "machine-friendly" way, so that iterating over the navigation axes is always
+fast.
 
-
-- When `as_signal*D` is called, it really just calls `transpose` with
-  `optimize=True`. The `optimize` argument means that if the user happens to
-  request to read the book such that one word with 5 letters requires looking
-  at 5 different pages, then HyperSpy (`numpy`) will **rewrite** the book so
-  that they are actually in lines now.  This will obviously create a new book
-  (i.e.. a copy of the data requiring more memory), but it will be faster to
-  read!
-
-This is the order used for :ref:`indexing the BaseSignal class <signal.indexing>`.
 
 .. _Setting_axis_properties:
 

--- a/doc/user_guide/getting_started.rst
+++ b/doc/user_guide/getting_started.rst
@@ -228,9 +228,9 @@ Depending how the array is arranged, some axes are faster to iterate than
 others. Consider an example of a book as the dataset in question. It is
 trivially simple to look at letters in a line, and then lines down the page,
 and finally pages in the whole book.  However if your words are written
-vertically, it's slightly inconvenient to read top-down (the lines are still
-horizontal, it's just the meaning that's vertical!). It's just awful if
-every letter is on a different page, and for every word you have to turn 5-6
+vertically, it can be inconvenient to read top-down (the lines are still
+horizontal, it's just the meaning that's vertical!). It's very time-consuming
+if every letter is on a different page, and for every word you have to turn 5-6
 pages. Exactly the same idea applies here - in order to iterate through the
 data (most often for plotting, but applies for any other operation too), you
 want to keep it ordered for "fast access".
@@ -238,30 +238,29 @@ want to keep it ordered for "fast access".
 In Python (more explicitly `numpy`) the "fast axes order" is C order (also
 called row-major order). This means that the **last** axis of a numpy array is
 fastest to iterate over (i.e. the lines in the book). An alternative ordering
-convention is the F order (column-major), where it is the reverse - the first
-axis of an array is the fastest to iterate over. In both cases, the further an
-axis is from the `fast axis` the slower it  is to iterate over it. In the book
-analogy you could think, for example, on reading the first lines of all pages,
-then the second and so on.
+convention is F order (column-major), where it is the reverse - the first axis
+of an array is the fastest to iterate over. In both cases, the further an axis
+is from the `fast axis` the slower it  is to iterate over it. In the book
+analogy you could think, for example, think about reading the first lines of
+all pages, then the second and so on.
 
-When data is acquired sequentially it is usually stored in acquisition
-order.When a dataset is loaded, HyperSpy generally stores in memory in the same
-order, which is good for the computer. However, HyperSpy aims at making things
-easy for humans, so it reorders and classify the axes for them.
-Let's imagine a single numpy array that contains
-pictures of a scene acquired with different exposure times on different days. In
-numpy the array dimensions are  ``(D, E, Y, X)``. This order makes it fast to
-iterate over the images in the order in which they were acquired. From a human
-point of view, this dataset is just a collection of images, so HyperSpy first
-classifies the image axes (X and Y) as `signal axes` and the remaining axes the
-`navigation axes`. The it reverses the order of each sets of axes because many
-humans are used to get the `X` axis first and, more generally the axes in
-acquisition order from left to right. So, the same axes in HyperSpy are
-displayed like this: (E, D | X, Y).
+When data is acquired sequentially it is usually stored in acquisition order.
+When a dataset is loaded, HyperSpy generally stores it in memory in the same
+order, which is good for the computer. However, HyperSpy will reorder and
+classify the axes to make it easier for humans. Let's imagine a single numpy
+array that contains pictures of a scene acquired with different exposure times
+on different days. In numpy the array dimensions are  ``(D, E, Y, X)``. This
+order makes it fast to iterate over the images in the order in which they were
+acquired. From a human point of view, this dataset is just a collection of
+images, so HyperSpy first classifies the image axes (X and Y) as `signal axes`
+and the remaining axes the `navigation axes`. The it reverses the order of each
+sets of axes because many humans are used to get the `X` axis first and, more
+generally the axes in acquisition order from left to right. So, the same axes
+in HyperSpy are displayed like this: (E, D | X, Y).
 
-Extending this to arbitrary dimensions, by default, we reverse the numpy
-axes, chop it into two chunks (signal and navigation), and then swap those
-chunks, at least when printing. As an example:
+Extending this to arbitrary dimensions, by default, we reverse the numpy axes,
+chop it into two chunks (signal and navigation), and then swap those chunks, at
+least when printing. As an example:
 
 .. code-block:: bash
     (a1, a2, a3, a4, a5, a6) # original (numpy)

--- a/doc/user_guide/getting_started.rst
+++ b/doc/user_guide/getting_started.rst
@@ -252,11 +252,11 @@ array that contains pictures of a scene acquired with different exposure times
 on different days. In numpy the array dimensions are  ``(D, E, Y, X)``. This
 order makes it fast to iterate over the images in the order in which they were
 acquired. From a human point of view, this dataset is just a collection of
-images, so HyperSpy first classifies the image axes (X and Y) as `signal axes`
-and the remaining axes the `navigation axes`. The it reverses the order of each
-sets of axes because many humans are used to get the `X` axis first and, more
-generally the axes in acquisition order from left to right. So, the same axes
-in HyperSpy are displayed like this: (E, D | X, Y).
+images, so HyperSpy first classifies the image axes (``X`` and ``Y``) as
+`signal axes` and the remaining axes the `navigation axes`. Then it reverses the
+order of each sets of axes because many humans are used to get the ``X`` axis
+first and, more generally the axes in acquisition order from left to right. So,
+the same axes in HyperSpy are displayed like this: ``(E, D | X, Y)``.
 
 Extending this to arbitrary dimensions, by default, we reverse the numpy axes,
 chop it into two chunks (signal and navigation), and then swap those chunks, at

--- a/doc/user_guide/getting_started.rst
+++ b/doc/user_guide/getting_started.rst
@@ -245,21 +245,26 @@ does this for several reasons:
   slow, as you have to "pick the same line from all pages", or something
   similar.
 
-- Most datasets are recorded in C order. Taking an EDS / EELS map as an
-  example, the dataset has three dimensions/axes - the fast, and slow
-  real-space, and the energy channels. Thinking how the microscope works,
-  it's obvious that the energy axis is the fastest, then the x, and finally
-  the y is the slow axis. To record it in C-order, it is stored in an array
-  (y, x, E). If this was a SPED dataset, it would be recorded in (y_real,
-  x_real, y_recip, x_recip) with real and reciprocal spaces respectively.
+- When a dataset is loaded, HyperSpy generally stores the data in a `numpy`
+  array in C order. Consider the book example again. We have three dimensions
+  in this "dataset" - horizontal lines (X), vertical columns (Y) and pages in
+  the book (P). These dimensions also clearly can be
+  arranged in order by how quickly one can read one full dimension - X being the
+  fastest (reading a line of text is nearly effortless), Y taking some getting
+  used to, and finally P being slowest and the least comfortable. To record
+  such dataset in C order (last is fastest), we arrange the axes in (P, Y,
+  X) order. If we had a full library of books (another axis, B), this would
+  extend to (B, P, Y, X).
 
 - In HyperSpy we want to order these things for humans, namely **the x axis
-  goes before y**. For EDS/EELS we go from (y, x, E) to `<x, y | E>` in
-  HyperSpy, and for SPED from (y2, x2, y1, x1) to `<x2, y2 | x1, y1>`. So
-  actually the axes that are "close" in the last example are not y2 and x1,
-  but x2 and y1, even though in HyperSpy these appear to be at opposite ends.
+  goes before y**. Let's say the library had all pages of all books taken
+  pictures of to create the (B, P, Y, X) dataset. To look at those pictures in
+  HyperSpy, we move the axes to be in the order (P, B | X, Y), where X is, in
+  fact, before Y, and pages are before books. This can be confusing,
+  because in this example B and X axes seem to be "close", but in the
+  underlying array it is the opposite.
 
-- Extending this to arbitrary dimensions, we essentially reverse the numpy
+- Extending this to arbitrary dimensions, by default, we reverse the numpy
   axes, chop it into two chunks (signal and navigation), and then swap those
   chunks, at least when printing. As an example:
 

--- a/hyperspy/signal.py
+++ b/hyperspy/signal.py
@@ -29,6 +29,7 @@ import logging
 import numpy as np
 import scipy as sp
 from matplotlib import pyplot as plt
+import numbers
 
 from hyperspy.axes import AxesManager
 from hyperspy import io
@@ -2359,7 +2360,7 @@ class BaseSignal(FancySlicing,
                 step_sizes = ([shape[axis] // number_of_parts, ] *
                               number_of_parts)
 
-        if isinstance(step_sizes, int):
+        if isinstance(step_sizes, numbers.Integral):
             step_sizes = [step_sizes] * int(len_axis / step_sizes)
 
         splitted = []


### PR DESCRIPTION
Fixes a small bug in the s.split() which prevented stacked signals from being split after saving.

I have not investigated the cause of why, in the metadata, ’s.metadata._HyperSpy.Stacking_history.step_sizes’ is read with type ‘np.int64’, rather than ‘int’