### PR TITLE
orpca now consistent with old implementation

### DIFF
--- a/hyperspy/learn/rpca.py
+++ b/hyperspy/learn/rpca.py
@@ -550,6 +550,7 @@ def orpca(X, rank, fast=False,
        algorithms", arXiv:1609.04747, (2016), http://arxiv.org/abs/1609.04747.
 
     """
+    X = X.T
     _orpca = ORPCA(rank, fast=fast, lambda1=lambda1,
                    lambda2=lambda2, method=method,
                    learning_rate=learning_rate, init=init,
@@ -557,4 +558,5 @@ def orpca(X, rank, fast=False,
                    momentum=momentum)
     _orpca._setup(X, normalize=True)
     _orpca.fit(X)
-    return _orpca.finish()
+    Xhat, Ehat, U, S, V = _orpca.finish()
+    return Xhat.T, Ehat, U, S, V

--- a/hyperspy/tests/mva/test_rpca.py
+++ b/hyperspy/tests/mva/test_rpca.py
@@ -9,7 +9,7 @@ class TestRPCA:
     def setup_method(self, method):
         # Define shape etc.
         m = 256  # Dimensionality
-        n = 256  # Number of samples
+        n = 250  # Number of samples
         r = 3
         s = 0.01
 
@@ -106,6 +106,15 @@ class TestORPCA:
         # Check the low-rank component MSE
         normX = np.linalg.norm(X - self.A) / (self.m * self.n)
         assert normX < self.tol
+
+    def test_fast(self):
+        X, E, U, S, V = orpca(self.X, rank=self.rank, fast=True)
+        # Only check shapes
+        assert X.shape == (self.m, self.n)
+        assert E.shape == (self.m, self.n)
+        assert U.shape == (self.m, self.rank)
+        assert S.shape == (self.rank,)
+        assert V.shape == (self.n, self.rank)
 
     def test_method_BCD(self):
         X, E, U, S, V = orpca(self.X, rank=self.rank, method='BCD')


### PR DESCRIPTION
a quick fix for https://github.com/hyperspy/hyperspy/issues/1557

No tests for now.. But the class / function should probably be made consistent in some other PR anyway (currently class takes the transpose of the function. The function is left purely to keep the API, no other reason actually..), so I'll leave the tests for that.
