### PR TITLE
Changed default behavior: Activate progressbar only if running interactively

### DIFF
--- a/hyperspy/_signals/lazy.py
+++ b/hyperspy/_signals/lazy.py
@@ -21,7 +21,7 @@ from functools import partial
 
 import numpy as np
 import math as math
-import sys
+import __main__ as main
 import dask.array as da
 import dask.delayed as dd
 from dask import threaded
@@ -89,12 +89,10 @@ class LazySignal(BaseSignal):
         """Attempt to store the full signal in memory.."""
 
         if progressbar is None:
-            """By default, activate progress bar if stdout is a terminal.
+            """By default, activate progress bar if running interactively.
             Otherwise the progress bar mangles any output that is
-            redirected to a file. Currently, dask writes progress bars to
-            stdout. This should be changed in dask to match the behavior of
-            tqdm that writes to stderr, and subsequently here."""
-            progressbar = sys.stdout.isatty()
+            redirected to a file. """
+            progressbar = not hasattr(main, '__file__')
         if progressbar:
             cm = ProgressBar
         else:

--- a/hyperspy/_signals/lazy.py
+++ b/hyperspy/_signals/lazy.py
@@ -21,6 +21,7 @@ from functools import partial
 
 import numpy as np
 import math as math
+import sys
 import dask.array as da
 import dask.delayed as dd
 from dask import threaded
@@ -84,8 +85,16 @@ class LazySignal(BaseSignal):
     """
     _lazy = True
 
-    def compute(self, progressbar=True):
+    def compute(self, progressbar=None):
         """Attempt to store the full signal in memory.."""
+
+        if progressbar is None:
+            """By default, activate progress bar if stdout is a terminal.
+            Otherwise the progress bar mangles any output that is
+            redirected to a file. Currently, dask writes progress bars to
+            stdout. This should be changed in dask to match the behavior of
+            tqdm that writes to stderr, and subsequently here."""
+            progressbar = sys.stdout.isatty()
         if progressbar:
             cm = ProgressBar
         else:


### PR DESCRIPTION
Otherwise deactivate progress by default. Fix for issue #1842 

Currently dask uses stdout for progress bars. A fix to switch to stderr by default and give users control
is in preparation.

