### PR TITLE
Multiple stacking bugfixes

### DIFF
--- a/hyperspy/_signals/lazy.py
+++ b/hyperspy/_signals/lazy.py
@@ -170,7 +170,11 @@ class LazySignal(BaseSignal):
             if self.data.chunks != new_chunks and rechunk:
                 res = self.data.rechunk(new_chunks)
         else:
-            res = da.from_array(self.data, chunks=new_chunks)
+            if isinstance(self.data, np.ma.masked_array):
+                data = np.where(self.data.mask, np.nan, np.array(self.data))
+            else:
+                data = self.data
+            res = da.from_array(data, chunks=new_chunks)
         assert isinstance(res, da.Array)
         return res
 

--- a/hyperspy/_signals/lazy.py
+++ b/hyperspy/_signals/lazy.py
@@ -171,7 +171,7 @@ class LazySignal(BaseSignal):
                 res = self.data.rechunk(new_chunks)
         else:
             if isinstance(self.data, np.ma.masked_array):
-                data = np.where(self.data.mask, np.nan, np.array(self.data))
+                data = np.where(self.data.mask, np.nan, self.data)
             else:
                 data = self.data
             res = da.from_array(data, chunks=new_chunks)

--- a/hyperspy/tests/signal/test_lazy.py
+++ b/hyperspy/tests/signal/test_lazy.py
@@ -104,3 +104,10 @@ def test_as_array_dask(sig):
 def test_as_array_fail():
     with pytest.raises(ValueError):
         to_array('asd', chunks=None)
+
+def test_ma_lazify():
+    s = hs.signals.BaseSignal(np.ma.masked_array(data=[1,2,3], mask=[0,1,0]))
+    l = s.as_lazy()
+    assert np.isnan(l.data[1].compute())
+    ss = hs.stack([s,s])
+    assert np.isnan(ss.data[:,1]).all()

--- a/hyperspy/tests/utils/test_stack.py
+++ b/hyperspy/tests/utils/test_stack.py
@@ -41,17 +41,23 @@ class TestUtilsStack:
 
     def test_stack_not_default(self):
         s = self.signal
-        s1 = s.deepcopy() + 1
-        s2 = s.deepcopy() * 4
+        s1 = s.inav[:, :-1] + 1
+        s2 = s.inav[:, ::2] * 4
         result_signal = utils.stack([s, s1, s2], axis=1)
         axis_size = s.axes_manager[1].size
+        axs1 = s1.axes_manager[1].size
+        axs2 = s2.axes_manager[1].size
         result_list = result_signal.split()
         assert len(result_list) == 3
-        np.testing.assert_array_almost_equal(
-            result_list[0].data, result_signal.inav[:, :axis_size].data)
-        result_signal = utils.stack([s, s1, s2], axis='y')
-        np.testing.assert_array_almost_equal(
-            result_list[0].data, result_signal.inav[:, :axis_size].data)
+        for rs in [result_signal, utils.stack([s, s1, s2], axis='y')]:
+            np.testing.assert_array_almost_equal(
+                result_list[0].data, rs.inav[:, :axis_size].data)
+            np.testing.assert_array_almost_equal(
+                s.data, rs.inav[:, :axis_size].data)
+            np.testing.assert_array_almost_equal(
+                s1.data, rs.inav[:, axis_size:axis_size + axs1].data)
+            np.testing.assert_array_almost_equal(
+                s2.data, rs.inav[:, axis_size + axs1:].data)
 
     def test_stack_bigger_than_ten(self):
         s = self.signal


### PR DESCRIPTION
 - A bug was present where stacking of signals with masked data was not possible due to dask not having masked arrays itself.
 - stacking with non-default axis was neither tested properly nor worked, now does.

Now we replace masked elements with `np.nan` (as we did for the circular ROI in particular) and are able to lazify and stack such signals.

The behaviour is different from the default numpy, though, which may have been an older bug in numpy/our stacking:

Previously, stacking two arrays resulted in the mask disappearing (this is also how our stacking behaved):
```python
>>> ar = np.ma.masked_array(data=[1,2,3], mask=[0,1,0])
>>> ar
masked_array(data = [1 -- 3],
             mask = [False  True False],
       fill_value = 999999)
>>> np.stack([ar,ar])
masked_array(data =
 [[1 2 3]
 [1 2 3]],
             mask =
 False,
       fill_value = 999999)
```

Now, effectively, this happens:
```python
>>> np.stack([np.where(x.mask, np.nan, x) for x in [ar, ar]])
array([[  1.,  nan,   3.],
       [  1.,  nan,   3.]])
>>> res = hs.stack([hs.signals.BaseSignal(x) for x in [ar, ar]])
>>> res
<Signal1D, title: Stack of , dimensions: (2|3)>
>>> res.data
array([[  1.,  nan,   3.],
       [  1.,  nan,   3.]])
```
Which actually preserves the mask / gets rid of the data that was masked.
