### PR TITLE
Fixed MRC plugin after NumPy update

### DIFF
--- a/hyperspy/io_plugins/mrc.py
+++ b/hyperspy/io_plugins/mrc.py
@@ -159,8 +159,8 @@ def file_reader(filename, endianess='<', **kwds):
     if lazy:
         mmap_mode = 'r'
     data = np.memmap(f, mode=mmap_mode, offset=f.tell(),
-                     dtype=get_data_type(std_header['MODE'], endianess)
-                     ).squeeze().reshape((NX, NY, NZ), order='F').T
+                     dtype=get_data_type(std_header['MODE'][0], endianess)
+                     ).squeeze().reshape((NX[0], NY[0], NZ[0]), order='F').T
 
     original_metadata = {'std_header': sarray2dict(std_header)}
     # Convert bytes to unicode


### PR DESCRIPTION
Fixed #1705
Starting from some recent version of NumPy it is an error to use 1D arrays for indexing -
 so we need to extract scalars here. Info: https://stackoverflow.com/a/42444003