### PR TITLE
Remove preferences that affect the outcome of the analysis

### DIFF
--- a/hyperspy/_components/eels_cl_edge.py
+++ b/hyperspy/_components/eels_cl_edge.py
@@ -81,12 +81,10 @@ class EELSCLEdge(Component):
         Decreasing the value increases the level of smoothing.
 
     fine_structure_active : bool
-        Activates/deactivates the fine structure feature. Its
-        default value can be choosen in the preferences.
+        Activates/deactivates the fine structure feature.
 
     """
-    _fine_structure_smoothing = \
-        preferences.EELS.fine_structure_smoothing
+    _fine_structure_smoothing = 0.3
 
     def __init__(self, element_subshell, GOS=None):
         # Declare the parameters
@@ -103,8 +101,8 @@ class EELSCLEdge(Component):
         self.name = "_".join([self.element, self.subshell])
         self.energy_scale = None
         self.effective_angle.free = False
-        self.fine_structure_active = preferences.EELS.fine_structure_active
-        self.fine_structure_width = preferences.EELS.fine_structure_width
+        self.fine_structure_active = False
+        self.fine_structure_width = 30.
         self.fine_structure_coeff.ext_force_positive = False
         self.GOS = None
         # Set initial actions

--- a/hyperspy/component.py
+++ b/hyperspy/component.py
@@ -648,7 +648,7 @@ class Parameter(t.HasTraits):
 
         """
         if format is None:
-            format = preferences.General.default_export_format
+            format = "hspy"
         if name is None:
             name = self.component.name + '_' + self.name
         filename = incremental_filename(slugify(name) + '.' + format)

--- a/hyperspy/defaults_parser.py
+++ b/hyperspy/defaults_parser.py
@@ -117,12 +117,6 @@ class GeneralConfig(t.HasTraits):
 
 
 class MachineLearningConfig(t.HasTraits):
-    multiple_files = t.Bool(
-        True,
-        label='Export to multiple files',
-        desc='If enabled, on exporting the PCA or ICA results one file'
-        'per factor and loading will be created. Otherwise only two files'
-        'will contain the factors and loadings')
     same_window = t.Bool(
         True,
         label='Plot components in the same window',

--- a/hyperspy/defaults_parser.py
+++ b/hyperspy/defaults_parser.py
@@ -148,7 +148,7 @@ template = {
     'General': GeneralConfig(),
     'EELS': EELSConfig(),
     'EDS': EDSConfig(),
-    }
+}
 
 # Set the enums defaults
 template['General'].logging_level = 'WARNING'

--- a/hyperspy/defaults_parser.py
+++ b/hyperspy/defaults_parser.py
@@ -80,11 +80,6 @@ else:
 
 
 class GeneralConfig(t.HasTraits):
-    default_export_format = t.Enum(
-        *default_write_ext,
-        desc='Using the hspy format is highly reccomended because is the '
-        'only one fully supported. The Ripple (rpl) format it is useful '
-        'to export data to other software that do not support hspy')
     interactive = t.CBool(
         True,
         desc='If enabled, HyperSpy will prompt the user when options are '

--- a/hyperspy/defaults_parser.py
+++ b/hyperspy/defaults_parser.py
@@ -144,23 +144,11 @@ class EDSConfig(t.HasTraits):
         desc='default value for the elevation angle in degree.')
 
 
-class PlotConfig(t.HasTraits):
-    default_style_to_compare_spectra = t.Enum(
-        'overlap',
-        'cascade',
-        'mosaic',
-        'heatmap',
-        desc=' the default style use to compare spectra with the'
-        ' function utils.plot.plot_spectra')
-    plot_on_load = t.CBool(
-        False,
-        desc='If enabled, the object will be plot automatically on loading')
-
 template = {
     'General': GeneralConfig(),
     'EELS': EELSConfig(),
     'EDS': EDSConfig(),
-    'Plot': PlotConfig(), }
+    }
 
 # Set the enums defaults
 template['General'].logging_level = 'WARNING'
@@ -228,7 +216,6 @@ class Preferences(t.HasTraits):
     EELS = t.Instance(EELSConfig)
     EDS = t.Instance(EDSConfig)
     General = t.Instance(GeneralConfig)
-    Plot = t.Instance(PlotConfig)
 
     def gui(self):
         import hyperspy.gui.preferences
@@ -244,8 +231,7 @@ class Preferences(t.HasTraits):
 preferences = Preferences(
     EELS=template['EELS'],
     EDS=template['EDS'],
-    General=template['General'],
-    Plot=template['Plot'])
+    General=template['General'],)
 
 if preferences.General.logger_on:
     turn_logging_on(verbose=0)

--- a/hyperspy/defaults_parser.py
+++ b/hyperspy/defaults_parser.py
@@ -116,14 +116,6 @@ class GeneralConfig(t.HasTraits):
             turn_logging_off()
 
 
-class MachineLearningConfig(t.HasTraits):
-    same_window = t.Bool(
-        True,
-        label='Plot components in the same window',
-        desc='If enabled the principal and independent components will all'
-        ' be plotted in the same window')
-
-
 class EELSConfig(t.HasTraits):
     eels_gos_files_path = t.Directory(
         guess_gos_path(),
@@ -202,7 +194,6 @@ template = {
     'General': GeneralConfig(),
     'EELS': EELSConfig(),
     'EDS': EDSConfig(),
-    'MachineLearning': MachineLearningConfig(),
     'Plot': PlotConfig(), }
 
 # Set the enums defaults
@@ -271,7 +262,6 @@ class Preferences(t.HasTraits):
     EELS = t.Instance(EELSConfig)
     EDS = t.Instance(EDSConfig)
     General = t.Instance(GeneralConfig)
-    MachineLearning = t.Instance(MachineLearningConfig)
     Plot = t.Instance(PlotConfig)
 
     def gui(self):
@@ -289,8 +279,6 @@ preferences = Preferences(
     EELS=template['EELS'],
     EDS=template['EDS'],
     General=template['General'],
-    Model=template['Model'],
-    MachineLearning=template['MachineLearning'],
     Plot=template['Plot'])
 
 if preferences.General.logger_on:

--- a/hyperspy/defaults_parser.py
+++ b/hyperspy/defaults_parser.py
@@ -116,11 +116,6 @@ class GeneralConfig(t.HasTraits):
             turn_logging_off()
 
 
-class ModelConfig(t.HasTraits):
-    default_fitter = t.Enum('leastsq', 'mpfit',
-                            desc='Choose leastsq if no bounding is required. '
-                            'Otherwise choose mpfit')
-
 
 class MachineLearningConfig(t.HasTraits):
     multiple_files = t.Bool(
@@ -216,7 +211,6 @@ class PlotConfig(t.HasTraits):
 
 template = {
     'General': GeneralConfig(),
-    'Model': ModelConfig(),
     'EELS': EELSConfig(),
     'EDS': EDSConfig(),
     'MachineLearning': MachineLearningConfig(),
@@ -287,7 +281,6 @@ config2template(template, config)
 class Preferences(t.HasTraits):
     EELS = t.Instance(EELSConfig)
     EDS = t.Instance(EDSConfig)
-    Model = t.Instance(ModelConfig)
     General = t.Instance(GeneralConfig)
     MachineLearning = t.Instance(MachineLearningConfig)
     Plot = t.Instance(PlotConfig)

--- a/hyperspy/defaults_parser.py
+++ b/hyperspy/defaults_parser.py
@@ -116,7 +116,6 @@ class GeneralConfig(t.HasTraits):
             turn_logging_off()
 
 
-
 class MachineLearningConfig(t.HasTraits):
     multiple_files = t.Bool(
         True,

--- a/hyperspy/defaults_parser.py
+++ b/hyperspy/defaults_parser.py
@@ -197,10 +197,6 @@ class PlotConfig(t.HasTraits):
     plot_on_load = t.CBool(
         False,
         desc='If enabled, the object will be plot automatically on loading')
-    pylab_inline = t.CBool(
-        False,
-        desc="If True the figure are displayed inline."
-        "HyperSpy must be restarted for changes to take effect")
 
 template = {
     'General': GeneralConfig(),

--- a/hyperspy/defaults_parser.py
+++ b/hyperspy/defaults_parser.py
@@ -109,11 +109,6 @@ class GeneralConfig(t.HasTraits):
         desc='Use parallel threads for computations by default.'
     )
 
-    lazy = t.CBool(
-        False,
-        desc='Load data lazily by default.'
-    )
-
     def _logger_on_changed(self, old, new):
         if new is True:
             turn_logging_on()

--- a/hyperspy/defaults_parser.py
+++ b/hyperspy/defaults_parser.py
@@ -121,40 +121,6 @@ class EELSConfig(t.HasTraits):
         guess_gos_path(),
         label='GOS directory',
         desc='The GOS files are required to create the EELS edge components')
-    fine_structure_width = t.CFloat(
-        30,
-        label='Fine structure length',
-        desc='The default length of the fine structure from the edge onset')
-    fine_structure_active = t.CBool(
-        False,
-        label='Enable fine structure',
-        desc="If enabled, the regions of the EELS spectrum defined as fine "
-        "structure will be fitted with a spline. Please note that it "
-        "enabling this feature only makes sense when the model is "
-        "convolved to account for multiple scattering")
-    fine_structure_smoothing = t.Range(
-        0.,
-        1.,
-        value=0.3,
-        label='Fine structure smoothing factor',
-        desc='The lower the value the smoother the fine structure spline fit')
-    synchronize_cl_with_ll = t.CBool(False)
-    preedge_safe_window_width = t.CFloat(
-        2,
-        label='Pre-onset region (in eV)',
-        desc='Some functions needs to define the regions between two '
-        'ionisation edges. Due to limited energy resolution or chemical '
-        'shift, the region is limited on its higher energy side by '
-        'the next ionisation edge onset minus an offset defined by this '
-        'parameters')
-    min_distance_between_edges_for_fine_structure = t.CFloat(
-        0,
-        label='Minimum distance between edges',
-        desc='When automatically setting the fine structure energy regions, '
-        'the fine structure of an EELS edge component is automatically '
-        'disable if the next ionisation edge onset distance to the '
-        'higher energy side of the fine structure region is lower that '
-        'the value of this parameter')
 
 
 class EDSConfig(t.HasTraits):

--- a/hyperspy/drawing/utils.py
+++ b/hyperspy/drawing/utils.py
@@ -928,7 +928,7 @@ def set_axes_decor(ax, axes_decor):
 
 def plot_spectra(
         spectra,
-        style='default',
+        style='overlap',
         color=None,
         line_style=None,
         padding=1.,
@@ -947,9 +947,8 @@ def plot_spectra(
     spectra : iterable object
         Ordered spectra list to plot. If `style` is "cascade" or "mosaic"
         the spectra can have different size and axes.
-    style : {'default', 'overlap', 'cascade', 'mosaic', 'heatmap'}
-        The style of the plot. The default is "overlap" and can be
-        customized in `preferences`.
+    style : {'overlap', 'cascade', 'mosaic', 'heatmap'}
+        The style of the plot.
     color : matplotlib color or a list of them or `None`
         Sets the color of the lines of the plots (no action on 'heatmap').
         If a list, if its length is less than the number of spectra to plot,
@@ -1004,8 +1003,9 @@ def plot_spectra(
     """
     import hyperspy.signal
 
+    # Before v1.3 default would read the value from prefereces.
     if style == "default":
-        style = preferences.Plot.default_style_to_compare_spectra
+        style = "overlap"
 
     if color is not None:
         if isinstance(color, str):

--- a/hyperspy/io.py
+++ b/hyperspy/io.py
@@ -48,7 +48,7 @@ def load(filenames=None,
          stack=False,
          stack_axis=None,
          new_axis_name="stack_element",
-         lazy=None,
+         lazy=False,
          **kwds):
     """
     Load potentially multiple supported file into an hyperspy structure
@@ -105,9 +105,8 @@ def load(filenames=None,
         until it finds a name that is not yet in use.
     lazy : {None, bool}
         Open the data lazily - i.e. without actually reading the data from the
-        disk until required. Allows opening arbitrary-sized datasets.
-        If None, default from preferences is used.
-
+        disk until required. Allows opening arbitrary-sized datasets. default
+        is `False`.
     print_info: bool
         For SEMPER unf- and EMD (Berkley)-files, if True (default is False)
         additional information read during loading is printed for a quick
@@ -143,8 +142,6 @@ def load(filenames=None,
             lazy = True
             warnings.warn(warn_str.format(k), VisibleDeprecationWarning)
             del kwds[k]
-    if lazy is None:
-        lazy = preferences.General.lazy
     kwds['signal_type'] = signal_type
 
     if filenames is None:

--- a/hyperspy/io.py
+++ b/hyperspy/io.py
@@ -227,9 +227,6 @@ def load(filenames=None,
                                         **kwds)
                        for filename in filenames]
 
-        if preferences.Plot.plot_on_load:
-            for obj in objects:
-                obj.plot()
         if len(objects) == 1:
             objects = objects[0]
     return objects

--- a/hyperspy/model.py
+++ b/hyperspy/model.py
@@ -880,7 +880,7 @@ class BaseModel(list):
             ' reduced chi-squared'
         return tmp
 
-    def fit(self, fitter=None, method='ls', grad=False,
+    def fit(self, fitter="leastsq", method='ls', grad=False,
             bounded=False, ext_bounding=False, update_plot=False,
             **kwargs):
         """Fits the model to the experimental data.
@@ -895,11 +895,11 @@ class BaseModel(list):
 
         Parameters
         ----------
-        fitter : {None, "leastsq", "mpfit", "odr", "Nelder-Mead",
+        fitter : {"leastsq", "mpfit", "odr", "Nelder-Mead",
                  "Powell", "CG", "BFGS", "Newton-CG", "L-BFGS-B", "TNC",
                  "Differential Evolution"}
-            The optimization algorithm used to perform the fitting. If None the
-            fitter defined in `preferences.Model.default_fitter` is used.
+            The optimization algorithm used to perform the fitting. Deafault
+            is "leastsq".
 
                 "leastsq" performs least-squares optimization, and supports
                 bounds on parameters.
@@ -954,8 +954,8 @@ class BaseModel(list):
 
         """
 
-        if fitter is None:
-            fitter = preferences.Model.default_fitter
+        if fitter is None: # None meant "from preferences" before v1.3
+            fitter = "leastsq"
         switch_aap = (update_plot != self._plot_active)
         if switch_aap is True and update_plot is False:
             cm = self.suspend_update

--- a/hyperspy/model.py
+++ b/hyperspy/model.py
@@ -954,7 +954,7 @@ class BaseModel(list):
 
         """
 
-        if fitter is None: # None meant "from preferences" before v1.3
+        if fitter is None:  # None meant "from preferences" before v1.3
             fitter = "leastsq"
         switch_aap = (update_plot != self._plot_active)
         if switch_aap is True and update_plot is False:

--- a/hyperspy/models/eelsmodel.py
+++ b/hyperspy/models/eelsmodel.py
@@ -29,6 +29,13 @@ from hyperspy._signals.eels import EELSSpectrum
 
 _logger = logging.getLogger(__name__)
 
+# When automatically setting the fine structure energy regions,
+# the fine structure of an EELS edge component is automatically
+# disable if the next ionisation edge onset distance to the
+# higher energy side of the fine structure region is lower that
+# the value of this parameter
+_MIN_DISTANCE_BETWEEN_EDGES_FOR_FINE_STRUCTURE = 0
+
 
 class EELSModel(Model1D):
 
@@ -213,8 +220,7 @@ class EELSModel(Model1D):
 
     def resolve_fine_structure(
             self,
-            preedge_safe_window_width=preferences.EELS.
-            preedge_safe_window_width,
+            preedge_safe_window_width=2,
             i1=0):
         """Adjust the fine structure of all edges to avoid overlapping
 
@@ -225,7 +231,8 @@ class EELSModel(Model1D):
         ----------
         preedge_safe_window_width : float
             minimum distance between the fine structure of an ionization edge
-            and that of the following one.
+            and that of the following one. Default 2 (eV).
+
         """
 
         if self._suspend_auto_fine_structure_width is True:
@@ -248,8 +255,7 @@ class EELSModel(Model1D):
                     self._active_edges[i1].onset_energy.value)
                 if (self._active_edges[i1].fine_structure_width >
                         distance_between_edges - preedge_safe_window_width):
-                    min_d = preferences.EELS.\
-                        min_distance_between_edges_for_fine_structure
+                    min_d = _MIN_DISTANCE_BETWEEN_EDGES_FOR_FINE_STRUCTURE
                     if (distance_between_edges -
                             preedge_safe_window_width) <= min_d:
                         _logger.info((

--- a/hyperspy/models/eelsmodel.py
+++ b/hyperspy/models/eelsmodel.py
@@ -36,6 +36,8 @@ _logger = logging.getLogger(__name__)
 # the value of this parameter
 _MIN_DISTANCE_BETWEEN_EDGES_FOR_FINE_STRUCTURE = 0
 
+_PREEDGE_SAFE_WINDOW_WIDTH = 2
+
 
 class EELSModel(Model1D):
 
@@ -254,10 +256,10 @@ class EELSModel(Model1D):
                     self._active_edges[i2].onset_energy.value -
                     self._active_edges[i1].onset_energy.value)
                 if (self._active_edges[i1].fine_structure_width >
-                        distance_between_edges - preedge_safe_window_width):
+                        distance_between_edges - _PREEDGE_SAFE_WINDOW_WIDTH):
                     min_d = _MIN_DISTANCE_BETWEEN_EDGES_FOR_FINE_STRUCTURE
                     if (distance_between_edges -
-                            preedge_safe_window_width) <= min_d:
+                            _PREEDGE_SAFE_WINDOW_WIDTH) <= min_d:
                         _logger.info((
                             "Automatically deactivating the fine structure "
                             "of edge number %d to avoid conflicts with edge "
@@ -268,7 +270,7 @@ class EELSModel(Model1D):
                         self.resolve_fine_structure(i1=i2)
                     else:
                         new_fine_structure_width = (
-                            distance_between_edges - preedge_safe_window_width)
+                            distance_between_edges - _PREEDGE_SAFE_WINDOW_WIDTH)
                         _logger.info((
                             "Automatically changing the fine structure "
                             "width of edge %d from %s eV to %s eV to avoid "
@@ -427,7 +429,7 @@ class EELSModel(Model1D):
         if iee is not None:
             to_disable = [edge for edge in self._active_edges
                           if edge.onset_energy.value >= iee]
-            E2 = iee - preferences.EELS.preedge_safe_window_width
+            E2 = iee - _PREEDGE_SAFE_WINDOW_WIDTH
             self.disable_edges(to_disable)
         else:
             E2 = None
@@ -476,7 +478,7 @@ class EELSModel(Model1D):
                 E2 = ea[-1]
             else:
                 E2 = E2 - \
-                    preferences.EELS.preedge_safe_window_width
+                    _PREEDGE_SAFE_WINDOW_WIDTH
 
         if not powerlaw.estimate_parameters(
                 self.signal, E1, E2, only_current=False):
@@ -491,7 +493,7 @@ class EELSModel(Model1D):
         ea = self.axis.axis[self.channel_switches]
         if start_energy is None:
             start_energy = ea[0]
-        preedge_safe_window_width = preferences.EELS.preedge_safe_window_width
+        preedge_safe_window_width = _PREEDGE_SAFE_WINDOW_WIDTH
         # Declare variables
         active_edges = self._active_edges
         edge = active_edges[edgenumber]
@@ -515,7 +517,7 @@ class EELSModel(Model1D):
         else:
             nextedgeenergy = (
                 active_edges[edgenumber + i].onset_energy.value -
-                preedge_safe_window_width)
+                _PREEDGE_SAFE_WINDOW_WIDTH)
 
         # Backup the fsstate
         to_activate_fs = []

--- a/hyperspy/models/eelsmodel.py
+++ b/hyperspy/models/eelsmodel.py
@@ -30,8 +30,6 @@ from hyperspy._signals.eels import EELSSpectrum
 _logger = logging.getLogger(__name__)
 
 
-
-
 class EELSModel(Model1D):
 
     """Build an EELS model

--- a/hyperspy/signal.py
+++ b/hyperspy/signal.py
@@ -245,7 +245,7 @@ class MVATools(object):
 
     def _plot_factors_or_pchars(self, factors, comp_ids=None,
                                 calibrate=True, avg_char=False,
-                                same_window=None, comp_label='PC',
+                                same_window=True, comp_label='PC',
                                 img_data=None,
                                 plot_shifts=True, plot_char=4,
                                 cmap=plt.cm.gray, quiver_color='white',
@@ -266,7 +266,7 @@ class MVATools(object):
             manager.
         same_window : bool
             if True, plots each factor to the same window.  They are
-            not scaled.
+            not scaled. Default True.
         comp_label : string
             Title of the plot
         cmap : a matplotlib colormap
@@ -301,7 +301,7 @@ class MVATools(object):
            If None, uses matplotlib's autoscaling.
         """
         if same_window is None:
-            same_window = preferences.MachineLearning.same_window
+            same_window = True
         if comp_ids is None:
             comp_ids = range(factors.shape[1])
 
@@ -374,12 +374,12 @@ class MVATools(object):
             return f
 
     def _plot_loadings(self, loadings, comp_ids, calibrate=True,
-                       same_window=None, comp_label=None,
+                       same_window=True, comp_label=None,
                        with_factors=False, factors=None,
                        cmap=plt.cm.gray, no_nans=False, per_row=3,
                        axes_decor='all'):
         if same_window is None:
-            same_window = preferences.MachineLearning.same_window
+            same_window = True
         if comp_ids is None:
             comp_ids = range(loadings.shape[0])
 
@@ -745,7 +745,7 @@ class MVATools(object):
     def plot_decomposition_factors(self,
                                    comp_ids,
                                    calibrate=True,
-                                   same_window=None,
+                                   same_window=True,
                                    comp_label=None,
                                    cmap=plt.cm.gray,
                                    per_row=3,
@@ -771,7 +771,7 @@ class MVATools(object):
 
         same_window : bool
             if True, plots each factor to the same window.  They are
-            not scaled.
+            not scaled. Default is True.
 
         title : string
             Title of the plot.
@@ -780,8 +780,7 @@ class MVATools(object):
             characteristics, the colormap used for the scatter plot of
             some peak characteristic.
         per_row : int, the number of plots in each row, when the
-        same_window
-            parameter is True.
+        same_window parameter is True.
 
         See Also
         --------
@@ -794,7 +793,7 @@ class MVATools(object):
                                       "You can use "
                                       "`plot_decomposition_results` instead.")
         if same_window is None:
-            same_window = preferences.MachineLearning.same_window
+            same_window = True
         factors = self.learning_results.factors
         if comp_ids is None:
             comp_ids = self.learning_results.output_dimension
@@ -812,7 +811,7 @@ class MVATools(object):
                                             per_row=per_row)
 
     def plot_bss_factors(self, comp_ids=None, calibrate=True,
-                         same_window=None, comp_label=None,
+                         same_window=True, comp_label=None,
                          per_row=3, title=None):
         """Plot factors from blind source separation results. In case of 1D
         signal axis, each factors line can be toggled on and off by clicking
@@ -835,7 +834,7 @@ class MVATools(object):
 
         same_window : bool
             if True, plots each factor to the same window.  They are
-            not scaled.
+            not scaled. Default is True.
 
         title : string
             Title of the plot.
@@ -860,7 +859,7 @@ class MVATools(object):
                                       "`plot_decomposition_results` instead.")
 
         if same_window is None:
-            same_window = preferences.MachineLearning.same_window
+            same_window = True
         factors = self.learning_results.bss_factors
         title = self._change_API_comp_label(title, comp_label)
         if title is None:
@@ -876,7 +875,7 @@ class MVATools(object):
     def plot_decomposition_loadings(self,
                                     comp_ids,
                                     calibrate=True,
-                                    same_window=None,
+                                    same_window=True,
                                     comp_label=None,
                                     with_factors=False,
                                     cmap=plt.cm.gray,
@@ -904,7 +903,7 @@ class MVATools(object):
 
         same_window : bool
             if True, plots each factor to the same window.  They are
-            not scaled.
+            not scaled. Default is True.
 
         title : string
             Title of the plot.
@@ -943,7 +942,7 @@ class MVATools(object):
                                       "You can use "
                                       "`plot_decomposition_results` instead.")
         if same_window is None:
-            same_window = preferences.MachineLearning.same_window
+            same_window = True
         loadings = self.learning_results.loadings.T
         if with_factors:
             factors = self.learning_results.factors
@@ -970,7 +969,7 @@ class MVATools(object):
             axes_decor=axes_decor)
 
     def plot_bss_loadings(self, comp_ids=None, calibrate=True,
-                          same_window=None, comp_label=None,
+                          same_window=True, comp_label=None,
                           with_factors=False, cmap=plt.cm.gray,
                           no_nans=False, per_row=3, axes_decor='all',
                           title=None):
@@ -995,7 +994,7 @@ class MVATools(object):
 
         same_window : bool
             if True, plots each factor to the same window.  They are
-            not scaled.
+            not scaled. Default is True.
 
         title : string
             Title of the plot.
@@ -1034,7 +1033,7 @@ class MVATools(object):
                                       "You can use "
                                       "`plot_bss_results` instead.")
         if same_window is None:
-            same_window = preferences.MachineLearning.same_window
+            same_window = True
         title = self._change_API_comp_label(title, comp_label)
         if title is None:
             title = self._get_plot_title('BSS loadings of',

--- a/hyperspy/signal.py
+++ b/hyperspy/signal.py
@@ -460,7 +460,7 @@ class MVATools(object):
                         factors,
                         folder=None,
                         comp_ids=None,
-                        multiple_files=None,
+                        multiple_files=True,
                         save_figures=False,
                         save_figures_format='png',
                         factor_prefix=None,
@@ -480,7 +480,7 @@ class MVATools(object):
         from hyperspy._signals.signal1d import Signal1D
 
         if multiple_files is None:
-            multiple_files = preferences.MachineLearning.multiple_files
+            multiple_files = True
 
         if factor_format is None:
             factor_format = 'hspy'
@@ -611,7 +611,7 @@ class MVATools(object):
                          loadings,
                          folder=None,
                          comp_ids=None,
-                         multiple_files=None,
+                         multiple_files=True,
                          loading_prefix=None,
                          loading_format="hspy",
                          save_figures_format='png',
@@ -627,7 +627,7 @@ class MVATools(object):
         from hyperspy._signals.signal1d import Signal1D
 
         if multiple_files is None:
-            multiple_files = preferences.MachineLearning.multiple_files
+            multiple_files = True
 
         if loading_format is None:
             loading_format = 'hspy'
@@ -1075,7 +1075,7 @@ class MVATools(object):
                                      comp_label=None,
                                      cmap=plt.cm.gray,
                                      same_window=False,
-                                     multiple_files=None,
+                                     multiple_files=True,
                                      no_nans=True,
                                      per_row=3,
                                      save_figures=False,
@@ -1189,7 +1189,7 @@ class MVATools(object):
                            comp_ids=None,
                            folder=None,
                            calibrate=True,
-                           multiple_files=None,
+                           multiple_files=True,
                            save_figures=False,
                            factor_prefix='bss_factor',
                            factor_format="hspy",
@@ -1238,12 +1238,8 @@ class MVATools(object):
               separate file.
         multiple_files : Bool
             If True, on exporting a file per factor and per loading
-            will be
-            created. Otherwise only two files will be created, one
-            for the
-            factors and another for the loadings. The default value
-            can be
-            chosen in the preferences.
+            will be created. Otherwise only two files will be created, one
+            for the factors and another for the loadings. Default is True.
         save_figures : Bool
             If True the same figures that are obtained when using the
             plot

--- a/hyperspy/tests/model/test_eelsmodel.py
+++ b/hyperspy/tests/model/test_eelsmodel.py
@@ -5,7 +5,6 @@ from numpy.testing import assert_allclose
 
 import hyperspy.api as hs
 from hyperspy.decorators import lazifyTestClass
-from hyperspy.models.eelsmodel import _PREEDGE_SAFE_WINDOW_WIDTH
 
 
 @lazifyTestClass
@@ -94,7 +93,7 @@ class TestEELSModel:
         m.suspend_auto_fine_structure_width()
         m.resume_auto_fine_structure_width()
         window = (m["C_K"].onset_energy.value -
-                  m["B_K"].onset_energy.value - _PREEDGE_SAFE_WINDOW_WIDTH)
+                  m["B_K"].onset_energy.value - m._preedge_safe_window_width)
         m.enable_fine_structure()
         m.resolve_fine_structure()
         assert window == m["B_K"].fine_structure_width

--- a/hyperspy/tests/model/test_eelsmodel.py
+++ b/hyperspy/tests/model/test_eelsmodel.py
@@ -5,6 +5,7 @@ from numpy.testing import assert_allclose
 
 import hyperspy.api as hs
 from hyperspy.decorators import lazifyTestClass
+from hyperspy.models.eelsmodel import _PREEDGE_SAFE_WINDOW_WIDTH
 
 
 @lazifyTestClass
@@ -93,8 +94,7 @@ class TestEELSModel:
         m.suspend_auto_fine_structure_width()
         m.resume_auto_fine_structure_width()
         window = (m["C_K"].onset_energy.value -
-                  m["B_K"].onset_energy.value -
-                  hs.preferences.EELS.preedge_safe_window_width)
+                  m["B_K"].onset_energy.value - _PREEDGE_SAFE_WINDOW_WIDTH)
         m.enable_fine_structure()
         m.resolve_fine_structure()
         assert window == m["B_K"].fine_structure_width


### PR DESCRIPTION
The preferences removed had the potential of changing the outcome of the analysis, breaking the portability of HyperSpy scripts. Fixes #1556 

List of removed preferences:

* ``General.default_export_format``
* ``General.lazy``
* ``Model.default_fitter``
* ``Machine_learning.multiple_files``
* ``Machine_learning.same_window``
* ``Plot.default_style_to_compare_spectra`` 
* ``Plot.plot_on_load`` 
* ``Plot.pylab_inline`` 
* ``EELS.fine_structure_width``
* ``EELS.fine_structure_active``
* ``EELS.fine_structure_smoothing``
* ``EELS.synchronize_cl_with_ll``
* ``EELS.preedge_safe_window_width``
* ``EELS.min_distance_between_edges_for_fine_structure``
