### PR TITLE
bcf_fix_addendum

### DIFF
--- a/hyperspy/io_plugins/bcf.py
+++ b/hyperspy/io_plugins/bcf.py
@@ -677,7 +677,7 @@ class HyperHeader(object):
         image = Container()
         image.width = int(xml_node.find('./Width').text)  # in pixels
         image.height = int(xml_node.find('./Height').text)  # in pixels
-        image.dtype = 'u' + xml_node.find('./ItemSize').text 
+        image.dtype = 'u' + xml_node.find('./ItemSize').text  # in bytes ('u1','u2','u4') 
         image.plane_count = int(xml_node.find('./PlaneCount').text)
         image.images = []
         for i in range(image.plane_count):

--- a/hyperspy/io_plugins/bcf.py
+++ b/hyperspy/io_plugins/bcf.py
@@ -688,14 +688,12 @@ class HyperHeader(object):
                 item = self.gen_hspy_item_dict_basic()
                 data = array1.reshape((image.height, image.width))
                 desc = img.find('./Description')
-                #detector_name = str(dscrp.text) if  else ''
                 item['data'] = data
                 item['axes'][0]['size'] = image.height
                 item['axes'][1]['size'] = image.width
                 item['metadata']['Signal'] = {'record_by': 'image'}
                 item['metadata']['General'] = {}
                 if desc is not None:
-                    item['metadata']['Signal']['signal_type'] = str(desc.text)
                     item['metadata']['General']['title'] = str(desc.text)
                 if overview and (rect_node is not None):
                     item['metadata']['Markers'] = {'overview': over_dict}

--- a/hyperspy/io_plugins/bcf.py
+++ b/hyperspy/io_plugins/bcf.py
@@ -677,22 +677,26 @@ class HyperHeader(object):
         image = Container()
         image.width = int(xml_node.find('./Width').text)  # in pixels
         image.height = int(xml_node.find('./Height').text)  # in pixels
+        image.dtype = 'u' + xml_node.find('./ItemSize').text 
         image.plane_count = int(xml_node.find('./PlaneCount').text)
         image.images = []
         for i in range(image.plane_count):
             img = xml_node.find("./Plane" + str(i))
             raw = codecs.decode((img.find('./Data').text).encode('ascii'),'base64')
-            array1 = np.frombuffer(raw, dtype=np.uint16)
+            array1 = np.frombuffer(raw, dtype=image.dtype)
             if any(array1):
                 item = self.gen_hspy_item_dict_basic()
                 data = array1.reshape((image.height, image.width))
-                detector_name = str(img.find('./Description').text)
+                desc = img.find('./Description')
+                #detector_name = str(dscrp.text) if  else ''
                 item['data'] = data
                 item['axes'][0]['size'] = image.height
                 item['axes'][1]['size'] = image.width
-                item['metadata']['General'] = {'title': detector_name}
-                item['metadata']['Signal'] = {'signal_type': detector_name,
-                                              'record_by': 'image'}
+                item['metadata']['Signal'] = {'record_by': 'image'}
+                item['metadata']['General'] = {}
+                if desc is not None:
+                    item['metadata']['Signal']['signal_type'] = str(desc.text)
+                    item['metadata']['General']['title'] = str(desc.text)
                 if overview and (rect_node is not None):
                     item['metadata']['Markers'] = {'overview': over_dict}
                 image.images.append(item)


### PR DESCRIPTION
### Some more fixes for bcf

which accidentally missed the #1833. 
This PR fixes the main error addressed at the beginning of #1801.

Up till this PR, all SEM images contained inside bcf xml header were thought to be statically of 16bit dtype.
The new sample files shed the light that <ItemSize> tag holds dtype information (it is saved as integer where 1 = uint8; 2 = uint16 and so on..).

Additionally, some microscopes/OEM with EBSD bcf have no description for some of SEM signal/images, which is addressed too in this PR.

