### PR TITLE
Make ripple format a bit more tolerant

### DIFF
--- a/hyperspy/io_plugins/ripple.py
+++ b/hyperspy/io_plugins/ripple.py
@@ -162,7 +162,7 @@ def parse_ripple(fp):
                 err = 'Separator in line "%s" is wrong, ' % line
                 err += 'it should be a <TAB> ("\\t")'
                 raise IOError(err)
-            line = line.split(sep)  # now it's a list
+            line = [seg.strip() for seg in line.split(sep)]  # now it's a list
             if (line[0] in rpl_keys) is True:
                 value_type = rpl_keys[line[0]]
                 if isinstance(value_type, tuple):  # is selection list


### PR DESCRIPTION
The ripple format stipulates that the separator between keys and values is a single tab. However, it is not uncommon to find ripple files with spaces and/or a mixture of tabs and spaces in the wild. This let's HyperSpy load these mildly illegal files.