### PR TITLE
Fix filenames with square brackets not loading 

### DIFF
--- a/hyperspy/io.py
+++ b/hyperspy/io.py
@@ -173,7 +173,7 @@ def load(filenames=None,
             raise ValueError("No file provided to reader")
 
     if isinstance(filenames, str):
-        filenames = natsorted([f for f in glob.glob(filenames)
+        filenames = natsorted([f for f in glob.glob(glob.escape(filenames))
                                if os.path.isfile(f)])
         if not filenames:
             raise ValueError('No file name matches this pattern')


### PR DESCRIPTION
Fixes #1325. This way I won't rediscover the bug next year.