### PR TITLE
Fix arrow keys navigation not connected without navigator

### DIFF
--- a/hyperspy/drawing/mpl_hie.py
+++ b/hyperspy/drawing/mpl_hie.py
@@ -81,11 +81,13 @@ class MPL_HyperImage_Explorer(MPL_HyperExplorer):
         imf.plot(**kwargs)
         self.signal_plot = imf
 
-        if self.navigator_plot is not None and imf.figure is not None:
-            self.navigator_plot.events.closed.connect(
-                self._on_navigator_plot_closing, [])
-            imf.events.closed.connect(self.close_navigator_plot, [])
-            self.signal_plot.figure.canvas.mpl_connect(
-                'key_press_event', self.axes_manager.key_navigator)
-            self.navigator_plot.figure.canvas.mpl_connect(
-                'key_press_event', self.axes_manager.key_navigator)
+        if imf.figure is not None:
+            if self.axes_manager.navigation_axes:
+                self.signal_plot.figure.canvas.mpl_connect(
+                    'key_press_event', self.axes_manager.key_navigator)
+            if self.navigator_plot is not None:
+                self.navigator_plot.figure.canvas.mpl_connect(
+                    'key_press_event', self.axes_manager.key_navigator)
+                self.navigator_plot.events.closed.connect(
+                    self._on_navigator_plot_closing, [])
+                imf.events.closed.connect(self.close_navigator_plot, [])

--- a/hyperspy/drawing/mpl_hse.py
+++ b/hyperspy/drawing/mpl_hse.py
@@ -118,18 +118,20 @@ class MPL_HyperSignal1D_Explorer(MPL_HyperExplorer):
 
         self.signal_plot = sf
         sf.plot()
-        if self.navigator_plot is not None and sf.figure is not None:
-            self.navigator_plot.events.closed.connect(
-                self._on_navigator_plot_closing, [])
-            sf.events.closed.connect(self.close_navigator_plot, [])
-            self.signal_plot.figure.canvas.mpl_connect(
-                'key_press_event', self.axes_manager.key_navigator)
-            self.navigator_plot.figure.canvas.mpl_connect(
-                'key_press_event', self.axes_manager.key_navigator)
-            self.signal_plot.figure.canvas.mpl_connect(
-                'key_press_event', self.key2switch_right_pointer)
-            self.navigator_plot.figure.canvas.mpl_connect(
-                'key_press_event', self.key2switch_right_pointer)
+        if sf.figure is not None:
+            if self.axes_manager.navigation_axes:
+                self.signal_plot.figure.canvas.mpl_connect(
+                    'key_press_event', self.axes_manager.key_navigator)
+            if self.navigator_plot is not None:
+                self.navigator_plot.events.closed.connect(
+                    self._on_navigator_plot_closing, [])
+                sf.events.closed.connect(self.close_navigator_plot, [])
+                self.signal_plot.figure.canvas.mpl_connect(
+                    'key_press_event', self.key2switch_right_pointer)
+                self.navigator_plot.figure.canvas.mpl_connect(
+                    'key_press_event', self.key2switch_right_pointer)
+                self.navigator_plot.figure.canvas.mpl_connect(
+                    'key_press_event', self.axes_manager.key_navigator)
 
     def key2switch_right_pointer(self, event):
         if event.key == "e":


### PR DESCRIPTION
When plotting multi-dimensional signals without displaying a navigator figure, navigating the signal with the arrow keys is not possible.

This fixes it.