### PR TITLE
expression component substitutions

### DIFF
--- a/doc/user_guide/model.rst
+++ b/doc/user_guide/model.rst
@@ -124,6 +124,19 @@ parameters for spectroscopy than the one that ships with HyperSpy:
     ... centre=0,
     ... module="numpy")
 
+If the expression is inconvenient to write out in full (e.g. it's long and/or
+complicated), multiple substitutions can be given, separated by semicolumns.
+Both symbolic and numerical substitutions are allowed:
+
+.. code-block:: python
+
+    >>> expression = "h / sqrt(p2) ; p2 = 2 * m0 * e1 * x * brackets;"
+    >>> expression += "brackets = 1 + (e1 * x) / (2 * m0 * c * c) ;"
+    >>> expression += "m0 = 9.1e-31 ; c = 3e8; e1 = 1.6e-19 ; h = 6.6e-34"
+    >>> wavelength = hs.model.components1D.Expression(
+    ... expression=expression,
+    ... name="Electron wavelength with voltage")
+
 :py:class:`~._components.expression.Expression` uses `Sympy
 <http://www.sympy.org>`_ internally to turn the string into
 a funtion. By default it "translates" the expression using

--- a/hyperspy/_components/expression.py
+++ b/hyperspy/_components/expression.py
@@ -19,6 +19,16 @@ def _fill_function_args(fn):
     return fn_wrapped
 
 
+def _parse_substitutions(string, simultaneous=True):
+    import sympy
+    splits = map(str.strip, string.split(';'))
+    expr = sympy.sympify(next(splits))
+    # We substitute one by one manually, as passing all at the same time does
+    # not work as we want (subsitutions inside other substitutions do not work)
+    for sub in splits:
+        expr = expr.subs(*tuple(map(str.strip, sub.split('='))))
+    return expr
+
 class Expression(Component):
 
     """Create a component from a string expression.
@@ -34,7 +44,8 @@ class Expression(Component):
         Parameters
         ----------
         expression: str
-            Component function in SymPy text expression format. See the SymPy
+            Component function in SymPy text expression format with
+            substitutions separated by `;`. See examples and the SymPy
             documentation for details. The only additional constraint is that
             the variable must be `x`. Also, in `module` is "numexpr" the
             functions are limited to those that numexpr support. See its
@@ -72,6 +83,17 @@ class Expression(Component):
         ... x0=0,
         ... position="x0",)
 
+        Substitutions for long or complicated expressions are separated by
+        semicolumns:
+
+        >>> expr = 'A*B/(A+B) ; A = sin(x)+one; B = cos(y) - two; y = tan(x)'
+        >>> comp = hs.model.components1D.Expression(
+        ... expression=expr,
+        ... name='my function')
+        >>> comp.parameters
+        (<Parameter one of my function component>,
+         <Parameter two of my function component>)
+
         """
 
         import sympy
@@ -94,7 +116,7 @@ class Expression(Component):
 
         if autodoc:
             self.__doc__ = _CLASS_DOC % (
-                name, sympy.latex(sympy.sympify(expression)))
+                name, sympy.latex(_parse_substitutions(expression)))
 
     def function(self, x):
         return self._f(x, *[p.value for p in self.parameters])
@@ -102,7 +124,7 @@ class Expression(Component):
     def compile_function(self, module="numpy"):
         import sympy
         from sympy.utilities.lambdify import lambdify
-        expr = sympy.sympify(self._str_expression)
+        expr = _parse_substitutions(self._str_expression)
 
         rvars = sympy.symbols([s.name for s in expr.free_symbols], real=True)
         real_expr = expr.subs(

--- a/hyperspy/tests/model/test_components.py
+++ b/hyperspy/tests/model/test_components.py
@@ -260,6 +260,14 @@ class TestExpression:
             0.00033845077175778578)
 
 
+def test_expression_substitution():
+    expr = 'A / B; A = x+2; B= x-c'
+    comp = hs.model.components1D.Expression(expr, name='testcomp',
+                                            autodoc=True,
+                                            c=2)
+    assert ''.join(p.name for p in comp.parameters) == 'c'
+    assert comp.function(1) == -3
+
 class TestScalableFixedPattern:
 
     def setup_method(self, method):


### PR DESCRIPTION
If the expression is inconvenient to write out in full (e.g. it's long and/or complicated), multiple substitutions can be given, separated by semi-columns. Both symbolic and numerical substitutions are allowed:

```python 
>>> expression = "h / sqrt(p2) ; p2 = 2 * m0 * e1 * x * brackets;"
>>> expression += "brackets = 1 + (e1 * x) / (2 * m0 * c * c) ;"
>>> expression += "m0 = 9.1e-31 ; c = 3e8; e1 = 1.6e-19 ; h = 6.6e-34"
>>> wavelength = hs.model.components1D.Expression(
 ... expression=expression,
 ... name="Electron wavelength with voltage")
```