### PR TITLE
Enable reading of older EDAX TEAM/Vision .spd and .spc files

### DIFF
--- a/hyperspy/io_plugins/edax.py
+++ b/hyperspy/io_plugins/edax.py
@@ -509,7 +509,7 @@ def get_spc_dtype_list(load_all=False, endianess='<', version=0.61):
                 ('longImageFileName', end + '256i1'),  # 20480
             ]
 
-        if version == 0.7:
+        if version >= 0.7:
             dtype_list.extend([
                 ('ADCTimeConstantNew', end + 'f4'),  # 20736
 
@@ -696,7 +696,7 @@ def get_ipr_dtype_list(endianess='<', version=333):
             ('nOverlayElements', end + 'u2'),
             ('overlayColors', end + '16u2')]
 
-    if version == 334:
+    if version >= 334:
         dtype_list.extend([
             ('timeConstantNew', end + 'f4'),
             ('reserved4', end + '2f4'),

--- a/hyperspy/tests/io/test_edax.py
+++ b/hyperspy/tests/io/test_edax.py
@@ -7,7 +7,7 @@ import tempfile
 import gc
 
 import numpy as np
-from numpy.testing import assert_allclose
+from numpy.testing import assert_allclose, assert_equal
 import pytest
 
 from hyperspy.io import load
@@ -16,7 +16,10 @@ from hyperspy import signals
 TEST_FILES = ('Live Map 2_Img.ipr',
               'single_spect.spc',
               'spd_map.spc',
-              'spd_map.spd')
+              'spd_map.spd',
+              'Garnet1_Img.IPR',
+              'spc0_61-ipr333.SPC',
+              'spc0_61-ipr333.spd')
 MY_PATH = os.path.dirname(__file__)
 
 
@@ -47,8 +50,93 @@ def spc(tmpdir):
     os.listdir(tmpdir)
     return load(os.path.join(tmpdir, "single_spect.spc"))
 
+@pytest.fixture(scope="module")
+def spc_loadAllMetadata(tmpdir):
+    os.listdir(tmpdir)
+    return load(os.path.join(tmpdir, "single_spect.spc"),
+                load_all_spc=True)
 
-class TestSpcSpectrum:
+@pytest.fixture(scope="module")
+def spd_061_xrf(tmpdir):
+    signal = load(os.path.join(tmpdir, 'spc0_61-ipr333_xrf.spd'))
+    yield signal
+    signal.data._mmap.close()
+
+@pytest.fixture(scope="module")
+def spc_061_xrf(tmpdir):
+    os.listdir(tmpdir)
+    return load(os.path.join(tmpdir, "spc0_61-ipr333_xrf.SPC"))
+
+@pytest.fixture(scope="module")
+def spc_061_xrf_loadAllMetadata(tmpdir):
+    os.listdir(tmpdir)
+    return load(os.path.join(tmpdir, "spc0_61-ipr333_xrf.SPC"),
+                load_all_spc=True)
+
+
+class TestSpcSpectrum_v061_xrf:
+
+    def test_data(self, spc_061_xrf):
+        assert np.uint32 == spc_061_xrf.data.dtype     # test datatype
+        assert (4000,) == spc_061_xrf.data.shape       # test data shape
+        assert (
+            [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 319, 504, 639, 924,
+             1081, 1326, 1470, 1727, 1983, 2123, 2278, 2509, 2586, 2639,
+             2681, 2833, 2696, 2704, 2812, 2745, 2709, 2647, 2608, 2620,
+             2571, 2669] == spc_061_xrf.data[:40].tolist())   # test 40 datapoints
+
+    def test_parameters(self, spc_061_xrf):
+        elements = spc_061_xrf.metadata.as_dictionary()['Sample']['elements']
+        sem_dict = spc_061_xrf.metadata.as_dictionary()[
+            'Acquisition_instrument']['SEM']  # this will eventually need to
+                                              #  be changed when XRF-specific
+                                              #  features are added
+        eds_dict = sem_dict['Detector']['EDS']
+        signal_dict = spc_061_xrf.metadata.as_dictionary()['Signal']
+
+        # Testing SEM parameters
+        assert_allclose(30, sem_dict['beam_energy'])
+        assert_allclose(0, sem_dict['Stage']['tilt_alpha'])
+
+        # Testing EDS parameters
+        assert_allclose(45, eds_dict['azimuth_angle'])
+        assert_allclose(35, eds_dict['elevation_angle'])
+        assert_allclose(137.92946, eds_dict['energy_resolution_MnKa'],
+                        atol=1E-5)
+        assert_allclose(2561.0, eds_dict['live_time'], atol=1E-6)
+
+        # Testing elements
+        assert ({'Al', 'Ca', 'Cl', 'Cr', 'Fe', 'K', 'Mg', 'Mn', 'Si', 'Y'} ==
+                set(elements))
+
+        # Testing HyperSpy parameters
+        assert True == signal_dict['binned']
+        assert 'EDS_SEM' == signal_dict['signal_type']
+        assert isinstance(spc_061_xrf, signals.EDSSEMSpectrum)
+
+    def test_axes(self, spc_061_xrf):
+        spc_ax_manager = {'axis-0': {'name': 'Energy',
+                                     'navigate': False,
+                                     'offset': 0.0,
+                                     'scale': 0.01,
+                                     'size': 4000,
+                                     'units': 'keV'}}
+        assert (spc_ax_manager ==
+                spc_061_xrf.axes_manager.as_dictionary())
+
+    def test_load_all_spc(self, spc_061_xrf_loadAllMetadata):
+        spc_header = spc_061_xrf_loadAllMetadata.original_metadata[
+            'spc_header']
+
+        assert_allclose(4, spc_header['analysisType'])
+        assert_allclose(4, spc_header['analyzerType'])
+        assert_allclose(2013, spc_header['collectDateYear'])
+        assert_allclose(9, spc_header['collectDateMon'])
+        assert_allclose(26, spc_header['collectDateDay'])
+        assert_equal(b'Garnet1.', spc_header['fileName'].view('|S8')[0])
+        assert_allclose(45, spc_header['xRayTubeZ'])
+
+class TestSpcSpectrum_v070_eds:
 
     def test_data(self, spc):
         assert np.uint32 == spc.data.dtype     # test datatype
@@ -94,8 +182,21 @@ class TestSpcSpectrum:
         assert (spc_ax_manager ==
                 spc.axes_manager.as_dictionary())
 
+    def test_load_all_spc(self, spc_loadAllMetadata):
+        spc_header = spc_loadAllMetadata.original_metadata['spc_header']
 
-class TestSpdMap:
+        assert_allclose(4, spc_header['analysisType'])
+        assert_allclose(5, spc_header['analyzerType'])
+        assert_allclose(2016, spc_header['collectDateYear'])
+        assert_allclose(4, spc_header['collectDateMon'])
+        assert_allclose(19, spc_header['collectDateDay'])
+        assert_equal(b'C:\\ProgramData\\EDAX\\jtaillon\\Cole\\Mapping\\Lsm\\'
+                     b'GFdCr\\950\\Area 1\\spectrum20160419153851427_0.spc',
+                     spc_header['longFileName'].view('|S256')[0])
+        assert_allclose(0, spc_header['xRayTubeZ'])
+
+
+class TestSpdMap_070_eds:
 
     def test_data(self, spd):
         assert np.uint16 == spd.data.dtype     # test d_type
@@ -200,6 +301,117 @@ class TestSpdMap:
                         eds_dict['live_time'])
         assert_allclose(spc_header.evPerChan,
                         spd.axes_manager[2].scale * 1000)
+        assert_allclose(spc_header.kV,
+                        sem_dict['beam_energy'])
+        assert_allclose(spc_header.numElem,
+                        len(elements))
+
+
+class TestSpdMap_061_xrf:
+
+    def test_data(self, spd_061_xrf):
+        assert np.uint16 == spd_061_xrf.data.dtype     # test d_type
+        assert (200, 256, 2000) == spd_061_xrf.data.shape  # test d_shape
+        assert ([[[0, 0, 0, 0, 0],
+                  [0, 0, 0, 0, 0],
+                  [0, 0, 0, 0, 0],
+                  [0, 0, 0, 0, 0],
+                  [0, 0, 0, 1, 0]],
+                 [[0, 0, 0, 0, 0],
+                  [0, 0, 0, 0, 0],
+                  [0, 0, 0, 0, 0],
+                  [0, 0, 0, 0, 0],
+                  [0, 0, 0, 0, 0]],
+                 [[0, 0, 0, 0, 0],
+                  [0, 0, 0, 0, 0],
+                  [0, 0, 0, 0, 0],
+                  [0, 0, 0, 0, 0],
+                  [0, 0, 0, 0, 1]],
+                 [[0, 0, 0, 0, 0],
+                  [0, 0, 0, 0, 0],
+                  [0, 0, 0, 0, 0],
+                  [0, 0, 0, 0, 0],
+                  [0, 0, 0, 0, 1]],
+                 [[0, 0, 0, 0, 0],
+                  [0, 0, 0, 0, 0],
+                  [0, 0, 0, 0, 0],
+                  [0, 0, 0, 0, 0],
+                  [0, 0, 0, 0, 0]]] ==
+                spd_061_xrf.data[15:20, 15:20, 15:20].tolist())
+
+    def test_parameters(self, spd_061_xrf):
+        elements = spd_061_xrf.metadata.as_dictionary()['Sample']['elements']
+        sem_dict = spd_061_xrf.metadata.as_dictionary()[
+            'Acquisition_instrument']['SEM']
+        eds_dict = sem_dict['Detector']['EDS']
+        signal_dict = spd_061_xrf.metadata.as_dictionary()['Signal']
+
+        # Testing SEM parameters
+        assert_allclose(30, sem_dict['beam_energy'])
+        assert_allclose(0, sem_dict['Stage']['tilt_alpha'])
+
+        # Testing EDS parameters
+        assert_allclose(45, eds_dict['azimuth_angle'])
+        assert_allclose(35, eds_dict['elevation_angle'])
+        assert_allclose(137.92946, eds_dict['energy_resolution_MnKa'],
+                        atol=1E-5)
+        assert_allclose(2561.0, eds_dict['live_time'], atol=1E-4)
+
+        # Testing elements
+        assert {'Al', 'Ca', 'Cl', 'Cr', 'Fe', 'K', 'Mg', 'Mn', 'Si',
+                'Y'} == set(elements)
+
+        # Testing HyperSpy parameters
+        assert True == signal_dict['binned']
+        assert 'EDS_SEM' == signal_dict['signal_type']
+        assert isinstance(spd_061_xrf, signals.EDSSEMSpectrum)
+
+    def test_axes(self, spd_061_xrf):
+        spd_ax_manager = {'axis-0': {'name': 'y',
+                                     'navigate': True,
+                                     'offset': 0.0,
+                                     'scale': 565.1920166015625,
+                                     'size': 200,
+                                     'units': '$\\mu m$'},
+                          'axis-1': {'name': 'x',
+                                     'navigate': True,
+                                     'offset': 0.0,
+                                     'scale': 565.1920166015625,
+                                     'size': 256,
+                                     'units': '$\\mu m$'},
+                          'axis-2': {'name': 'Energy',
+                                     'navigate': False,
+                                     'offset': 0.0,
+                                     'scale': 0.01,
+                                     'size': 2000,
+                                     'units': 'keV'}}
+        assert (spd_ax_manager ==
+                spd_061_xrf.axes_manager.as_dictionary())
+
+    def test_ipr_reading(self, spd_061_xrf):
+        ipr_header = spd_061_xrf.original_metadata['ipr_header']
+        assert_allclose(565.1920166015625, ipr_header['mppX'])
+        assert_allclose(565.1920166015625, ipr_header['mppY'])
+
+    def test_spc_reading(self, spd_061_xrf):
+        # Test to make sure that spc metadata matches spd_061_xrf metadata
+        spc_header = spd_061_xrf.original_metadata['spc_header']
+
+        elements = spd_061_xrf.metadata.as_dictionary()['Sample']['elements']
+        sem_dict = spd_061_xrf.metadata.as_dictionary()[
+            'Acquisition_instrument']['SEM']
+        eds_dict = sem_dict['Detector']['EDS']
+
+        assert_allclose(spc_header.azimuth,
+                        eds_dict['azimuth_angle'])
+        assert_allclose(spc_header.detReso,
+                        eds_dict['energy_resolution_MnKa'])
+        assert_allclose(spc_header.elevation,
+                        eds_dict['elevation_angle'])
+        assert_allclose(spc_header.liveTime,
+                        eds_dict['live_time'])
+        assert_allclose(spc_header.evPerChan,
+                        spd_061_xrf.axes_manager[2].scale * 1000)
         assert_allclose(spc_header.kV,
                         sem_dict['beam_energy'])
         assert_allclose(spc_header.numElem,

--- a/hyperspy/tests/io/test_edax.py
+++ b/hyperspy/tests/io/test_edax.py
@@ -17,8 +17,8 @@ TEST_FILES = ('Live Map 2_Img.ipr',
               'single_spect.spc',
               'spd_map.spc',
               'spd_map.spd',
-              'Garnet1_Img.IPR',
-              'spc0_61-ipr333.SPC',
+              'Garnet1_Img.ipr',
+              'spc0_61-ipr333.spc',
               'spc0_61-ipr333.spd')
 MY_PATH = os.path.dirname(__file__)
 
@@ -65,12 +65,12 @@ def spd_061_xrf(tmpdir):
 @pytest.fixture(scope="module")
 def spc_061_xrf(tmpdir):
     os.listdir(tmpdir)
-    return load(os.path.join(tmpdir, "spc0_61-ipr333_xrf.SPC"))
+    return load(os.path.join(tmpdir, "spc0_61-ipr333_xrf.spc"))
 
 @pytest.fixture(scope="module")
 def spc_061_xrf_loadAllMetadata(tmpdir):
     os.listdir(tmpdir)
-    return load(os.path.join(tmpdir, "spc0_61-ipr333_xrf.SPC"),
+    return load(os.path.join(tmpdir, "spc0_61-ipr333_xrf.spc"),
                 load_all_spc=True)
 
 


### PR DESCRIPTION
Resolves #1771 

Basically, there are some added fields in newer versions of the .ipr and .spc file formats from EDAX (versions 334 and 0.70, respectively) that cause the existing code to not work on older files. This PR fixes this by reducing the number of fields read from .ipr files (since we only care about two fields anyway for spatial calibration). For .spc files, it checks the version number, and only reads the additional fields if the version is 0.7.

Passes existing EDAX tests

## Todo:
- [x] Write tests for older file versions
