### PR TITLE
Temporarily disable broken pytest-sugar

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -55,7 +55,7 @@ before_script: # configure a headless display to test plot generation
 
 script:
   - python -c 'import matplotlib.pyplot as plt; print(plt.get_backend())';
-  - pip install coverage coveralls pytest pytest-cov pytest-mpl #pytest-sugar;
+  - pip install coverage coveralls pytest pytest-cov pytest-mpl
     py.test --mpl --cov=hyperspy --pyargs hyperspy;
 
 #after_failure: # run only on failure in case there is a need to check matplotlib image comparison

--- a/.travis.yml
+++ b/.travis.yml
@@ -55,7 +55,7 @@ before_script: # configure a headless display to test plot generation
 
 script:
   - python -c 'import matplotlib.pyplot as plt; print(plt.get_backend())';
-  - pip install coverage coveralls pytest pytest-cov pytest-mpl
+  - pip install coverage coveralls pytest pytest-cov pytest-mpl;
     py.test --mpl --cov=hyperspy --pyargs hyperspy;
 
 #after_failure: # run only on failure in case there is a need to check matplotlib image comparison

--- a/.travis.yml
+++ b/.travis.yml
@@ -55,7 +55,7 @@ before_script: # configure a headless display to test plot generation
 
 script:
   - python -c 'import matplotlib.pyplot as plt; print(plt.get_backend())';
-  - pip install coverage coveralls pytest pytest-cov pytest-mpl pytest-sugar;
+  - pip install coverage coveralls pytest pytest-cov pytest-mpl #pytest-sugar;
     py.test --mpl --cov=hyperspy --pyargs hyperspy;
 
 #after_failure: # run only on failure in case there is a need to check matplotlib image comparison


### PR DESCRIPTION
py.test is making all of our tests fail in Travis due to Frozenball/pytest-sugar/issues/132 . This PR disables pytest sugar in travis. If merged, once the next version of pytest sugar is released we can revert this PR.

