### PR TITLE
Add hack for BCF used MSXML decimal non-compliance 

### DIFF
--- a/hyperspy/io.py
+++ b/hyperspy/io.py
@@ -31,7 +31,6 @@ from hyperspy.misc.utils import (strlist2enumeration, find_subclasses)
 from hyperspy.misc.utils import stack as stack_method
 from hyperspy.io_plugins import io_plugins, default_write_ext
 from hyperspy.exceptions import VisibleDeprecationWarning
-from traits.trait_errors import TraitError
 from hyperspy.defaults_parser import preferences
 from hyperspy.ui_registry import get_gui
 
@@ -302,28 +301,7 @@ def load_with_reader(filename,
                 signal_dict["metadata"]["Signal"] = {}
             if signal_type is not None:
                 signal_dict['metadata']["Signal"]['signal_type'] = signal_type
-            try:
-                objects.append(dict2signal(signal_dict, lazy=lazy))
-            except TraitError:
-                if reader.short_name == 'bcf':
-                    print(
-"""The BCF reader can't read the badly formated file.
-This could be caused by a non-compliance of pascal implementation
-used by Bruker Esprit to decimal/float type data serialisation
-standards of XML. It can be hacked around by temporary setting
-the decimal and thousand separators, before loading the file,
-with a following function:
-
->>> hs.hyperspy.io_plugins.bcf.set_NUM_FORMAT(t_sep, d_sep)
-
-e.g. when locale with Esprit is German or Polish:
->>> hs.hyperspy.io_plugins.bcf.set_NUM_FORMAT('', ',')
-e.g. for French:
->>> hs.hyperspy.io_plugins.bcf.set_NUM_FORMAT('.', ',')
-
-To prevent this error in the future, please, consider of
-setting the locale to en_US on OS with Esprit.""")
-                raise
+            objects.append(dict2signal(signal_dict, lazy=lazy))
             folder, filename = os.path.split(os.path.abspath(filename))
             filename, extension = os.path.splitext(filename)
             objects[-1].tmp_parameters.folder = folder

--- a/hyperspy/io.py
+++ b/hyperspy/io.py
@@ -311,20 +311,19 @@ def load_with_reader(filename,
 This could be caused by a non-compliance of pascal implementation
 used by Bruker Esprit to decimal/float type data serialisation
 standards of XML. It can be hacked around by temporary setting
-the hint of decimal and thousand separator, before loading the file,
-by following function:
+the decimal and thousand separators, before loading the file,
+with a following function:
 
 >>> hs.hyperspy.io_plugins.bcf.set_NUM_FORMAT(t_sep, d_sep)
 
-e.g. when locale with Esprit is German:
+e.g. when locale with Esprit is German or Polish:
 >>> hs.hyperspy.io_plugins.bcf.set_NUM_FORMAT('', ',')
 e.g. for French:
 >>> hs.hyperspy.io_plugins.bcf.set_NUM_FORMAT('.', ',')
 
 To prevent this error in the future, please, consider of
 setting the locale to en_US on OS with Esprit.""")
-                else:
-                    raise
+                raise
             folder, filename = os.path.split(os.path.abspath(filename))
             filename, extension = os.path.splitext(filename)
             objects[-1].tmp_parameters.folder = folder

--- a/hyperspy/io_plugins/bcf.py
+++ b/hyperspy/io_plugins/bcf.py
@@ -79,10 +79,10 @@ Falling back to slow python only backend.""")
 # define re with two capturing groups with comma in between
 # firstgroup looks for numeric value after <tag> (the '>' char) with or
 # without minus sign, second group looks for numeric value with following
-# closing <\tag> (the '<' char); '([Ee]-?\d*)' part checks for scientific
-# notation (e.g. 8,843E-7); pattern is binary, as raw xml string
-# is binary: 
-fix_dec_patterns = re.compile(b'(>-?\d+),(\d*([Ee]-?\d*)?<)')
+# closing <\tag> (the '<' char); '([Ee]-?\d*)' part (optionally a third group)
+# checks for scientific notation (e.g. 8,843E-7 -> 'E-7');
+# compiled pattern is binary, as raw xml string is binary.: 
+fix_dec_patterns = re.compile(b'(>-?\\d+),(\\d*([Ee]-?\\d*)?<)')
 
 
 class Container(object):

--- a/hyperspy/io_plugins/bcf.py
+++ b/hyperspy/io_plugins/bcf.py
@@ -92,7 +92,7 @@ def set_NUM_FORMAT(t_sep, d_sep):
             r'^(\d|'+NUM_FORMAT[0]+')*'+NUM_FORMAT[1]+'{1}\d*$')
     else:
         raise ValueError(
-            """thousand and decimal separator should be entered as strings""")
+            """thousand and decimal separators should be entered as the strings""")
 
 
 class Container(object):

--- a/hyperspy/io_plugins/bcf.py
+++ b/hyperspy/io_plugins/bcf.py
@@ -79,9 +79,10 @@ Falling back to slow python only backend.""")
 # define re with two capturing groups with comma in between
 # firstgroup looks for numeric value after <tag> (the '>' char) with or
 # without minus sign, second group looks for numeric value with following
-# closing <\tag> (the '<' char); pattern is binary, as raw xml string
+# closing <\tag> (the '<' char); '([Ee]-?\d*)' part checks for scientific
+# notation (e.g. 8,843E-7); pattern is binary, as raw xml string
 # is binary: 
-fix_dec_patterns = re.compile(b'(>-?\d+),(\d*<)')
+fix_dec_patterns = re.compile(b'(>-?\d+),(\d*([Ee]-?\d*)?<)')
 
 
 class Container(object):

--- a/hyperspy/io_plugins/bcf.py
+++ b/hyperspy/io_plugins/bcf.py
@@ -76,6 +76,11 @@ except ImportError:  # pragma: no cover
     _logger.info("""unbcf_fast library is not present...
 Falling back to slow python only backend.""")
 
+# define re with two capturing groups with comma in between
+# firstgroup looks for numeric value after <tag> (the '>' char) with or
+# without minus sign, second group looks for numeric value with following
+# closing <\tag> (the '<' char); pattern is binary, as raw xml string
+# is binary: 
 fix_dec_patterns = re.compile(b'(>-?\d+),(\d*<)')
 
 

--- a/hyperspy/tests/io/test_bcf.py
+++ b/hyperspy/tests/io/test_bcf.py
@@ -198,8 +198,8 @@ def test_wrong_file():
 def test_decimal_regex():
     lxml = pytest.importorskip("lxml")
     from hyperspy.io_plugins.bcf import fix_dec_patterns
-    dummy_xml_positive = b'<dummy_tag>85,658<\\dummy_tag>'
-    dummy_xml_negative = b'<dum_tag>12,25,23,45,56,12,45<\\dum_tag>'
+    dummy_xml_positive = b'<dummy_tag>85,658</dummy_tag>'
+    dummy_xml_negative = b'<dum_tag>12,25,23,45,56,12,45</dum_tag>'
     assert b'85.658' in fix_dec_patterns.sub(b'\\1.\\2', dummy_xml_positive)
     assert b'.' not in fix_dec_patterns.sub(b'\\1.\\2', dummy_xml_negative)
     

--- a/hyperspy/tests/io/test_bcf.py
+++ b/hyperspy/tests/io/test_bcf.py
@@ -198,8 +198,13 @@ def test_wrong_file():
 def test_decimal_regex():
     lxml = pytest.importorskip("lxml")
     from hyperspy.io_plugins.bcf import fix_dec_patterns
-    dummy_xml_positive = b'<dummy_tag>85,658</dummy_tag>'
-    dummy_xml_negative = b'<dum_tag>12,25,23,45,56,12,45</dum_tag>'
-    assert b'85.658' in fix_dec_patterns.sub(b'\\1.\\2', dummy_xml_positive)
-    assert b'.' not in fix_dec_patterns.sub(b'\\1.\\2', dummy_xml_negative)
+    dummy_xml_positive = [b'<dummy_tag>85,658</dummy_tag>',
+                          b'<dummy_tag>85,658E-8</dummy_tag>',
+                          b'<dummy_tag>-85,658E-8</dummy_tag>']
+    dummy_xml_negative = [b'<dum_tag>12,25,23,45,56,12,45</dum_tag>',
+                          b'<dum_tag>12e1,23,-24E-5</dum_tag>']
+    for i in dummy_xml_positive:
+        assert b'85.658' in fix_dec_patterns.sub(b'\\1.\\2', i)
+    for j in dummy_xml_negative:
+        assert b'.' not in fix_dec_patterns.sub(b'\\1.\\2', j)
     

--- a/hyperspy/tests/io/test_bcf.py
+++ b/hyperspy/tests/io/test_bcf.py
@@ -200,6 +200,6 @@ def test_decimal_regex():
     from hyperspy.io_plugins.bcf import fix_dec_patterns
     dummy_xml_positive = b'<dummy_tag>85,658<\\dummy_tag>'
     dummy_xml_negative = b'<dum_tag>12,25,23,45,56,12,45<\\dum_tag>'
-    assert '85.658' in fix_dec_patterns.sub(b'\\1.\\2', dummy_xml_positive)
-    assert '.' not in fix_dec_patterns.sub(b'\\1.\\2', dummy_xml_negative)
+    assert b'85.658' in fix_dec_patterns.sub(b'\\1.\\2', dummy_xml_positive)
+    assert b'.' not in fix_dec_patterns.sub(b'\\1.\\2', dummy_xml_negative)
     

--- a/hyperspy/tests/io/test_bcf.py
+++ b/hyperspy/tests/io/test_bcf.py
@@ -193,7 +193,7 @@ def test_wrong_file():
     lxml = pytest.importorskip("lxml")
     filename = os.path.join(my_path, 'bcf_data', 'Nope.bcf')
     with pytest.raises(TypeError):
-        load(filename)fix_dec_patterns = re.compile(b'(>-?\d+),(\d*<)')
+        load(filename)
 
 def test_decimal_regex():
     lxml = pytest.importorskip("lxml")

--- a/hyperspy/tests/io/test_bcf.py
+++ b/hyperspy/tests/io/test_bcf.py
@@ -193,4 +193,13 @@ def test_wrong_file():
     lxml = pytest.importorskip("lxml")
     filename = os.path.join(my_path, 'bcf_data', 'Nope.bcf')
     with pytest.raises(TypeError):
-        load(filename)
+        load(filename)fix_dec_patterns = re.compile(b'(>-?\d+),(\d*<)')
+
+def test_decimal_regex():
+    lxml = pytest.importorskip("lxml")
+    from hyperspy.io_plugins.bcf import fix_dec_patterns
+    dummy_xml_positive = b'<dummy_tag>85,658<\\dummy_tag>'
+    dummy_xml_negative = b'<dum_tag>12,25,23,45,56,12,45<\\dum_tag>'
+    assert '85.658' in fix_dec_patterns.sub(b'\\1.\\2', dummy_xml_positive)
+    assert '.' not in fix_dec_patterns.sub(b'\\1.\\2', dummy_xml_negative)
+    

--- a/hyperspy/tests/io/test_bcf.py
+++ b/hyperspy/tests/io/test_bcf.py
@@ -200,7 +200,9 @@ def test_decimal_regex():
     from hyperspy.io_plugins.bcf import fix_dec_patterns
     dummy_xml_positive = [b'<dummy_tag>85,658</dummy_tag>',
                           b'<dummy_tag>85,658E-8</dummy_tag>',
-                          b'<dummy_tag>-85,658E-8</dummy_tag>']
+                          b'<dummy_tag>-85,658E-8</dummy_tag>',
+                          b'<dum_tag>-85.658</dum_tag>',  # negative check
+                          b'<dum_tag>85.658E-8</dum_tag>']  # negative check
     dummy_xml_negative = [b'<dum_tag>12,25,23,45,56,12,45</dum_tag>',
                           b'<dum_tag>12e1,23,-24E-5</dum_tag>']
     for i in dummy_xml_positive:


### PR DESCRIPTION
There is many bugs in Esprit and its file formats.
The non-compliance to XML standard is well know (one of the reason behind using lxml, is often inappropriate formatted XML).
Suddenly another non-compliance were found. Some (not all) of XML values are saved in the localized form.
The XML bugs are introduced by MSXML implementation wrapped by standard delphi libraries, which is used by Bruker in Esprit. Not to mention that fixing it (MSXML) is not possible as it is there for nearly 2 decades.
Locale converted numbers creeps only into limited XML nodes, only single numeric value bearing nodes. Arrays are not affected, they are serialised into XML complying the standard.
No problem is caused, while locale on Windows where Esprit is installed stays en_US; however setting it to any locale with decimal separator other than dot (`.`) makes evaluation of non-compliant decimal, XML serialized, values to fail, leading to recognition of the  decimal value as list of length=2, leading to TraitError.

~~This PR adds a short note to io.py if TraitError is raised during bcf loading,
and it adds the possibility to temporary enable other number format checking, which is set by an added function.~~
The check and fix can ~~'t~~ be automated, but this is rather a hack around---not the bug-fix of--- the Bruker's->delphi->MSXML bug.  

~~- [x] updated io.py to throw information when the TraitError is raised, and how to get around it~~
~~- [x] bcf.py - inserted the function and updated other to set decimal and thousand separators, using it for decimal search and  normalization of it when parsing XML.~~
- [x] bcf.py - injected regular expression to find and replace decimal commas before parsing XML string
- [x] ~~tests? test for hack around?~~ test the compiled regular expression feeding positive and negative XML snippets
- [x] ready for review (if no tests is needed, it should be ready)