### PR TITLE
stricter control on samfire test random numbers, generic bounded fitter

### DIFF
--- a/hyperspy/tests/samfire/test_samfire.py
+++ b/hyperspy/tests/samfire/test_samfire.py
@@ -37,8 +37,6 @@ class Mock_queue(object):
     def put(self, value):
         self.var.append(value)
 
-np.random.seed(123)
-
 
 def generate_test_model():
 
@@ -50,6 +48,7 @@ def generate_test_model():
     total = None
 # blurs = [0., 0.5, 1., 2.,5.]
     blurs = [1.5]
+    rnd = np.random.RandomState(17)
     radius = 5
     domain = 15
 # do circle/domain
@@ -74,7 +73,7 @@ def generate_test_model():
             blur)
         gs01.centre.map['is_set'][:] = True
         gs01.A.map['values'][:] = 100 * \
-            np.random.random((domain, domain)) + 300000
+            rnd.rand(domain, domain) + 300000
         gs01.A.map['values'][mask] *= 0.75
         gs01.A.map['values'] = gaussian_filter(gs01.A.map['values'], blur)
         gs01.A.map['is_set'][:] = True
@@ -100,7 +99,7 @@ def generate_test_model():
         gs03.centre.map['values'][mask] = 900
         gs03.centre.map['is_set'][:] = True
         gs03.A.map['values'][:] = 100 * \
-            np.random.random((domain, domain)) + 50000
+            rnd.rand(domain, domain) + 50000
         gs03.A.map['values'][mask] *= 0.
         gs03.A.map['is_set'][:] = True
 
@@ -114,8 +113,7 @@ def generate_test_model():
                 (lor_map, gs01.centre.map['values'].copy()), axis=1)
 
     s = Signal1D(total)
-    s.add_poissonian_noise()
-    s.data += 0.1
+    s.data = rnd.poisson(lam=s.data) + 0.1
     s.estimate_poissonian_noise_variance()
 
     m = s.inav[:, :7].create_model()
@@ -310,7 +308,6 @@ class TestSamfireEmpty:
 class TestSamfireMain:
 
     def setup_method(self, method):
-        np.random.seed(1)
         self.model, self.lor1, self.g, self.lor2 = generate_test_model()
         self.shape = (7, 15)
 
@@ -322,7 +319,7 @@ class TestSamfireMain:
         samf.strategies[0].radii = 1.
         samf.strategies.remove(1)
         samf.optional_components = [self.model[2]]
-        samf.start(fitter='mpfit', bounded=True)
+        samf.start(bounded=True)
         # let at most 3 pixels to fail randomly.
         fitmask = samf.metadata.marker == -np.ones(self.shape)
         print('number of pixels failed: {}'.format(


### PR DESCRIPTION
Another slightly hopeful fix for https://github.com/hyperspy/hyperspy/issues/1522