### PR TITLE
FIX: switch to integer division for plot_images label detection

### DIFF
--- a/hyperspy/drawing/utils.py
+++ b/hyperspy/drawing/utils.py
@@ -684,7 +684,7 @@ def plot_images(images,
         if len(label_list) > n:
             del label_list[n:]
         if len(label_list) < n:
-            label_list *= (n / len(label_list)) + 1
+            label_list *= (n // len(label_list)) + 1
             del label_list[n:]
 
     else:


### PR DESCRIPTION
Resolves #1691

Note: This whole labeling business is done much more elegantly in `plot_spectra`, but this was an easier fix. We might consider changing them to use the same code at a later date.