### PR TITLE
Fix plotting error when calling draw_animated too early

### DIFF
--- a/hyperspy/drawing/figure.py
+++ b/hyperspy/drawing/figure.py
@@ -47,8 +47,14 @@ class BlittedFigure(object):
                 artists.extend(ax.artists)
                 artists.append(ax.get_yaxis())
                 artists.append(ax.get_xaxis())
-                [ax.draw_artist(a) for a in artists if
-                 a.get_animated() is True]
+                try:
+                    [ax.draw_artist(a) for a in artists if
+                     a.get_animated() is True]
+                except AttributeError:
+                     # The method was called before draw. This is a quick
+                     # fix. Properly fixing the issue involves avoiding
+                     # calling this method too early in the code.
+                    pass
             if canvas.supports_blit:
                 canvas.blit(self.figure.bbox)
 


### PR DESCRIPTION
This is a quickfix as the proper fix involves not calling draw_animated
too early instead of skipping the exception. However, this fix is
general while our tests are not comprehensive, so I think that it is less risky
to go for this solution for now.