### PR TITLE
ENH: BCF xml parsing: drop lxml, use xml.etree

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,7 @@ before_install:
 install:
 
   - if [[ $MINIMAL_ENV == 'False' ]] ; then
-      DEPS="pip numpy scipy matplotlib>=2.0.2 ipython h5py sympy scikit-learn dill natsort setuptools scikit-image cython lxml ipyparallel dask traits traitsui";
+      DEPS="pip numpy scipy matplotlib>=2.0.2 ipython h5py sympy scikit-learn dill natsort setuptools scikit-image cython ipyparallel dask traits traitsui";
     else DEPS="pip ipython numpy scipy matplotlib>=2.0.2 h5py sympy scikit-image";
     fi
   - conda create -n testenv --yes python=$PYTHON;

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -21,7 +21,7 @@ environment:
        CONDA_NPY: "19"
        WP_URL: 'https://github.com/winpython/winpython/releases/download/1.3.20160209/WinPython-32bit-3.5.1.2.exe'
        WP_CRC: '172d19a743ccfaf55af779d15f29f67fca83a46f08b0af855dfaf809b4184c0d'
-       DEPS: "numpy scipy matplotlib>=2.0.2 ipython h5py sympy scikit-learn dill setuptools natsort scikit-image cython lxml ipyparallel dask=0.13"
+       DEPS: "numpy scipy matplotlib>=2.0.2 ipython h5py sympy scikit-learn dill setuptools natsort scikit-image cython ipyparallel dask=0.13"
 
      - PYTHON: "C:\\Miniconda35-x64"
        PYTHON_VERSION: "3.5.x"
@@ -31,21 +31,21 @@ environment:
        CONDA_NPY: "19"
        WP_URL: 'https://github.com/winpython/winpython/releases/download/1.3.20160209/WinPython-64bit-3.5.1.2.exe'
        WP_CRC: '07e854b9aa7a31d8bbf7829d04a45b6d6266603690520e365199af2d98751ab1'
-       DEPS: "numpy scipy matplotlib>=2.0.2 ipython h5py sympy scikit-learn dill setuptools natsort scikit-image cython lxml ipyparallel dask=0.13"
+       DEPS: "numpy scipy matplotlib>=2.0.2 ipython h5py sympy scikit-learn dill setuptools natsort scikit-image cython ipyparallel dask=0.13"
 
      - PYTHON: "C:\\Miniconda36"
        PYTHON_VERSION: "3.6.x"
        PYTHON_MAJOR: 3
        PYTHON_ARCH: "32"
        CONDA_PY: "36"
-       DEPS: "numpy scipy matplotlib>=2.0.2 ipython h5py sympy scikit-learn dill setuptools natsort scikit-image cython lxml ipyparallel dask=0.13"
+       DEPS: "numpy scipy matplotlib>=2.0.2 ipython h5py sympy scikit-learn dill setuptools natsort scikit-image cython ipyparallel dask=0.13"
 
      - PYTHON: "C:\\Miniconda36-x64"
        PYTHON_VERSION: "3.6.x"
        PYTHON_MAJOR: 3
        PYTHON_ARCH: "64"
        CONDA_PY: "36"
-       DEPS: "numpy scipy matplotlib>=2.0.2 ipython h5py sympy scikit-learn dill setuptools natsort scikit-image cython lxml ipyparallel dask=0.13"
+       DEPS: "numpy scipy matplotlib>=2.0.2 ipython h5py sympy scikit-learn dill setuptools natsort scikit-image cython ipyparallel dask=0.13"
 
 
 

--- a/doc/user_guide/install.rst
+++ b/doc/user_guide/install.rst
@@ -141,7 +141,6 @@ full functionality:
 
 Alternatively you can select the extra functionalities required:
 
-* ``bcf`` to install required libraries to read Brucker files.
 * ``learning`` to install required libraries for some machine learning features.
 * ``gui-jupyter`` to install required libraries to use the
   `Jupyter widgets <http://ipywidgets.readthedocs.io/en/stable/>`_
@@ -154,7 +153,7 @@ For example:
 
 .. code-block:: bash
 
-    $ pip install hyperspy[bcf, gui-jupyter]
+    $ pip install hyperspy[learning, gui-jupyter]
 
 See also :ref:`install-dependencies`.
 

--- a/hyperspy/io_plugins/__init__.py
+++ b/hyperspy/io_plugins/__init__.py
@@ -21,7 +21,7 @@ import logging
 
 from hyperspy.io_plugins import (msa, digital_micrograph, fei, mrc, ripple,
                                  tiff, semper_unf, blockfile, dens, emd,
-                                 protochips, edax)
+                                 protochips, edax, bcf)
 
 io_plugins = [msa, digital_micrograph, fei, mrc, ripple, tiff, semper_unf,
               blockfile, dens, emd, protochips, edax, bcf]

--- a/hyperspy/io_plugins/__init__.py
+++ b/hyperspy/io_plugins/__init__.py
@@ -24,7 +24,7 @@ from hyperspy.io_plugins import (msa, digital_micrograph, fei, mrc, ripple,
                                  protochips, edax)
 
 io_plugins = [msa, digital_micrograph, fei, mrc, ripple, tiff, semper_unf,
-              blockfile, dens, emd, protochips, edax]
+              blockfile, dens, emd, protochips, edax, bcf]
 
 _logger = logging.getLogger(__name__)
 
@@ -50,14 +50,6 @@ try:
     io_plugins.append(image)
 except ImportError:
     _logger.info('The Signal2D (PIL) IO features are not available')
-
-try:
-    from hyperspy.io_plugins import bcf
-    io_plugins.append(bcf)
-except ImportError:
-    _logger.warning('The Bruker composite file reader can not be loaded '
-                    'because the lxml library is not installed. To enable it '
-                    'install the Python lxml package.')
 
 default_write_ext = set()
 for plugin in io_plugins:

--- a/hyperspy/io_plugins/bcf.py
+++ b/hyperspy/io_plugins/bcf.py
@@ -27,7 +27,6 @@
 # Plugin characteristics
 # ----------------------
 format_name = 'bruker composite file bcf'
-short_name = 'bcf'
 description = """the proprietary format used by Bruker's
 Esprit(R) software to save hypermaps together with 16bit SEM imagery,
 EDS spectra and metadata describing the dimentions of the data and

--- a/hyperspy/io_plugins/bcf.py
+++ b/hyperspy/io_plugins/bcf.py
@@ -45,6 +45,8 @@ writes = False
 
 import io
 
+from collections import defaultdict
+import xml.etree.ElementTree as ET
 import codecs
 from ast import literal_eval
 from datetime import datetime, timedelta
@@ -54,9 +56,6 @@ import dask.delayed as dd
 from struct import unpack as strct_unp
 from zlib import decompress as unzip_block
 import logging
-import re
-from collections import defaultdict
-import xml.etree.ElementTree as ET
 
 _logger = logging.getLogger(__name__)
 
@@ -70,8 +69,6 @@ except ImportError:  # pragma: no cover
     fast_unbcf = False
     _logger.info("""unbcf_fast library is not present...
 Falling back to slow python only backend.""")
-
-fix_dec_patterns = re.compile(b'(>-?\d+),(\d*<)')
 
 
 class Container(object):
@@ -863,8 +860,7 @@ class BCF_reader(SFS_reader):
         SFS_reader.__init__(self, filename)
         header_file = self.get_file('EDSDatabase/HeaderData')
         header_byte_str = header_file.get_as_BytesIO_string().getvalue()
-        hd_bt_str = fix_dec_patterns.sub(b'\\1.\\2', header_byte_str)
-        self.header = HyperHeader(hd_bt_str, instrument=instrument)
+        self.header = HyperHeader(header_byte_str, instrument=instrument)
         self.hypermap = {}
 
     def persistent_parse_hypermap(self, index=0, downsample=None,

--- a/hyperspy/io_plugins/bcf.py
+++ b/hyperspy/io_plugins/bcf.py
@@ -438,7 +438,7 @@ def dictionarize(t):
                 dd[k].append(v)
         d = {t.tag: {k:interpret(v[0]) if len(v) == 1 else v for k, v in dd.items()}}
     if t.attrib:
-        d[t.tag].update(('@' + k, interpret(v)) for k, v in t.attrib.items())
+        d[t.tag].update(('XmlClass' + k if list(t) else k, interpret(v)) for k, v in t.attrib.items())
     if t.text:
         text = t.text.strip()
         if children or t.attrib:
@@ -635,10 +635,11 @@ class HyperHeader(object):
         """parse image from bruker xml image node."""
         if overview:
             rect_node = xml_node.findall("./ChildClassInstances"
-                "/ClassInstance[@Type='TRTRectangleOverlayElement' and"
-                " @Name='Map']/TRTSolidOverlayElement/"
+                "/ClassInstance["
+                #"@Type='TRTRectangleOverlayElement' and "
+                "@Name='Map']/TRTSolidOverlayElement/"
                 "TRTBasicLineOverlayElement/TRTOverlayElement")[0]
-            over_rect = dictionarize(rect_node)['Rect']
+            over_rect = dictionarize(rect_node)['TRTOverlayElement']['Rect']
             rect = {'y1': over_rect['Top'] * self.y_res,
                     'x1': over_rect['Left'] * self.x_res,
                     'y2': over_rect['Bottom'] * self.y_res,
@@ -685,8 +686,9 @@ class HyperHeader(object):
             overview_node = root.findall(
                 "./ClassInstance[@Type='TRTContainerClass']"
                 "/ChildClassInstances"
-                "/ClassInstance[@Type='TRTContainerClass' "
-                "and @Name='OverviewImages']"
+                "/ClassInstance["
+                #"@Type='TRTContainerClass' and "
+                "@Name='OverviewImages']"
                 "/ChildClassInstances"
                 "/ClassInstance[@Type='TRTImageData']")
             if len(overview_node) > 0:  # in case there is no image
@@ -707,7 +709,7 @@ class HyperHeader(object):
             for j in elements.findall(
                     "./ClassInstance[@Type='TRTSpectrumRegion']"):
                 tmp_d = dictionarize(j)
-                self.elements[tmp_d['@Name']] = {'line': tmp_d['Line'],
+                self.elements[tmp_d['XmlClassName']] = {'line': tmp_d['Line'],
                                                  'energy': tmp_d['Energy'],
                                                  'width': tmp_d['Width']}
         except IndexError:

--- a/hyperspy/tests/io/bcf_data/test_original_metadata.json
+++ b/hyperspy/tests/io/bcf_data/test_original_metadata.json
@@ -5,7 +5,7 @@
         "Z": 40234.7,
         "X": 62409.2,
         "Tilt": 0.5,
-        "@Type": "TRTSEMStageData",
+        "XmlClassType": "TRTSEMStageData",
         "Rotation": 329.49719
     },
     "Detector": {
@@ -534,7 +534,7 @@
         "Type": "XFlash 6|10",
         "SiDeadLayerThickness": 0.029,
         "WindowType": "slew AP3.3",
-        "@Type": "TRTDetectorHeader",
+        "XmlClassType": "TRTDetectorHeader",
         "DetectorThickness": 0.45,
         "ShiftFactor2": -0.982,
         "TailFactor": 1,
@@ -547,7 +547,7 @@
     },
     "Microscope": {
         "DX": 8.73678506197784,
-        "@Type": "TRTSEMData",
+        "XmlClassType": "TRTSEMData",
         "Flags": 16776960,
         "HV": 20,
         "WD": 7.69044,
@@ -562,7 +562,7 @@
             "Type": "RTESMA"
         },
         "AzimutAngle": 90.0,
-        "@Type": "TRTESMAHeader",
+        "XmlClassType": "TRTESMAHeader",
         "PrimaryEnergy": 20.0,
         "ReferenceFactor": -1,
         "BaseRefStdDev": 0.001917334934,
@@ -571,7 +571,7 @@
     "Spectrum": {
         "SigmaLin": 0.0004466391048,
         "Time": "17:5:2",
-        "@Type": "TRTSpectrumHeader",
+        "XmlClassType": "TRTSpectrumHeader",
         "ChannelCount": 2048,
         "SigmaAbs": 0.0002286813269,
         "Date": "1.4.2016",
@@ -664,7 +664,7 @@
         "ZeroPeakPosition": 95,
         "ZeroPeakFrequency": 33332,
         "ShapingTime": 130000,
-        "@Type": "TRTSpectrumHardwareHeader",
+        "XmlClassType": "TRTSpectrumHardwareHeader",
         "Amplification": 20000.0
     },
     "DSP Configuration": {
@@ -675,7 +675,7 @@
         "PixelAverage": 16,
         "ChannelCount": 2,
         "ImageWidth": 100,
-        "@Type": "TRTDSPConfiguration",
+        "XmlClassType": "TRTDSPConfiguration",
         "ChannelName0": "BSE",
         "PixelTime": 2,
         "Channel1": 1,

--- a/hyperspy/tests/io/bcf_data/test_original_metadata.json
+++ b/hyperspy/tests/io/bcf_data/test_original_metadata.json
@@ -5,7 +5,7 @@
         "Z": 40234.7,
         "X": 62409.2,
         "Tilt": 0.5,
-        "XmlClassType": "TRTSEMStageData",
+        "@Type": "TRTSEMStageData",
         "Rotation": 329.49719
     },
     "Detector": {
@@ -534,7 +534,7 @@
         "Type": "XFlash 6|10",
         "SiDeadLayerThickness": 0.029,
         "WindowType": "slew AP3.3",
-        "XmlClassType": "TRTDetectorHeader",
+        "@Type": "TRTDetectorHeader",
         "DetectorThickness": 0.45,
         "ShiftFactor2": -0.982,
         "TailFactor": 1,
@@ -547,7 +547,7 @@
     },
     "Microscope": {
         "DX": 8.73678506197784,
-        "XmlClassType": "TRTSEMData",
+        "@Type": "TRTSEMData",
         "Flags": 16776960,
         "HV": 20,
         "WD": 7.69044,
@@ -562,7 +562,7 @@
             "Type": "RTESMA"
         },
         "AzimutAngle": 90.0,
-        "XmlClassType": "TRTESMAHeader",
+        "@Type": "TRTESMAHeader",
         "PrimaryEnergy": 20.0,
         "ReferenceFactor": -1,
         "BaseRefStdDev": 0.001917334934,
@@ -571,7 +571,7 @@
     "Spectrum": {
         "SigmaLin": 0.0004466391048,
         "Time": "17:5:2",
-        "XmlClassType": "TRTSpectrumHeader",
+        "@Type": "TRTSpectrumHeader",
         "ChannelCount": 2048,
         "SigmaAbs": 0.0002286813269,
         "Date": "1.4.2016",
@@ -664,7 +664,7 @@
         "ZeroPeakPosition": 95,
         "ZeroPeakFrequency": 33332,
         "ShapingTime": 130000,
-        "XmlClassType": "TRTSpectrumHardwareHeader",
+        "@Type": "TRTSpectrumHardwareHeader",
         "Amplification": 20000.0
     },
     "DSP Configuration": {
@@ -675,7 +675,7 @@
         "PixelAverage": 16,
         "ChannelCount": 2,
         "ImageWidth": 100,
-        "XmlClassType": "TRTDSPConfiguration",
+        "@Type": "TRTDSPConfiguration",
         "ChannelName0": "BSE",
         "PixelTime": 2,
         "Channel1": 1,

--- a/hyperspy/tests/io/test_bcf.py
+++ b/hyperspy/tests/io/test_bcf.py
@@ -145,21 +145,6 @@ def test_hyperspy_wrap_downsampled():
     assert hype.axes_manager[1].units == 'µm'
 
 
-def test_fast_bcf():
-    from hyperspy.io_plugins import bcf
-
-    for bcffile in test_files:
-        filename = os.path.join(my_path, 'bcf_data', bcffile)
-        thingy = bcf.BCF_reader(filename)
-        for j in range(2, 5, 1):
-            print('downsampling:', j)
-            bcf.fast_unbcf = True              # manually enabling fast parsing
-            hmap1 = thingy.parse_hypermap(downsample=j)    # using cython
-            bcf.fast_unbcf = False            # manually disabling fast parsing
-            hmap2 = thingy.parse_hypermap(downsample=j)    # py implementation
-            np.testing.assert_array_equal(hmap1, hmap2)
-
-
 def test_get_mode():
     filename = os.path.join(my_path, 'bcf_data', test_files[0])
     s = load(filename, select_type='spectrum', instrument='SEM')
@@ -183,7 +168,21 @@ def test_get_mode():
 
 
 def test_wrong_file():
-    lxml = pytest.importorskip("lxml")
     filename = os.path.join(my_path, 'bcf_data', 'Nope.bcf')
     with pytest.raises(TypeError):
         load(filename)
+
+
+def test_fast_bcf():
+    thingy = pytest.importorskip("hyperspy.io_plugins.unbcf_fast")
+    from hyperspy.io_plugins import bcf
+    for bcffile in test_files:
+        filename = os.path.join(my_path, 'bcf_data', bcffile)
+        thingy = bcf.BCF_reader(filename)
+        for j in range(2, 5, 1):
+            print('downsampling:', j)
+            bcf.fast_unbcf = True              # manually enabling fast parsing
+            hmap1 = thingy.parse_hypermap(downsample=j)    # using cython
+            bcf.fast_unbcf = False            # manually disabling fast parsing
+            hmap2 = thingy.parse_hypermap(downsample=j)    # py implementation
+            np.testing.assert_array_equal(hmap1, hmap2)

--- a/hyperspy/tests/io/test_bcf.py
+++ b/hyperspy/tests/io/test_bcf.py
@@ -23,7 +23,6 @@ my_path = os.path.dirname(__file__)
 
 
 def test_load_16bit():
-    lxml = pytest.importorskip("lxml")
     # test bcf from hyperspy load function level
     # some of functions can be not covered
     # it cant use cython parsing implementation, as it is not compiled
@@ -42,7 +41,6 @@ def test_load_16bit():
 
 
 def test_load_16bit_reduced():
-    lxml = pytest.importorskip("lxml")
     filename = os.path.join(my_path, 'bcf_data', test_files[0])
     print('testing downsampled 16bit bcf...')
     s = load(filename, downsample=4, cutoff_at_kV=10)
@@ -61,7 +59,6 @@ def test_load_16bit_reduced():
 
 
 def test_load_8bit():
-    lxml = pytest.importorskip("lxml")
     for bcffile in test_files[1:3]:
         filename = os.path.join(my_path, 'bcf_data', bcffile)
         print('testing simple 8bit bcf...')
@@ -75,7 +72,6 @@ def test_load_8bit():
 
 
 def test_hyperspy_wrap():
-    lxml = pytest.importorskip("lxml")
     filename = os.path.join(my_path, 'bcf_data', test_files[0])
     print('testing bcf wrap to hyperspy signal...')
     hype = load(filename, select_type='spectrum')
@@ -135,7 +131,6 @@ def test_hyperspy_wrap():
 
 
 def test_hyperspy_wrap_downsampled():
-    lxml = pytest.importorskip("lxml")
     filename = os.path.join(my_path, 'bcf_data', test_files[0])
     print('testing bcf wrap to hyperspy signal...')
     hype = load(filename, select_type='spectrum', downsample=5)
@@ -151,7 +146,6 @@ def test_hyperspy_wrap_downsampled():
 
 
 def test_fast_bcf():
-    lxml = pytest.importorskip("lxml")
     from hyperspy.io_plugins import bcf
 
     for bcffile in test_files:
@@ -167,7 +161,6 @@ def test_fast_bcf():
 
 
 def test_get_mode():
-    lxml = pytest.importorskip("lxml")
     filename = os.path.join(my_path, 'bcf_data', test_files[0])
     s = load(filename, select_type='spectrum', instrument='SEM')
     assert s.metadata.Signal.signal_type == "EDS_SEM"

--- a/setup.py
+++ b/setup.py
@@ -66,7 +66,6 @@ install_req = ['scipy>=0.15',
 
 extras_require = {
     "learning": ['scikit-learn'],
-    "bcf": ['lxml'],
     "gui-jupyter": ["hyperspy_gui_ipywidgets"],
     "gui-traitsui": ["hyperspy_gui_traitsui"],
     "test": ["pytest>=3", "pytest-mpl", "matplotlib>=2.0.2"],

--- a/stdeb.cfg
+++ b/stdeb.cfg
@@ -11,7 +11,6 @@ Depends:
     ipython-notebook,
     python-h5py,
     python-sklearn,
-    python3-lxml,
     python-skimage,
     python-requests,
     python-sympy,


### PR DESCRIPTION
### This PR drops usage of lxml and adopts built-in xml.etree.ElementTree
- it is not a first time when travis ci and appveyor fail/skips tests due to lxml geting inculded in/out from default anaconda library list.
- xml.etree is faster at parsing
- reduces installation complexity (so that bcf would be installed even with minimal installation)
- reduces dependency (as etree is built-in and distributed with python)

### Progress of the PR
- [x] getting working replacement of bcf.py
  - [x]  adopt complicated xpath definitions to significantly narrowed down etree xpath subset (fix overview image reading)
- [x] remove lxml checks in other files (`io/__init__.py`),
- [x] update relevant parts in documentations
- [x] update installation scripts dropping lxml dependency (setup.py, .travis.yml, apveyor.yml ...)
- [x] check tests and do some adjustment if needed to pass all of them, (original metadata structure is not changed ~~going to be very minory changed, adding the XML attributes with '@attribute' notation~~)
- [x] ~~find faulty xml example (I believe I encountered one once), and adopt regex code for its fixing prior-parsing, (containing numbers in the tags: e.g. ```<1>good day</1>```)~~ can't find such faulty bcf file. I have only bruker eds `*.spx` and project files with messy xml tags. Without working bug example this will wait until I or somebody will find such buggy bcf file.
- [x] ready for review.

