### PR TITLE
Fix issue random failure async mrcz

### DIFF
--- a/hyperspy/tests/io/test_mrcz.py
+++ b/hyperspy/tests/io/test_mrcz.py
@@ -39,7 +39,7 @@ from hyperspy.misc.test_utils import assert_deep_almost_equal
 #==============================================================================
 tmpDir = tempfile.gettempdir()
 
-MAX_ASYNC_TIME = 2.0
+MAX_ASYNC_TIME = 10.0
 dtype_list = ['float32', 'int8', 'int16', 'uint16', 'complex64']
 
 
@@ -111,6 +111,8 @@ class TestPythonMrcz:
                     break
                 except IOError:
                     sleep(0.001)
+            print("Time to save file: {} s".format(
+                    perf_counter() - (t_stop - MAX_ASYNC_TIME)))
 
         reSignal = load(mrcName)
         try:

--- a/hyperspy/tests/io/test_mrcz.py
+++ b/hyperspy/tests/io/test_mrcz.py
@@ -113,6 +113,7 @@ class TestPythonMrcz:
                     sleep(0.001)
             print("Time to save file: {} s".format(
                     perf_counter() - (t_stop - MAX_ASYNC_TIME)))
+            sleep(0.005)
 
         reSignal = load(mrcName)
         try:


### PR DESCRIPTION
Fix the asynchronous save/load cycle of the mrcz tests, which can happen occasionally in appveyor: add an additional sleep as recommended by @robbmcleod.
It has been tested over 6 appveyor build, which ran all fine while before it was failing every other build.