### PR TITLE
Fix variance transpose

### DIFF
--- a/hyperspy/signal.py
+++ b/hyperspy/signal.py
@@ -3078,7 +3078,7 @@ class BaseSignal(FancySlicing,
         else:
             return self.sum(axis=axis, out=out)
     integrate1D.__doc__ %= (ONE_AXIS_PARAMETER, OUT_ARG)
-    
+
     def indexmin(self, axis, out=None):
         """Returns a signal with the index of the minimum along an axis.
 
@@ -3175,7 +3175,7 @@ class BaseSignal(FancySlicing,
             out.data[:] = data
             out.events.data_changed.trigger(obj=out)
     valuemax.__doc__ %= (ONE_AXIS_PARAMETER, OUT_ARG)
-    
+
     def valuemin(self, axis, out=None):
         """Returns a signal with the value of coordinates of the minimum along an axis.
 
@@ -4342,6 +4342,7 @@ class BaseSignal(FancySlicing,
             return isinstance(thing, Iterable) and \
                 not isinstance(thing, str)
         am = self.axes_manager
+        ns = self.axes_manager.navigation_axes + self.axes_manager.signal_axes
         ax_list = am._axes
         if isinstance(signal_axes, int):
             if navigation_axes is not None:
@@ -4354,19 +4355,18 @@ class BaseSignal(FancySlicing,
                 raise ValueError("Can't have negative number of signal axes")
             elif signal_axes == 0:
                 signal_axes = ()
-                navigation_axes = ax_list
+                navigation_axes = ax_list[::-1]
             else:
-                navigation_axes = ax_list[:-signal_axes]
-                signal_axes = ax_list[-signal_axes:]
+                navigation_axes = ax_list[:-signal_axes][::-1]
+                signal_axes = ax_list[-signal_axes:][::-1]
         elif iterable_not_string(signal_axes):
-            signal_axes = tuple(am[ax] for ax in reversed(signal_axes))
+            signal_axes = tuple(am[ax] for ax in signal_axes)
             if navigation_axes is None:
-                navigation_axes = tuple(ax for ax in ax_list if ax not in
-                                        signal_axes)
+                navigation_axes = tuple(ax for ax in ax_list
+                                        if ax not in signal_axes)[::-1]
             elif iterable_not_string(navigation_axes):
                 # want to keep the order
-                navigation_axes = tuple(am[ax] for ax in
-                                        reversed(navigation_axes))
+                navigation_axes = tuple(am[ax] for ax in navigation_axes)
                 intersection = set(signal_axes).intersection(navigation_axes)
                 if len(intersection):
                     raise ValueError("At least one axis found in both spaces:"
@@ -4386,18 +4386,18 @@ class BaseSignal(FancySlicing,
                         "Can't have negative number of navigation axes")
                 elif navigation_axes == 0:
                     navigation_axes = ()
-                    signal_axes = ax_list
+                    signal_axes = ax_list[::-1]
                 else:
-                    signal_axes = ax_list[navigation_axes:]
-                    navigation_axes = ax_list[:navigation_axes]
+                    signal_axes = ax_list[navigation_axes:][::-1]
+                    navigation_axes = ax_list[:navigation_axes][::-1]
             elif iterable_not_string(navigation_axes):
                 navigation_axes = tuple(am[ax] for ax in
-                                        reversed(navigation_axes))
-                signal_axes = tuple(ax for ax in ax_list if ax not in
-                                    navigation_axes)
+                                        navigation_axes)
+                signal_axes = tuple(ax for ax in ax_list
+                                    if ax not in navigation_axes)[::-1]
             elif navigation_axes is None:
-                signal_axes = list(reversed(am.navigation_axes))
-                navigation_axes = list(reversed(am.signal_axes))
+                signal_axes = am.navigation_axes
+                navigation_axes = am.signal_axes
             else:
                 raise ValueError(
                     "The passed navigation_axes argument is not valid")
@@ -4406,6 +4406,9 @@ class BaseSignal(FancySlicing,
         # translate to axes idx from actual objects for variance
         idx_sig = [ax.index_in_axes_manager for ax in signal_axes]
         idx_nav = [ax.index_in_axes_manager for ax in navigation_axes]
+        # From now on we operate with axes in array order
+        signal_axes = signal_axes[::-1]
+        navigation_axes = navigation_axes[::-1]
         # get data view
         array_order = tuple(
             ax.index_in_array for ax in navigation_axes)

--- a/hyperspy/signal.py
+++ b/hyperspy/signal.py
@@ -1865,11 +1865,11 @@ class BaseSignal(FancySlicing,
             self._plot = mpl_hie.MPL_HyperImage_Explorer()
         else:
             raise ValueError(
-                    "Plotting is not supported for this view. "
-                    "Try e.g. 's.transpose(signal_axes=1).plot()' for "
-                    "plotting as a 1D signal, or "
-                    "'s.transpose(signal_axes=(1,2)).plot()' "
-                    "for plotting as a 2D signal.")
+                "Plotting is not supported for this view. "
+                "Try e.g. 's.transpose(signal_axes=1).plot()' for "
+                "plotting as a 1D signal, or "
+                "'s.transpose(signal_axes=(1,2)).plot()' "
+                "for plotting as a 2D signal.")
 
         self._plot.axes_manager = axes_manager
         self._plot.signal_data_function = self.__call__

--- a/hyperspy/tests/signal/test_tools.py
+++ b/hyperspy/tests/signal/test_tools.py
@@ -184,7 +184,7 @@ class Test3D:
         self.signal.axes_manager[2].name = "E"
         self.signal.axes_manager[0].scale = 0.5
         self.data = self.signal.data.copy()
-        
+
     def test_indexmin(self):
         s = self.signal.indexmin('E')
         ar = self.data.argmin(2)
@@ -200,7 +200,7 @@ class Test3D:
         assert s.data.ndim == 2
         assert s.axes_manager.signal_dimension == 0
         assert s.axes_manager.navigation_dimension == 2
-        
+
     def test_valuemin(self):
         s = self.signal.valuemin('x')
         ar = self.signal.axes_manager['x'].index2value(self.data.argmin(1))
@@ -716,7 +716,9 @@ class TestTranspose:
 
     def test_signal_int_transpose(self):
         t = self.s.transpose(signal_axes=2)
+        var = t.metadata.Signal.Noise_properties.variance
         assert t.axes_manager.signal_shape == (6, 5)
+        assert var.axes_manager.signal_shape == (6, 5)
         assert ([ax.name for ax in t.axes_manager.signal_axes] ==
                 ['f', 'e'])
         assert isinstance(t, signals.Signal2D)
@@ -725,19 +727,25 @@ class TestTranspose:
 
     def test_signal_iterable_int_transpose(self):
         t = self.s.transpose(signal_axes=[0, 5, 4])
+        var = t.metadata.Signal.Noise_properties.variance
         assert t.axes_manager.signal_shape == (6, 1, 2)
+        assert var.axes_manager.signal_shape == (6, 1, 2)
         assert ([ax.name for ax in t.axes_manager.signal_axes] ==
                 ['f', 'a', 'b'])
 
     def test_signal_iterable_names_transpose(self):
         t = self.s.transpose(signal_axes=['f', 'a', 'b'])
+        var = t.metadata.Signal.Noise_properties.variance
         assert t.axes_manager.signal_shape == (6, 1, 2)
+        assert var.axes_manager.signal_shape == (6, 1, 2)
         assert ([ax.name for ax in t.axes_manager.signal_axes] ==
                 ['f', 'a', 'b'])
 
     def test_signal_iterable_axes_transpose(self):
         t = self.s.transpose(signal_axes=self.s.axes_manager.signal_axes[:2])
+        var = t.metadata.Signal.Noise_properties.variance
         assert t.axes_manager.signal_shape == (6, 5)
+        assert var.axes_manager.signal_shape == (6, 5)
         assert ([ax.name for ax in t.axes_manager.signal_axes] ==
                 ['f', 'e'])
 
@@ -751,18 +759,24 @@ class TestTranspose:
 
     def test_navigation_int_transpose(self):
         t = self.s.transpose(navigation_axes=2)
+        var = t.metadata.Signal.Noise_properties.variance
         assert t.axes_manager.navigation_shape == (2, 1)
+        assert var.axes_manager.navigation_shape == (2, 1)
         assert ([ax.name for ax in t.axes_manager.navigation_axes] ==
                 ['b', 'a'])
 
     def test_navigation_iterable_int_transpose(self):
         t = self.s.transpose(navigation_axes=[0, 5, 4])
+        var = t.metadata.Signal.Noise_properties.variance
         assert t.axes_manager.navigation_shape == (6, 1, 2)
+        assert var.axes_manager.navigation_shape == (6, 1, 2)
         assert ([ax.name for ax in t.axes_manager.navigation_axes] ==
                 ['f', 'a', 'b'])
 
     def test_navigation_iterable_names_transpose(self):
         t = self.s.transpose(navigation_axes=['f', 'a', 'b'])
+        var = t.metadata.Signal.Noise_properties.variance
+        assert var.axes_manager.navigation_shape == (6, 1, 2)
         assert t.axes_manager.navigation_shape == (6, 1, 2)
         assert ([ax.name for ax in t.axes_manager.navigation_axes] ==
                 ['f', 'a', 'b'])
@@ -771,7 +785,9 @@ class TestTranspose:
         t = self.s.transpose(
             navigation_axes=self.s.axes_manager.signal_axes[
                 :2])
+        var = t.metadata.Signal.Noise_properties.variance
         assert t.axes_manager.navigation_shape == (6, 5)
+        assert var.axes_manager.navigation_shape == (6, 5)
         assert ([ax.name for ax in t.axes_manager.navigation_axes] ==
                 ['f', 'e'])
 


### PR DESCRIPTION
The outcome of transposing a signal is different for the signal and its variances:

```python

>>> import hyperspy.api as hs
>>> import numpy as np
>>> s = hs.signals.Signal2D(np.empty((2,3,4,5,6)))
>>> s.estimate_poissonian_noise_variance()
>>> s.T
<BaseSignal, title: , dimensions: (6, 5|4, 3, 2)>
>>> s.T.metadata.Signal.Noise_properties.variance
<BaseSignal, title: Variance of , dimensions: (5, 6|2, 3, 4)>
```

This PR fixes it and adds tests.
