### PR TITLE
Add `doc` entry to extras_require to install doc dependencies

### DIFF
--- a/doc/user_guide/install.rst
+++ b/doc/user_guide/install.rst
@@ -152,6 +152,7 @@ Alternatively you can select the extra functionalities required:
 * ``gui-traitsui`` to install required libraries to use the GUI elements based
   on `traitsui <http://docs.enthought.com/traitsui/>`_
 * ``test`` to install required libraries to run HyperSpy's unit tests.
+* ``doc`` to install required libraries to build HyperSpy's documentation.
 
 For example:
 

--- a/setup.py
+++ b/setup.py
@@ -70,6 +70,7 @@ extras_require = {
     "gui-jupyter": ["hyperspy_gui_ipywidgets"],
     "gui-traitsui": ["hyperspy_gui_traitsui"],
     "test": ["pytest>=3", "pytest-mpl", "matplotlib>=2.0.2"],
+    "doc": ["sphinx", "numpydoc", "sphinxcontrib-napoleon", "sphinx_rtd_theme"],
 }
 extras_require["all"] = list(itertools.chain(*list(extras_require.values())))
 


### PR DESCRIPTION
### Description of the change
Add `doc` entry to the extra_requires dictionary in `setup.py` to install the dependencies required to build the documentation.

### Progress of the PR
- [x] update `setup.py`,
- [x] update doc,
- [x] ready for review.

### Minimal example
```
pip install -e .[doc]
```

