### PR TITLE
Model.components empty on restored model

### DIFF
--- a/hyperspy/component.py
+++ b/hyperspy/component.py
@@ -896,13 +896,14 @@ class Component(t.HasTraits):
 
     def _set_name(self, value):
         old_value = self._name
+        if old_value == value:
+            return
         if self.model:
             for component in self.model:
                 if value == component.name:
-                    if not (component is self):
-                        raise ValueError(
-                            "Another component already has "
-                            "the name " + str(value))
+                    raise ValueError(
+                        "Another component already has "
+                        "the name " + str(value))
             self._name = value
             setattr(self.model.components, slugify(
                 value, valid_variable_name=True), self)
@@ -1272,6 +1273,7 @@ class Component(t.HasTraits):
             the parameters of the component, to be later used for setting up
             correct twins.
         """
+
         if dic['_id_name'] == self._id_name:
             id_dict = {}
             for p in dic['parameters']:
@@ -1283,6 +1285,7 @@ class Component(t.HasTraits):
                 else:
                     raise ValueError(
                         "_id_name of parameters in component and dictionary do not match")
+
             load_from_dictionary(self, dic)
             return id_dict
         else:

--- a/hyperspy/tests/model/test_model_storing.py
+++ b/hyperspy/tests/model/test_model_storing.py
@@ -145,8 +145,10 @@ class TestModelSaving:
         s = Signal1D(range(100))
         m = s.create_model()
         m.append(Gaussian())
-        m.components.Gaussian.A.value = 13
-        m.components.Gaussian.name = 'something'
+        m[-1].A.value = 13
+        m[-1].name = 'something'
+        m.append(Gaussian())
+        m[-1].A.value = 3
         self.m = m
 
     def test_save_and_load_model(self):
@@ -156,6 +158,7 @@ class TestModelSaving:
         assert hasattr(l.models, 'a')
         n = l.models.restore('a')
         assert n.components.something.A.value == 13
+        assert n.components.Gaussian.A.value == 3
 
     def teardown_method(self, method):
         gc.collect()        # Make sure any memmaps are closed first!


### PR DESCRIPTION
When restoring a model using e.g. ``s.models.restore``, the components are missing in ``model.components``. 

This PR fixes it and adds a test.