### PR TITLE
Fix #1548: workaround to avoid updating numpy when building windows bundle installer

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -131,10 +131,10 @@ before_deploy:
   - "%CMD_IN_ENV% %WP_INSTDIR%/scripts/env.bat"
   # Give info about python vesion and compiler used to compile the python
   - "%CMD_IN_ENV% python.exe -c \"import sys; print(sys.version)\""
-  - "%CMD_IN_ENV% pip install --upgrade tqdm notebook cython ipython configobj start_jupyter_cm ipywidgets ipyparallel sympy"
+  - "%CMD_IN_ENV% pip install --upgrade tqdm notebook cython ipython configobj start_jupyter_cm ipywidgets ipyparallel sympy pytest"
   # uninstall and reinstall matplotlib to get the 2.0 version without using --upgrade option (to avoid upgrading numpy and breaking scipy...)
   - "%CMD_IN_ENV% pip uninstall -y matplotlib"
-  - "%CMD_IN_ENV% pip install matplotlib pytest pytest-mpl"
+  - "%CMD_IN_ENV% pip install matplotlib pytest-mpl"
   - "%CMD_IN_ENV% pip install dask==0.13"
   - "%CMD_IN_ENV% pip install .[all]"
   # Try to run twice as workaround for permission error

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -131,7 +131,10 @@ before_deploy:
   - "%CMD_IN_ENV% %WP_INSTDIR%/scripts/env.bat"
   # Give info about python vesion and compiler used to compile the python
   - "%CMD_IN_ENV% python.exe -c \"import sys; print(sys.version)\""
-  - "%CMD_IN_ENV% pip install --upgrade tqdm notebook cython ipython configobj start_jupyter_cm ipywidgets ipyparallel pytest pytest-mpl sympy"
+  - "%CMD_IN_ENV% pip install --upgrade tqdm notebook cython ipython configobj start_jupyter_cm ipywidgets ipyparallel sympy"
+  # uninstall and reinstall matplotlib to get the 2.0 version without using --upgrade option (to avoid upgrading numpy and breaking scipy...)
+  - "%CMD_IN_ENV% pip uninstall -y matplotlib"
+  - "%CMD_IN_ENV% pip install matplotlib pytest pytest-mpl"
   - "%CMD_IN_ENV% pip install dask==0.13"
   - "%CMD_IN_ENV% pip install .[all]"
   # Try to run twice as workaround for permission error


### PR DESCRIPTION
The issue in #1548 is due to a non working update of numpy when matplotlib and pytest-mpl are upgraded using pip. Thanks @francisco-dlp to point it out!

Would it be worth testing also the winpython bluid in appveyor?