### PR TITLE
Use sympy string expressions instead of functions for ``Parameter.twin_function``

### DIFF
--- a/doc/user_guide/model.rst
+++ b/doc/user_guide/model.rst
@@ -523,15 +523,25 @@ For example:
             A	5.000000
             centre	0.000000
 
+.. deprecated:: 1.1.3
+    Setting the :py:attr:`~.component.Parameter.twin_function` and
+    :py:attr:`~.component.Parameter.twin_inverse_function` attributes. Set the
+    :py:attr:`~.component.Parameter.twin_function_expr` and
+    :py:attr:`~.component.Parameter.twin_inverse_function_expr` attributes
+    instead.
+
+.. versionadded:: 1.1.3
+    :py:attr:`~.component.Parameter.twin_function_expr` and
+    :py:attr:`~.component.Parameter.twin_inverse_function_expr`.
 
 By default the coupling function is the identity function. However it is
 possible to set a different coupling function by setting the
-:py:attr:`~.component.Parameter.twin_function` and
-:py:attr:`~.component.Parameter.twin_inverse_function` attributes.  For
+:py:attr:`~.component.Parameter.twin_function_expr` and
+:py:attr:`~.component.Parameter.twin_inverse_function_expr` attributes.  For
 example:
 
-    >>> gaussian2.A.twin_function = lambda x: x**2
-    >>> gaussian2.A.twin_inverse_function = lambda x: np.sqrt(np.abs(x))
+    >>> gaussian2.A.twin_function_expr = "x**2"
+    >>> gaussian2.A.twin_inverse_function_expr = "sqrt(abs(x))"
     >>> gaussian2.A.value = 4
     >>> m.print_current_values()
     Components	Parameter	Value

--- a/hyperspy/component.py
+++ b/hyperspy/component.py
@@ -82,11 +82,6 @@ class Parameter(t.HasTraits):
         twin inverse function with the value provided. The string is
         parsed using sympy, so permitted values are any valid sympy expressions
         of one variable.
-        The inverse of twin_function. If it is None then it is not
-        possible to set the value of the parameter twin by setting
-        the value of the current parameter.**Setting this attribute manually
-        is deprecated in HyperSpy 1.1.3. It will become private in
-        HyperSpy 2.0. Please use ``twin_function_expr`` instead.**
     twin_function : function
         **Setting this attribute manually
         is deprecated in HyperSpy newer than 1.1.2. It will become private in

--- a/hyperspy/component.py
+++ b/hyperspy/component.py
@@ -74,7 +74,7 @@ class Parameter(t.HasTraits):
         twin function with the value of the twin parameter. The string is
         parsed using sympy, so permitted values are any valid sympy expressions
         of one variable. If the function is invertible the twin inverse function
-        is set automatically. 
+        is set automatically.
     twin_inverse_function : str
         Expression of the ``twin_inverse_function`` that enables setting the
         value of the twin parameter. If ``twin`` is not
@@ -256,6 +256,7 @@ class Parameter(t.HasTraits):
                 "will raise an AttributeError unless you set manually "
                 "``twin_inverse_function_expr``. Otherwise, set the value of "
                 "its twin parameter instead.".format(value, self))
+
     @property
     def twin_inverse_function_expr(self):
         if self.twin:
@@ -282,10 +283,11 @@ class Parameter(t.HasTraits):
     @property
     def twin_inverse_function(self):
         if (not self.twin_inverse_function_expr and
-            self.twin_function_expr and self._twin_inverse_function_expr):
+                self.twin_function_expr and self._twin_inverse_function_expr):
             return lambda x: self._twin_inverse_sympy(x).pop()
         else:
             return self._twin_inverse_function
+
     @twin_inverse_function.setter
     def twin_inverse_function(self, value):
         self._twin_inverse_function = value

--- a/hyperspy/component.py
+++ b/hyperspy/component.py
@@ -17,13 +17,14 @@
 # along with  HyperSpy.  If not, see <http://www.gnu.org/licenses/>.
 
 import os
-
-import numpy as np
 import functools
 import warnings
 
+import numpy as np
 import traits.api as t
 from traits.trait_numeric import Array
+import sympy
+from sympy.utilities.lambdify import lambdify
 
 from hyperspy.defaults_parser import preferences
 from hyperspy.misc.utils import slugify
@@ -66,14 +67,20 @@ class Parameter(t.HasTraits):
         If it is not None, the value of the current parameter is
         a function of the given Parameter. The function is by default
         the identity function, but it can be defined by twin_function
+    twin_function_expr: str
+        A function of `x` where `x` is the value of the "twin" parameter.
     twin_function : function
         Function that, if selt.twin is not None, takes self.twin.value
         as its only argument and returns a float or array that is
-        returned when getting Parameter.value
+        returned when getting Parameter.value. **Setting this attribute manually
+        is deprecated in HyperSpy 1.1.3. It will become private in
+        HyperSpy 2.0. Please use ``twin_function_expr`` instead.**
     twin_inverse_function : function
         The inverse of twin_function. If it is None then it is not
         possible to set the value of the parameter twin by setting
-        the value of the current parameter.
+        the value of the current parameter.**Setting this attribute manually
+        is deprecated in HyperSpy 1.1.3. It will become private in
+        HyperSpy 2.0. Please use ``twin_function_expr`` instead.**
     ext_force_positive : bool
         If True, the parameter value is set to be the absolute value
         of the input value i.e. if we set Parameter.value = -3, the
@@ -117,6 +124,8 @@ class Parameter(t.HasTraits):
 
     bmin = t.Property(NoneFloat(), label="Lower bounds")
     bmax = t.Property(NoneFloat(), label="Upper bounds")
+    _twin_function_expr = ""
+    _twin_inverse_function = None
 
     def __init__(self):
         self._twins = set()
@@ -134,8 +143,8 @@ class Parameter(t.HasTraits):
             value : {float | array}
                 The new value of the parameter
             """, arguments=["obj", 'value'])
-        self.twin_function = lambda x: x
-        self.twin_inverse_function = lambda x: x
+        self.twin_function = None
+        self.twin_inverse_function = None
         self.std = None
         self.component = None
         self.grad = None
@@ -153,9 +162,8 @@ class Parameter(t.HasTraits):
                            'ext_bounded': None,
                            'name': None,
                            'ext_force_positive': None,
+                        #    'twin_function_expr': "",
                            'self': ('id', None),
-                           'twin_function': ('fn', None),
-                           'twin_inverse_function': ('fn', None),
                            }
         self._slicing_whitelist = {'map': 'inav'}
 
@@ -199,11 +207,49 @@ class Parameter(t.HasTraits):
     def __len__(self):
         return self._number_of_elements
 
+    @property
+    def twin_function_expr(self):
+        if self.twin:
+            return self._twin_function_expr
+        else:
+            return ""
+
+    @twin_function_expr.setter
+    def twin_function_expr(self, value):
+        if not value:
+            self.twin_function = None
+            self.twin_inverse_function = None
+            self._twin_function_expr = ""
+            return
+        expr = sympy.sympify(value)
+        if len(expr.free_symbols) != 1:
+            raise ValueError("The expression must contain only one variable.")
+        x = tuple(expr.free_symbols)[0]
+        self.twin_function = lambdify(x, expr.evalf())
+        y = sympy.Symbol(x.name + "2")
+        inv = sympy.solveset(sympy.Eq(y, expr), x)
+        self._twin_inverse_sympy = lambdify(y, inv)
+        self._twin_function_expr = value
+
+    @property
+    def twin_inverse_function(self):
+        if self.twin_function_expr:
+            return lambda x: self._twin_inverse_sympy(x).pop()
+        else:
+            return self._twin_inverse_function
+
+    @twin_inverse_function.setter
+    def twin_inverse_function(self, value):
+        self._twin_inverse_function = value
+
     def _get_value(self):
         if self.twin is None:
             return self.__value
         else:
-            return self.twin_function(self.twin.value)
+            if self.twin_function:
+                return self.twin_function(self.twin.value)
+            else:
+                return self.twin.value
 
     def _set_value(self, value):
         try:
@@ -225,9 +271,17 @@ class Parameter(t.HasTraits):
         old_value = self.__value
 
         if self.twin is not None:
-            if self.twin_inverse_function is not None:
-                self.twin.value = self.twin_inverse_function(value)
-            return
+            if self.twin_function is not None:
+                if self.twin_inverse_function is not None:
+                    self.twin.value = self.twin_inverse_function(value)
+                    return
+                else:
+                    raise AttributeError(
+                        "This parameter has a ``twin_function`` but"
+                        "its ``twin_inverse_function`` is not defined.")
+            else:
+                self.twin.value = value
+                return
 
         if self.ext_bounded is False:
             self.__value = value

--- a/hyperspy/component.py
+++ b/hyperspy/component.py
@@ -162,7 +162,7 @@ class Parameter(t.HasTraits):
                            'ext_bounded': None,
                            'name': None,
                            'ext_force_positive': None,
-                        #    'twin_function_expr': "",
+                           #    'twin_function_expr': "",
                            'self': ('id', None),
                            }
         self._slicing_whitelist = {'map': 'inav'}

--- a/hyperspy/component.py
+++ b/hyperspy/component.py
@@ -226,10 +226,18 @@ class Parameter(t.HasTraits):
             raise ValueError("The expression must contain only one variable.")
         x = tuple(expr.free_symbols)[0]
         self.twin_function = lambdify(x, expr.evalf())
-        y = sympy.Symbol(x.name + "2")
-        inv = sympy.solveset(sympy.Eq(y, expr), x)
-        self._twin_inverse_sympy = lambdify(y, inv)
         self._twin_function_expr = value
+        y = sympy.Symbol(x.name + "2")
+        try:
+            inv = sympy.solveset(sympy.Eq(y, expr), x)
+            self._twin_inverse_sympy = lambdify(y, inv)
+        except:
+            # Not all may have a suitable solution.
+            self._twin_inverse_function = None
+            _logger.warning(
+                "Couldn't invert {}, setting the value of {} will raise an "
+                "AttributeError. Set its twin value instead.".format(value,
+                                                                     self))
 
     @property
     def twin_inverse_function(self):

--- a/hyperspy/models/edsmodel.py
+++ b/hyperspy/models/edsmodel.py
@@ -44,6 +44,7 @@ def _get_weight(element, line, weight_line=None):
             element]['Atomic_properties']['Xray_lines'][line]['weight']
     return "x * {}".format(weight_line)
 
+
 def _get_sigma(E, E_ref, units_factor, return_f=False):
     """
     Calculates an approximate sigma value, accounting for peak broadening due
@@ -467,7 +468,8 @@ class EDSModel(Model1D):
                 component.centre.free = True
                 E = component.centre.value
                 fact = float(ax.value2index(E)) / ax.value2index(E_ref)
-                component.centre.twin_function_expr = _get_scale(E, E_ref, fact)
+                component.centre.twin_function_expr = _get_scale(
+                    E, E_ref, fact)
                 component.centre.twin = component_ref.centre
                 ref.append(E)
         return ref

--- a/hyperspy/models/edsmodel.py
+++ b/hyperspy/models/edsmodel.py
@@ -42,17 +42,9 @@ def _get_weight(element, line, weight_line=None):
     if weight_line is None:
         weight_line = elements_db[
             element]['Atomic_properties']['Xray_lines'][line]['weight']
-    return lambda x: x * weight_line
+    return "x * {}".format(weight_line)
 
-
-def _get_iweight(element, line, weight_line=None):
-    if weight_line is None:
-        weight_line = elements_db[
-            element]['Atomic_properties']['Xray_lines'][line]['weight']
-    return lambda x: x / weight_line
-
-
-def _get_sigma(E, E_ref, units_factor):
+def _get_sigma(E, E_ref, units_factor, return_f=False):
     """
     Calculates an approximate sigma value, accounting for peak broadening due
     to the detector, for a peak at energy E given a known width at a reference
@@ -84,17 +76,21 @@ def _get_sigma(E, E_ref, units_factor):
         Microanalysis", Plenum, third edition, p 315.
     """
     energy2sigma_factor = 2.5 / (eV2keV * (sigma2fwhm**2))
-    return lambda sig_ref: math.sqrt(abs(
-        energy2sigma_factor * (E - E_ref) * units_factor +
-        np.power(sig_ref, 2)))
+    if return_f:
+        return lambda sig_ref: math.sqrt(abs(
+            energy2sigma_factor * (E - E_ref) * units_factor +
+            np.power(sig_ref, 2)))
+    else:
+        return "sqrt(abs({} * ({} - {}) * {} + sig_ref ** 2))".format(
+            energy2sigma_factor, E, E_ref, units_factor)
 
 
 def _get_offset(diff):
-    return lambda E: E + diff
+    return "x + {}".format(diff)
 
 
 def _get_scale(E1, E_ref1, fact):
-    return lambda E: E1 + fact * (E - E_ref1)
+    return "{} + {} * (x - {})".format(E1, fact, E_ref1)
 
 
 class EDSModel(Model1D):
@@ -264,9 +260,7 @@ class EDSModel(Model1D):
                         component_sub.centre.free = False
                         component_sub.sigma.free = False
                         component_sub.name = xray_sub
-                        component_sub.A.twin_function = _get_weight(
-                            element, li)
-                        component_sub.A.twin_inverse_function = _get_iweight(
+                        component_sub.A.twin_function_expr = _get_weight(
                             element, li)
                         component_sub.A.twin = component.A
                         self.append(component_sub)
@@ -412,11 +406,8 @@ class EDSModel(Model1D):
             else:
                 component.sigma.free = True
                 E = component.centre.value
-                component.sigma.twin_function = _get_sigma(
+                component.sigma.twin_function_expr = _get_sigma(
                     E, E_ref, self.units_factor)
-                component.sigma.twin_inverse_function = _get_sigma(
-                    E_ref, E, self.units_factor)
-                component.sigma.twin = component_ref.sigma
 
     def _set_energy_resolution(self, xray_lines, *args, **kwargs):
         """
@@ -434,7 +425,8 @@ class EDSModel(Model1D):
                                                                    'auto')
         FWHM_MnKa_old *= eV2keV / self.units_factor
         get_sigma_Mn_Ka = _get_sigma(
-            energy_Mn_Ka, self[xray_lines[0]].centre.value, self.units_factor)
+            energy_Mn_Ka, self[xray_lines[0]].centre.value, self.units_factor,
+            return_f=True)
         FWHM_MnKa = get_sigma_Mn_Ka(self[xray_lines[0]].sigma.value
                                     ) * eV2keV / self.units_factor * sigma2fwhm
         if FWHM_MnKa < 110:
@@ -475,9 +467,7 @@ class EDSModel(Model1D):
                 component.centre.free = True
                 E = component.centre.value
                 fact = float(ax.value2index(E)) / ax.value2index(E_ref)
-                component.centre.twin_function = _get_scale(E, E_ref, fact)
-                component.centre.twin_inverse_function = _get_scale(
-                    E_ref, E, 1. / fact)
+                component.centre.twin_function_expr = _get_scale(E, E_ref, fact)
                 component.centre.twin = component_ref.centre
                 ref.append(E)
         return ref
@@ -531,8 +521,7 @@ class EDSModel(Model1D):
                 component.centre.free = True
                 E = component.centre.value
                 diff = E_ref - E
-                component.centre.twin_function = _get_offset(-diff)
-                component.centre.twin_inverse_function = _get_offset(diff)
+                component.centre.twin_function_expr = _get_offset(-diff)
                 component.centre.twin = component_ref.centre
                 ref.append(E)
         return ref
@@ -657,9 +646,7 @@ class EDSModel(Model1D):
                         component_sub.A.bmin = 1e-10
                         component_sub.A.bmax = None
                         weight_line = component_sub.A.value / component.A.value
-                        component_sub.A.twin_function = _get_weight(
-                            element, li, weight_line)
-                        component_sub.A.twin_inverse_function = _get_iweight(
+                        component_sub.A.twin_function_expr = _get_weight(
                             element, li, weight_line)
                         component_sub.A.twin = component.A
                     else:

--- a/hyperspy/models/edsmodel.py
+++ b/hyperspy/models/edsmodel.py
@@ -409,6 +409,8 @@ class EDSModel(Model1D):
                 E = component.centre.value
                 component.sigma.twin_function_expr = _get_sigma(
                     E, E_ref, self.units_factor)
+                component.sigma.twin_inverse_function_expr = _get_sigma(
+                    E_ref, E, self.units_factor)
 
     def _set_energy_resolution(self, xray_lines, *args, **kwargs):
         """
@@ -436,8 +438,9 @@ class EDSModel(Model1D):
         else:
             self.signal.set_microscope_parameters(
                 energy_resolution_MnKa=FWHM_MnKa)
-            warnings.warn("Energy resolution (FWHM at Mn Ka) changed from " +
-                          "%lf to %lf eV" % (FWHM_MnKa_old, FWHM_MnKa))
+            _logger.info("Energy resolution (FWHM at Mn Ka) changed from " +
+                          "{:.2f} to {:.2f} eV".format(
+                              FWHM_MnKa_old, FWHM_MnKa))
             for component in self:
                 if component.isbackground is False:
                     line_FWHM = self.signal._get_line_energy(

--- a/hyperspy/models/edsmodel.py
+++ b/hyperspy/models/edsmodel.py
@@ -439,8 +439,8 @@ class EDSModel(Model1D):
             self.signal.set_microscope_parameters(
                 energy_resolution_MnKa=FWHM_MnKa)
             _logger.info("Energy resolution (FWHM at Mn Ka) changed from " +
-                          "{:.2f} to {:.2f} eV".format(
-                              FWHM_MnKa_old, FWHM_MnKa))
+                         "{:.2f} to {:.2f} eV".format(
+                             FWHM_MnKa_old, FWHM_MnKa))
             for component in self:
                 if component.isbackground is False:
                     line_FWHM = self.signal._get_line_energy(

--- a/hyperspy/models/eelsmodel.py
+++ b/hyperspy/models/eelsmodel.py
@@ -199,6 +199,7 @@ class EELSModel(Model1D):
                 edge = EELSCLEdge(e_shells.pop(), GOS=self.GOS)
 
                 edge.intensity.twin = master_edge.intensity
+                edge.onset_energy.twin = master_edge.onset_energy
                 edge.onset_energy.twin_function_expr = "x + {}".format(
                     (edge.GOS.onset_energy - master_edge.GOS.onset_energy))
                 edge.free_onset_energy = False

--- a/hyperspy/models/eelsmodel.py
+++ b/hyperspy/models/eelsmodel.py
@@ -30,14 +30,6 @@ from hyperspy._signals.eels import EELSSpectrum
 _logger = logging.getLogger(__name__)
 
 
-def _give_me_delta(master, slave):
-    return lambda x: x + slave - master
-
-
-def _give_me_idelta(master, slave):
-    return lambda x: x - slave + master
-
-
 class EELSModel(Model1D):
 
     """Build an EELS model
@@ -207,13 +199,8 @@ class EELSModel(Model1D):
                 edge = EELSCLEdge(e_shells.pop(), GOS=self.GOS)
 
                 edge.intensity.twin = master_edge.intensity
-                delta = _give_me_delta(master_edge.GOS.onset_energy,
-                                       edge.GOS.onset_energy)
-                idelta = _give_me_idelta(master_edge.GOS.onset_energy,
-                                         edge.GOS.onset_energy)
-                edge.onset_energy.twin_function = delta
-                edge.onset_energy.twin_inverse_function = idelta
-                edge.onset_energy.twin = master_edge.onset_energy
+                edge.onset_energy.twin_function_expr = "x + {}".format(
+                    (edge.GOS.onset_energy - master_edge.GOS.onset_energy))
                 edge.free_onset_energy = False
                 self.append(edge)
 

--- a/hyperspy/tests/model/test_edsmodel.py
+++ b/hyperspy/tests/model/test_edsmodel.py
@@ -84,9 +84,7 @@ class TestlineFit:
         reso = s.metadata.Acquisition_instrument.TEM.Detector.EDS.\
             energy_resolution_MnKa,
         s.set_microscope_parameters(energy_resolution_MnKa=150)
-        with assert_warns(message=r"Energy resolution \(FWHM at Mn Ka\) "
-                          "changed from"):
-            m.calibrate_energy_axis(calibrate='resolution')
+        m.calibrate_energy_axis(calibrate='resolution')
         np.testing.assert_allclose(
             s.metadata.Acquisition_instrument.TEM.Detector.EDS.
             energy_resolution_MnKa, reso, atol=1)

--- a/hyperspy/tests/model/test_model_as_dictionary.py
+++ b/hyperspy/tests/model/test_model_as_dictionary.py
@@ -55,14 +55,8 @@ class TestParameterDictionary:
         self.par = Parameter()
         self.par.name = 'asd'
         self.par._id_name = 'newone'
-
-        def ft(x):
-            return x * x
-
-        def fit(x):
-            return x * x + 1
-        self.par.twin_function = ft
-        self.par.twin_inverse_function = fit
+        self.par.twin_function_expr = "x * x"
+        self.par.twin_inverse_function_expr = "x * x + 1"
         self.par._axes_manager = DummyAxesManager()
         self.par._create_array()
         self.par.value = 1
@@ -156,6 +150,8 @@ class TestComponentDictionary:
 
     def test_load_dictionary(self):
         c = self.comp
+        c.par1.twin_function_expr = "x + 2"
+        c.par2.twin_function_expr = "x - 2"
         d = c.as_dictionary(True)
         n = Component(self.parameter_names)
 
@@ -175,12 +171,8 @@ class TestComponentDictionary:
                 pc.twin_inverse_function(rn))
             dn = pn.as_dictionary()
             del dn['self']
-            del dn['twin_function']
-            del dn['twin_inverse_function']
             dc = pc.as_dictionary()
             del dc['self']
-            del dc['twin_function']
-            del dc['twin_inverse_function']
             print(list(dn.keys()))
             print(list(dc.keys()))
             nt.assert_dict_equal(dn, dc)

--- a/hyperspy/tests/model/test_model_storing.py
+++ b/hyperspy/tests/model/test_model_storing.py
@@ -31,8 +31,6 @@ def clean_model_dictionary(d):
     for c in d['components']:
         for p in c['parameters']:
             del p['self']
-            del p['twin_function']
-            del p['twin_inverse_function']
     return d
 
 


### PR DESCRIPTION
Fixes #1397 by adding ``Parameter.twin_function_expr`` and ``Parameter.twin_inverse_function_expr``. Deprecates setting ``twin_function`` and ``twin_inverse_function``. When ``twin_function_expr`` is invertible its inverse is automatically set courtesy of sympy.

TODO
--------
* [x] Test the eels model with hartree-slater (not possible in unittests due to missing xs)