### PR TITLE
Fix ScaleableFixedPattern missing arguments

### DIFF
--- a/hyperspy/_components/scalable_fixed_pattern.py
+++ b/hyperspy/_components/scalable_fixed_pattern.py
@@ -64,7 +64,7 @@ class ScalableFixedPattern(Component):
 
     """
 
-    def __init__(self, signal1D, yscale=1, xscale=1, shift=0, interpolate=True):
+    def __init__(self, signal1D, yscale=1.0, xscale=1.0, shift=0.0, interpolate=True):
 
         Component.__init__(self, ['yscale', 'xscale', 'shift'])
 

--- a/hyperspy/_components/scalable_fixed_pattern.py
+++ b/hyperspy/_components/scalable_fixed_pattern.py
@@ -64,7 +64,7 @@ class ScalableFixedPattern(Component):
 
     """
 
-    def __init__(self, signal1D):
+    def __init__(self, signal1D, yscale=1, xscale=1, shift=0, interpolate=True):
 
         Component.__init__(self, ['yscale', 'xscale', 'shift'])
 
@@ -72,15 +72,15 @@ class ScalableFixedPattern(Component):
         self._whitelist['signal1D'] = ('init,sig', signal1D)
         self.signal = signal1D
         self.yscale.free = True
-        self.yscale.value = 1.
-        self.xscale.value = 1.
-        self.shift.value = 0.
+        self.yscale.value = yscale
+        self.xscale.value = xscale
+        self.shift.value = shift
 
         self.prepare_interpolator()
         # Options
         self.isbackground = True
         self.convolved = False
-        self.interpolate = True
+        self.interpolate = interpolate
 
     def prepare_interpolator(self, kind='linear', fill_value=0, **kwargs):
         """Prepare interpolation.


### PR DESCRIPTION
### Description of the change
Fixes #1862. Tested and works as expected.

### Progress of the PR
- [x] ready for review.

### Minimal example of the bug fix or the new feature
```python
import hyperspy.api as hs

s = hs.datasets.example_signals.EDS_SEM_Spectrum()
m = s.create_model(auto_add_lines=False, auto_background=False)
c = hs.model.components1D.ScalableFixedPattern(s, xscale=5, interpolate=False)
c.xscale.free = False
m.append(c)
m.fit()
m.plot()
```

 