### PR TITLE
create_model fails with some lazy signals

### DIFF
--- a/hyperspy/_signals/complex_signal.py
+++ b/hyperspy/_signals/complex_signal.py
@@ -20,7 +20,6 @@ from functools import wraps
 
 import numpy as np
 import dask.array as da
-import h5py
 
 from hyperspy.signal import BaseSignal
 from hyperspy._signals.lazy import LazySignal
@@ -262,16 +261,16 @@ class ComplexSignal(ComplexSignal_mixin, BaseSignal):
     angle.__doc__ = ComplexSignal_mixin.angle.__doc__
 
 
-class LazyComplexSignal(ComplexSignal_mixin, LazySignal):
+class LazyComplexSignal(ComplexSignal, LazySignal):
 
     @format_title('absolute')
     def _get_amplitude(self):
         amplitude = da.numpy_compat.builtins.abs(self)
-        return super()._get_amplitude(amplitude)
+        return super(ComplexSignal, self)._get_amplitude(amplitude)
 
     def _get_phase(self):
         phase = self._deepcopy_with_new_data(da.angle(self.data))
-        return super()._get_phase(phase)
+        return super(ComplexSignal, self)._get_phase(phase)
 
     def _set_real(self, real):
         if isinstance(real, BaseSignal):
@@ -300,5 +299,5 @@ class LazyComplexSignal(ComplexSignal_mixin, LazySignal):
 
     def angle(self, deg=False):
         angle = self._deepcopy_with_new_data(da.angle(self.data, deg))
-        return super().angle(angle, deg=deg)
+        return super(ComplexSignal, self).angle(angle, deg=deg)
     angle.__doc__ = ComplexSignal_mixin.angle.__doc__

--- a/hyperspy/_signals/complex_signal1d.py
+++ b/hyperspy/_signals/complex_signal1d.py
@@ -34,7 +34,7 @@ class ComplexSignal1D(ComplexSignal, CommonSignal1D):
         self.metadata.Signal.binned = False
 
 
-class LazyComplexSignal1D(LazyComplexSignal, CommonSignal1D):
+class LazyComplexSignal1D(ComplexSignal1D, LazyComplexSignal):
 
     """BaseSignal subclass for lazy complex 1-dimensional data."""
 

--- a/hyperspy/_signals/complex_signal2d.py
+++ b/hyperspy/_signals/complex_signal2d.py
@@ -47,9 +47,9 @@ class Complex2Dmixin:
             Offset of the ramp at the fulcrum.
         Notes
         -----
-            The fulcrum of the linear ramp is at the origin and the slopes are given in units of
-            the axis with the according scale taken into account. Both are available via the
-            `axes_manager` of the signal.
+            The fulcrum of the linear ramp is at the origin and the slopes are
+            given in units of the axis with the according scale taken into
+            account. Both are available via the `axes_manager` of the signal.
 
         """
         phase = self.phase
@@ -96,7 +96,7 @@ class ComplexSignal2D(Complex2Dmixin, ComplexSignal, CommonSignal2D):
     pass
 
 
-class LazyComplexSignal2D(Complex2Dmixin, LazyComplexSignal, CommonSignal2D):
+class LazyComplexSignal2D(ComplexSignal2D, LazyComplexSignal):
 
     """BaseSignal subclass for lazy complex 2-dimensional data."""
     pass

--- a/hyperspy/_signals/dielectric_function.py
+++ b/hyperspy/_signals/dielectric_function.py
@@ -124,5 +124,5 @@ class DielectricFunction(DielectricFunction_mixin, ComplexSignal1D):
     pass
 
 
-class LazyDielectricFunction(DielectricFunction_mixin, LazyComplexSignal1D):
+class LazyDielectricFunction(DielectricFunction, LazyComplexSignal1D):
     pass

--- a/hyperspy/_signals/eds.py
+++ b/hyperspy/_signals/eds.py
@@ -1053,5 +1053,5 @@ class EDSSpectrum(EDS_mixin, Signal1D):
     pass
 
 
-class LazyEDSSpectrum(EDS_mixin, LazySignal1D):
+class LazyEDSSpectrum(EDSSpectrum, LazySignal1D):
     pass

--- a/hyperspy/_signals/eds.py
+++ b/hyperspy/_signals/eds.py
@@ -25,8 +25,7 @@ from matplotlib import pyplot as plt
 from distutils.version import LooseVersion
 
 from hyperspy import utils
-from hyperspy._signals.signal1d import Signal1D
-from hyperspy.signals import LazySignal1D
+from hyperspy._signals.signal1d import Signal1D, LazySignal1D
 from hyperspy.misc.elements import elements as elements_db
 from hyperspy.misc.eds import utils as utils_eds
 from hyperspy.misc.utils import isiterable

--- a/hyperspy/_signals/eds_sem.py
+++ b/hyperspy/_signals/eds_sem.py
@@ -310,5 +310,5 @@ class EDSSEMSpectrum(EDSSEM_mixin, EDSSpectrum):
     pass
 
 
-class LazyEDSSEMSpectrum(EDSSEM_mixin, LazyEDSSpectrum):
+class LazyEDSSEMSpectrum(EDSSEMSpectrum, LazyEDSSpectrum):
     pass

--- a/hyperspy/_signals/eds_tem.py
+++ b/hyperspy/_signals/eds_tem.py
@@ -659,5 +659,5 @@ class EDSTEMSpectrum(EDSTEM_mixin, EDSSpectrum):
     pass
 
 
-class LazyEDSTEMSpectrum(EDSTEM_mixin, LazyEDSSpectrum):
+class LazyEDSTEMSpectrum(EDSTEMSpectrum, LazyEDSSpectrum):
     pass

--- a/hyperspy/_signals/eels.py
+++ b/hyperspy/_signals/eels.py
@@ -1331,12 +1331,10 @@ class EELSSpectrum_mixin:
                           dictionary=dictionary)
         return model
 
-
-class LazyEELSSpectrum(EELSSpectrum_mixin, LazySignal1D):
-
-    pass
-
-
 class EELSSpectrum(EELSSpectrum_mixin, Signal1D):
 
     pass
+class LazyEELSSpectrum(EELSSpectrum, LazySignal1D):
+
+    pass
+

--- a/hyperspy/_signals/hologram_image.py
+++ b/hyperspy/_signals/hologram_image.py
@@ -22,7 +22,8 @@ import scipy.constants as constants
 import numpy as np
 from dask.array import Array as daArray
 
-from hyperspy.signals import (Signal2D, BaseSignal, Signal1D, LazySignal)
+from hyperspy.signals import (Signal2D, BaseSignal, Signal1D)
+from hyperspy._signals.lazy import LazySignal
 from hyperspy.misc.holography.reconstruct import (
     reconstruct, estimate_sideband_position, estimate_sideband_size)
 

--- a/hyperspy/decorators.py
+++ b/hyperspy/decorators.py
@@ -27,7 +27,7 @@ import types
 
 def lazify(func, **kwargs):
     from hyperspy.signal import BaseSignal
-
+    from hyperspy.model import BaseModel
     @wraps(func)
     def lazified_func(self, *args, **kwds):
         for k in self.__dict__.keys():
@@ -36,6 +36,13 @@ def lazify(func, **kwargs):
                 if isinstance(v, BaseSignal):
                     v = v.as_lazy()
                     setattr(self, k, v)
+                elif isinstance(v, BaseModel):
+                    if hasattr(v, "signal"):
+                        am = v.signal.axes_manager
+                        v.signal = v.signal.as_lazy()
+                        # Keep the axes_manager from the original signal that
+                        # the model assigns to the components
+                        v.signal.axes_manager = am
         self.__dict__.update(kwargs)
         return func(self, *args, **kwds)
     return lazified_func

--- a/hyperspy/gui/egerton_quantification.py
+++ b/hyperspy/gui/egerton_quantification.py
@@ -413,7 +413,7 @@ class SpikesRemoval(SpanSelectorInSignal1D):
             minimum = max(0, self.argmax - 50)
             maximum = min(len(self.signal()) - 1, self.argmax + 50)
             thresh_label = DerivativeTextParameters(
-                text="$\mathsf{\delta}_\mathsf{max}=$",
+                text=r"$\mathsf{\delta}_\mathsf{max}=$",
                 color="black")
             self.ax.legend([thresh_label], [repr(int(self.derivmax))],
                            handler_map={DerivativeTextParameters:

--- a/hyperspy/io.py
+++ b/hyperspy/io.py
@@ -25,13 +25,13 @@ import numpy as np
 from natsort import natsorted
 from hyperspy.drawing.marker import markers_metadata_dict_to_markers
 
-from .misc.io.tools import ensure_directory
-from .misc.io.tools import overwrite as overwrite_method
-from .misc.utils import (strlist2enumeration, find_subclasses)
-from .misc.utils import stack as stack_method
-from .io_plugins import io_plugins, default_write_ext
-from .exceptions import VisibleDeprecationWarning
-from .defaults_parser import preferences
+from hyperspy.misc.io.tools import ensure_directory
+from hyperspy.misc.io.tools import overwrite as overwrite_method
+from hyperspy.misc.utils import (strlist2enumeration, find_subclasses)
+from hyperspy.misc.utils import stack as stack_method
+from hyperspy.io_plugins import io_plugins, default_write_ext
+from hyperspy.exceptions import VisibleDeprecationWarning
+from hyperspy.defaults_parser import preferences
 
 _logger = logging.getLogger(__name__)
 

--- a/hyperspy/io_plugins/edax.py
+++ b/hyperspy/io_plugins/edax.py
@@ -869,7 +869,7 @@ def spd_reader(filename,
         if nav_units not in [None, 'um']:
             _logger.warning("Did not understand nav_units input \"{}\". "
                             "Defaulting to microns.\n".format(nav_units))
-        nav_units = '$\mu m$'
+        nav_units = r'$\mu m$'
 
     # Create navigation axes dictionaries:
     x_axis = {

--- a/hyperspy/misc/utils.py
+++ b/hyperspy/misc/utils.py
@@ -986,7 +986,8 @@ def map_result_construction(signal,
                             ragged,
                             sig_shape=None,
                             lazy=False):
-    from hyperspy.signals import (BaseSignal, LazySignal)
+    from hyperspy.signals import BaseSignal
+    from hyperspy._lazy_signals import LazySignal
     res = None
     if inplace:
         sig = signal

--- a/hyperspy/signals.py
+++ b/hyperspy/signals.py
@@ -40,18 +40,13 @@ The Signal class and its specilized subclasses:
 
 # -*- coding: utf-8 -*-
 from hyperspy.signal import BaseSignal
-from hyperspy._signals.lazy import LazySignal
-from hyperspy._signals.signal1d import (Signal1D, LazySignal1D)
-from hyperspy._signals.signal2d import (Signal2D, LazySignal2D)
-from hyperspy._signals.eels import (EELSSpectrum, LazyEELSSpectrum)
-from hyperspy._signals.eds_sem import (EDSSEMSpectrum, LazyEDSSEMSpectrum)
-from hyperspy._signals.eds_tem import (EDSTEMSpectrum, LazyEDSTEMSpectrum)
-from hyperspy._signals.complex_signal import (ComplexSignal, LazyComplexSignal)
-from hyperspy._signals.complex_signal1d import (ComplexSignal1D,
-                                                LazyComplexSignal1D)
-from hyperspy._signals.complex_signal2d import (ComplexSignal2D,
-                                                LazyComplexSignal2D)
-from hyperspy._signals.dielectric_function import (DielectricFunction,
-                                                   LazyDielectricFunction)
-from hyperspy._signals.hologram_image import (HologramImage,
-                                              LazyHologramImage)
+from hyperspy._signals.signal1d import Signal1D
+from hyperspy._signals.signal2d import Signal2D
+from hyperspy._signals.eels import EELSSpectrum
+from hyperspy._signals.eds_sem import EDSSEMSpectrum
+from hyperspy._signals.eds_tem import EDSTEMSpectrum
+from hyperspy._signals.complex_signal import ComplexSignal
+from hyperspy._signals.complex_signal1d import ComplexSignal1D
+from hyperspy._signals.complex_signal2d import ComplexSignal2D
+from hyperspy._signals.dielectric_function import DielectricFunction
+from hyperspy._signals.hologram_image import HologramImage

--- a/hyperspy/tests/model/test_chi_squared.py
+++ b/hyperspy/tests/model/test_chi_squared.py
@@ -20,8 +20,10 @@ import numpy as np
 
 from hyperspy._signals.signal1d import Signal1D
 from hyperspy.components1d import Gaussian
+from hyperspy.decorators import lazifyTestClass
 
 
+@lazifyTestClass
 class TestChiSquared:
 
     def setup_method(self, method):

--- a/hyperspy/tests/model/test_edsmodel.py
+++ b/hyperspy/tests/model/test_edsmodel.py
@@ -4,8 +4,10 @@ from hyperspy.misc.test_utils import assert_warns
 
 from hyperspy.misc.eds import utils as utils_eds
 from hyperspy.misc.elements import elements as elements_db
+from hyperspy.decorators import lazifyTestClass
 
 
+@lazifyTestClass
 class TestlineFit:
 
     def setup_method(self, method):
@@ -165,6 +167,7 @@ class TestlineFit:
             '$\\mathrm{Zn}_{\\mathrm{Ka}}$']
 
 
+@lazifyTestClass
 class TestMaps:
 
     def setup_method(self, method):

--- a/hyperspy/tests/model/test_eelsmodel.py
+++ b/hyperspy/tests/model/test_eelsmodel.py
@@ -4,8 +4,10 @@ import pytest
 from numpy.testing import assert_allclose
 
 import hyperspy.api as hs
+from hyperspy.decorators import lazifyTestClass
 
 
+@lazifyTestClass
 class TestCreateEELSModel:
 
     def setup_method(self, method):
@@ -67,6 +69,7 @@ class TestCreateEELSModel:
             m = self.s.create_model(ll=ll)
 
 
+@lazifyTestClass
 class TestEELSModel:
 
     def setup_method(self, method):
@@ -159,6 +162,7 @@ class TestEELSModel:
                 150)
 
 
+@lazifyTestClass
 class TestFitBackground:
 
     def setup_method(self, method):

--- a/hyperspy/tests/model/test_fancy_indexing.py
+++ b/hyperspy/tests/model/test_fancy_indexing.py
@@ -22,8 +22,10 @@ import time
 from hyperspy._signals.signal1d import Signal1D
 from hyperspy._signals.eels import EELSSpectrum
 from hyperspy.components1d import Gaussian
+from hyperspy.decorators import lazifyTestClass
 
 
+@lazifyTestClass
 class TestModelIndexing:
 
     def setup_method(self, method):
@@ -100,6 +102,7 @@ class TestModelIndexing:
         assert m[0]._active_array[0, 0]
 
 
+@lazifyTestClass
 class TestModelIndexingClass:
 
     def setup_method(self, method):
@@ -119,6 +122,7 @@ class TestModelIndexingClass:
         assert isinstance(m_eels, type(m_eels.inav[1:]))
 
 
+@lazifyTestClass
 class TestEELSModelSlicing:
 
     def setup_method(self, method):

--- a/hyperspy/tests/model/test_model.py
+++ b/hyperspy/tests/model/test_model.py
@@ -6,6 +6,7 @@ from matplotlib.testing.decorators import cleanup
 
 import hyperspy.api as hs
 from hyperspy.misc.utils import slugify
+from hyperspy.decorators import lazifyTestClass
 
 
 class TestModelJacobians:
@@ -600,6 +601,7 @@ class TestModel2D:
         np.testing.assert_allclose(gt.sigma_y.value, 2.)
 
 
+@lazifyTestClass
 class TestModelFitBinned:
 
     def setup_method(self, method):
@@ -728,6 +730,7 @@ class TestModelFitBinned:
             self.m.fit(method="dummy")
 
 
+@lazifyTestClass
 class TestModelWeighted:
 
     def setup_method(self, method):
@@ -869,6 +872,7 @@ class TestModelScalarVariance:
         np.testing.assert_allclose(self.m.red_chisq.data, 0.86206965)
 
 
+@lazifyTestClass
 class TestModelSignalVariance:
 
     def setup_method(self, method):
@@ -894,6 +898,7 @@ class TestModelSignalVariance:
                                    0.91453032901427167)
 
 
+@lazifyTestClass
 class TestMultifit:
 
     def setup_method(self, method):
@@ -1091,6 +1096,7 @@ class TestAsSignal:
                                                         np.ones((2, 5)) * 2]))
 
 
+@lazifyTestClass
 class TestCreateModel:
 
     def setup_method(self, method):

--- a/hyperspy/tests/signal/test_assign_subclass.py
+++ b/hyperspy/tests/signal/test_assign_subclass.py
@@ -4,6 +4,7 @@ import numpy as np
 
 import hyperspy.api as hs
 from hyperspy.io import assign_signal_subclass
+from hyperspy import _lazy_signals
 
 
 testcase = namedtuple('testcase', ['dtype', 'sig_dim', 'sig_type', 'cls'])
@@ -44,7 +45,7 @@ def test_assignment_class():
                 signal_dimension=case.sig_dim,
                 signal_type=case.sig_type,
                 lazy=True) is
-            getattr(hs.signals, lazyclass))
+            getattr(_lazy_signals, lazyclass))
 
 
 class TestConvertBaseSignal:
@@ -56,7 +57,7 @@ class TestConvertBaseSignal:
         assert not self.s._lazy
         self.s._lazy = True
         self.s._assign_subclass()
-        assert isinstance(self.s, hs.signals.LazySignal)
+        assert isinstance(self.s, _lazy_signals.LazySignal)
         assert self.s._lazy
 
     def test_base_to_1d(self):
@@ -87,9 +88,9 @@ class TestConvertSignal1D:
     def test_lazy_to_eels_and_back(self):
         self.s = self.s.as_lazy()
         self.s.set_signal_type("EELS")
-        assert isinstance(self.s, hs.signals.LazyEELSSpectrum)
+        assert isinstance(self.s, _lazy_signals.LazyEELSSpectrum)
         self.s.set_signal_type("")
-        assert isinstance(self.s, hs.signals.LazySignal1D)
+        assert isinstance(self.s, _lazy_signals.LazySignal1D)
 
     def test_signal1d_to_eels(self):
         self.s.set_signal_type("EELS")

--- a/hyperspy/tests/signal/test_inheritance.py
+++ b/hyperspy/tests/signal/test_inheritance.py
@@ -1,0 +1,15 @@
+import numpy as np
+import pytest
+
+from hyperspy.misc.utils import find_subclasses
+from hyperspy.signal import BaseSignal
+import hyperspy.signals
+
+
+@pytest.mark.parametrize("signal",
+                         find_subclasses(hyperspy.signals, BaseSignal))
+def test_lazy_signal_inheritance(signal):
+    bs = getattr(hyperspy.signals, signal)
+    s = bs(np.empty((2,) * bs._signal_dimension))
+    ls = s.as_lazy()
+    assert isinstance(ls, bs)

--- a/hyperspy/tests/signal/test_lazy.py
+++ b/hyperspy/tests/signal/test_lazy.py
@@ -6,6 +6,7 @@ from dask.threaded import get
 import hyperspy.api as hs
 from hyperspy._signals.lazy import (_reshuffle_mixed_blocks,
                                     to_array)
+from hyperspy import _lazy_signals
 
 
 @pytest.fixture(scope='module')
@@ -13,7 +14,7 @@ def signal():
     ar = da.from_array(np.arange(6. * 9 * 7 * 11).reshape((6, 9, 7, 11)),
                        chunks=((2, 1, 3), (4, 5), (7,), (11,))
                        )
-    return hs.signals.LazySignal2D(ar)
+    return _lazy_signals.LazySignal2D(ar)
 
 
 @pytest.mark.parametrize("sl", [(0, 0),

--- a/hyperspy/tests/signal/test_signal_subclass_conversion.py
+++ b/hyperspy/tests/signal/test_signal_subclass_conversion.py
@@ -4,6 +4,7 @@ import pytest
 
 from hyperspy.signals import BaseSignal
 from hyperspy import signals
+from hyperspy import _lazy_signals
 from hyperspy.exceptions import DataDimensionError
 from hyperspy.decorators import lazifyTestClass
 
@@ -27,7 +28,7 @@ class Test1d:
         s.set_signal_type("EELS")
         assert s.metadata.Signal.signal_type == "EELS"
         if s._lazy:
-            _class = signals.LazyEELSSpectrum
+            _class = _lazy_signals.LazyEELSSpectrum
         else:
             _class = signals.EELSSpectrum
         assert isinstance(s, _class)
@@ -63,7 +64,7 @@ class Test2d:
         s = im.as_signal1D(0)
         assert s.metadata.Signal.signal_type == "EELS"
         if s._lazy:
-            _class = signals.LazyEELSSpectrum
+            _class = _lazy_signals.LazyEELSSpectrum
         else:
             _class = signals.EELSSpectrum
         assert isinstance(s, _class)


### PR DESCRIPTION
This PR includes fixes for the following two bugs:

* Most lazy signals were not instances of their standard counterparts. This was breaking model creation from lazy signals.
* ``hs.signals`` included lazy signals.

It also lazifies selected model tests.