### PR TITLE
Add unfolding and get_*_model to lazy signals

### DIFF
--- a/hyperspy/_signals/lazy.py
+++ b/hyperspy/_signals/lazy.py
@@ -255,9 +255,6 @@ class LazySignal(BaseSignal):
     def __array__(self, dtype=None):
         return self.data.__array__(dtype=dtype)
 
-    def _unfold(self, *args):
-        raise lazyerror
-
     def _make_sure_data_is_contiguous(self, log=None):
         self._make_lazy(rechunk=True)
 

--- a/hyperspy/_signals/lazy.py
+++ b/hyperspy/_signals/lazy.py
@@ -771,14 +771,17 @@ class LazySignal(BaseSignal):
             if reproject:
                 if algorithm == 'PCA':
                     method = obj.transform
-                    post = lambda a: np.concatenate(a, axis=0)
+
+                    def post(a): return np.concatenate(a, axis=0)
                 elif algorithm == 'ORPCA':
                     method = obj.project
                     obj.R = []
-                    post = lambda a: obj.finish()[4]
+
+                    def post(a): return obj.finish()[4]
                 elif algorithm == 'ONMF':
                     method = obj.project
-                    post = lambda a: np.concatenate(a, axis=1).T
+
+                    def post(a): return np.concatenate(a, axis=1).T
 
                 _map = map(lambda thing: method(thing),
                            self._block_iterator(

--- a/hyperspy/_signals/lazy.py
+++ b/hyperspy/_signals/lazy.py
@@ -255,9 +255,6 @@ class LazySignal(BaseSignal):
     def __array__(self, dtype=None):
         return self.data.__array__(dtype=dtype)
 
-    # def _unfold(self, *args):
-    #     raise lazyerror
-
     def _make_sure_data_is_contiguous(self, log=None):
         self._make_lazy(rechunk=True)
 

--- a/hyperspy/_signals/lazy.py
+++ b/hyperspy/_signals/lazy.py
@@ -255,6 +255,9 @@ class LazySignal(BaseSignal):
     def __array__(self, dtype=None):
         return self.data.__array__(dtype=dtype)
 
+    # def _unfold(self, *args):
+    #     raise lazyerror
+
     def _make_sure_data_is_contiguous(self, log=None):
         self._make_lazy(rechunk=True)
 
@@ -771,17 +774,14 @@ class LazySignal(BaseSignal):
             if reproject:
                 if algorithm == 'PCA':
                     method = obj.transform
-
-                    def post(a): return np.concatenate(a, axis=0)
+                    post = lambda a: np.concatenate(a, axis=0)
                 elif algorithm == 'ORPCA':
                     method = obj.project
                     obj.R = []
-
-                    def post(a): return obj.finish()[4]
+                    post = lambda a: obj.finish()[4]
                 elif algorithm == 'ONMF':
                     method = obj.project
-
-                    def post(a): return np.concatenate(a, axis=1).T
+                    post = lambda a: np.concatenate(a, axis=1).T
 
                 _map = map(lambda thing: method(thing),
                            self._block_iterator(

--- a/hyperspy/_signals/lazy.py
+++ b/hyperspy/_signals/lazy.py
@@ -774,14 +774,17 @@ class LazySignal(BaseSignal):
             if reproject:
                 if algorithm == 'PCA':
                     method = obj.transform
-                    post = lambda a: np.concatenate(a, axis=0)
+
+                    def post(a): return np.concatenate(a, axis=0)
                 elif algorithm == 'ORPCA':
                     method = obj.project
                     obj.R = []
-                    post = lambda a: obj.finish()[4]
+
+                    def post(a): return obj.finish()[4]
                 elif algorithm == 'ONMF':
                     method = obj.project
-                    post = lambda a: np.concatenate(a, axis=1).T
+
+                    def post(a): return np.concatenate(a, axis=1).T
 
                 _map = map(lambda thing: method(thing),
                            self._block_iterator(

--- a/hyperspy/learn/mva.py
+++ b/hyperspy/learn/mva.py
@@ -26,7 +26,7 @@ from matplotlib.ticker import MaxNLocator, FuncFormatter
 try:
     import mdp
     mdp_installed = True
-except:
+except BaseException:
     mdp_installed = False
 
 
@@ -327,7 +327,7 @@ class MVA():
                             var_array = np.polyval(
                                 polyfit, dc[
                                     signal_mask, navigation_mask])
-                        except:
+                        except BaseException:
                             raise ValueError(
                                 'var_func must be either a function or an '
                                 'array defining the coefficients of a polynom')
@@ -421,7 +421,8 @@ class MVA():
             if reproject in ('signal', 'both'):
                 if algorithm not in ('nmf', 'sparse_pca',
                                      'mini_batch_sparse_pca'):
-                    factors = (np.linalg.pinv(loadings) @ (dc[navigation_mask, :] - mean)).T
+                    factors = (np.linalg.pinv(loadings) @ (
+                        dc[navigation_mask, :] - mean)).T
                     target.factors = factors
                 else:
                     _logger.info("Reprojecting the signal is not yet "
@@ -667,7 +668,7 @@ class MVA():
             # more predictable way
             sorting_indices = np.argsort(
                 lr.explained_variance[:number_of_components] @ np.abs(w.T)
-                )[::-1]
+            )[::-1]
             w[:] = w[sorting_indices, :]
         lr.unmixing_matrix = w
         lr.on_loadings = on_loadings

--- a/hyperspy/learn/mva.py
+++ b/hyperspy/learn/mva.py
@@ -51,7 +51,7 @@ def centering_and_whitening(X):
     del _
     K = (u / (d / np.sqrt(X.shape[1]))).T
     del u, d
-    X1 = np.dot(K, X)
+    X1 = K @ X
     return X1.T, K
 
 
@@ -414,15 +414,14 @@ class MVA():
             if reproject in ('navigation', 'both'):
                 if algorithm not in ('nmf', 'sparse_pca',
                                      'mini_batch_sparse_pca'):
-                    loadings_ = np.dot(dc[:, signal_mask] - mean, factors)
+                    loadings_ = (dc[:, signal_mask] - mean) @ factors
                 else:
                     loadings_ = sk.transform(dc[:, signal_mask])
                 target.loadings = loadings_
             if reproject in ('signal', 'both'):
                 if algorithm not in ('nmf', 'sparse_pca',
                                      'mini_batch_sparse_pca'):
-                    factors = np.dot(np.linalg.pinv(loadings),
-                                     dc[navigation_mask, :] - mean).T
+                    factors = (np.linalg.pinv(loadings) @ (dc[navigation_mask, :] - mean)).T
                     target.factors = factors
                 else:
                     _logger.info("Reprojecting the signal is not yet "
@@ -660,15 +659,15 @@ class MVA():
             lr.bss_node = temp_function(**kwargs)
             lr.bss_node.train(factors)
             unmixing_matrix = lr.bss_node.get_recmatrix()
-        w = np.dot(unmixing_matrix, invsqcovmat)
+        w = unmixing_matrix @ invsqcovmat
         if lr.explained_variance is not None:
             # The output of ICA is not sorted in any way what makes it
             # difficult to compare results from different unmixings. The
             # following code is an experimental attempt to sort them in a
             # more predictable way
-            sorting_indices = np.argsort(np.dot(
-                lr.explained_variance[:number_of_components],
-                np.abs(w.T)))[::-1]
+            sorting_indices = np.argsort(
+                lr.explained_variance[:number_of_components] @ np.abs(w.T)
+                )[::-1]
             w[:] = w[sorting_indices, :]
         lr.unmixing_matrix = w
         lr.on_loadings = on_loadings
@@ -779,12 +778,12 @@ class MVA():
         w = lr.unmixing_matrix
         n = len(w)
         if lr.on_loadings:
-            lr.bss_loadings = np.dot(lr.loadings[:, :n], w.T)
-            lr.bss_factors = np.dot(lr.factors[:, :n], np.linalg.inv(w))
+            lr.bss_loadings = lr.loadings[:, :n] @  w.T
+            lr.bss_factors = lr.factors[:, :n] @ np.linalg.inv(w)
         else:
 
-            lr.bss_factors = np.dot(lr.factors[:, :n], w.T)
-            lr.bss_loadings = np.dot(lr.loadings[:, :n], np.linalg.inv(w))
+            lr.bss_factors = lr.factors[:, :n] @ w.T
+            lr.bss_loadings = lr.loadings[:, :n] @ np.linalg.inv(w)
 
     def _auto_reverse_bss_component(self, target):
         n_components = target.bss_factors.shape[1]
@@ -822,7 +821,7 @@ class MVA():
             factors = target.bss_factors
             loadings = target.bss_loadings.T
         if components is None:
-            a = np.dot(factors, loadings)
+            a = factors @ loadings
             signal_name = 'model from %s with %i components' % (
                 mva_type, factors.shape[1])
         elif hasattr(components, '__iter__'):
@@ -831,12 +830,11 @@ class MVA():
             for i in range(len(components)):
                 tfactors[:, i] = factors[:, components[i]]
                 tloadings[i, :] = loadings[components[i], :]
-            a = np.dot(tfactors, tloadings)
+            a = tfactors @ tloadings
             signal_name = 'model from %s with components %s' % (
                 mva_type, components)
         else:
-            a = np.dot(factors[:, :components],
-                       loadings[:components, :])
+            a = factors[:, :components] @ loadings[:components, :]
             signal_name = 'model from %s with %i components' % (
                 mva_type, components)
 


### PR DESCRIPTION
### Description of the change

Enable the following previously unsupported features for lazy signals:

* ``Signal.unfold``
* ``Signal.get_decomposition_model``
* ``Signal.get_bss_model``

### Progress of the PR
- [x] Change implemented (can be split into several points),
- [ ] add tests,
- [ ] ready for review.

### Minimal example of the bug fix or the new feature

```python
>>> import hyperspy.api as hs
>>> import numpy as np
>>> s = hs.signals.Signal1D(np.random.random((32, 32, 100))).as_lazy()
>>> s.decomposition(output_dimension=2)
>>> sc = s.get_decomposition_model(2)
<LazySignal1D, title:  model from decomposition with 2 components, dimensions: (32, 32|100)>
>>> s.unfold()
>>> s
<LazySignal1D, title: , unfolded dimensions: (1024|100)>

```

