### PR TITLE
Fix restoring eels model

### DIFF
--- a/hyperspy/component.py
+++ b/hyperspy/component.py
@@ -1273,6 +1273,7 @@ class Component(t.HasTraits):
             correct twins.
         """
         if dic['_id_name'] == self._id_name:
+            load_from_dictionary(self, dic)
             id_dict = {}
             for p in dic['parameters']:
                 idname = p['_id_name']
@@ -1283,7 +1284,6 @@ class Component(t.HasTraits):
                 else:
                     raise ValueError(
                         "_id_name of parameters in component and dictionary do not match")
-            load_from_dictionary(self, dic)
             return id_dict
         else:
             raise ValueError( "_id_name of component and dictionary do not match, \ncomponent._id_name = %s\

--- a/hyperspy/tests/io/test_hdf5.py
+++ b/hyperspy/tests/io/test_hdf5.py
@@ -340,7 +340,7 @@ class TestLoadingOOMReadOnly:
         s.save('tmp.hdf5', overwrite=True)
         self.shape = (10000, 10000, 100)
         del s
-        f = h5py.File('tmp.hdf5', model='r+')
+        f = h5py.File('tmp.hdf5', mode='r+')
         s = f['Experiments/__unnamed__']
         del s['data']
         s.create_dataset(

--- a/hyperspy/tests/model/test_model_storing.py
+++ b/hyperspy/tests/model/test_model_storing.py
@@ -160,3 +160,30 @@ class TestModelSaving:
     def teardown_method(self, method):
         gc.collect()        # Make sure any memmaps are closed first!
         remove('tmp.hdf5')
+
+
+class TestEELSModelSaving:
+
+    def setup_method(self, method):
+        s = Signal1D(range(100))
+        s.axes_manager[0].offset = 280
+        s.set_signal_type("EELS")
+        s.add_elements(["C"])
+        s.set_microscope_parameters(100, 10, 10)
+        m = s.create_model(auto_background=False)
+        m.components.C_K.fine_structure_smoothing = 0.5
+        m.components.C_K.fine_structure_width = 50
+        m.components.C_K.fine_structure_active = True
+        self.m = m
+
+    def test_save_and_load_model(self):
+        m = self.m
+        m.save('tmp.hdf5', overwrite=True)
+        l = load('tmp.hdf5')
+        assert hasattr(l.models, 'a')
+        n = l.models.restore('a')
+        assert n[0].fine_structure_width == 50
+
+    def teardown_method(self, method):
+        gc.collect()        # Make sure any memmaps are closed first!
+        remove('tmp.hdf5')


### PR DESCRIPTION
Restoring EELS model using `s.models.restore` raises an exception when the fine structure parameters of any ``EELSCLEdge`` has been customised.

This PR fixes the issue and adds a test. 