### PR TITLE
Improve parsing of the "intensity" axis in the DM reader

### DIFF
--- a/hyperspy/io_plugins/digital_micrograph.py
+++ b/hyperspy/io_plugins/digital_micrograph.py
@@ -883,15 +883,6 @@ class ImageObject(object):
                 "ImageList.TagGroup0.ImageTags": (
                     "Acquisition_instrument.TEM.microscope",
                     self._get_microscope_name),
-                "ImageList.TagGroup0.ImageData.Calibrations.Brightness.Units": (
-                    "Signal.quantity",
-                    self._get_quantity),
-                "ImageList.TagGroup0.ImageData.Calibrations.Brightness.Scale": (
-                    "Signal.Noise_properties.Variance_linear_model.gain_factor",
-                    None),
-                "ImageList.TagGroup0.ImageData.Calibrations.Brightness.Origin": (
-                    "Signal.Noise_properties.Variance_linear_model.gain_offset",
-                    None),
             })
 
         if self.signal_type == "EELS":
@@ -964,6 +955,17 @@ class ImageObject(object):
                     "Acquisition_instrument.TEM.Camera.exposure",
                     None),
             })
+        mapping.update({
+            "ImageList.TagGroup0.ImageData.Calibrations.Brightness.Units": (
+                "Signal.quantity",
+                self._get_quantity),
+            "ImageList.TagGroup0.ImageData.Calibrations.Brightness.Scale": (
+                "Signal.Noise_properties.Variance_linear_model.gain_factor",
+                None),
+            "ImageList.TagGroup0.ImageData.Calibrations.Brightness.Origin": (
+                "Signal.Noise_properties.Variance_linear_model.gain_offset",
+                None),
+        })
         return mapping
 
 


### PR DESCRIPTION
Small change in the mapping of the `original_metadata` to the `metadata` to parse intensity units and calibration of DM files for all images (not only the ones generated from a microscope).