### PR TITLE
User guide

### DIFF
--- a/doc/dev_guide.rst
+++ b/doc/dev_guide.rst
@@ -30,7 +30,7 @@ are currently implemented as well as much information about how everything works
 -- so read it well:
 `HyperSpy User-Guide <www.hyperspy.org/hyperspy-doc/current/index.html>`_.
 
-For developing the code the home of hyperspy is on github and you'll see that
+For developing the code the home of HyperSpy is on github and you'll see that
 a lot of this guide boils down to using that platform well. so visit the
 following link and poke around the code, issues, and pull requests: `HyperSpy
 on Github <https://github.com/hyperspy/hyperspy>`_.
@@ -163,7 +163,7 @@ tests reside in the ``hyperspy.tests`` module. To run them:
 
    py.test --pyargs hyperspy
 
-Or, from hyperspy's project folder simply:
+Or, from HyperSpy's project folder simply:
 
 .. code:: bash
 

--- a/doc/user_guide/getting_started.rst
+++ b/doc/user_guide/getting_started.rst
@@ -53,7 +53,7 @@ but some features such as navigation sliders may be missing.
 
 .. warning::
         When using the qt4 backend in Python 2 the matplotlib magic must be
-        executed after importing hyperspy and qt must be the default hyperspy
+        executed after importing HyperSpy and qt must be the default HyperSpy
         backend.
 
 .. NOTE::
@@ -114,7 +114,7 @@ working with HyperSpy/Python interactively.
 Loading data
 ------------
 
-Once hyperspy is running, to load from a supported file format (see
+Once HyperSpy is running, to load from a supported file format (see
 :ref:`supported-formats`) simply type:
 
 .. code-block:: python

--- a/doc/user_guide/io.rst
+++ b/doc/user_guide/io.rst
@@ -330,6 +330,10 @@ is widely used to exchange single spectrum data, but it does not support
 multidimensional data. It can be used to exchange single spectra with Gatan's
 Digital Micrograph.
 
+.. WARNING::
+    If several spectra are loaded and stacked (``hs.load('pattern', stack_signals=True``)
+    the calibration read from the first spectrum and applied to all other spectra.
+
 Extra saving arguments
 ^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/doc/user_guide/tools.rst
+++ b/doc/user_guide/tools.rst
@@ -678,6 +678,10 @@ are not equal `numpy broadcasting rules apply
 <http://docs.scipy.org/doc/numpy/user/basics.broadcasting.html>`_ independently
 for the navigation and signal axes.
 
+.. WARNING::
+
+    Hyperspy does not check if the calibration of the signals matches.
+
 In the following example `s2` has only one navigation axis while `s` has two.
 However, because the size of their first navigation axis is the same, their
 dimensions are compatible and `s2` is

--- a/doc/user_guide/tools.rst
+++ b/doc/user_guide/tools.rst
@@ -42,7 +42,7 @@ currently available specialised :py:class:`~.signal.BaseSignal` subclasses.
 
 
 The :py:mod:`~.signals` module, which contains all available signal subclasses,
-is imported in the user namespace when loading hyperspy. In the following
+is imported in the user namespace when loading HyperSpy. In the following
 example we create a Signal2D instance from a 2D numpy array:
 
 .. code-block:: python
@@ -454,7 +454,7 @@ features differ from numpy):
 
   + Allow independent indexing of signal and navigation dimensions
   + Support indexing with decimal numbers.
-  + Use the image order for indexing i.e. [x, y, z,...] (hyperspy) vs
+  + Use the image order for indexing i.e. [x, y, z,...] (HyperSpy) vs
     [...,z,y,x] (numpy)
 
 * HyperSpy indexing does not:

--- a/doc/user_guide/tools.rst
+++ b/doc/user_guide/tools.rst
@@ -353,13 +353,13 @@ Example:
     >>> s = hs.signals.BaseSignal(np.random.random((2,4,6)))
     >>> s.axes_manager[0].name = 'E'
     >>> s
-    <BaseSignal, title: , dimensions: (4, 2|6)>
+    <BaseSignal, title: , dimensions: (|6, 4, 2)>
     >>> # by default perform operation over all navigation axes
     >>> s.sum()
-    <BaseSignal, title: , dimensions: (|6)>
+    <BaseSignal, title: , dimensions: (|6, 4, 2)>
     >>> # can also pass axes individually
     >>> s.sum('E')
-    <BaseSignal, title: , dimensions: (2|6)>
+    <Signal2D, title: , dimensions: (|4, 2)>
     >>> # or a tuple of axes to operate on, with duplicates, by index or directly
     >>> ans = s.sum((-1, s.axes_manager[1], 'E', 0))
     >>> ans
@@ -549,7 +549,7 @@ data treating navigation axes using ``inav`` and signal axes using ``isig``.
 
     >>> s = hs.signals.Signal1D(np.arange(2*3*4).reshape((2,3,4)))
     >>> s
-    <Signal1D, title: , dimensions: (10, 10, 10)>
+    <Signal1D, title: , dimensions: (3, 2|4)>
     >>> s.data
     array([[[ 0,  1,  2,  3],
         [ 4,  5,  6,  7],
@@ -568,13 +568,22 @@ data treating navigation axes using ``inav`` and signal axes using ``isig``.
     >>> s.inav[0,0].data
     array([0, 1, 2, 3])
     >>> s.inav[0,0].axes_manager
-    <Axes manager, axes: (<t axis, size: 4>,)>
+    <Axes manager, axes: (|4)>
+                Name |   size |  index |  offset |   scale |  units
+    ================ | ====== | ====== | ======= | ======= | ======
+    ---------------- | ------ | ------ | ------- | ------- | ------
+                   t |      4 |        |       0 |       1 | <undefined>
     >>> s.inav[0,0].isig[::-1].data
     array([3, 2, 1, 0])
     >>> s.isig[0]
-    <Signal1D, title: , dimensions: (2, 3)>
+    <BaseSignal, title: , dimensions: (3, 2)>
     >>> s.isig[0].axes_manager
-    <Axes manager, axes: (<x axis, size: 3, index: 0>, <y axis, size: 2, index: 0>)>
+    <Axes manager, axes: (3, 2|)>
+                Name |   size |  index |  offset |   scale |  units
+    ================ | ====== | ====== | ======= | ======= | ======
+                   x |      3 |      0 |       0 |       1 | <undefined>
+                   y |      2 |      0 |       0 |       1 | <undefined>
+    ---------------- | ------ | ------ | ------- | ------- | ------
     >>> s.isig[0].data
     array([[ 0,  4,  8],
        [12, 16, 20]])
@@ -586,7 +595,7 @@ further in the following:
 
     >>> s = hs.signals.Signal1D(np.arange(2*3*4).reshape((2,3,4)))
     >>> s
-    <Signal1D, title: , dimensions: (10, 10, 10)>
+    <Signal1D, title: , dimensions: (3, 2|4)>
     >>> s.data
     array([[[ 0,  1,  2,  3],
         [ 4,  5,  6,  7],
@@ -605,11 +614,20 @@ further in the following:
     >>> s.inav[0,0].data
     array([0, 1, 2, 3])
     >>> s.inav[0,0].axes_manager
-    <Axes manager, axes: (<t axis, size: 4>,)>
+    <Axes manager, axes: (|4)>
+                Name |   size |  index |  offset |   scale |  units
+    ================ | ====== | ====== | ======= | ======= | ======
+    ---------------- | ------ | ------ | ------- | ------- | ------
+                   t |      4 |        |       0 |       1 | <undefined>
     >>> s.isig[0]
-    <Signal1D, title: , dimensions: (2, 3)>
+    <BaseSignal, title: , dimensions: (2, 3)>
     >>> s.isig[0].axes_manager
-    <Axes manager, axes: (<x axis, size: 3, index: 0>, <y axis, size: 2, index: 0>)>
+    <Axes manager, axes: (3, 2|)>
+                Name |   size |  index |  offset |   scale |  units
+    ================ | ====== | ====== | ======= | ======= | ======
+                   x |      3 |      0 |       0 |       1 | <undefined>
+                   y |      2 |      0 |       0 |       1 | <undefined>
+    ---------------- | ------ | ------ | ------- | ------- | ------
     >>> s.isig[0].data
     array([[ 0,  4,  8],
        [12, 16, 20]])
@@ -622,7 +640,7 @@ dimensions respectively:
 
     >>> s = hs.signals.Signal1D(np.arange(2*3*4).reshape((2,3,4)))
     >>> s
-    <Signal1D, title: , dimensions: (10, 10, 10)>
+    <Signal1D, title: , dimensions: (3, 2|4)>
     >>> s.data
     array([[[ 0,  1,  2,  3],
         [ 4,  5,  6,  7],
@@ -636,7 +654,7 @@ dimensions respectively:
     >>> s.inav[0,0] = 1
     >>> s.inav[0,0].data
     array([1, 1, 1, 1])
-    >>> s.inav[0,0] = s[1,1]
+    >>> s.inav[0,0] = s.inav[1,1]
     >>> s.inav[0,0].data
     array([16, 17, 18, 19])
 
@@ -1261,13 +1279,13 @@ operation.
 
 .. code-block:: python
 
-    >>> s = signals.Signal1D(np.arange(10))
+    >>> s = hs.signals.Signal1D(np.arange(10))
     >>> s_sum = s.sum(0)
     >>> s_sum.data
-    array(45)
+    array([45])
     >>> s.isig[:5].sum(0, out=s_sum)
     >>> s_sum.data
-    array(10)
+    array([10])
     >>> s_roi = s.isig[:3]
     >>> s_roi
     <Signal1D, title: , dimensions: (|3)>
@@ -1294,11 +1312,11 @@ signal changes.
     >>> s = hs.signals.Signal1D(np.arange(10.))
     >>> ssum = hs.interactive(s.sum, axis=0)
     >>> ssum.data
-    array(45.0)
+    array([45.0])
     >>> s.data /= 10
-    >>> s.events.data_changed.trigger()
+    >>> s.events.data_changed.trigger(s)
     >>> ssum.data
-    4.5
+    array([ 4.5])
 
 The interactive operations can be chained.
 

--- a/doc/user_guide/tools.rst
+++ b/doc/user_guide/tools.rst
@@ -764,7 +764,7 @@ to make a horizontal "collage" of the image stack:
 .. code-block:: python
 
     >>> import scipy.ndimage
-    >>> image_stack = hs.signals.Signal2D(np.array([scipy.misc.lena()]*5))
+    >>> image_stack = hs.signals.Signal2D(np.array([scipy.misc.ascent()]*5))
     >>> image_stack.axes_manager[1].name = "x"
     >>> image_stack.axes_manager[2].name = "y"
     >>> for image, angle in zip(image_stack, (0, 45, 90, 135, 180)):
@@ -793,7 +793,7 @@ using an external function can be more easily accomplished using the
 .. code-block:: python
 
     >>> import scipy.ndimage
-    >>> image_stack = hs.signals.Signal2D(np.array([scipy.misc.lena()]*4))
+    >>> image_stack = hs.signals.Signal2D(np.array([scipy.misc.ascent()]*4))
     >>> image_stack.axes_manager[1].name = "x"
     >>> image_stack.axes_manager[2].name = "y"
     >>> image_stack.map(scipy.ndimage.rotate,
@@ -814,7 +814,7 @@ arguments as in the following example.
 .. code-block:: python
 
     >>> import scipy.ndimage
-    >>> image_stack = hs.signals.Signal2D(np.array([scipy.misc.lena()]*4))
+    >>> image_stack = hs.signals.Signal2D(np.array([scipy.misc.ascent()]*4))
     >>> image_stack.axes_manager[1].name = "x"
     >>> image_stack.axes_manager[2].name = "y"
     >>> angles = hs.signals.BaseSignal(np.array([0, 45, 90, 135]))
@@ -936,7 +936,7 @@ with same dimension.
 
 .. code-block:: python
 
-    >>> image = hs.signals.Signal2D(scipy.misc.lena())
+    >>> image = hs.signals.Signal2D(scipy.misc.ascent())
     >>> image = hs.stack([hs.stack([image]*3,axis=0)]*3,axis=1)
     >>> image.plot()
 

--- a/doc/user_guide/visualisation.rst
+++ b/doc/user_guide/visualisation.rst
@@ -136,7 +136,7 @@ arguments are supported as well:
 .. code-block:: python
 
     >>> import scipy
-    >>> img = hs.signals.Signal2D(scipy.misc.lena())
+    >>> img = hs.signals.Signal2D(scipy.misc.ascent())
     >>> img.plot(colorbar=True, scalebar=False,
     >>> 	 axes_ticks=True, cmap='RdYlBu_r', saturated_pixels=0)
 
@@ -408,7 +408,7 @@ different slices of a multidimensional image (a *hyperimage*):
 .. code-block:: python
 
     >>> import scipy
-    >>> image = hs.signals.Signal2D([scipy.misc.lena()]*6)
+    >>> image = hs.signals.Signal2D([scipy.misc.ascent()]*6)
     >>> angles = hs.signals.BaseSignal(range(10,70,10))
     >>> image.map(scipy.ndimage.rotate, angle=angles.T, reshape=False)
     >>> hs.plot.plot_images(image, tight_layout=True)
@@ -430,7 +430,7 @@ In this example, the axes labels and the ticks are also disabled with `axes_deco
 .. code-block:: python
 
     >>> import scipy
-    >>> image = hs.signals.Signal2D([scipy.misc.lena()]*6)
+    >>> image = hs.signals.Signal2D([scipy.misc.ascent()]*6)
     >>> angles = hs.signals.BaseSignal(range(10,70,10))
     >>> image.map(scipy.ndimage.rotate, angle=angles.T, reshape=False)
     >>> hs.plot.plot_images(
@@ -459,7 +459,7 @@ This example also demonstrates how to wrap labels using `labelwrap` (for prevent
     >>> image0.metadata.General.title = 'Rocky Raccoon - R'
 
     >>> # load lena into 6 hyperimage
-    >>> image1 = hs.signals.Signal2D([scipy.misc.lena()]*6)
+    >>> image1 = hs.signals.Signal2D([scipy.misc.ascent()]*6)
     >>> angles = hs.signals.BaseSignal(np.arange(10,70,10)).T
     >>> image1.map(scipy.ndimage.rotate, angle=angles, reshape=False)
 
@@ -582,7 +582,7 @@ a file:
 .. code-block:: python
 
     >>> import scipy.misc
-    >>> s = hs.signals.Signal1D(scipy.misc.lena()[100:160:10])
+    >>> s = hs.signals.Signal1D(scipy.misc.ascent()[100:160:10])
     >>> cascade_plot = hs.plot.plot_spectra(s, style='cascade')
     >>> cascade_plot.figure.savefig("cascade_plot.png")
 
@@ -604,7 +604,7 @@ and provide the legend labels:
 .. code-block:: python
 
     >>> import scipy.misc
-    >>> s = hs.signals.Signal1D(scipy.misc.lena()[100:160:10])
+    >>> s = hs.signals.Signal1D(scipy.misc.ascent()[100:160:10])
     >>> color_list = ['red', 'red', 'blue', 'blue', 'red', 'red']
     >>> line_style_list = ['-','--','steps','-.',':','-']
     >>> hs.plot.plot_spectra(s, style='cascade', color=color_list,
@@ -625,8 +625,8 @@ generate a list of colors that follows a certain colormap:
 
     >>> import scipy.misc
     >>> fig, axarr = plt.subplots(1,2)
-    >>> s1 = hs.signals.Signal1D(scipy.misc.lena()[100:160:10])
-    >>> s2 = hs.signals.Signal1D(scipy.misc.lena()[200:260:10])
+    >>> s1 = hs.signals.Signal1D(scipy.misc.ascent()[100:160:10])
+    >>> s2 = hs.signals.Signal1D(scipy.misc.ascent()[200:260:10])
     >>> hs.plot.plot_spectra(s1,
     >>>                         style='cascade',
     >>>                         color=[plt.cm.RdBu(i/float(len(s1)-1))
@@ -653,7 +653,7 @@ There are also two other styles, "heatmap" and "mosaic":
 .. code-block:: python
 
     >>> import scipy.misc
-    >>> s = hs.signals.Signal1D(scipy.misc.lena()[100:160:10])
+    >>> s = hs.signals.Signal1D(scipy.misc.ascent()[100:160:10])
     >>> hs.plot.plot_spectra(s, style='heatmap')
 
 .. figure::  images/plot_spectra_heatmap.png
@@ -666,7 +666,7 @@ There are also two other styles, "heatmap" and "mosaic":
 .. code-block:: python
 
     >>> import scipy.misc
-    >>> s = hs.signals.Signal1D(scipy.misc.lena()[100:120:10])
+    >>> s = hs.signals.Signal1D(scipy.misc.ascent()[100:120:10])
     >>> hs.plot.plot_spectra(s, style='mosaic')
 
 .. figure::  images/plot_spectra_mosaic.png
@@ -682,7 +682,7 @@ For the "heatmap" style, different `matplotlib color schemes <http://matplotlib.
 
     >>> import matplotlib.cm
     >>> import scipy.misc
-    >>> s = hs.signals.Signal1D(scipy.misc.lena()[100:120:10])
+    >>> s = hs.signals.Signal1D(scipy.misc.ascent()[100:120:10])
     >>> ax = hs.plot.plot_spectra(s, style="heatmap")
     >>> ax.images[0].set_cmap(matplotlib.cm.jet)
 
@@ -701,7 +701,7 @@ that are passed directly to matplotlib.pyplot.figure as keyword arguments:
 .. code-block:: python
 
     >>> import scipy.misc
-    >>> s = hs.signals.Signal1D(scipy.misc.lena()[100:160:10])
+    >>> s = hs.signals.Signal1D(scipy.misc.ascent()[100:160:10])
     >>> legendtext = ['Plot 0', 'Plot 1', 'Plot 2', 'Plot 3', 'Plot 4', 'Plot 5']
     >>> cascade_plot = hs.plot.plot_spectra(
     >>>     s, style='cascade', legend=legendtext, dpi=60,
@@ -722,7 +722,7 @@ The function returns a matplotlib ax object, which can be used to customize the 
 .. code-block:: python
 
     >>> import scipy.misc
-    >>> s = hs.signals.Signal1D(scipy.misc.lena()[100:160:10])
+    >>> s = hs.signals.Signal1D(scipy.misc.ascent()[100:160:10])
     >>> cascade_plot = hs.plot.plot_spectra(s)
     >>> cascade_plot.set_xlabel("An axis")
     >>> cascade_plot.set_ylabel("Another axis")
@@ -742,8 +742,8 @@ subplots in the same figure. This will only work for "cascade" and "overlap" sty
 
     >>> import scipy.misc
     >>> fig, axarr = plt.subplots(1,2)
-    >>> s1 = hs.signals.Signal1D(scipy.misc.lena()[100:160:10])
-    >>> s2 = hs.signals.Signal1D(scipy.misc.lena()[200:260:10])
+    >>> s1 = hs.signals.Signal1D(scipy.misc.ascent()[100:160:10])
+    >>> s2 = hs.signals.Signal1D(scipy.misc.ascent()[200:260:10])
     >>> hs.plot.plot_spectra(s1, style='cascade',color='blue',ax=axarr[0],fig=fig)
     >>> hs.plot.plot_spectra(s2, style='cascade',color='red',ax=axarr[1],fig=fig)
     >>> fig.canvas.draw()
@@ -846,7 +846,7 @@ can be used in a static way
 .. code-block:: python
 
     >>> import scipy.misc
-    >>> im = hs.signals.Signal2D(scipy.misc.lena())
+    >>> im = hs.signals.Signal2D(scipy.misc.ascent())
     >>> m = hs.plot.markers.rectangle(x1=150, y1=100, x2=400, y2=400, color='red')
     >>> im.add_marker(m)
 

--- a/doc/user_guide/visualisation.rst
+++ b/doc/user_guide/visualisation.rst
@@ -90,7 +90,7 @@ To close all the figures run the following command:
 .. NOTE::
 
     This is a `matplotlib <http://matplotlib.sourceforge.net/>`_ command.
-    Matplotlib is the library that hyperspy uses to produce the plots. You can
+    Matplotlib is the library that HyperSpy uses to produce the plots. You can
     learn how to pan/zoom and more  `in the matplotlib documentation
     <http://matplotlib.sourceforge.net/users/navigation_toolbar.html>`_
 


### PR DESCRIPTION
This is an update to "Warn calibration v2 #1572".

- replaces scipy.misc.lena() (removed from scipy) by scipy.misc.ascent(). Question: Are the figures in `doc/user_guide/images` auto-generated or do I have to provide new figures for lena cases?
- fixed various typos
- warn the user in the User Guide about possible calibration issues. No changes are made to the code. So we still load EDS data with mixed calibrations as before. But the user has been warned in the User Guide.
