### PR TITLE
Warn calibration v2

### DIFF
--- a/hyperspy/io.py
+++ b/hyperspy/io.py
@@ -125,8 +125,10 @@ def _check_calibration_is_ok(s, calibration):
 
     if not _calibration_ok:
         _calibration_msg = ", ".join(_calibration_msg)
-        _logger.warning(f"Mismatched calibration when stacking signals: {_calibration_msg}")
-        _logger.warning("The calibration of the first signal will be applied to all signals")
+        _logger.warning(
+            f"Mismatched calibration when stacking signals: {_calibration_msg}. "
+            "The calibration of the first signal will be applied to all signals"
+        )
 
     return _calibration_ok
 

--- a/hyperspy/io.py
+++ b/hyperspy/io.py
@@ -359,7 +359,7 @@ def load(filenames=None,
                             signals[0].append(obj)
                         else: # warn and dont append
                             _logger.warning('wrong calibration encountered while loading signals from ' + filename)
-                elif n > 1:
+                else:
                     for j in range(n):
                         signals[j].append(obj[j])
             # Next, merge the signals in the `stack_axis` direction:

--- a/hyperspy/tests/io/test_calibration_stack_warnings.py
+++ b/hyperspy/tests/io/test_calibration_stack_warnings.py
@@ -1,0 +1,58 @@
+import logging
+import os
+import tempfile
+
+import hyperspy.api as hs
+import pytest
+
+
+def test_calibration_all(caplog):
+    s1 = hs.signals.Signal1D([1.0, 2.0, 3.0])
+    s2 = hs.signals.Signal1D([1.0, 2.0, 3.0])
+
+    s1.axes_manager[0].scale = 1.0
+    s1.axes_manager[0].offset = 1.0
+    s1.axes_manager[0].units = "cm"
+
+    s2.axes_manager[0].scale = 2.0
+    s2.axes_manager[0].offset = 1.0 + 1e-5
+    s2.axes_manager[0].units = "mm"
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        f1 = os.path.join(tmpdir, "s1.hspy")
+        f2 = os.path.join(tmpdir, "s2.hspy")
+
+        s1.save(f1, overwrite=True)
+        s2.save(f2, overwrite=True)
+
+        with caplog.at_level(logging.WARNING):
+            _ = hs.load([f1, f2], stack=True)
+
+    assert "Mismatched calibration when stacking signals" in caplog.text
+    assert "scale" in caplog.text
+    assert "offset" in caplog.text
+    assert "units" in caplog.text
+
+
+def test_calibration_units_only(caplog):
+    s1 = hs.signals.Signal1D([1.0, 2.0, 3.0])
+    s2 = hs.signals.Signal1D([1.0, 2.0, 3.0])
+
+    s2.axes_manager[0].scale = 1.0
+    s2.axes_manager[0].offset = 0.0
+    s2.axes_manager[0].units = "mm"
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        f1 = os.path.join(tmpdir, "s1.hspy")
+        f2 = os.path.join(tmpdir, "s2.hspy")
+
+        s1.save(f1, overwrite=True)
+        s2.save(f2, overwrite=True)
+
+        with caplog.at_level(logging.WARNING):
+            _ = hs.load([f1, f2], stack=True)
+
+    assert "Mismatched calibration when stacking signals" in caplog.text
+    assert "scale" not in caplog.text
+    assert "offset" not in caplog.text
+    assert "units" in caplog.text


### PR DESCRIPTION
This fixes Issue #1570 . Signals not matching calibration data `scale`, `offset`, `units` of first signal are omitted and a warning is issued.

V2: restructured code. Fixed logic (`if ... elif` -> `if ... else`).
