### PR TITLE
Add pytest-sugar to travis and mention it in the dev_guide

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -54,7 +54,7 @@ before_script: # configure a headless display to test plot generation
 
 script:
   - python -c 'import matplotlib.pyplot as plt; print(plt.get_backend())';
-  - pip install coverage coveralls pytest pytest-cov pytest-mpl;
+  - pip install coverage coveralls pytest pytest-cov pytest-mpl pytest-sugar;
     py.test --mpl --cov=hyperspy --pyargs hyperspy;
 
 after_success:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -71,7 +71,7 @@ install:
   - "%CMD_IN_ENV% conda install -yq %DEPS%"
     # Having 'sip' folder on path confuses import of `sip`.
   - "%CMD_IN_ENV% conda install pip"
-  - "pip install pytest-mpl pytest-sugar"
+  - "pip install pytest-mpl"
     # Force to have the freetype font in matplotlib from pip for plot testing
   - "pip uninstall -y matplotlib"
   - "pip install matplotlib"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -71,7 +71,7 @@ install:
   - "%CMD_IN_ENV% conda install -yq %DEPS%"
     # Having 'sip' folder on path confuses import of `sip`.
   - "%CMD_IN_ENV% conda install pip"
-  - "pip install pytest-mpl"
+  - "pip install pytest-mpl pytest-sugar"
     # Force to have the freetype font in matplotlib from pip for plot testing
   - "pip uninstall -y matplotlib"
   - "pip install matplotlib"

--- a/doc/dev_guide.rst
+++ b/doc/dev_guide.rst
@@ -195,6 +195,9 @@ Useful hints on testing:
   your PR. There should be a link to it at the bottom of your PR on the github
   PR page. This service can help you to find how well your code is being tested
   and exactly which part is not currently tested.
+* `pytest-sugar <https://pypi.python.org/pypi/pytest-sugar>`_ can be installed
+  to have a nicer look and feel of py.test in the console (encoding issue have
+  been reported in the Windows console).
 
 
 .. _plot-test-label:


### PR DESCRIPTION
#1706
This PR only add pytest-sugar to travis for better look and feel of pytest. It does not introduce a new dependency to hyperspy.