### PR TITLE
Make warnings about missing GUI features optional

### DIFF
--- a/doc/user_guide/getting_started.rst
+++ b/doc/user_guide/getting_started.rst
@@ -54,7 +54,15 @@ and the
 
 By default, HyperSpy warns the user if one of the GUI packages is not installed.
 These warnings can be turned off using the :py:class:`~.defaults_parser.Preferences`
-class (see :ref:`here <configuring-hyperspy-label>` for more information).
+class: (see :ref:`here <configuring-hyperspy-label>` for more information), or
+directly via:
+
+    .. code-block:: python
+
+       >>> import hyperspy.api as hs
+       >>> hs.preferences.GUIs.warn_if_guis_are_missing = False
+       >>> hs.preferences.save()
+
 
 Now you are ready to load
 your data (see below).

--- a/doc/user_guide/getting_started.rst
+++ b/doc/user_guide/getting_started.rst
@@ -52,6 +52,10 @@ that you have installed at least one of HyperSpy's GUI packages:
 and the
 `traitsui GUI <https://github.com/hyperspy/hyperspy_gui_traitsui>`_.
 
+By default, HyperSpy warns the user if one of the GUI packages is not installed.
+These warnings can be turned off using the :py:class:`~.defaults_parser.Preferences`
+class (see :ref:`here <configuring-hyperspy-label>` for more information).
+
 Now you are ready to load
 your data (see below).
 

--- a/doc/user_guide/getting_started.rst
+++ b/doc/user_guide/getting_started.rst
@@ -53,9 +53,9 @@ and the
 `traitsui GUI <https://github.com/hyperspy/hyperspy_gui_traitsui>`_.
 
 By default, HyperSpy warns the user if one of the GUI packages is not installed.
-These warnings can be turned off using the :py:class:`~.defaults_parser.Preferences`
-class: (see :ref:`here <configuring-hyperspy-label>` for more information), or
-directly via:
+These warnings can be turned off using the :py:class:`~.defaults_parser.Preferences` GUI
+(see :ref:`here <configuring-hyperspy-label>` for more information) or programmatically
+as follows:
 
     .. code-block:: python
 

--- a/hyperspy/api.py
+++ b/hyperspy/api.py
@@ -8,13 +8,17 @@ try:
     # Register ipywidgets by importing the module
     import hyperspy_gui_ipywidgets
 except ImportError:
-    _logger.warning(
-        "The ipywidgets GUI elements are not available, probably because the "
-        "hyperspy_gui_ipywidgets package is not installed.")
+    from hyperspy.defaults_parser import preferences
+    if preferences.GUIs.warn_if_guis_are_missing:
+        _logger.warning(
+            "The ipywidgets GUI elements are not available, probably because the "
+            "hyperspy_gui_ipywidgets package is not installed.")
 try:
     # Register traitui UI elements by importing the module
     import hyperspy_gui_traitsui
 except ImportError:
-    _logger.warning(
-        "The traitsui GUI elements are not available, probably because the "
-        "hyperspy_gui_traitui package is not installed.")
+    from hyperspy.defaults_parser import preferences
+    if preferences.GUIs.warn_if_guis_are_missing:
+        _logger.warning(
+            "The traitsui GUI elements are not available, probably because the "
+            "hyperspy_gui_traitui package is not installed.")

--- a/hyperspy/defaults_parser.py
+++ b/hyperspy/defaults_parser.py
@@ -134,6 +134,9 @@ class GUIs(t.HasTraits):
         True,
         desc="Display traitsui user interface elements. "
         "Requires installing hyperspy_gui_traitsui.")
+    warn_if_guis_are_missing = t.CBool(
+        True,
+        desc="Display warnings, if hyperspy_gui_ipywidgets or hyperspy_gui_traitsui are missing.")
 
 
 class EDSConfig(t.HasTraits):


### PR DESCRIPTION
Added `preferences.GUIs.warn_if_guis_are_missing` option, which can be used to toggle warnings about missing installations of `hyperspy_gui_ipywidgets` or `hyperspy_gui_traitsui`.

This is just a small suggestions if someone decides to not install one of the gui interfaces and is annoyed by the warning each time hyperspy is imported.

Maybe it is better to still warn if none of the options are installed?

If there are arguments against this change, feel free to close this PR :-)...