### PR TITLE
Fix bcf hitachi: doc addendum

### DIFF
--- a/doc/user_guide/io.rst
+++ b/doc/user_guide/io.rst
@@ -575,14 +575,14 @@ currently supported by HyperSpy.
 
 Extra loading arguments
 ^^^^^^^^^^^^^^^^^^^^^^^
-select_type: One of ('spectrum', 'image'). If specified just selected type of
-data is returned. (default None)
+select_type: one of (None, 'spectrum', 'image'). If specified, only the corresponding
+type of data, either spectrum or image, is returned. By default (None), all data are loaded.
 
-index: One of (None, int, "all"). Index of dataset in bcf file, which can hold few datasets.
-Default None value result in first or the only dataset returned (the lowest index available).
-When set to 'all' it result in loading all available datasets.
+index: one of (None, int, "all"). Allow to select the index of the dataset in the bcf file,
+which can contains several datasets. Default None value result in loading the first dataset.
+When set to 'all', all available datasets will be loaded and returned as separate signals.
 
-downsample: the downsample ratio of hyperspectral array (hight and width only),
+downsample: the downsample ratio of hyperspectral array (height and width only),
 can be integer >=1, where '1' results in no downsampling (default 1). The
 underlying method of downsampling is unchangeable: sum. Differently than
 block_reduce from skimage.measure it is memory efficient (does not creates

--- a/doc/user_guide/io.rst
+++ b/doc/user_guide/io.rst
@@ -578,7 +578,9 @@ Extra loading arguments
 select_type: One of ('spectrum', 'image'). If specified just selected type of
 data is returned. (default None)
 
-index: index of dataset in bcf v2 files, which can hold few datasets (delaut 0)
+index: One of (None, int, "all"). Index of dataset in bcf file, which can hold few datasets.
+Default None value result in first or the only dataset returned (the lowest index available).
+When set to 'all' it result in loading all available datasets.
 
 downsample: the downsample ratio of hyperspectral array (hight and width only),
 can be integer >=1, where '1' results in no downsampling (default 1). The
@@ -586,7 +588,7 @@ underlying method of downsampling is unchangeable: sum. Differently than
 block_reduce from skimage.measure it is memory efficient (does not creates
 intermediate arrays, works inplace).
 
-cutoff_at_kV: if set (can be int of float >= 0) can be used either to crop or
+cutoff_at_kV: if set (can be int or float >= 0) can be used either to crop or
 enlarge energy (or channels) range at max values. (default None)
 
 Example of loading reduced (downsampled, and with energy range cropped)

--- a/hyperspy/io_plugins/bcf.py
+++ b/hyperspy/io_plugins/bcf.py
@@ -528,6 +528,7 @@ class HyperHeader(object):
     Arguments:
     xml_str -- the uncompressed to be provided with extracted Header xml
     from bcf.
+    indexes -- list of indexes of available datasets
 
     Methods:
     estimate_map_channels, estimate_map_depth
@@ -744,14 +745,14 @@ class HyperHeader(object):
 
         Arguments:
         index -- index of the hypermap if multiply hypermaps are
-        present in the same bcf. (default 0)
+          present in the same bcf. (default 0)
         downsample -- downsample factor (should be integer; default 1)
         for_numpy -- False produce unsigned, True signed (or unsigned) types:
-        if hypermap will be loaded using the pure python
-        function where numpy's inplace integer addition will be used --
-        the dtype should be signed; if cython implementation will
-        be used (default), then any returned dtypes can be safely
-        unsigned. (default False)
+          if hypermap will be loaded using the pure python
+          function where numpy's inplace integer addition will be used --
+          the dtype should be signed; if cython implementation will
+          be used (default), then any returned dtypes can be safely
+          unsigned. (default False)
 
         Returns:
         numpy dtype large enought to use in final hypermap numpy array.
@@ -861,6 +862,8 @@ class BCF_reader(SFS_reader):
         SFS_reader.__init__(self, filename)
         header_file = self.get_file('EDSDatabase/HeaderData')
         self.available_indexes = []
+        # get list of presented indexes from file tree of binary sfs container
+        # while looking for file names containg the hypercube data:
         for i in self.vfs['EDSDatabase'].keys():
             if 'SpectrumData' in i:
                 self.available_indexes.append(int(i[-1]))


### PR DESCRIPTION
some additional docstrings and minimal addition to documentation concerning PR #1752.

The major change of PR #1752 is handling of dataset internal indexes in bcf.

Previously it was using xml tag which tells how many dataset there is in the bcf file, then for that range (0, 1...) the parser was looking for xml tags with those indexes.
However as some bugs with Hitachi bcf showed, that indexes not always starts from 0, but can be arbitrary numbers.

Current implementation, does check for indexes outside of XML, looking inside the single file syste (SFS) container file tree and extracting indexes from available binary data cube filenames, which directly correspond to spectra tags in XML.

Additionally it changed the default value of index= kwarg to None, which result in loading single, lowest index bearing dataset, and accepts additional value of 'all' to load all datasets.
It is future proof, as I have seen no such multi dataset files, except single file, with second dataset being empty. 

- [x]  ready for review
