### PR TITLE
hyperspy hdf5 extension hdf5 -> hspy

### DIFF
--- a/doc/user_guide/io.rst
+++ b/doc/user_guide/io.rst
@@ -211,16 +211,40 @@ of arbitrary dimensions. It is based on the `HDF5 open standard
 applications
 <http://www.hdfgroup.org/products/hdf5_tools/SWSummarybyName.htm>`_.
 
-Note that only HDF5 files written by HyperSpy are supported
+Only loading of HDF5 files following the HyperSpy specification are supported.
+
+.. versionadded:: 1.2
+    Saving hdf5 files with extension ``.hspy``.
+
+The default extension is ``.hdf5`` but, in order to make it explicit that the
+HDF5 follows the HyperSpy specification, it is possible to save it with the
+``.hspy`` extension as follows.
+
+
+.. code-block:: python
+
+    >>> s = hs.signals.BaseSignal([0])
+    >>> s.save('test.hspy')
+
+It is possible to use the ``.hspy`` extension by default by changing the
+value is ``preferences`` using the GUI or programatically:
+
+.. code-block:: python
+
+    >>> hs.preferences.General.hspy_extension = True
+    >>> hs.save() # make the changes permanent
+
+From HyperSpy 1.3 ``.hspy`` will be the default extension.
 
 .. versionadded:: 0.8
+    Saving list, tuples and signals present in `:py:attr:`~.metadata``.
 
-It is also possible to save more complex structures (i.e. lists, tuples and
-signals) in :py:attr:`~.metadata` of the signal. Please note that in order to
-increase saving efficiency and speed, if possible, the inner-most structures
-are converted to numpy arrays when saved. This procedure homogenizes any types
-of the objects inside, most notably casting numbers as strings if any other
-strings are present:
+When saving to hdf5, all supported objects in the signal's :py:attr:`~.metadata`
+is stored. This includes  lists, tuples and signals. Please note
+that in order to increase saving efficiency and speed, if possible, the
+inner-most structures are converted to numpy arrays when saved. This procedure
+homogenizes any types of the objects inside, most notably casting numbers as
+strings if any other strings are present:
 
 .. code-block:: python
 

--- a/hyperspy/defaults_parser.py
+++ b/hyperspy/defaults_parser.py
@@ -94,6 +94,11 @@ class GeneralConfig(t.HasTraits):
         desc='Using the hdf5 format is highly reccomended because is the '
         'only one fully supported. The Ripple (rpl) format it is useful '
         'to export data to other software that do not support hdf5')
+    hspy_extension = t.CBool(
+        False,
+        desc='If enabled, HyperSpy will use the "hspy" extension when saving '
+        'to HDF5 instead of the "hdf5" extension. "hspy" will be the default'
+        'extension from HyperSpy v1.3')
     interactive = t.CBool(
         True,
         desc='If enabled, HyperSpy will prompt the user when options are '

--- a/hyperspy/io.py
+++ b/hyperspy/io.py
@@ -439,7 +439,8 @@ def save(filename, signal, overwrite=None, **kwds):
     if extension == '':
         extension = \
             preferences.General.default_file_format
-        extension = extension if extension != "hdf5" else "hspy"
+        if preferences.General.hspy_extension:
+            extension = extension if extension != "hdf5" else "hspy"
         filename = filename + '.' + extension
     writer = None
     for plugin in io_plugins:

--- a/hyperspy/io.py
+++ b/hyperspy/io.py
@@ -439,8 +439,8 @@ def save(filename, signal, overwrite=None, **kwds):
     if extension == '':
         extension = \
             preferences.General.default_file_format
-        filename = filename + '.' + \
-            preferences.General.default_file_format
+        extension = extension if extension != "hdf5" else "hspy"
+        filename = filename + '.' + extension
     writer = None
     for plugin in io_plugins:
         if extension.lower() in plugin.file_extensions:

--- a/hyperspy/io_plugins/hdf5.py
+++ b/hyperspy/io_plugins/hdf5.py
@@ -40,8 +40,8 @@ description = \
 
 full_support = False
 # Recognised file extension
-file_extensions = ['hdf', 'h4', 'hdf4', 'h5', 'hdf5', 'he4', 'he5']
-default_extension = 4
+file_extensions = ['hdf', 'h4', 'hdf4', 'h5', 'hdf5', 'he4', 'he5', "hspy"]
+default_extension = 7
 
 # Writing capabilities
 writes = True

--- a/hyperspy/tests/io/test_hdf5.py
+++ b/hyperspy/tests/io/test_hdf5.py
@@ -37,6 +37,7 @@ from hyperspy.datasets.example_signals import EDS_TEM_Spectrum
 from hyperspy.utils import markers
 from hyperspy.drawing.marker import dict2marker
 from hyperspy.misc.test_utils import sanitize_dict as san_dict
+from hyperspy.api import preferences
 
 my_path = os.path.dirname(__file__)
 
@@ -185,8 +186,44 @@ class TestLoadingNewSavedMetadata:
 @pytest.fixture()
 def tmpfilepath():
     with tempfile.TemporaryDirectory() as tmp:
-        yield os.path.join(tmp, "test.hdf5")
+        yield os.path.join(tmp, "test")
         gc.collect()        # Make sure any memmaps are closed first!
+
+def get_ext():
+    if preferences.General.hspy_extension:
+        return ".hspy"
+    else:
+        return ".hdf5"
+
+
+
+def test_hspy_extension(tmpfilepath):
+    # test_marker_point_y2_data_deleted.hdf5 has 5 markers,
+    # where one of them is missing the y2 value, however the
+    # the point marker only needs the x1 and y1 value to work
+    # so this should load
+    try:
+        hspy_extension = preferences.General.hspy_extension
+        preferences.General.hspy_extension = True
+        s = BaseSignal([0])
+        s.save(tmpfilepath)
+        assert os.path.exists(tmpfilepath + ".hspy")
+    finally:
+        preferences.General.hspy_extension = hspy_extension
+
+def test_hdf5_extension(tmpfilepath):
+    # test_marker_point_y2_data_deleted.hdf5 has 5 markers,
+    # where one of them is missing the y2 value, however the
+    # the point marker only needs the x1 and y1 value to work
+    # so this should load
+    try:
+        hspy_extension = preferences.General.hspy_extension
+        preferences.General.hspy_extension = False
+        s = BaseSignal([0])
+        s.save(tmpfilepath)
+        assert os.path.exists(tmpfilepath + ".hdf5")
+    finally:
+        preferences.General.hspy_extension = hspy_extension
 
 
 class TestSavingMetadataContainers:
@@ -198,7 +235,7 @@ class TestSavingMetadataContainers:
         s = self.s
         s.metadata.set_item('test', ['a', 'b', '\u6f22\u5b57'])
         s.save(tmpfilepath)
-        l = load(tmpfilepath)
+        l = load(tmpfilepath + get_ext())
         assert isinstance(l.metadata.test[0], str)
         assert isinstance(l.metadata.test[1], str)
         assert isinstance(l.metadata.test[2], str)
@@ -216,7 +253,7 @@ class TestSavingMetadataContainers:
         s = self.s
         s.metadata.set_item('test', [[1., 2], ('3', 4)])
         s.save(tmpfilepath)
-        l = load(tmpfilepath)
+        l = load(tmpfilepath + get_ext())
         assert isinstance(l.metadata.test, list)
         assert isinstance(l.metadata.test[0], list)
         assert isinstance(l.metadata.test[1], tuple)
@@ -225,7 +262,7 @@ class TestSavingMetadataContainers:
         s = self.s
         s.metadata.set_item('test', [[1., 2], ['3', 4]])
         s.save(tmpfilepath)
-        l = load(tmpfilepath)
+        l = load(tmpfilepath + get_ext())
         assert isinstance(l.metadata.test[0][0], float)
         assert isinstance(l.metadata.test[0][1], float)
         assert isinstance(l.metadata.test[1][0], str)
@@ -235,7 +272,7 @@ class TestSavingMetadataContainers:
         s = self.s
         s.metadata.set_item('test', (BaseSignal([1]), 0.1, 'test_string'))
         s.save(tmpfilepath)
-        l = load(tmpfilepath)
+        l = load(tmpfilepath + get_ext())
         assert isinstance(l.metadata.test, tuple)
         assert isinstance(l.metadata.test[0], Signal1D)
         assert isinstance(l.metadata.test[1], float)
@@ -245,7 +282,7 @@ class TestSavingMetadataContainers:
         s = self.s
         s.metadata.set_item('test', Point2DROI(1, 2))
         s.save(tmpfilepath)
-        l = load(tmpfilepath)
+        l = load(tmpfilepath + get_ext())
         assert 'test' not in l.metadata
 
     def test_date_time(self, tmpfilepath):
@@ -254,7 +291,7 @@ class TestSavingMetadataContainers:
         s.metadata.General.date = date
         s.metadata.General.time = time
         s.save(tmpfilepath)
-        l = load(tmpfilepath)
+        l = load(tmpfilepath + get_ext())
         assert l.metadata.General.date == date
         assert l.metadata.General.time == time
 
@@ -267,7 +304,7 @@ class TestSavingMetadataContainers:
         s.metadata.General.authors = authors
         s.metadata.General.doi = doi
         s.save(tmpfilepath)
-        l = load(tmpfilepath)
+        l = load(tmpfilepath + get_ext())
         assert l.metadata.General.notes == notes
         assert l.metadata.General.authors == authors
         assert l.metadata.General.doi == doi
@@ -277,7 +314,7 @@ class TestSavingMetadataContainers:
         quantity = "Intensity (electron)"
         s.metadata.Signal.quantity = quantity
         s.save(tmpfilepath)
-        l = load(tmpfilepath)
+        l = load(tmpfilepath + get_ext())
         assert l.metadata.Signal.quantity == quantity
 
 
@@ -640,7 +677,7 @@ def test_lazy_metadata_arrays(tmpfilepath):
     s = BaseSignal([1, 2, 3])
     s.metadata.array = np.arange(10.)
     s.save(tmpfilepath)
-    l = load(tmpfilepath, lazy=True)
+    l = load(tmpfilepath + get_ext(), lazy=True)
     # Can't deepcopy open hdf5 file handles
     with pytest.raises(TypeError):
         l.deepcopy()

--- a/hyperspy/tests/io/test_hdf5.py
+++ b/hyperspy/tests/io/test_hdf5.py
@@ -198,10 +198,6 @@ def get_ext():
 
 
 def test_hspy_extension(tmpfilepath):
-    # test_marker_point_y2_data_deleted.hdf5 has 5 markers,
-    # where one of them is missing the y2 value, however the
-    # the point marker only needs the x1 and y1 value to work
-    # so this should load
     try:
         hspy_extension = preferences.General.hspy_extension
         preferences.General.hspy_extension = True
@@ -213,10 +209,6 @@ def test_hspy_extension(tmpfilepath):
 
 
 def test_hdf5_extension(tmpfilepath):
-    # test_marker_point_y2_data_deleted.hdf5 has 5 markers,
-    # where one of them is missing the y2 value, however the
-    # the point marker only needs the x1 and y1 value to work
-    # so this should load
     try:
         hspy_extension = preferences.General.hspy_extension
         preferences.General.hspy_extension = False

--- a/hyperspy/tests/io/test_hdf5.py
+++ b/hyperspy/tests/io/test_hdf5.py
@@ -189,12 +189,12 @@ def tmpfilepath():
         yield os.path.join(tmp, "test")
         gc.collect()        # Make sure any memmaps are closed first!
 
+
 def get_ext():
     if preferences.General.hspy_extension:
         return ".hspy"
     else:
         return ".hdf5"
-
 
 
 def test_hspy_extension(tmpfilepath):
@@ -210,6 +210,7 @@ def test_hspy_extension(tmpfilepath):
         assert os.path.exists(tmpfilepath + ".hspy")
     finally:
         preferences.General.hspy_extension = hspy_extension
+
 
 def test_hdf5_extension(tmpfilepath):
     # test_marker_point_y2_data_deleted.hdf5 has 5 markers,


### PR DESCRIPTION
Change hyperspy hdf5 file extension to hspy.

# Advantages:

* hyperspy cannot load any hdf5 file, only those recorded using its own standard. Adding the extension would make this clearer.
* HyperSpyUI could associate itself only with hspy files, allowing other programs to associate themselves with general hdf5 files.
* Anybody receiving a hspy file will have an easier time at finding the right software to open it.

# Disadvantages
* It is less straightforward to realize that the hspy file can be opened with any hdf5 reader.

If everybody agrees, maybe this could make it into the 1.2 release?
