### PR TITLE
Fix #762, parse tags for dm files created with the stack builder plugin.

### DIFF
--- a/hyperspy/io_plugins/digital_micrograph.py
+++ b/hyperspy/io_plugins/digital_micrograph.py
@@ -822,12 +822,12 @@ class ImageObject(object):
         if 'source' in self.imdict.ImageTags.keys():
             # For stack created with the stack builder plugin
             tags_path = 'ImageList.TagGroup0.ImageTags.source.Tags at creation'
-            ImageTags_dict = self.imdict.ImageTags.source['Tags at creation']
+            image_tags_dict = self.imdict.ImageTags.source['Tags at creation']
         else:
             # Standard tags
             tags_path = 'ImageList.TagGroup0.ImageTags'
-            ImageTags_dict = self.imdict.ImageTags
-        is_scanning = "DigiScan" in ImageTags_dict.keys()
+            image_tags_dict = self.imdict.ImageTags
+        is_scanning = "DigiScan" in image_tags_dict.keys()
         mapping = {
             "{}.DataBar.Acquisition Date".format(tags_path): (
                 "General.date", self._get_date),
@@ -853,14 +853,14 @@ class ImageObject(object):
                 "Sample.description", self._parse_string),
         }
 
-        if "Microscope_Info" in ImageTags_dict.keys():
+        if "Microscope_Info" in image_tags_dict.keys():
             is_TEM = is_diffraction = None
-            if "Illumination_Mode" in ImageTags_dict['Microscope_Info'].keys():
+            if "Illumination_Mode" in image_tags_dict['Microscope_Info'].keys():
                 is_TEM = (
-                    'TEM' == ImageTags_dict.Microscope_Info.Illumination_Mode)
-            if "Imaging_Mode" in ImageTags_dict['Microscope_Info'].keys():
+                    'TEM' == image_tags_dict.Microscope_Info.Illumination_Mode)
+            if "Imaging_Mode" in image_tags_dict['Microscope_Info'].keys():
                 is_diffraction = (
-                    'DIFFRACTION' == ImageTags_dict.Microscope_Info.Imaging_Mode)
+                    'DIFFRACTION' == image_tags_dict.Microscope_Info.Imaging_Mode)
 
             if is_TEM:
                 if is_diffraction:
@@ -948,7 +948,7 @@ class ImageObject(object):
                     "Acquisition_instrument.TEM.Detector.EDS.real_time",
                     None),
             })
-        elif "DigiScan" in ImageTags_dict.keys():
+        elif "DigiScan" in image_tags_dict.keys():
             mapping.update({
                 "{}.DigiScan.Sample Time".format(tags_path): (
                     "Acquisition_instrument.TEM.dwell_time",

--- a/hyperspy/io_plugins/digital_micrograph.py
+++ b/hyperspy/io_plugins/digital_micrograph.py
@@ -819,68 +819,74 @@ class ImageObject(object):
             return tag
 
     def get_mapping(self):
-        is_scanning = "DigiScan" in self.imdict.ImageTags.keys()
+        if 'source' in self.imdict.ImageTags.keys():
+            # For stack created with the stack builder plugin
+            tags_path = 'ImageList.TagGroup0.ImageTags.source.Tags at creation'
+            ImageTags_dict = self.imdict.ImageTags.source['Tags at creation']
+        else:
+            # Standard tags
+            tags_path = 'ImageList.TagGroup0.ImageTags'
+            ImageTags_dict = self.imdict.ImageTags
+        is_scanning = "DigiScan" in ImageTags_dict.keys()
         mapping = {
-            "ImageList.TagGroup0.ImageTags.DataBar.Acquisition Date": (
+            "{}.DataBar.Acquisition Date".format(tags_path): (
                 "General.date", self._get_date),
-            "ImageList.TagGroup0.ImageTags.DataBar.Acquisition Time": (
+            "{}.DataBar.Acquisition Time".format(tags_path): (
                 "General.time", self._get_time),
-            "ImageList.TagGroup0.ImageTags.Microscope Info.Voltage": (
+            "{}.Microscope Info.Voltage".format(tags_path): (
                 "Acquisition_instrument.TEM.beam_energy", lambda x: x / 1e3),
-            "ImageList.TagGroup0.ImageTags.Microscope Info.Stage Position.Stage Alpha": (
+            "{}.Microscope Info.Stage Position.Stage Alpha".format(tags_path): (
                 "Acquisition_instrument.TEM.Stage.tilt_alpha", None),
-            "ImageList.TagGroup0.ImageTags.Microscope Info.Stage Position.Stage X": (
+            "{}.Microscope Info.Stage Position.Stage X".format(tags_path): (
                 "Acquisition_instrument.TEM.Stage.x", lambda x: x * 1e-3),
-            "ImageList.TagGroup0.ImageTags.Microscope Info.Stage Position.Stage Y": (
+            "{}.Microscope Info.Stage Position.Stage Y".format(tags_path): (
                 "Acquisition_instrument.TEM.Stage.y", lambda x: x * 1e-3),
-            "ImageList.TagGroup0.ImageTags.Microscope Info.Stage Position.Stage Z": (
+            "{}.Microscope Info.Stage Position.Stage Z".format(tags_path): (
                 "Acquisition_instrument.TEM.Stage.z", lambda x: x * 1e-3),
-            "ImageList.TagGroup0.ImageTags.Microscope Info.Illumination Mode": (
+            "{}.Microscope Info.Illumination Mode".format(tags_path): (
                 "Acquisition_instrument.TEM.acquisition_mode", self._get_mode),
-            "ImageList.TagGroup0.ImageTags.Microscope Info.Probe Current (nA)": (
+            "{}.Microscope Info.Probe Current (nA)".format(tags_path): (
                 "Acquisition_instrument.TEM.beam_current", None),
-            "ImageList.TagGroup0.ImageTags.Session Info.Operator": (
+            "{}.Session Info.Operator".format(tags_path): (
                 "General.authors", self._parse_string),
-            "ImageList.TagGroup0.ImageTags.Session Info.Specimen": (
+            "{}.Session Info.Specimen".format(tags_path): (
                 "Sample.description", self._parse_string),
         }
 
-        if "Microscope_Info" in self.imdict.ImageTags.keys():
+        if "Microscope_Info" in ImageTags_dict.keys():
             is_TEM = is_diffraction = None
-            if "Illumination_Mode" in self.imdict.ImageTags[
-                    'Microscope_Info'].keys():
+            if "Illumination_Mode" in ImageTags_dict['Microscope_Info'].keys():
                 is_TEM = (
-                    'TEM' == self.imdict.ImageTags.Microscope_Info.Illumination_Mode)
-            if "Imaging_Mode" in self.imdict.ImageTags[
-                    'Microscope_Info'].keys():
+                    'TEM' == ImageTags_dict.Microscope_Info.Illumination_Mode)
+            if "Imaging_Mode" in ImageTags_dict['Microscope_Info'].keys():
                 is_diffraction = (
-                    'DIFFRACTION' == self.imdict.ImageTags.Microscope_Info.Imaging_Mode)
+                    'DIFFRACTION' == ImageTags_dict.Microscope_Info.Imaging_Mode)
 
             if is_TEM:
                 if is_diffraction:
                     mapping.update({
-                        "ImageList.TagGroup0.ImageTags.Microscope Info.Indicated Magnification": (
+                        "{}.Microscope Info.Indicated Magnification".format(tags_path): (
                             "Acquisition_instrument.TEM.camera_length",
                             None),
                     })
                 else:
                     mapping.update({
-                        "ImageList.TagGroup0.ImageTags.Microscope Info.Indicated Magnification": (
+                        "{}.Microscope Info.Indicated Magnification".format(tags_path): (
                             "Acquisition_instrument.TEM.magnification",
                             None),
                     })
             else:
                 mapping.update({
-                    "ImageList.TagGroup0.ImageTags.Microscope Info.STEM Camera Length": (
+                    "{}.Microscope Info.STEM Camera Length".format(tags_path): (
                         "Acquisition_instrument.TEM.camera_length",
                         None),
-                    "ImageList.TagGroup0.ImageTags.Microscope Info.Indicated Magnification": (
+                    "{}.Microscope Info.Indicated Magnification".format(tags_path): (
                         "Acquisition_instrument.TEM.magnification",
                         None),
                 })
 
             mapping.update({
-                "ImageList.TagGroup0.ImageTags": (
+                tags_path: (
                     "Acquisition_instrument.TEM.microscope",
                     self._get_microscope_name),
             })
@@ -891,66 +897,66 @@ class ImageObject(object):
             else:
                 mapped_attribute = 'exposure'
             mapping.update({
-                "ImageList.TagGroup0.ImageTags.EELS.Acquisition.Date": (
+                "{}.EELS.Acquisition.Date".format(tags_path): (
                     "General.date",
                     self._get_date),
-                "ImageList.TagGroup0.ImageTags.EELS.Acquisition.Start time": (
+                "{}.EELS.Acquisition.Start time".format(tags_path): (
                     "General.time",
                     self._get_time),
-                "ImageList.TagGroup0.ImageTags.EELS.Experimental Conditions." +
+                "{}.EELS.Experimental Conditions.".format(tags_path) +
                 "Collection semi-angle (mrad)": (
                     "Acquisition_instrument.TEM.Detector.EELS.collection_angle",
                     None),
-                "ImageList.TagGroup0.ImageTags.EELS.Experimental Conditions." +
+                "{}.EELS.Experimental Conditions.".format(tags_path) +
                 "Convergence semi-angle (mrad)": (
                     "Acquisition_instrument.TEM.convergence_angle",
                     None),
-                "ImageList.TagGroup0.ImageTags.EELS.Acquisition.Integration time (s)": (
+                "{}.EELS.Acquisition.Integration time (s)".format(tags_path): (
                     "Acquisition_instrument.TEM.Detector.EELS.%s" % mapped_attribute,
                     None),
-                "ImageList.TagGroup0.ImageTags.EELS.Acquisition.Number_of_frames": (
+                "{}.EELS.Acquisition.Number_of_frames".format(tags_path): (
                     "Acquisition_instrument.TEM.Detector.EELS.frame_number",
                     None),
-                "ImageList.TagGroup0.ImageTags.EELS_Spectrometer.Aperture_label": (
+                "{}.EELS_Spectrometer.Aperture_label".format(tags_path): (
                     "Acquisition_instrument.TEM.Detector.EELS.aperture_size",
                     lambda string: float(string.replace('mm', ''))),
-                "ImageList.TagGroup0.ImageTags.EELS Spectrometer.Instrument name": (
+                "{}.EELS Spectrometer.Instrument name".format(tags_path): (
                     "Acquisition_instrument.TEM.Detector.EELS.spectrometer",
                     None),
             })
         elif self.signal_type == "EDS_TEM":
             mapping.update({
-                "ImageList.TagGroup0.ImageTags.EDS.Acquisition.Date": (
+                "{}.EDS.Acquisition.Date".format(tags_path): (
                     "General.date",
                     self._get_date),
-                "ImageList.TagGroup0.ImageTags.EDS.Acquisition.Start time": (
+                "{}.EDS.Acquisition.Start time".format(tags_path): (
                     "General.time",
                     self._get_time),
-                "ImageList.TagGroup0.ImageTags.EDS.Detector_Info.Azimuthal_angle": (
+                "{}.EDS.Detector_Info.Azimuthal_angle".format(tags_path): (
                     "Acquisition_instrument.TEM.Detector.EDS.azimuth_angle",
                     None),
-                "ImageList.TagGroup0.ImageTags.EDS.Detector_Info.Elevation_angle": (
+                "{}.EDS.Detector_Info.Elevation_angle".format(tags_path): (
                     "Acquisition_instrument.TEM.Detector.EDS.elevation_angle",
                     None),
-                "ImageList.TagGroup0.ImageTags.EDS.Solid_angle": (
+                "{}.EDS.Solid_angle".format(tags_path): (
                     "Acquisition_instrument.TEM.Detector.EDS.solid_angle",
                     None),
-                "ImageList.TagGroup0.ImageTags.EDS.Live_time": (
+                "{}.EDS.Live_time".format(tags_path): (
                     "Acquisition_instrument.TEM.Detector.EDS.live_time",
                     None),
-                "ImageList.TagGroup0.ImageTags.EDS.Real_time": (
+                "{}.EDS.Real_time".format(tags_path): (
                     "Acquisition_instrument.TEM.Detector.EDS.real_time",
                     None),
             })
-        elif "DigiScan" in self.imdict.ImageTags.keys():
+        elif "DigiScan" in ImageTags_dict.keys():
             mapping.update({
-                "ImageList.TagGroup0.ImageTags.DigiScan.Sample Time": (
+                "{}.DigiScan.Sample Time".format(tags_path): (
                     "Acquisition_instrument.TEM.dwell_time",
                     lambda x: x / 1e6),
             })
         else:
             mapping.update({
-                "ImageList.TagGroup0.ImageTags.Acquisition.Parameters.Detector." +
+                "{}.Acquisition.Parameters.Detector.".format(tags_path) +
                 "exposure_s": (
                     "Acquisition_instrument.TEM.Camera.exposure",
                     None),

--- a/hyperspy/tests/io/test_dm_stackbuilder_plugin.py
+++ b/hyperspy/tests/io/test_dm_stackbuilder_plugin.py
@@ -20,6 +20,8 @@
 import os
 
 from hyperspy.io import load
+from numpy.testing import assert_allclose
+
 
 my_path = os.path.dirname(__file__)
 
@@ -27,10 +29,30 @@ my_path = os.path.dirname(__file__)
 class TestStackBuilder:
 
     def test_load_stackbuilder_imagestack(self):
-        image_stack = load(
-            my_path +
-            "/dm_stackbuilder_plugin/test_stackbuilder_imagestack.dm3")
+        image_stack = load(os.path.join(my_path, "dm_stackbuilder_plugin",
+                                        "test_stackbuilder_imagestack.dm3"))
         data_dimensions = image_stack.data.ndim
         am = image_stack.axes_manager
         axes_dimensions = am.signal_dimension + am.navigation_dimension
         assert data_dimensions == axes_dimensions
+        md = image_stack.metadata
+        assert md.Acquisition_instrument.TEM.acquisition_mode == "STEM"
+        assert_allclose(md.Acquisition_instrument.TEM.beam_current, 0.0)
+        assert_allclose(md.Acquisition_instrument.TEM.beam_energy, 200.0)
+        assert_allclose(md.Acquisition_instrument.TEM.camera_length, 15.0)
+        assert_allclose(
+            md.Acquisition_instrument.TEM.dwell_time, 0.03000005078125)
+        assert_allclose(md.Acquisition_instrument.TEM.magnification, 200000.0)
+        assert md.Acquisition_instrument.TEM.microscope == "JEM-ARM200F"
+        assert md.General.date == "2015-05-17"
+        assert md.General.original_filename == "test_stackbuilder_imagestack.dm3"
+        assert md.General.title == "stackbuilder_test4_16x2"
+        assert md.General.time == "17:00:16"
+        assert md.Sample.description == "DWNC"
+        assert md.Signal.quantity == "Electrons (Counts)"
+        assert md.Signal.signal_type == ""
+        assert md.Signal.binned == False
+        assert_allclose(md.Signal.Noise_properties.Variance_linear_model.gain_factor,
+                        0.15674974)
+        assert_allclose(md.Signal.Noise_properties.Variance_linear_model.gain_offset,
+                        2228741.5)


### PR DESCRIPTION
### Description of the change
This PR tweaks the path to parse the metadata of dm files created with the stack builder plugin. Fix #762.

### Progress of the PR
- [x] Tweak path to parse the metadata,
- [x] add tests,
- [x] ready for review.

### Minimal example of the bug fix or the new feature
```python
>>> import os
>>> import hyperspy.api as hs
>>> s = hs.load(os.path.join(os.path.split(hs.__file__)[0], 'tests', 'io', 'dm_stackbuilder_plugin', 'test_stackbuilder_imagestack.dm3'))
>>> s.metadata
├── Acquisition_instrument
│   └── TEM
│       ├── acquisition_mode = STEM
│       ├── beam_current = 0.0
│       ├── beam_energy = 200.0
│       ├── camera_length = 15.0
│       ├── dwell_time = 0.03000005078125
│       ├── magnification = 200000.0
│       └── microscope = JEM-ARM200F
├── General
│   ├── date = 2015-05-17
│   ├── original_filename = test_stackbuilder_imagestack.dm3
│   ├── time = 17:00:16
│   └── title = stackbuilder_test4_16x2
├── Sample
│   └── description = DWNC
└── Signal
    ├── Noise_properties
    │   └── Variance_linear_model
    │       ├── gain_factor = 0.15674974024295807
    │       └── gain_offset = 2228741.5
    ├── binned = False
    ├── quantity = Electrons (Counts)
    └── signal_type = 
```

