### PR TITLE
Lazy chunking improvements

### DIFF
--- a/hyperspy/_signals/lazy.py
+++ b/hyperspy/_signals/lazy.py
@@ -814,6 +814,11 @@ class LazySignal(BaseSignal):
         target.explained_variance = explained_variance
         target.explained_variance_ratio = explained_variance_ratio
 
+    def transpose(self, *args, **kwargs):
+        res = super().transpose(*args, **kwargs)
+        res._make_lazy(rechunk=True)
+        return res
+    transpose.__doc__ = BaseSignal.transpose.__doc__
 
 def _reshuffle_mixed_blocks(array, ndim, sshape, nav_chunks):
     """Reshuffles dask block-shuffled array

--- a/hyperspy/tests/io/test_hdf5.py
+++ b/hyperspy/tests/io/test_hdf5.py
@@ -24,8 +24,10 @@ import tempfile
 
 import h5py
 import numpy as np
+import dask
 import dask.array as da
 import pytest
+from distutils.version import LooseVersion
 
 from hyperspy.io import load
 from hyperspy.io_plugins.hdf5 import get_signal_chunks
@@ -665,7 +667,8 @@ def test_strings_from_py2():
     s = EDS_TEM_Spectrum()
     assert s.metadata.Sample.elements.dtype.char == "U"
 
-
+@pytest.mark.skipif(LooseVersion(dask.__version__) >= LooseVersion('0.14.1'),
+                    reason='Fixed in later dask versions')
 def test_lazy_metadata_arrays(tmpfilepath):
     s = BaseSignal([1, 2, 3])
     s.metadata.array = np.arange(10.)

--- a/hyperspy/tests/signal/test_lazy.py
+++ b/hyperspy/tests/signal/test_lazy.py
@@ -53,7 +53,6 @@ def test_blockiter_bothmasks(signal, flat, dtype, nm, sm):
     real_second = get(signal.data.dask, (signal.data.name, 0, 1, 0, 0)).copy()
     # Don't want to rechunk, so change dtype manually
     signal.data = signal.data.astype(dtype)
-    # signal.change_dtype(dtype)
     it = signal._block_iterator(flat_signal=flat,
                                 navigation_mask=nm,
                                 signal_mask=sm,

--- a/hyperspy/tests/signal/test_lazy.py
+++ b/hyperspy/tests/signal/test_lazy.py
@@ -9,7 +9,7 @@ from hyperspy._signals.lazy import (_reshuffle_mixed_blocks,
 from hyperspy import _lazy_signals
 
 
-@pytest.fixture(scope='module')
+@pytest.fixture
 def signal():
     ar = da.from_array(np.arange(6. * 9 * 7 * 11).reshape((6, 9, 7, 11)),
                        chunks=((2, 1, 3), (4, 5), (7,), (11,))
@@ -51,7 +51,9 @@ sig_mask[0, :] = True
 def test_blockiter_bothmasks(signal, flat, dtype, nm, sm):
     real_first = get(signal.data.dask, (signal.data.name, 0, 0, 0, 0)).copy()
     real_second = get(signal.data.dask, (signal.data.name, 0, 1, 0, 0)).copy()
-    signal.change_dtype(dtype)
+    # Don't want to rechunk, so change dtype manually
+    signal.data = signal.data.astype(dtype)
+    # signal.change_dtype(dtype)
     it = signal._block_iterator(flat_signal=flat,
                                 navigation_mask=nm,
                                 signal_mask=sm,

--- a/hyperspy/tests/signal/test_tools.py
+++ b/hyperspy/tests/signal/test_tools.py
@@ -1,6 +1,7 @@
 from unittest import mock
 
 import numpy as np
+import dask.array as da
 from numpy.testing import assert_array_equal, assert_allclose
 
 import pytest
@@ -814,3 +815,14 @@ class TestTranspose:
 
         t = self.s.transpose(signal_axes=['f', 'a', 'b'], optimize=True)
         assert t.data.base is not self.s.data
+
+
+def test_lazy_transpose_rechunks():
+    ar = da.ones((50, 50, 256, 256), chunks=(5, 5, 256, 256))
+    s = signals.Signal2D(ar).as_lazy()
+    s1 = s.T
+    chunks = s1.data.chunks
+    assert len(chunks[0]) != 1
+    assert len(chunks[1]) != 1
+    assert len(chunks[2]) == 1
+    assert len(chunks[3]) == 1

--- a/hyperspy/tests/signal/test_tools.py
+++ b/hyperspy/tests/signal/test_tools.py
@@ -826,3 +826,20 @@ def test_lazy_transpose_rechunks():
     assert len(chunks[1]) != 1
     assert len(chunks[2]) == 1
     assert len(chunks[3]) == 1
+
+
+def test_lazy_changetype_rechunk():
+    ar = da.ones((50, 50, 256, 256), chunks=(5, 5, 256, 256), dtype='uint8')
+    s = signals.Signal2D(ar).as_lazy()
+    s._make_lazy(rechunk=True)
+    assert s.data.dtype is np.dtype('uint8')
+    chunks_old = s.data.chunks
+    s.change_dtype('float')
+    assert s.data.dtype is np.dtype('float')
+    chunks_new = s.data.chunks
+    assert (len(chunks_old[0]) * len(chunks_old[1]) <
+            len(chunks_new[0]) * len(chunks_new[1]))
+    s.change_dtype('uint8')
+    assert s.data.dtype is np.dtype('uint8')
+    chunks_newest = s.data.chunks
+    assert chunks_newest == chunks_new


### PR DESCRIPTION
Fixes https://github.com/hyperspy/hyperspy/issues/1560 

Also improves `change_dtype` behaviour to chunk according to the larger dtype before actually casting to not crash the memory. e.g. `uint8` with `(8, 8, 16, 16)` to `float` will first get rechunked to `(1, 1, 16, 16)` and only then re-cast as `float`.