### PR TITLE
Bugfix lazy memmap

### DIFF
--- a/hyperspy/io_plugins/blockfile.py
+++ b/hyperspy/io_plugins/blockfile.py
@@ -140,10 +140,12 @@ def get_header_from_signal(signal, endianess='<'):
     return header, note
 
 
-def file_reader(filename, endianess='<', mmap_mode='c',
+def file_reader(filename, endianess='<', mmap_mode=None,
                 lazy=False, **kwds):
     _logger.debug("Reading blockfile: %s" % filename)
     metadata = {}
+    if mmap_mode is None:
+        mmap_mode = 'r' if lazy else 'c'
     # Makes sure we open in right mode:
     if '+' in mmap_mode or ('write' in mmap_mode and
                             'copyonwrite' != mmap_mode):

--- a/hyperspy/tests/io/test_blockfile.py
+++ b/hyperspy/tests/io/test_blockfile.py
@@ -207,6 +207,11 @@ def test_load_to_memory():
 
 def test_load_readonly():
     s = hs.load(FILE2, lazy=True)
+    k = next(filter(lambda x: x.startswith("array-original"),
+                    s.data.dask.keys()))
+    mm = s.data.dask[k]
+    assert isinstance(mm, np.memmap)
+    assert not mm.flags["WRITEABLE"]
     with pytest.raises(NotImplementedError):
         s.data[:] = 23
 


### PR DESCRIPTION
A quick fix to change default blockfile `mmap_mode` depending on `lazy`.

Previously default was `c`, which requires as much memory as the data to be allocated, thus to load a file lazily minimal command had to be `hs.load(filename, lazy=True, mmap_mode='r')`.

Now default is `None` and gets assigned to `c` if `lazy=False` and `r` if `True`. Any user-given `mmap_mode` value is still preserved and behavior unchanged, but loading lazily is simpler:
`hs.load(filename, lazy=True)`.