### PR TITLE
Fancy metadata

### DIFF
--- a/hyperspy/misc/utils.py
+++ b/hyperspy/misc/utils.py
@@ -406,23 +406,31 @@ class DictionaryTreeBrowser(object):
                                 {'[%d]' % i: v for i, v in enumerate(value)},
                                 double_lines=True)
                         else:
-                            string += "<li>%s = %s</li>" % (
+                            string += """
+                            <ul style="margin: 0px; list-style-position: outside;">
+                            <li style='margin-left:1em; padding-left: 0.5em'>%s = %s</li></ul>""" % (
                                 key, strvalue)
                             continue
 
                 if isinstance(value, DictionaryTreeBrowser):
-                    string += '''<ul style="margin: 0px; list-style-position: outside;">
-                    <details open>
-                    <summary>
-                    <li style="display: inline;">
-                    %s
-                    </li></summary>''' % (key)
-                    string += value._get_html_print_items()
-                    string += '</details></ul>'
+                    if value.keys():
+                        string += """<ul style="margin: 0px; list-style-position: outside;">
+                        <details closed>
+                        <summary>
+                        <li style="display: inline;">
+                        %s
+                        </li></summary>""" % (key)
+                        string += value._get_html_print_items()
+                        string += '</details></ul>'
+                    else:
+                        string += """<ul style="margin: 0px; list-style-position: outside;">
+                        <li style='margin-left:1em; padding-left: 0.5em'>%s</li></ul>""" % (
+                        key)
                 else:
                     _, strvalue = check_long_string(value, max_len)
                     strvalue = replace_html_symbols(strvalue)
-                    string += "<li style='margin-left:3em; padding-left: 0.5em'>%s = %s</li>" % (
+                    string += """<ul style="margin: 0px; list-style-position: outside;">
+                    <li style='margin-left:1em; padding-left: 0.5em'>%s = %s</li></ul>""" % (
                         key, strvalue)
         string += ""
         return string

--- a/hyperspy/misc/utils.py
+++ b/hyperspy/misc/utils.py
@@ -411,7 +411,7 @@ class DictionaryTreeBrowser(object):
                             continue
 
                 if isinstance(value, DictionaryTreeBrowser):
-                    string += '''<ul style="margin: 0px;">
+                    string += '''<ul style="margin: 0px; list-style-position: outside;">
                     <details open>
                     <summary>
                     <li style="display: inline;">
@@ -422,7 +422,7 @@ class DictionaryTreeBrowser(object):
                 else:
                     _, strvalue = check_long_string(value, max_len)
                     strvalue = replace_html_symbols(strvalue)
-                    string += "<li style='margin-left:2.2em;'>%s = %s</li>" % (
+                    string += "<li style='margin-left:3em; padding-left: 0.5em'>%s = %s</li>" % (
                         key, strvalue)
         string += ""
         return string

--- a/hyperspy/misc/utils.py
+++ b/hyperspy/misc/utils.py
@@ -416,7 +416,7 @@ class DictionaryTreeBrowser(object):
                     if value.keys():
                         string += """<ul style="margin: 0px; list-style-position: outside;">
                         <details closed>
-                        <summary>
+                        <summary style="display: list-item;">
                         <li style="display: inline;">
                         %s
                         </li></summary>""" % (key)

--- a/hyperspy/tests/test_dictionary_tree_browser.py
+++ b/hyperspy/tests/test_dictionary_tree_browser.py
@@ -1,7 +1,7 @@
 
 import numpy as np
 
-from hyperspy.misc.utils import DictionaryTreeBrowser
+from hyperspy.misc.utils import DictionaryTreeBrowser, check_long_string, replace_html_symbols, add_key_value
 from hyperspy.signal import BaseSignal
 
 
@@ -166,3 +166,40 @@ class TestDictionaryBrowser:
         assert self.tree.get_item('Node1.Node31.leaf311', 44) == 44
         assert self.tree.get_item('Node1.Node21.leaf311', 44) == 44
         assert self.tree.get_item('.Node1.Node21.leaf311', 44) == 44
+
+    def test_html(self):
+        "Test that the method actually runs"
+        # We do not have a way to validate html
+        # without relying on more dependencies
+        tree = self.tree
+        tree['<myhtmltag>'] = "5 < 6"
+        tree['<mybrokenhtmltag'] = "<hello>"
+        tree['mybrokenhtmltag2>'] = ""
+        tree._get_html_print_items()
+
+def test_check_long_string():
+    max_len = 20
+    value = "Hello everyone this is a long string"
+    truth, shortened = check_long_string(value, max_len)
+    assert truth == False
+    assert shortened == 'Hello everyone this is a long string'
+
+    value = "No! It was not a long string! This is a long string!"
+    truth, shortened = check_long_string(value, max_len)
+    assert truth == True
+    assert shortened == 'No! It was not a lon ... is is a long string!'
+
+def test_replace_html_symbols():
+    assert '&lt;&gt;&amp' == replace_html_symbols('<>&')
+    assert 'no html symbols' == replace_html_symbols('no html symbols')
+    assert '&lt;mix&gt;' == replace_html_symbols('<mix>')
+
+def test_add_key_value():
+    key = "<foo>"
+    value = ">bar<"
+
+    string = """<ul style="margin: 0px; list-style-position: outside;">
+        <li style='margin-left:1em; padding-left: 0.5em'>{} = {}</li></ul>
+        """.format(replace_html_symbols(key), replace_html_symbols(value))
+
+    assert string == '<ul style="margin: 0px; list-style-position: outside;">\n        <li style=\'margin-left:1em; padding-left: 0.5em\'>&lt;foo&gt; = &gt;bar&lt;</li></ul>\n        '


### PR DESCRIPTION
### Description of the change
I've enhanced the metadata with a html view to make it look a bit nicer. It works nicely in Firefox and Chrome. Microsoft browers display a less fancy version, although it is fine for use.

### Progress of the PR
- [x] ready for review.

### Minimal example of the bug fix or the new feature
```python
%matplotlib inline
import hyperspy.api as hs
s = hs.datasets.example_signals.EDS_SEM_Spectrum()
s.metadata
```
![image](https://user-images.githubusercontent.com/2721423/35176563-33739bc0-fd7a-11e7-9beb-c9a9351e6247.png)

