### PR TITLE
Fix post checkout githook

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -111,7 +111,6 @@ for leftover in raw_extensions:
                     path +
                     '.cpython-*.so'))
 
-
 def count_c_extensions(extensions):
     c_num = 0
     for extension in extensions:
@@ -201,7 +200,7 @@ def find_post_checkout_cleanup_line():
 # after changing branches:
 if os.path.exists(git_dir) and (not os.path.exists(hook_ignorer)):
     exec_str = sys.executable
-    recythonize_str = ' '.join([exec_str,
+    recythonize_str = ' '.join(['"%s"'%exec_str,'"%s"'%
                                 os.path.join(setup_path, 'setup.py'),
                                 'clean --all build_ext --inplace\n'])
     if os.name == 'nt':
@@ -224,7 +223,7 @@ if os.path.exists(git_dir) and (not os.path.exists(hook_ignorer)):
             line_n = find_post_checkout_cleanup_line()
             if line_n is not None:
                 hook_lines[line_n] = 'rm ' + \
-                    ' '.join([i for i in cleanup_list]) + '\n'
+                    ' '.join(['"%s"' % i for i in cleanup_list]) + '\n'
                 hook_lines[line_n + 1] = recythonize_str
             else:
                 hook_lines.append('\n#cleanup_cythonized_and_compiled:\n')

--- a/setup.py
+++ b/setup.py
@@ -182,7 +182,7 @@ Installation will continue in 5 sec...""")
 
 
 # HOOKS ######
-post_checout_hook_file = os.path.join(setup_path, '.git/hooks/post-checkout')
+post_checkout_hook_file = os.path.join(setup_path, '.git/hooks/post-checkout')
 git_dir = os.path.join(setup_path, '.git')
 hook_ignorer = os.path.join(setup_path, '.hook_ignore')
 
@@ -190,7 +190,7 @@ hook_ignorer = os.path.join(setup_path, '.hook_ignore')
 def find_post_checkout_cleanup_line():
     """find the line index in the git post-checkout hooks
     'rm extension1 extension2 ...'"""
-    with open(post_checout_hook_file, 'r') as pchook:
+    with open(post_checkout_hook_file, 'r') as pchook:
         hook_lines = pchook.readlines()
         for i in range(1, len(hook_lines), 1):
             if re.search('#cleanup_cythonized_and_compiled:',
@@ -209,16 +209,16 @@ if os.path.exists(git_dir) and (not os.path.exists(hook_ignorer)):
         recythonize_str = recythonize_str.replace('\\', '/')
         for i in range(len(cleanup_list)):
             cleanup_list[i] = cleanup_list[i].replace('\\', '/')
-    if (not os.path.exists(post_checout_hook_file)):
-        with open(post_checout_hook_file, 'w') as pchook:
+    if (not os.path.exists(post_checkout_hook_file)):
+        with open(post_checkout_hook_file, 'w') as pchook:
             pchook.write('#!/bin/sh\n')
             pchook.write('#cleanup_cythonized_and_compiled:\n')
             pchook.write('rm ' + ' '.join([i for i in cleanup_list]) + '\n')
             pchook.write(recythonize_str)
         hook_mode = 0o777  # make it executable
-        os.chmod(post_checout_hook_file, hook_mode)
+        os.chmod(post_checkout_hook_file, hook_mode)
     else:
-        with open(post_checout_hook_file, 'r') as pchook:
+        with open(post_checkout_hook_file, 'r') as pchook:
             hook_lines = pchook.readlines()
         if re.search(r'#!/bin/.*?sh', hook_lines[0]) is not None:
             line_n = find_post_checkout_cleanup_line()
@@ -231,7 +231,7 @@ if os.path.exists(git_dir) and (not os.path.exists(hook_ignorer)):
                 hook_lines.append(
                     'rm ' + ' '.join([i for i in cleanup_list]) + '\n')
                 hook_lines.append(recythonize_str)
-            with open(post_checout_hook_file, 'w') as pchook:
+            with open(post_checkout_hook_file, 'w') as pchook:
                 pchook.writelines(hook_lines)
 
 

--- a/setup.py
+++ b/setup.py
@@ -213,7 +213,7 @@ if os.path.exists(git_dir) and (not os.path.exists(hook_ignorer)):
         with open(post_checkout_hook_file, 'w') as pchook:
             pchook.write('#!/bin/sh\n')
             pchook.write('#cleanup_cythonized_and_compiled:\n')
-            pchook.write('rm ' + ' '.join([i for i in cleanup_list]) + '\n')
+            pchook.write('rm ' + ' '.join(['"%s"' % i for i in cleanup_list]) + '\n')
             pchook.write(recythonize_str)
         hook_mode = 0o777  # make it executable
         os.chmod(post_checkout_hook_file, hook_mode)
@@ -229,7 +229,7 @@ if os.path.exists(git_dir) and (not os.path.exists(hook_ignorer)):
             else:
                 hook_lines.append('\n#cleanup_cythonized_and_compiled:\n')
                 hook_lines.append(
-                    'rm ' + ' '.join([i for i in cleanup_list]) + '\n')
+                    'rm ' + ' '.join(['"%s"' % i for i in cleanup_list]) + '\n')
                 hook_lines.append(recythonize_str)
             with open(post_checkout_hook_file, 'w') as pchook:
                 pchook.writelines(hook_lines)


### PR DESCRIPTION
Fix the post checkout git hook, such that all paths for `rm` gets quoted. Without this, something could go wrong if e.g. the repository is in the path `C:\windows development files\hyperspy` (will try to delete `C:\windows`, `development` and `hyperspy/hyperspy/io_plugins/unbcf_fast.c`).

Note: That command should not actually do anything to `c:\Windows` since `rm` should not delete folders, but you get my drift.

An alternative is of course to remove the post-checkout code from the setup.py code, and make it an opt-in feature instead. I would argue that installing hooks automatically is a little confusing (and possibly rude).

Someone will have to confirm if this quoting (double quotes) will work safely on other OSes than Windows.