### PR TITLE
TYPO: fix typos in axes.py

### DIFF
--- a/hyperspy/axes.py
+++ b/hyperspy/axes.py
@@ -141,7 +141,7 @@ class DataAxis(t.HasTraits):
     def _value_changed(self, name, old, new):
         old_index = self.index
         new_index = self.value2index(new)
-        if self.continuous_value is False:  # Only values in the grid alowed
+        if self.continuous_value is False:  # Only values in the grid allowed
             if old_index != new_index:
                 self.index = new_index
                 if new == self.axis[self.index]:
@@ -158,7 +158,7 @@ class DataAxis(t.HasTraits):
                 elif new_value == new and not\
                         self._suppress_value_changed_trigger:
                     self.events.value_changed.trigger(obj=self, value=new)
-        else:  # Intergrid values are alowed. This feature is deprecated
+        else:  # Intergrid values are allowed. This feature is deprecated
             self.events.value_changed.trigger(obj=self, value=new)
             if old_index != new_index:
                 self._suppress_update_value = True
@@ -264,7 +264,7 @@ class DataAxis(t.HasTraits):
 
     def _slice_me(self, slice_):
         """Returns a slice to slice the corresponding data axis and
-        change the offset and scale of the DataAxis acordingly.
+        change the offset and scale of the DataAxis accordingly.
 
         Parameters
         ----------
@@ -464,7 +464,7 @@ class AxesManager(t.HasTraits):
 
     """Contains and manages the data axes.
 
-    It supports indexing, slicing, subscriptins and iteration. As an iterator,
+    It supports indexing, slicing, subscripting and iteration. As an iterator,
     iterate over the navigation coordinates returning the current indices.
     It can only be indexed and sliced to access the DataAxis objects that it
     contains. Standard indexing and slicing follows the "natural order" as in
@@ -483,13 +483,10 @@ class AxesManager(t.HasTraits):
         Get and set the current coordinates if the navigation dimension
         is not 0. If the navigation dimension is 0 it raises
         AttributeError when attempting to set its value.
-
-
     indices : tuple
         Get and set the current indices if the navigation dimension
         is not 0. If the navigation dimension is 0 it raises
         AttributeError when attempting to set its value.
-
     signal_axes, navigation_axes : list
         Contain the corresponding DataAxis objects
 
@@ -570,7 +567,7 @@ class AxesManager(t.HasTraits):
         self.events.any_axis_changed = Event("""
             Event that trigger when the space defined by the axes transforms.
 
-            Specifically, it triggers when one or more of the folloing
+            Specifically, it triggers when one or more of the following
             attributes changes on one or more of the axes:
                 `offset`, `size`, `scale`
 
@@ -642,7 +639,7 @@ class AxesManager(t.HasTraits):
         elif (isfloat(y.real) and not y.real.is_integer() or
                 isfloat(y.imag) and not y.imag.is_integer()):
             raise TypeError("axesmanager indices must be integers, "
-                            "complex intergers or strings")
+                            "complex integers or strings")
         if y.imag == 0:  # Natural order
             return self._get_axes_in_natural_order()[y]
         elif y.imag == 3:  # Array order
@@ -773,12 +770,12 @@ class AxesManager(t.HasTraits):
     def __next__(self):
         """
         Standard iterator method, updates the index and returns the
-        current coordiantes
+        current coordinates
 
         Returns
         -------
         val : tuple of ints
-            Returns a tuple containing the coordiantes of the current
+            Returns a tuple containing the coordinates of the current
             iteration.
 
         """
@@ -1077,7 +1074,7 @@ class AxesManager(t.HasTraits):
         Parameters
         ----------
         coordinates : tuple
-            The len of the the tuple must coincide with the navigation
+            The len of the tuple must coincide with the navigation
             dimension
 
         """
@@ -1108,7 +1105,7 @@ class AxesManager(t.HasTraits):
         Parameters
         ----------
         indices : tuple
-            The len of the the tuple must coincide with the navigation
+            The len of the tuple must coincide with the navigation
             dimension
 
         """
@@ -1132,7 +1129,7 @@ class AxesManager(t.HasTraits):
         ----------
         attr : string
             The DataAxis attribute to set.
-        values: any
+        values : any
             If iterable, it must have the same number of items
             as axes are in this AxesManager instance. If not iterable,
             the attribute of all the axes are set to the given value.


### PR DESCRIPTION
Fixed a few typos and docstring formatting in axes.py