### PR TITLE
Fix deprecation warning invalid escape sequence

### DIFF
--- a/hyperspy/_components/lorentzian.py
+++ b/hyperspy/_components/lorentzian.py
@@ -23,22 +23,22 @@ from hyperspy.component import Component
 
 class Lorentzian(Component):
 
-    """Cauchy-Lorentz distribution (a.k.a. Lorentzian function) component
+    r"""Cauchy-Lorentz distribution (a.k.a. Lorentzian function) component
 
     .. math::
 
-        f(x)=\\frac{a}{\pi}\left[\\frac{\gamma}{\left(x-x_{0}\\right)^{2}+\gamma^{2}}\\right]
+        f(x)=\frac{a}{\pi}\left[\frac{\gamma}{\left(x-x_{0}\right)^{2}+\gamma^{2}}\right]
 
-    +------------+-----------+
-    | Parameter  | Attribute |
-    +------------+-----------+
-    +------------+-----------+
-    |     a      |     A     |
-    +------------+-----------+
-    |   gamma    |   gamma   |
-    +------------+-----------+
-    |    x0      |  centre   |
-    +------------+-----------+
+    +---------------------+-----------+
+    |     Parameter       | Attribute |
+    +---------------------+-----------+
+    +---------------------+-----------+
+    |      :math:`a`      |     A     |
+    +---------------------+-----------+
+    |    :math:`\gamma`   |   gamma   |
+    +---------------------+-----------+
+    |      :math:`x_0`    |  centre   |
+    +---------------------+-----------+
 
     """
 

--- a/hyperspy/_components/volume_plasmon_drude.py
+++ b/hyperspy/_components/volume_plasmon_drude.py
@@ -23,23 +23,22 @@ from hyperspy.component import Component
 
 class VolumePlasmonDrude(Component):
 
-    """Drude volume plasmon energy loss function component
+    r"""Drude volume plasmon energy loss function component, the energy loss 
+    function is defined as:
 
     .. math::
 
-       Energy loss function defined as:
+       f(E) = \frac{E(\Delta E_p)E_p^2}{(E^2-E_p^2)^2+(E\Delta E_p)^2}
 
-       f(E) = \\frac{E(\Delta E_p)E_p^2}{(E^2-E_p^2)^2+(E\Delta E_p)^2}
-
-    +------------+-----------------+
-    | Parameter  |    Attribute    |
-    +------------+-----------------+
-    |    E_p     |  plasmon_energy |
-    +------------+-----------------+
-    | delta_E_p  |      fwhm       |
-    +------------+-----------------+
-    | intensity  |   intensity     |
-    +------------+-----------------+
+    +------------------+-----------------+
+    | Parameter        |    Attribute    |
+    +------------------+-----------------+
+    |:math:`E_p`       |  plasmon_energy |
+    +------------------+-----------------+
+    |:math:`\Delta E_p`|      fwhm       |
+    +------------------+-----------------+
+    | intensity        |   intensity     |
+    +------------------+-----------------+
 
     Notes
     -----

--- a/hyperspy/_signals/complex_signal.py
+++ b/hyperspy/_signals/complex_signal.py
@@ -115,8 +115,8 @@ class ComplexSignal_mixin:
 
     @format_title('angle')
     def angle(self, angle, deg=False):
-        """Return the angle (also known as phase or argument). If the data is real, the angle is 0
-        for positive values and 2$\pi$ for negative values.
+        r"""Return the angle (also known as phase or argument). If the data is real, the angle is 0
+        for positive values and :math:`2\pi` for negative values.
 
         Parameters
         ----------

--- a/hyperspy/_signals/dielectric_function.py
+++ b/hyperspy/_signals/dielectric_function.py
@@ -31,15 +31,23 @@ class DielectricFunction_mixin:
     _alias_signal_types = ["dielectric function"]
 
     def get_number_of_effective_electrons(self, nat, cumulative=False):
-        """Compute the number of effective electrons using the Bethe f-sum
+        r"""Compute the number of effective electrons using the Bethe f-sum
         rule.
 
         The Bethe f-sum rule gives rise to two definitions of the effective
-        number (see [Egerton2011]_):
-        $n_{\mathrm{eff}}\left(-\Im\left(\epsilon^{-1}\right)\right)$ that
-        we'll call neff1 and
-        $n_{\mathrm{eff}}\left(\epsilon_{2}\right)$ that we'll call neff2. This
-        method computes both.
+        number (see [Egerton2011]_), neff1 and neff2:
+
+            .. math::
+
+                n_{\mathrm{eff_{1}}} = n_{\mathrm{eff}}\left(-\Im\left(\epsilon^{-1}\right)\right)
+
+        and:
+
+            .. math::
+
+                n_{\mathrm{eff_{2}}} = n_{\mathrm{eff}}\left(\epsilon_{2}\right)
+
+        This method computes and return both.
 
         Parameters
         ----------

--- a/hyperspy/_signals/eels.py
+++ b/hyperspy/_signals/eels.py
@@ -29,7 +29,6 @@ from hyperspy._signals.signal1d import (Signal1D, LazySignal1D)
 from hyperspy.misc.elements import elements as elements_db
 import hyperspy.axes
 from hyperspy.defaults_parser import preferences
-from hyperspy.external.progressbar import progressbar
 from hyperspy.components1d import PowerLaw
 from hyperspy.misc.utils import (
     isiterable, closest_power_of_two, underline, signal_range_from_roi)
@@ -1014,7 +1013,7 @@ class EELSSpectrum_mixin:
                                 t=None,
                                 delta=0.5,
                                 full_output=False):
-        """Calculate the complex
+        r"""Calculate the complex
         dielectric function from a single scattering distribution (SSD) using
         the Kramers-Kronig relations.
 
@@ -1072,7 +1071,10 @@ class EELSSpectrum_mixin:
         -------
         eps: DielectricFunction instance
             The complex dielectric function results,
-                $\epsilon = \epsilon_1 + i*\epsilon_2$,
+
+                .. math::
+                    \epsilon = \epsilon_1 + i*\epsilon_2,
+
             contained in an DielectricFunction instance.
         output: Dictionary (optional)
             A dictionary of optional outputs with the following keys:

--- a/hyperspy/defaults_parser.py
+++ b/hyperspy/defaults_parser.py
@@ -39,7 +39,7 @@ def guess_gos_path():
         # installation
         # location in windows
         program_files = os.environ['PROGRAMFILES']
-        gos = 'Gatan\DigitalMicrograph\EELS Reference Data\H-S GOS Tables'
+        gos = 'Gatan\\DigitalMicrograph\\EELS Reference Data\\H-S GOS Tables'
         gos_path = os.path.join(program_files, gos)
 
         # Else, use the default location in the .hyperspy forlder

--- a/hyperspy/defaults_parser.py
+++ b/hyperspy/defaults_parser.py
@@ -18,7 +18,6 @@
 
 
 import os.path
-from os import cpu_count
 import configparser
 import logging
 
@@ -26,7 +25,6 @@ import traits.api as t
 
 from hyperspy.misc.config_dir import config_path, os_name, data_path
 from hyperspy.misc.ipython_tools import turn_logging_on, turn_logging_off
-from hyperspy.io_plugins import default_write_ext
 from hyperspy.ui_registry import add_gui_method
 
 defaults_file = os.path.join(config_path, 'hyperspyrc')

--- a/hyperspy/external/astroML/histtools.py
+++ b/hyperspy/external/astroML/histtools.py
@@ -328,7 +328,7 @@ def dasky_histogram(a, bins=10, **kwargs):
 
     See Also
     --------
-    numpy.histogram
+    numpy.histogram,
     astroML.plotting.hist
     """
     if not isinstance(a, da.Array):
@@ -352,11 +352,12 @@ def dasky_histogram(a, bins=10, **kwargs):
 
 
 def dasky_scotts_bin_width(data, return_bins=True):
-    """Dask version of scotts_bin_width
+    r"""Dask version of scotts_bin_width
 
     Parameters
     ----------
     data : dask array
+        the data
     return_bins : bool (optional)
         if True, then return the bin edges
 
@@ -369,16 +370,19 @@ def dasky_scotts_bin_width(data, return_bins=True):
 
     Notes
     -----
-    The optimal bin width is
+    The optimal bin width is:
+
     .. math::
+
         \Delta_b = \frac{3.5\sigma}{n^{1/3}}
+
     where :math:`\sigma` is the standard deviation of the data, and
     :math:`n` is the number of data points.
 
     See Also
     --------
-    knuth_bin_width
-    freedman_bin_width
+    knuth_bin_width, 
+    freedman_bin_width, 
     astroML.plotting.hist
     """
     if not isinstance(data, da.Array):
@@ -402,11 +406,12 @@ def dasky_scotts_bin_width(data, return_bins=True):
 
 
 def dasky_freedman_bin_width(data, return_bins=True):
-    """Dask version of freedman_bin_width
+    r"""Dask version of freedman_bin_width
 
     Parameters
     ----------
     data : dask array
+        the data
     return_bins : bool (optional)
         if True, then return the bin edges
 
@@ -420,15 +425,18 @@ def dasky_freedman_bin_width(data, return_bins=True):
     Notes
     -----
     The optimal bin width is
+
     .. math::
+
         \Delta_b = \frac{2(q_{75} - q_{25})}{n^{1/3}}
+
     where :math:`q_{N}` is the :math:`N` percent quartile of the data, and
     :math:`n` is the number of data points.
 
     See Also
     --------
-    knuth_bin_width
-    scotts_bin_width
+    knuth_bin_width,
+    scotts_bin_width,
     astroML.plotting.hist
     """
     if not isinstance(data, da.Array):

--- a/hyperspy/external/mpfit/mpfitexpr.py
+++ b/hyperspy/external/mpfit/mpfitexpr.py
@@ -58,7 +58,7 @@ def mpfitexpr(func, x, y, err, start_params, check=True, full_output=False,
     def myfunc(p, fjac=None, x=None, y=None, err=None):
         return [0, eval('(y-(%s))/err' % func, hash, locals())]
 
-    myre = "[^a-zA-Z]p\[(\d+)\]"
+    myre = r"[^a-zA-Z]p\[(\d+)\]"
     r = re.compile(myre)
     maxp = -1
     for m in re.finditer(r, func):

--- a/hyperspy/io_plugins/emd.py
+++ b/hyperspy/io_plugins/emd.py
@@ -180,7 +180,7 @@ class EMD(object):
             axis_units = dim.attrs.get('units', '')
             if isinstance(axis_units, bytes):
                 axis_units = axis_units.decode('utf-8')
-            units = re.findall('[^_\W]+', axis_units)
+            units = re.findall(r'[^_\W]+', axis_units)
             axis.units = ''.join(units)
             try:
                 if len(dim) == 1:

--- a/hyperspy/io_plugins/semper_unf.py
+++ b/hyperspy/io_plugins/semper_unf.py
@@ -359,7 +359,7 @@ class SemperFormat(object):
 
     @classmethod
     def load_from_unf(cls, filename, lazy=False):
-        """Load a `.unf`-file into a :class:`~.SemperFormat` object.
+        r"""Load a `.unf`-file into a :class:`~.SemperFormat` object.
 
         Parameters
         ----------

--- a/hyperspy/misc/eels/tools.py
+++ b/hyperspy/misc/eels/tools.py
@@ -208,14 +208,16 @@ def ratio(edge_A, edge_B):
 
 
 def eels_constant(s, zlp, t):
-    """Calculate the constant of proportionality (k) in the relationship
+    r"""Calculate the constant of proportionality (k) in the relationship
     between the EELS signal and the dielectric function.
     dielectric function from a single scattering distribution (SSD) using
     the Kramers-Kronig relations.
 
-    $S(E)=\frac{I_{0}t}{\pi a_{0}m_{0}v^{2}}\ln\left[1+\left(\frac{\beta}
-    {\theta_{E}}\right)^{2}\right]\Im(\frac{-1}{\epsilon(E)})=
-    k\Im(\frac{-1}{\epsilon(E)})$
+        .. math::
+
+            S(E)=\frac{I_{0}t}{\pi a_{0}m_{0}v^{2}}\ln\left[1+\left(\frac{\beta}
+            {\theta_{E}}\right)^{2}\right]\Im(\frac{-1}{\epsilon(E)})=
+            k\Im(\frac{-1}{\epsilon(E)})
 
 
     Parameters

--- a/hyperspy/misc/test_utils.py
+++ b/hyperspy/misc/test_utils.py
@@ -121,7 +121,7 @@ def all_warnings():
 
 @contextmanager
 def assert_warns(message=None, category=None):
-    """Context for use in testing to catch known warnings matching regexes
+    r"""Context for use in testing to catch known warnings matching regexes
 
     Parameters
     ----------
@@ -156,7 +156,7 @@ def assert_warns(message=None, category=None):
         # enter context
         yield w
         # exited user context, check the recorded warnings
-        remaining = [m for m in message if '\A\Z' not in m.split('|')]
+        remaining = [m for m in message if r'\A\Z' not in m.split('|')]
         for warn in w:
             found = False
             for match in message:

--- a/hyperspy/signal.py
+++ b/hyperspy/signal.py
@@ -3801,7 +3801,7 @@ class BaseSignal(FancySlicing,
                                            gain_factor=None,
                                            gain_offset=None,
                                            correlation_factor=None):
-        """Estimate the poissonian noise variance of the signal.
+        r"""Estimate the poissonian noise variance of the signal.
 
         The variance is stored in the
         ``metadata.Signal.Noise_properties.variance`` attribute.

--- a/hyperspy/tests/__init__.py
+++ b/hyperspy/tests/__init__.py
@@ -34,7 +34,7 @@ if fail_on_external:
     # Travis setup has these warnings, so ignore:
     warnings.filterwarnings(
         'ignore',
-        "BaseException\.message has been deprecated as of Python 2\.6",
+        r"BaseException\.message has been deprecated as of Python 2\.6",
         DeprecationWarning)
     # Don't care about warnings in hyperspy in this mode!
     warnings.filterwarnings('default', module="hyperspy")


### PR DESCRIPTION
### Description of the change
Fix deprecation warning due to invalid escape sequence. I used a [tool from the numpy](https://github.com/numpy/numpy/blob/master/tools/find_deprecated_escaped_characters.py) repository to find them all.

### Progress of the PR
- [x] set docstring to raw string,
- [x] improve docstring (latex formatting),
- [x] set string use in regular expression to raw string,
- [x] update windows path with 2 backslashes,
- [x] ready for review.
