### PR TITLE
Faster saving hspy format

### DIFF
--- a/hyperspy/io_plugins/hspy.py
+++ b/hyperspy/io_plugins/hspy.py
@@ -558,8 +558,10 @@ def overwrite_dataset(group, data, key, signal_axes=None, **kwds):
     else:
         if isinstance(data, da.Array):
             da.store(data.rechunk(dset.chunks), dset)
+        elif data.flags.c_contiguous:
+            dset.write_direct(data)
         else:
-            da.store(da.from_array(data, chunks=dset.chunks), dset)
+            dset[:] = data
 
 
 def hdfgroup2dict(group, dictionary=None, lazy=False):


### PR DESCRIPTION
Avoids converting numpy array to dask array (which is slow for large signals because it has to build a large DAG) when saving.

If people from https://github.com/hyperspy/hyperspy/issues/1739 could verify that saving is indeed faster, that would be good.
