### PR TITLE
New lazy close file

### DIFF
--- a/doc/user_guide/big_data.rst
+++ b/doc/user_guide/big_data.rst
@@ -58,6 +58,22 @@ around 35GB of memory. To store it in a floating-point format one would need
 almost 280GB of memory. However, with the lazy processing both of these steps
 are near-instantaneous and require very little computational resources.
 
+.. versionadded:: 1.4
+    :py:meth:`~._signals.lazy.LazySignal.close_file`
+
+Currently when loading an hdf5 file lazily the file remains open at
+least while the signal exists. In order to close it explicitly, use the
+:py:meth:`~._signals.lazy.LazySignal.close_file` method. Alternatively,
+you could close it on calling :py:meth:`~._signals.lazy.LazySignal.compute`
+by passing the keyword argument ``close_file=True`` e.g.:
+
+.. code-block:: python
+
+    >>> s = hs.load("file.hspy", lazy=True)
+    >>> ssum = s.sum(axis=0)
+    >>> ssum.compute(close_file=True) # closes the file.hspy file
+
+
 Lazy stacking
 ^^^^^^^^^^^^^
 

--- a/hyperspy/_signals/lazy.py
+++ b/hyperspy/_signals/lazy.py
@@ -84,16 +84,45 @@ class LazySignal(BaseSignal):
     """
     _lazy = True
 
-    def compute(self, progressbar=True):
-        """Attempt to store the full signal in memory.."""
+    def compute(self, progressbar=True, close_file=False):
+        """Attempt to store the full signal in memory.
+
+        close_file: bool
+            If True, attemp to close the file associated with the dask
+            array data if any. Note that closing the file will make all other
+            associated lazy signals inoperative.
+
+        """
         if progressbar:
             cm = ProgressBar
         else:
             cm = dummy_context_manager
         with cm():
-            self.data = self.data.compute()
+            da = self.data
+            data = da.compute()
+            if close_file:
+                self.close_file()
+            self.data = data
         self._lazy = False
         self._assign_subclass()
+
+    def close_file(self):
+        """Closes the associated data file if any.
+
+        Currently it only supports closing the file associated with a dask
+        array created from an h5py DataSet (default HyperSpy hdf5 reader).
+
+        """
+        arrkey = None
+        for key in self.data.dask.keys():
+            if "array-original" in key:
+                arrkey = key
+                break
+        if arrkey:
+            try:
+                self.data.dask[arrkey].file.close()
+            except AttributeError as e:
+                _logger.exception("Failed to close lazy Signal file")
 
     def _get_dask_chunks(self, axis=None, dtype=None):
         """Returns dask chunks
@@ -774,14 +803,17 @@ class LazySignal(BaseSignal):
             if reproject:
                 if algorithm == 'PCA':
                     method = obj.transform
-                    post = lambda a: np.concatenate(a, axis=0)
+
+                    def post(a): return np.concatenate(a, axis=0)
                 elif algorithm == 'ORPCA':
                     method = obj.project
                     obj.R = []
-                    post = lambda a: obj.finish()[4]
+
+                    def post(a): return obj.finish()[4]
                 elif algorithm == 'ONMF':
                     method = obj.project
-                    post = lambda a: np.concatenate(a, axis=1).T
+
+                    def post(a): return np.concatenate(a, axis=1).T
 
                 _map = map(lambda thing: method(thing),
                            self._block_iterator(

--- a/hyperspy/tests/io/test_hdf5.py
+++ b/hyperspy/tests/io/test_hdf5.py
@@ -355,6 +355,7 @@ class TestLoadingOOMReadOnly:
         assert self.shape == s.data.shape
         assert isinstance(s.data, da.Array)
         assert s._lazy
+        s.close_file()
 
     def teardown_method(self, method):
         gc.collect()        # Make sure any memmaps are closed first!

--- a/hyperspy/tests/io/test_hdf5.py
+++ b/hyperspy/tests/io/test_hdf5.py
@@ -361,7 +361,7 @@ class TestLoadingOOMReadOnly:
         gc.collect()        # Make sure any memmaps are closed first!
         try:
             remove('tmp.hdf5')
-        except:
+        except BaseException:
             # Don't fail tests if we cannot remove
             pass
 


### PR DESCRIPTION
Currently when loading a file lazily the file remains open, usually until the signal is deleted. However, in e.g. Windows, it seems that the file is not released even after the signal is deleted, causing issues with e.g. removing test files from our unittests. This PR adds a ``LazySignal.close_file`` method and a ``LazySignal.compute`` ``close_file`` argument to close the file that works only when the file is a hdf5 file.

This is already included in #1853 in order to make the appveyor tests pass, but I am submitting it separately for clarity.

### Progress of the PR
- [x] Change implemented (can be split into several points),
- [x] update docstring (if appropriate),
- [x] update user guide (if appropriate),
- [x] add tests,
- [x] ready for review.


