### PR TITLE
Add extra_requires to setup.py

### DIFF
--- a/doc/user_guide/install.rst
+++ b/doc/user_guide/install.rst
@@ -108,8 +108,28 @@ Install using `pip`:
 
 
 pip installs automatically the strictly required libraries. However, for full
-functionality you may need to install some other dependencies,
-see :ref:`install-dependencies`. Also, be aware that HyperSpy depends on a
+functionality you may need to install some other dependencies. To install with
+full functionality:
+
+
+.. code-block:: bash
+
+    $ pip install hyperspy[all]
+
+Alternatively you can select that extra functionality required:
+
+* ``bcf`` to install required libraries to read Brucker files.
+* ``learning`` to install required libraries for some machine learning features.
+
+For example:
+
+.. code-block:: bash
+
+    $ pip install hyperspy[bcf]
+
+See also :ref:`install-dependencies`.
+
+Finally, be aware that HyperSpy depends on a
 number of libraries that usually need to be compiled and therefore installing
 HyperSpy may require development tools. If the above does not work for you
 remember that the easiest way to install HyperSpy is

--- a/doc/user_guide/install.rst
+++ b/doc/user_guide/install.rst
@@ -120,12 +120,13 @@ Alternatively you can select that extra functionality required:
 
 * ``bcf`` to install required libraries to read Brucker files.
 * ``learning`` to install required libraries for some machine learning features.
+* ``gui-jupyter`` to install required libraries for Jupyter widgets
 
 For example:
 
 .. code-block:: bash
 
-    $ pip install hyperspy[bcf]
+    $ pip install hyperspy[bcf, gui-jupyter]
 
 See also :ref:`install-dependencies`.
 

--- a/setup.py
+++ b/setup.py
@@ -65,7 +65,9 @@ install_req = ['scipy',
 
 extras_require = {
     "learning": ['scikit-learn'],
-    "bcf": ['lxml'], }
+    "bcf": ['lxml'],
+    "gui-jupyter": "ipywidgets",
+}
 extras_require["all"] = list(itertools.chain(*list(extras_require.values())))
 
 # the hack to deal with setuptools + installing the package in ReadTheDoc:

--- a/setup.py
+++ b/setup.py
@@ -64,8 +64,8 @@ install_req = ['scipy',
                'scikit-image']
 
 extras_require = {
-    "learning" : ['scikit-learn'],
-    "bcf" : ['lxml'],}
+    "learning": ['scikit-learn'],
+    "bcf": ['lxml'], }
 extras_require["all"] = list(itertools.chain(*list(extras_require.values())))
 
 # the hack to deal with setuptools + installing the package in ReadTheDoc:

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ import warnings
 import os
 import subprocess
 import fileinput
-
+import itertools
 import re
 
 # stuff to check presence of compiler:
@@ -62,6 +62,11 @@ install_req = ['scipy',
                'python-dateutil',
                'ipyparallel',
                'scikit-image']
+
+extras_require = {
+    "learning" : ['scikit-learn'],
+    "bcf" : ['lxml'],}
+extras_require["all"] = list(itertools.chain(*list(extras_require.values())))
 
 # the hack to deal with setuptools + installing the package in ReadTheDoc:
 if 'readthedocs.org' in sys.executable:
@@ -330,6 +335,7 @@ with update_version_when_dev() as version:
                   'hyperspy.samfire_utils.goodness_of_fit_tests',
                   ],
         install_requires=install_req,
+        extras_require=extras_require,
         package_data={
             'hyperspy':
             [

--- a/setup.py
+++ b/setup.py
@@ -66,7 +66,7 @@ install_req = ['scipy',
 extras_require = {
     "learning": ['scikit-learn'],
     "bcf": ['lxml'],
-    "gui-jupyter": "ipywidgets",
+    "gui-jupyter": ["ipywidgets"],
 }
 extras_require["all"] = list(itertools.chain(*list(extras_require.values())))
 


### PR DESCRIPTION
Make it easy to install extra dependencies. Currently three options are available:

* bcf: bcf reader dependencies.
* learning: machine learning features.
* gui-jupyter: jupyter widgets
* all: install all extra dependencies.