### PR TITLE
Replaces int with numbers.Integral

### DIFF
--- a/hyperspy/signal.py
+++ b/hyperspy/signal.py
@@ -29,6 +29,7 @@ import logging
 import numpy as np
 import scipy as sp
 from matplotlib import pyplot as plt
+import numbers
 
 from hyperspy.axes import AxesManager
 from hyperspy import io
@@ -2359,7 +2360,7 @@ class BaseSignal(FancySlicing,
                 step_sizes = ([shape[axis] // number_of_parts, ] *
                               number_of_parts)
 
-        if isinstance(step_sizes, int):
+        if isinstance(step_sizes, numbers.Integral):
             step_sizes = [step_sizes] * int(len_axis / step_sizes)
 
         splitted = []


### PR DESCRIPTION
Fixes a small bug in the s.split() which prevented stacked signals from being split after saving.

I have not investigated the cause of why, in the metadata, `s.metadata._HyperSpy.Stacking_history.step_sizes` is read with type `np.int64`, rather than `int`.