### PR TITLE
Fix issue with installing the dev version in a windows anaconda

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -272,7 +272,8 @@ class update_version_when_dev:
         if self.release_version.endswith(".dev"):
             p = subprocess.Popen(["git", "describe",
                                   "--tags", "--dirty", "--always"],
-                                 stdout=subprocess.PIPE)
+                                 stdout=subprocess.PIPE,
+                                 shell=True)
             stdout = p.communicate()[0]
             if p.returncode != 0:
                 # Git is not available, we keep the version as is

--- a/setup.py
+++ b/setup.py
@@ -330,7 +330,7 @@ with update_version_when_dev() as version:
                   'hyperspy.samfire_utils.goodness_of_fit_tests',
                   ],
         install_requires=install_req,
-        test_require=["pytest>=3.0.2"],
+        tests_require=["pytest>=3.0.2"],
         extras_require=extras_require,
         package_data={
             'hyperspy':


### PR DESCRIPTION
### Description of the change
Fix #1704 issue reported by @k8macarthur on gitter when installing the dev version in a windows anaconda. I could reproduce locally in a fresh install. I don't know why appveyor does not have the issue but this PR seems to do the job.

### Progress of the PR
- [x] Add shell=True argument to subprocess.Popen in setup.py
- [x] Fix and tidy up path in setup.py.
- [x] ready for review.