### PR TITLE
Fix fei tests

### DIFF
--- a/hyperspy/io_plugins/fei.py
+++ b/hyperspy/io_plugins/fei.py
@@ -485,7 +485,7 @@ def ser_reader(filename, objects=None, *args, **kwds):
     else:
         axes = []
         array_shape = [None, ] * int(ndim)
-        spatial_axes = ["x", "y"]
+        spatial_axes = ["x", "y"][:ndim]
         for i in range(ndim):
             idim = 1 + i if order == "C" else ndim - i
             if (record_by == "spectrum" or

--- a/hyperspy/tests/io/test_fei.py
+++ b/hyperspy/tests/io/test_fei.py
@@ -192,8 +192,7 @@ class TestFEIReader():
         assert_allclose(s0.axes_manager[1].scale, 0.2, atol=1E-5)
         assert s0.axes_manager[1].units == 'eV'
         assert (s0.axes_manager[0].name == 'x')
-        assert (s0.axes_manager[1].name == 'y')
-        assert (s0.axes_manager[2].name == 'Energy')
+        assert (s0.axes_manager[1].name == 'Energy')
 
         fname1 = os.path.join(
             self.dirpathold, '16x16-line_profile_diagonal_10x1024.emi')
@@ -206,7 +205,7 @@ class TestFEIReader():
         assert s1.axes_manager[0].units == 'nm'
         assert_allclose(s1.axes_manager[1].scale, 0.2, atol=1E-5)
         assert s1.axes_manager[1].units == 'eV'
-        assert (s0.axes_manager[0].name == 'y')
+        assert (s0.axes_manager[0].name == 'x')
 
     def test_load_spectrum_area_scan(self):
         fname0 = os.path.join(


### PR DESCRIPTION
Fix the name of single navigation axis that was sometimes set to ``y`` instead of ``x``. Note that this does not implement setting the axis name to ``Position`` for oblique scan as proposed by @ericpre  in #1414.

(This branches from #1413, for a clean diff see last commit.)