### PR TITLE
Fix emd minimal saving 2

### DIFF
--- a/hyperspy/io_plugins/emd.py
+++ b/hyperspy/io_plugins/emd.py
@@ -384,24 +384,11 @@ def file_reader(filename, load_to_memory=True, log_info=False, **kwds):
 
 def file_writer(filename, signal, signal_metadata=None, user=None,
                 microscope=None, sample=None, comments=None, **kwds):
-    if user is None:  # If not provided, look in metadata:
-        user = signal.metadata.General.as_dictionary().get('user')
-    if user is None:  # If not found, check original_metadata:
-        user = signal.original_metadata.General.as_dictionary().get('user')
-    if microscope is None:  # If not provided, look in metadata:
-        microscope = signal.metadata.General.as_dictionary().get('microscope')
-    if microscope is None:  # If not found, check original_metadata:
-        microscope = signal.original_metadata.General.as_dictionary().get(
-            'microscope')
-    if sample is None:  # If not provided, look in metadata:
-        sample = signal.metadata.General.as_dictionary().get('sample')
-    if sample is None:  # If not found, check original_metadata:
-        sample = signal.original_metadata.General.as_dictionary().get('sample')
-    if comments is None:  # If not provided, look in metadata:
-        comments = signal.metadata.General.as_dictionary().get('comments')
-    if comments is None:  # If not found, check original_metadata:
-        comments = signal.original_metadata.General.as_dictionary().get(
-            'comments')
+    metadata = signal.metadata.General.as_dictionary()
+    user = user or metadata.get('user', None)
+    microscope = microscope or metadata.get('microscope', None)
+    sample = sample or metadata.get('sample', None)
+    comments = comments or metadata.get('comments', None)
     emd = EMD(
         user=user,
         microscope=microscope,

--- a/hyperspy/tests/io/test_emd.py
+++ b/hyperspy/tests/io/test_emd.py
@@ -67,6 +67,19 @@ def test_metadata():
     assert isinstance(signal, Signal2D)
 
 
+class TestMinimalSave():
+
+    def setup_method(self, method):
+        self.filename = 'testfile.emd'
+        self.signal = Signal1D([0, 1])
+
+    def test_minimal_save(self):
+        self.signal.save(self.filename)
+
+    def teardown_method(self, method):
+        remove(self.filename)
+
+
 class TestCaseSaveAndRead():
 
     def test_save_and_read(self):

--- a/hyperspy/tests/io/test_emd.py
+++ b/hyperspy/tests/io/test_emd.py
@@ -6,7 +6,7 @@
 
 import os.path
 from os import remove
-
+import tempfile
 
 import numpy as np
 
@@ -70,14 +70,12 @@ def test_metadata():
 class TestMinimalSave():
 
     def setup_method(self, method):
-        self.filename = 'testfile.emd'
+        with tempfile.TemporaryDirectory() as tmp:
+            self.filename = tmp + '/testfile.emd'
         self.signal = Signal1D([0, 1])
 
     def test_minimal_save(self):
         self.signal.save(self.filename)
-
-    def teardown_method(self, method):
-        remove(self.filename)
 
 
 class TestCaseSaveAndRead():


### PR DESCRIPTION
Bug-fix for #1415, resubmission of https://github.com/hyperspy/hyperspy/pull/1416

In this implementation I'm not checking `original_metadata`, due to discussion like the one in https://github.com/hyperspy/hyperspy/issues/1398#issuecomment-274500930. Do people think I should include look-up in the `original_metadata` as well (if it exist in the signal)?

(Sending this to RELEASE_next_minor, instead of RELEASE_next_patch due to the change to `pytest`. So I don't have to make a test for the old system first, then a new test for `pytest` when merging it into next_minor).