### PR TITLE
Allow failure of dill hdf5 test

### DIFF
--- a/hyperspy/tests/io/test_hdf5.py
+++ b/hyperspy/tests/io/test_hdf5.py
@@ -165,7 +165,7 @@ class TestLoadingNewSavedMetadata:
         assert (
             self.s.metadata.test.tuple_inside_list == [
                 137, (123, 44)])
-
+    @pytest.mark.xfail(reason="dill is not guaranteed to load across Python versions")
     def test_binary_string(self):
         import dill
         # apparently pickle is not "full" and marshal is not


### PR DESCRIPTION
Allow failure of dill test as dill does not guarantee loading across Python versions, see #1397. The issue itself is addressed in #1425.