### PR TITLE
Fix appveyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,7 +4,7 @@ shallow_clone: true
 environment:
 
   global:
-    TEST_DEPS: "pytest pytest-cov wheel pip"
+    TEST_DEPS: "pytest pytest-cov wheel"
     NSIS_DIR: "%PROGRAMFILES(x86)%/NSIS"
     MPLBACKEND: "agg"
 
@@ -68,8 +68,9 @@ install:
   # Install the dependencies of the project.
   - ps: Add-AppveyorMessage "Installing conda packages..."
   - "%CMD_IN_ENV% conda install -yq %TEST_DEPS%"
-  - "%CMD_IN_ENV% conda install -yq %DEPS% pip"
+  - "%CMD_IN_ENV% conda install -yq %DEPS%"
     # Having 'sip' folder on path confuses import of `sip`.
+  - "%CMD_IN_ENV% conda install -yq pip"
   - "pip install pytest-mpl"
     # Force to have the freetype font in matplotlib from pip for plot testing
   - "pip uninstall -y matplotlib"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -69,10 +69,10 @@ install:
   - ps: Add-AppveyorMessage "Installing conda packages..."
   - "%CMD_IN_ENV% conda install -yq %TEST_DEPS%"
   - "%CMD_IN_ENV% conda install -yq %DEPS%"
-    # Having 'sip' folder on path confuses import of `sip`.
-  - "%CMD_IN_ENV% conda install -yq pip"
+  # Having 'sip' folder on path confuses import of `sip`.
+  #- "%CMD_IN_ENV% conda install -yq pip"
   - "pip install pytest-mpl"
-    # Force to have the freetype font in matplotlib from pip for plot testing
+  # Force to have the freetype font in matplotlib from pip for plot testing
   - "pip uninstall -y matplotlib"
   - "pip install matplotlib"
   # TODO: Remove once anaconda taitsui package is at v5:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -21,7 +21,7 @@ environment:
        CONDA_NPY: "19"
        WP_URL: 'https://github.com/winpython/winpython/releases/download/1.3.20160209/WinPython-32bit-3.5.1.2.exe'
        WP_CRC: '172d19a743ccfaf55af779d15f29f67fca83a46f08b0af855dfaf809b4184c0d'
-       DEPS: "numpy scipy matplotlib>=2.0.2 ipython h5py sympy scikit-learn dill setuptools natsort scikit-image cython lxml ipyparallel dask=0.13"
+       DEPS: "numpy scipy matplotlib ipython h5py sympy scikit-learn dill setuptools natsort scikit-image cython lxml ipyparallel dask"
 
      - PYTHON: "C:\\Miniconda35-x64"
        PYTHON_VERSION: "3.5.x"
@@ -31,21 +31,21 @@ environment:
        CONDA_NPY: "19"
        WP_URL: 'https://github.com/winpython/winpython/releases/download/1.3.20160209/WinPython-64bit-3.5.1.2.exe'
        WP_CRC: '07e854b9aa7a31d8bbf7829d04a45b6d6266603690520e365199af2d98751ab1'
-       DEPS: "numpy scipy matplotlib>=2.0.2 ipython h5py sympy scikit-learn dill setuptools natsort scikit-image cython lxml ipyparallel dask=0.13"
+       DEPS: "numpy scipy matplotlib ipython h5py sympy scikit-learn dill setuptools natsort scikit-image cython lxml ipyparallel dask"
 
      - PYTHON: "C:\\Miniconda36"
        PYTHON_VERSION: "3.6.x"
        PYTHON_MAJOR: 3
        PYTHON_ARCH: "32"
        CONDA_PY: "36"
-       DEPS: "numpy scipy matplotlib>=2.0.2 ipython h5py sympy scikit-learn dill setuptools natsort scikit-image cython lxml ipyparallel dask=0.13"
+       DEPS: "numpy scipy matplotlib ipython h5py sympy scikit-learn dill setuptools natsort scikit-image cython lxml ipyparallel dask"
 
      - PYTHON: "C:\\Miniconda36-x64"
        PYTHON_VERSION: "3.6.x"
        PYTHON_MAJOR: 3
        PYTHON_ARCH: "64"
        CONDA_PY: "36"
-       DEPS: "numpy scipy matplotlib>=2.0.2 ipython h5py sympy scikit-learn dill setuptools natsort scikit-image cython lxml ipyparallel dask=0.13"
+       DEPS: "numpy scipy matplotlib ipython h5py sympy scikit-learn dill setuptools natsort scikit-image cython lxml ipyparallel dask"
 
 
 
@@ -68,9 +68,8 @@ install:
   # Install the dependencies of the project.
   - ps: Add-AppveyorMessage "Installing conda packages..."
   - "%CMD_IN_ENV% conda install -yq %TEST_DEPS%"
-  - "%CMD_IN_ENV% conda install -yq %DEPS%"
+  - "%CMD_IN_ENV% conda install -yq %DEPS% pip"
     # Having 'sip' folder on path confuses import of `sip`.
-  - "%CMD_IN_ENV% conda install pip"
   - "pip install pytest-mpl"
     # Force to have the freetype font in matplotlib from pip for plot testing
   - "pip uninstall -y matplotlib"


### PR DESCRIPTION
### Description of the change
Since a couple of days, the appveyor build tries to [upgrade pip](https://github.com/hyperspy/hyperspy/blob/RELEASE_next_minor/appveyor.yml#L73) and get stuck waiting for a reply (see this first occurrence of the issue in [this log](https://ci.appveyor.com/project/hyperspy/hyperspy/build/1.0.2620)). Adding the `-yq` works to upgrade pip, but it breaks the pip install...

### Progress of the PR
- [x] remove upgrading pip in appveyor.yml
- [x] remove useless version specification for dask and matplotlib when installing these with conda
- [x] the build appveyor builds are now working fine
- [x] ready for review.
