### PR TITLE
Bugfix fourier ratio deconvolution

### DIFF
--- a/hyperspy/_signals/eels.py
+++ b/hyperspy/_signals/eels.py
@@ -699,7 +699,7 @@ class EELSSpectrum_mixin:
 
         ll.hanning_taper()
         cl.hanning_taper()
-        if self._lazy or zlp._lazy:
+        if self._lazy or ll._lazy:
             rfft = da.fft.rfft
             irfft = da.fft.irfft
         else:

--- a/hyperspy/tests/signal/test_eels.py
+++ b/hyperspy/tests/signal/test_eels.py
@@ -208,3 +208,13 @@ class TestPowerLawExtrapolation:
         sc = self.s.isig[:300]
         s = sc.power_law_extrapolation(extrapolation_size=100)
         np.testing.assert_allclose(s.data, self.s.data, atol=10e-3)
+
+@lazifyTestClass
+class TestFourierRatioDeconvolution:
+
+    def test_running(self):
+        s = hs.signals.EELSSpectrum(np.arange(200))
+        s_ll = hs.signals.EELSSpectrum(np.zeros(100))
+        s_ll.data[18:23] = [3, 10, 20, 10, 3]
+        s_ll.axes_manager[0].offset = -20
+        s.fourier_ratio_deconvolution(s_ll)


### PR DESCRIPTION
s.fourier_ratio_deconvolution wasn't working due to a new lazy test calling the wrong variable name.