### PR TITLE
Fix deprecation warning and issue with numpy1.14

### DIFF
--- a/hyperspy/_signals/complex_signal.py
+++ b/hyperspy/_signals/complex_signal.py
@@ -94,8 +94,8 @@ class ComplexSignal_mixin:
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        if not np.issubdtype(self.data.dtype, complex):
-            self.data = self.data.astype(complex)
+        if not np.issubdtype(self.data.dtype, np.complexfloating):
+            self.data = self.data.astype(np.complexfloating)
 
     def change_dtype(self, dtype):
         """Change the data type.
@@ -107,7 +107,7 @@ class ComplexSignal_mixin:
             complex dtypes are allowed. If real valued properties are required use `real`,
             `imag`, `amplitude` and `phase` instead.
         """
-        if np.issubdtype(dtype, complex):
+        if np.issubdtype(dtype, np.complexfloating):
             self.data = self.data.astype(dtype)
         else:
             raise AttributeError(

--- a/hyperspy/io.py
+++ b/hyperspy/io.py
@@ -338,7 +338,7 @@ def assign_signal_subclass(dtype,
     import hyperspy._lazy_signals
     from hyperspy.signal import BaseSignal
     # Check if parameter values are allowed:
-    if np.issubdtype(dtype, complex):
+    if np.issubdtype(dtype, np.complexfloating):
         dtype = 'complex'
     elif ('float' in dtype.name or 'int' in dtype.name or
           'void' in dtype.name or 'bool' in dtype.name or

--- a/hyperspy/io_plugins/bcf.py
+++ b/hyperspy/io_plugins/bcf.py
@@ -159,7 +159,7 @@ class SFSTreeItem(object):
                 fn.seek(self.sfs.chunksize *
                         self._pointer_to_pointer_table + 0x138)
                 temp_table = fn.read(self.sfs.usable_chunk)
-            self.pointers = np.fromstring(temp_table[:self.size_in_chunks * 4],
+            self.pointers = np.frombuffer(temp_table[:self.size_in_chunks * 4],
                                           dtype='uint32').astype(np.int64) *\
                 self.sfs.chunksize + 0x138
 
@@ -1063,10 +1063,9 @@ class BCF_reader(SFS_reader):
                 elif flag == 1:  # and (chan1 != chan2)
                     # Unpack packed 12-bit data to 16-bit uints:
                     data1 = buffer1[offset:offset + data_size2]
-                    switched_i2 = np.fromstring(data1,
-                                                dtype='<u2'
-                                                ).byteswap(True)
-                    data2 = np.fromstring(switched_i2.tostring(),
+                    switched_i2 = np.frombuffer(data1, dtype='<u2'
+                                                ).byteswap(False)
+                    data2 = np.frombuffer(switched_i2.tostring(),
                                           dtype=np.uint8
                                           ).repeat(2)
                     mask = np.ones_like(data2, dtype=bool)
@@ -1074,8 +1073,8 @@ class BCF_reader(SFS_reader):
                     # Reinterpret expanded as 16-bit:
                     # string representation of array after switch will have
                     # always BE independently from endianess of machine
-                    exp16 = np.fromstring(data2[mask].tostring(),
-                                          dtype='>u2', count=n_of_pulses)
+                    exp16 = np.frombuffer(data2[mask].tostring(),
+                                          dtype='>u2', count=n_of_pulses).copy()
                     exp16[0::2] >>= 4           # Shift every second short by 4
                     exp16 &= np.uint16(0x0FFF)  # Mask all shorts to 12bit
                     pixel = np.bincount(exp16, minlength=chan1 - 1)

--- a/hyperspy/io_plugins/digital_micrograph.py
+++ b/hyperspy/io_plugins/digital_micrograph.py
@@ -666,7 +666,8 @@ class ImageObject(object):
             return self.unpack_packed_complex(data)
         elif self.imdict.ImageData.DataType in (8, 23):  # ABGR
             # Reorder the fields
-            data = data[['R', 'G', 'B', 'A']].copy()
+            data = data[['R', 'G', 'B', 'A']].astype(
+                    [('R', 'u1'), ('G', 'u1'), ('B', 'u1'), ('A', 'u1')])
         return data.reshape(self.shape, order=self.order)
 
     def unpack_new_packed_complex(self, data):

--- a/hyperspy/io_plugins/protochips.py
+++ b/hyperspy/io_plugins/protochips.py
@@ -22,6 +22,8 @@ import os
 from datetime import datetime as dt
 import warnings
 import logging
+from distutils.version import LooseVersion
+
 
 # Plugin characteristics
 # ----------------------
@@ -135,10 +137,12 @@ class ProtochipsCSV(object):
 
     def _read_data(self, header_line_number):
         names = [name.replace(' ', '_') for name in self.column_name]
+        # Necessary for numpy >= 1.14
+        kwargs = {'encoding':'latin1'} if np.__version__ >= LooseVersion("1.14") else {}
         data = np.genfromtxt(self.filename, delimiter=',', dtype=None,
                              names=names,
                              skip_header=header_line_number,
-                             unpack=True)
+                             unpack=True, **kwargs)
 
         self._data_dictionary = dict()
         for i, name, name_dtype in zip(range(len(names)), self.column_name,

--- a/hyperspy/io_plugins/semper_unf.py
+++ b/hyperspy/io_plugins/semper_unf.py
@@ -340,10 +340,10 @@ class SemperFormat(object):
             iform = 0  # byte
         elif np.issubdtype(data.dtype, np.int16):
             iform = 1  # int16
-        elif np.issubdtype(data.dtype, float) and data.dtype.itemsize <= 4:
+        elif np.issubdtype(data.dtype, np.floating) and data.dtype.itemsize <= 4:
             data = data.astype(np.float32)
             iform = 2  # float (4 byte or less)
-        elif np.issubdtype(data.dtype, complex) and data.dtype.itemsize <= 8:
+        elif np.issubdtype(data.dtype, np.complexfloating) and data.dtype.itemsize <= 8:
             data = data.astype(np.complex64)
             iform = 3  # complex (8 byte or less)
         elif np.issubdtype(data.dtype, np.int32):

--- a/hyperspy/learn/onmf.py
+++ b/hyperspy/learn/onmf.py
@@ -43,7 +43,7 @@ def _mrdivide(B, A):
             # square array
             return np.linalg.solve(A.T, B.T).T
         else:
-            return np.linalg.lstsq(A.T, B.T)[0].T
+            return np.linalg.lstsq(A.T, B.T, rcond=None)[0].T
     else:
         return B / A
 

--- a/hyperspy/misc/math_tools.py
+++ b/hyperspy/misc/math_tools.py
@@ -58,7 +58,7 @@ def isfloat(number):
 
     """
     if hasattr(number, "dtype"):
-        return np.issubdtype(number, np.float)
+        return np.issubdtype(number, np.floating)
     else:
         return isinstance(number, float)
 

--- a/hyperspy/signal.py
+++ b/hyperspy/signal.py
@@ -1987,7 +1987,7 @@ class BaseSignal(FancySlicing,
             navigator.axes_manager.indices = self.axes_manager.indices[
                 navigator.axes_manager.signal_dimension:]
             navigator.axes_manager._update_attributes()
-            if np.issubdtype(navigator().dtype, complex):
+            if np.issubdtype(navigator().dtype, np.complexfloating):
                 return np.abs(navigator())
             else:
                 return navigator()
@@ -2043,7 +2043,7 @@ class BaseSignal(FancySlicing,
                         "The navigator dimensions are not compatible with "
                         "those of self.")
             elif navigator == "data":
-                if np.issubdtype(self.data.dtype, complex):
+                if np.issubdtype(self.data.dtype, np.complexfloating):
                     self._plot.navigator_data_function = lambda axes_manager=None: np.abs(
                         self.data)
                 else:

--- a/hyperspy/tests/io/test_tiff.py
+++ b/hyperspy/tests/io/test_tiff.py
@@ -1,11 +1,9 @@
 import os
 import tempfile
-from distutils.version import LooseVersion
 
 import numpy as np
 import traits.api as t
 from numpy.testing import assert_allclose
-import pytest
 
 import hyperspy.api as hs
 from hyperspy.misc.test_utils import assert_deep_almost_equal


### PR DESCRIPTION
Many tests are failing (mainly because of deprecation warning) following the releases of numpy 1.14.

### Progress of the PR
- [x] ready for review.
