### PR TITLE
Interactive calibration for Signal2D

### DIFF
--- a/doc/user_guide/signal2d.rst
+++ b/doc/user_guide/signal2d.rst
@@ -104,6 +104,26 @@ It is possible to crop interactively using :ref:`roi-label`. For example:
    Interactive image cropping using a ROI.
 
 
+Interactive calibration
+-----------------------
+
+The scale can be calibrated interactively by using
+:py:meth:`~._signals.signal2d.Signal2D.calibrate`, which is used to
+set the scale by dragging a line across some feature of known size.
+
+.. code-block:: python
+
+    >>> s = hs.signals.Signal2D(np.random.random((200, 200)))
+    >>> s.calibrate()
+
+
+The same function can also be used non-interactively.
+
+.. code-block:: python
+
+    >>> s = hs.signals.Signal2D(np.random.random((200, 200)))
+    >>> s.calibrate(x0=1, y0=1, x1=5, y1=5, new_length=3.4, units="nm", interactive=False)
+
 
 Add a linear ramp
 -----------------

--- a/hyperspy/hyperspy_extension.yaml
+++ b/hyperspy/hyperspy_extension.yaml
@@ -258,6 +258,7 @@ GUI:
     - hyperspy.SimpleMessage
     - hyperspy.Signal1D.spikes_removal_tool
     - hyperspy.Signal2D.find_peaks
+    - hyperspy.Signal2D.calibrate
     - hyperspy.Point1DROI
     - hyperspy.Point2DROI
     - hyperspy.SpanROI

--- a/hyperspy/tests/signals/test_2D_tools.py
+++ b/hyperspy/tests/signals/test_2D_tools.py
@@ -25,6 +25,8 @@ from scipy.ndimage import fourier_shift
 
 import hyperspy.api as hs
 from hyperspy.decorators import lazifyTestClass
+from hyperspy.exceptions import SignalDimensionError
+from hyperspy.signal_tools import LineInSignal2D, Signal2DCalibration
 
 
 def _generate_parameters():
@@ -175,6 +177,154 @@ class TestAlignTools:
         assert np.all(d_al == self.aligned)
 
 
+@lazifyTestClass
+class TestGetSignal2DScale:
+    def setup_method(self, method):
+        self.s0 = hs.signals.Signal2D(np.ones((100, 50)))
+        self.s1 = hs.signals.Signal2D(np.ones((100, 200)))
+
+    def test_default_scale(self):
+        s = self.s0
+        x0, y0, x1, y1, length = 10.0, 10.0, 30.0, 10.0, 80.0
+        scale0 = s._get_signal2d_scale(x0=x0, y0=y0, x1=x1, y1=y1, length=length)
+        x0, y0, x1, y1 = 10, 10, 30, 10
+        scale1 = s._get_signal2d_scale(x0=x0, y0=y0, x1=x1, y1=y1, length=length)
+        # With the default scale (1), scale0 and scale1 have the same value
+        assert scale0 == scale1 == 4.0
+
+    def test_non_one_scale(self):
+        s = self.s0
+        sa = s.axes_manager.signal_axes
+        x0, y0, x1, y1, length = 4.0, 2.0, 4.0, 6.0, 16.0
+        sa[0].scale, sa[1].scale = 0.1, 0.1
+        scale0 = s._get_signal2d_scale(x0=x0, y0=y0, x1=x1, y1=y1, length=length)
+        x0, y0, x1, y1 = 4, 2, 4, 6
+        scale1 = s._get_signal2d_scale(x0=x0, y0=y0, x1=x1, y1=y1, length=length)
+        assert scale0 == 0.4
+        assert scale1 == 4
+
+    def test_diagonal(self):
+        length = (100 ** 2 + 50 ** 2) ** 0.5
+        s = self.s1
+        sa = s.axes_manager.signal_axes
+        sa[0].scale, sa[1].scale = 0.5, 1.0
+        scale0 = s._get_signal2d_scale(
+            x0=0.0, y0=0.0, x1=50.0, y1=50.0, length=length / 2
+        )
+        scale1 = s._get_signal2d_scale(x0=0, y0=0, x1=100, y1=50, length=length)
+        assert scale0 == 0.5
+        assert scale1 == 1.0
+
+    def test_string_input(self):
+        s = self.s0
+        with pytest.raises(TypeError):
+            s._get_signal2d_scale(x0="2.", y0="1", x1="3", y1="5", length=2)
+
+
+@lazifyTestClass
+class TestCalibrate2D:
+    def setup_method(self, method):
+        self.s0 = hs.signals.Signal2D(np.ones((100, 100)))
+        self.s1 = hs.signals.Signal2D(np.ones((100, 200)))
+        self.s2 = hs.signals.Signal2D(np.ones((3, 30, 40)))
+        self.s3 = hs.signals.Signal2D(np.ones((2, 3, 30, 440)))
+
+    def test_cli_default_scale(self):
+        s = self.s0
+        x0, y0, x1, y1, new_length = 10.0, 10.0, 30.0, 10.0, 5.0
+        units = "test"
+        s._calibrate(x0=x0, y0=y0, x1=x1, y1=y1, new_length=new_length, units=units)
+        sa = s.axes_manager.signal_axes
+        assert sa[0].units == sa[1].units == units
+        assert sa[0].scale == sa[1].scale == 0.25
+
+    def test_cli_non_one_scale(self):
+        s = self.s0
+        sa = s.axes_manager.signal_axes
+        sa[0].scale, sa[1].scale = 0.25, 0.25
+        x0, y0, x1, y1, new_length = 10.0, 10.0, 10.0, 20.0, 40.0
+        s._calibrate(x0=x0, y0=y0, x1=x1, y1=y1, new_length=new_length)
+        assert sa[0].scale == sa[1].scale == 1.0
+        x0, y0, x1, y1 = 10, 10, 10, 20
+        s._calibrate(x0=x0, y0=y0, x1=x1, y1=y1, new_length=new_length)
+        assert sa[0].scale == sa[1].scale == 4.0
+
+    def test_non_interactive_missing_parameters(self):
+        s = self.s1
+        with pytest.raises(ValueError, match="With interactive=False x0, y0,*"):
+            s.calibrate(x0=20, y0=30, interactive=False)
+
+    def test_non_interactive_not_same_input_scale(self, caplog):
+        s = self.s1
+        s.axes_manager[0].scale = 0.1
+        s.axes_manager[1].scale = 0.5
+        s.calibrate(x0=5, y0=2, x1=9, y1=5, new_length=2.5, interactive=False)
+        assert "The previous scaling is not the same for both axes" in caplog.text
+
+    def test_non_interactive_not_same_input_units(self, caplog):
+        s = self.s1
+        s.axes_manager[0].units = "nm"
+        s.axes_manager[1].units = "mm"
+        s.calibrate(x0=5, y0=2, x1=9, y1=5, new_length=2.5, interactive=False)
+        assert "The signal axes does not have the same units" in caplog.text
+
+    def test_non_interactive_default_scale(self):
+        s = self.s1
+        x0, y0, x1, y1, new_length = 10.0, 10.0, 10.0, 20.0, 40.0
+        units = "nm"
+        s.calibrate(
+            x0=x0,
+            y0=y0,
+            x1=x1,
+            y1=y1,
+            new_length=new_length,
+            interactive=False,
+            units=units,
+        )
+        sa = s.axes_manager.signal_axes
+        assert sa[0].units == sa[1].units == units
+        assert sa[0].scale == sa[1].scale == 4.0
+        x0, y0, x1, y1 = 10, 10, 10, 20
+        s.calibrate(
+            x0=x0, y0=y0, x1=x1, y1=y1, new_length=new_length, interactive=False
+        )
+        assert sa[0].scale == sa[1].scale == 4.0
+        assert sa[0].units == sa[1].units == units
+
+    def test_3d_signal(self):
+        s = self.s2
+        x0, y0, x1, y1, new_length = 10.0, 10.0, 30.0, 10.0, 5.0
+        units = "test"
+        s._calibrate(x0=x0, y0=y0, x1=x1, y1=y1, new_length=new_length, units=units)
+        sa = s.axes_manager.signal_axes
+        assert sa[0].units == sa[1].units == units
+        assert sa[0].scale == sa[1].scale == 0.25
+
+    def test_4d_signal(self):
+        s = self.s3
+        x0, y0, x1, y1, new_length = 10.0, 10.0, 30.0, 10.0, 5.0
+        units = "test"
+        s._calibrate(x0=x0, y0=y0, x1=x1, y1=y1, new_length=new_length, units=units)
+        sa = s.axes_manager.signal_axes
+        assert sa[0].units == sa[1].units == units
+        assert sa[0].scale == sa[1].scale == 0.25
+
+    def test_non_interactive_non_one_scale(self):
+        s = self.s1
+        x0, y0, x1, y1, new_length = 10.0, 10.0, 10.0, 20.0, 40.0
+        sa = s.axes_manager.signal_axes
+        sa[0].scale, sa[1].scale = 5.0, 5.0
+        s.calibrate(
+            x0=x0, y0=y0, x1=x1, y1=y1, new_length=new_length, interactive=False
+        )
+        assert sa[0].scale == sa[1].scale == 20.0
+        x0, y0, x1, y1 = 10, 10, 10, 20
+        s.calibrate(
+            x0=x0, y0=y0, x1=x1, y1=y1, new_length=new_length, interactive=False
+        )
+        assert sa[0].scale == sa[1].scale == 4.0
+
+
 def test_add_ramp():
     s = hs.signals.Signal2D(np.indices((3, 3)).sum(axis=0) + 4)
     s.add_ramp(-1, -1, -4)
@@ -185,3 +335,51 @@ def test_add_ramp_lazy():
     s = hs.signals.Signal2D(np.indices((3, 3)).sum(axis=0) + 4).as_lazy()
     s.add_ramp(-1, -1, -4)
     npt.assert_almost_equal(s.data.compute(), 0)
+
+
+def test_line_in_signal2d_wrong_signal_dimension():
+    s = hs.signals.Signal1D(np.zeros(100))
+    with pytest.raises(SignalDimensionError):
+        _ = LineInSignal2D(s)
+
+
+def test_line_in_signal2d():
+    s = hs.signals.Signal2D(np.zeros((100, 100)))
+    _ = LineInSignal2D(s)
+
+
+def test_signal_2d_calibration_wrong_signal_dimension():
+    s = hs.signals.Signal1D(np.zeros(100))
+    with pytest.raises(SignalDimensionError):
+        _ = Signal2DCalibration(s)
+
+
+def test_signal_2d_calibration():
+    s = hs.signals.Signal2D(np.zeros((100, 100)))
+    s2dc = Signal2DCalibration(s)
+    s2dc.x0, s2dc.x1 = 1, 11
+    s2dc.y0, s2dc.y1 = 20, 20
+    s2dc.new_length, s2dc.units = 50, "nm"
+    s2dc.apply()
+    assert s.axes_manager[0].scale == 5
+    assert s.axes_manager[1].scale == 5
+    assert s.axes_manager[0].units == "nm"
+    assert s.axes_manager[1].units == "nm"
+
+
+def test_signal_2d_calibration_no_new_length(caplog):
+    s = hs.signals.Signal2D(np.zeros((100, 100)))
+    s2dc = Signal2DCalibration(s)
+    s2dc.x0, s2dc.x1 = 1, 11
+    s2dc.y0, s2dc.y1 = 20, 20
+    s2dc.apply()
+    assert "Input a new length before pressing apply." in caplog.text
+
+
+def test_signal_2d_calibration_value_nan(caplog):
+    s = hs.signals.Signal2D(np.zeros((100, 100)))
+    s2dc = Signal2DCalibration(s)
+    s2dc.x0, s2dc.x1, s2dc.y0, s2dc.y1 = 1, np.nan, 20, 20
+    s2dc.new_length = 50
+    s2dc.apply()
+    assert "Line position is not valid" in caplog.text

--- a/upcoming_changes/1791.new.rst
+++ b/upcoming_changes/1791.new.rst
@@ -1,0 +1,1 @@
+Add :py:meth:`~._signals.signal2d.Signal2D.calibrate` method to :py:class:`~._signals.signal2d.Signal2D` signal, which allows for interactive calibration


### PR DESCRIPTION
This pull requests implements a interactive way of calibrating the signal dimensions in a Signal2D object. It is based on the calibration functionality for Signal1D.

Needs to be used with https://github.com/hyperspy/hyperspy_gui_traitsui/pull/3, or https://github.com/hyperspy/hyperspy_gui_ipywidgets/pull/2

### Progress of the PR
- [x] Initial implementation
- [x] Improve implementation
- [x] Add GUI elements to hyperspy_gui_ipywidgets
- [x] Add docstring to signal2d.calibrate
- [x] Update user guide
- [x] Add tests
- [x] Ready for review.

To test this, grab this branch + the traitsui pull request: https://github.com/hyperspy/hyperspy_gui_traitsui/pull/3.

```python
>>> import hyperspy.api as hs
>>> import numpy as np
>>> s = hs.signals.Signal2D(np.random.random((100, 100)))
>>> s.calibrate(toolkit='traitsui')
```
(This traitsui GUI image is slightly outdated now, since I did some minor changes in the most recent commit).
![calibrate_signal2d](https://user-images.githubusercontent.com/1690979/34157793-52bfeb66-e4c3-11e7-8e49-46b1064ee151.png)

```python
>>> import hyperspy.api as hs
>>> import numpy as np
>>> s = hs.signals.Signal2D(np.random.random((100, 100)))
>>> s.calibrate(toolkit='ipywidgets')
```

![ipywidget_calibrate2d](https://user-images.githubusercontent.com/1690979/34176071-e95753a8-e4fe-11e7-8c4c-0284659e9f5e.png)
