### PR TITLE
Add support for hotkeys in higher navigation dimensions

### DIFF
--- a/hyperspy/axes.py
+++ b/hyperspy/axes.py
@@ -931,9 +931,11 @@ class AxesManager(t.HasTraits):
             return
         x = self.navigation_axes[0]
         try:
-            if event.key == "right" or event.key == "ctrl+right" or event.key == "6" or event.key == "ctrl+6":
+            if event.key == "right" or event.key == "ctrl+right" or \
+                    event.key == "6" or event.key == "ctrl+6":
                 x.index += self._step
-            elif event.key == "left" or event.key == "ctrl+left" or event.key == "4" or event.key == "ctrl+4":
+            elif event.key == "left" or event.key == "ctrl+left" or \
+                    event.key == "4" or event.key == "ctrl+4":
                 x.index -= self._step
             elif event.key == "pageup":
                 self._step += 1
@@ -942,9 +944,11 @@ class AxesManager(t.HasTraits):
                     self._step -= 1
             elif self.navigation_dimension >= 2:
                 y = self.navigation_axes[1]
-                if event.key == "up" or event.key == "ctrl+up" or event.key == "8" or event.key == "ctrl+8":
+                if event.key == "up" or event.key == "ctrl+up" or \
+                        event.key == "8" or event.key == "ctrl+8":
                     y.index -= self._step
-                elif event.key == "down" or event.key == "ctrl+down" or event.key == "2" or event.key == "ctrl+2":
+                elif event.key == "down" or event.key == "ctrl+down" or \
+                        event.key == "2" or event.key == "ctrl+2":
                     y.index += self._step
                 elif self.navigation_dimension >= 3:
                     navdim = self.navigation_axes[2]
@@ -956,19 +960,24 @@ class AxesManager(t.HasTraits):
                         navdim = self.navigation_axes[3]
                         if event.key == "shift+up" or event.key == "shift+8":
                             navdim.index -= self._step
-                        elif event.key == "shift+down" or event.key == "shift+2":
+                        elif event.key == "shift+down" or \
+                                event.key == "shift+2":
                             navdim.index += self._step
                         elif self.navigation_dimension >= 5:
                             navdim = self.navigation_axes[4]
-                            if event.key == "ctrl+alt+right" or event.key == "ctrl+alt+6":
+                            if event.key == "ctrl+alt+right" or \
+                                    event.key == "ctrl+alt+6":
                                 navdim.index += self._step
-                            elif event.key == "ctrl+alt+left" or event.key == "ctrl+alt+4":
+                            elif event.key == "ctrl+alt+left" or \
+                                    event.key == "ctrl+alt+4":
                                 navdim.index -= self._step
                             elif self.navigation_dimension >= 6:
                                 navdim = self.navigation_axes[5]
-                                if event.key == "ctrl+alt+up" or event.key == "ctrl+alt+8":
+                                if event.key == "ctrl+alt+up" or \
+                                        event.key == "ctrl+alt+8":
                                     navdim.index -= self._step
-                                elif event.key == "ctrl+alt+down" or event.key == "ctrl+alt+2":
+                                elif event.key == "ctrl+alt+down" or \
+                                        event.key == "ctrl+alt+2":
                                     navdim.index += self._step
         except TraitError:
             pass
@@ -1069,11 +1078,11 @@ class AxesManager(t.HasTraits):
                                          args))
         if self.navigation_axes:
             text += "<table style='width:100%'>\n"
-            text += format_row('Navigation axis name', 'size', 'index', 'offset',
-                               'scale', 'units', tag='th')
+            text += format_row('Navigation axis name', 'size', 'index',
+                               'offset', 'scale', 'units', tag='th')
             for ax in self.navigation_axes:
-                text += format_row(ax.name, ax.size, ax.index, ax.offset, ax.scale,
-                                   ax.units)
+                text += format_row(ax.name, ax.size, ax.index, ax.offset,
+                                   ax.scale, ax.units)
             text += "</table>\n"
         if self.signal_axes:
             text += "<table style='width:100%'>\n"

--- a/hyperspy/axes.py
+++ b/hyperspy/axes.py
@@ -946,6 +946,30 @@ class AxesManager(t.HasTraits):
                     y.index -= self._step
                 elif event.key == "down" or event.key == "ctrl+down" or event.key == "2" or event.key == "ctrl+2":
                     y.index += self._step
+                elif self.navigation_dimension >= 3:
+                    navdim = self.navigation_axes[2]
+                    if event.key == "shift+right" or event.key == "shift+6":
+                        navdim.index += self._step
+                    elif event.key == "shift+left" or event.key == "shift+4":
+                        navdim.index -= self._step
+                    elif self.navigation_dimension >= 4:
+                        navdim = self.navigation_axes[3]
+                        if event.key == "shift+up" or event.key == "shift+8":
+                            navdim.index -= self._step
+                        elif event.key == "shift+down" or event.key == "shift+2":
+                            navdim.index += self._step
+                        elif self.navigation_dimension >= 5:
+                            navdim = self.navigation_axes[4]
+                            if event.key == "ctrl+alt+right" or event.key == "ctrl+alt+6":
+                                navdim.index += self._step
+                            elif event.key == "ctrl+alt+left" or event.key == "ctrl+alt+4":
+                                navdim.index -= self._step
+                            elif self.navigation_dimension >= 6:
+                                navdim = self.navigation_axes[5]
+                                if event.key == "ctrl+alt+up" or event.key == "ctrl+alt+8":
+                                    navdim.index -= self._step
+                                elif event.key == "ctrl+alt+down" or event.key == "ctrl+alt+2":
+                                    navdim.index += self._step
         except TraitError:
             pass
 

--- a/hyperspy/axes.py
+++ b/hyperspy/axes.py
@@ -940,7 +940,7 @@ class AxesManager(t.HasTraits):
             elif event.key == "pagedown":
                 if self._step > 1:
                     self._step -= 1
-            elif len(self.navigation_axes) == 2:
+            elif self.navigation_dimension >= 2:
                 y = self.navigation_axes[1]
                 if event.key == "up" or event.key == "8":
                     y.index -= self._step

--- a/hyperspy/axes.py
+++ b/hyperspy/axes.py
@@ -931,9 +931,9 @@ class AxesManager(t.HasTraits):
             return
         x = self.navigation_axes[0]
         try:
-            if event.key == "right" or event.key == "ctrl+right" or event.key == "6":
+            if event.key == "right" or event.key == "ctrl+right" or event.key == "6" or event.key == "ctrl+6":
                 x.index += self._step
-            elif event.key == "left" or event.key == "ctrl+left" or event.key == "4":
+            elif event.key == "left" or event.key == "ctrl+left" or event.key == "4" or event.key == "ctrl+4":
                 x.index -= self._step
             elif event.key == "pageup":
                 self._step += 1
@@ -942,9 +942,9 @@ class AxesManager(t.HasTraits):
                     self._step -= 1
             elif self.navigation_dimension >= 2:
                 y = self.navigation_axes[1]
-                if event.key == "up" or event.key == "ctrl+up" or event.key == "8":
+                if event.key == "up" or event.key == "ctrl+up" or event.key == "8" or event.key == "ctrl+8":
                     y.index -= self._step
-                elif event.key == "down" or event.key == "ctrl+down" or event.key == "2":
+                elif event.key == "down" or event.key == "ctrl+down" or event.key == "2" or event.key == "ctrl+2":
                     y.index += self._step
         except TraitError:
             pass

--- a/hyperspy/axes.py
+++ b/hyperspy/axes.py
@@ -926,7 +926,8 @@ class AxesManager(t.HasTraits):
 
     def key_navigator(self, event):
         'Set hotkeys for controlling the indices of the navigator plot'
-        if len(self.navigation_axes) not in (1, 2):
+        if s.axes_manager.navigation_dimension == 0:
+            # No need for current hotkeys
             return
         x = self.navigation_axes[0]
         try:

--- a/hyperspy/axes.py
+++ b/hyperspy/axes.py
@@ -938,7 +938,7 @@ class AxesManager(t.HasTraits):
             elif event.key == "pagedown":
                 if self._step > 1:
                     self._step -= 1
-            if len(self.navigation_axes) == 2:
+            elif len(self.navigation_axes) == 2:
                 y = self.navigation_axes[1]
                 if event.key == "up" or event.key == "8":
                     y.index -= self._step

--- a/hyperspy/axes.py
+++ b/hyperspy/axes.py
@@ -931,9 +931,9 @@ class AxesManager(t.HasTraits):
             return
         x = self.navigation_axes[0]
         try:
-            if event.key == "right" or event.key == "6":
+            if event.key == "right" or event.key == "ctrl+right" or event.key == "6":
                 x.index += self._step
-            elif event.key == "left" or event.key == "4":
+            elif event.key == "left" or event.key == "ctrl+left" or event.key == "4":
                 x.index -= self._step
             elif event.key == "pageup":
                 self._step += 1
@@ -942,9 +942,9 @@ class AxesManager(t.HasTraits):
                     self._step -= 1
             elif self.navigation_dimension >= 2:
                 y = self.navigation_axes[1]
-                if event.key == "up" or event.key == "8":
+                if event.key == "up" or event.key == "ctrl+up" or event.key == "8":
                     y.index -= self._step
-                elif event.key == "down" or event.key == "2":
+                elif event.key == "down" or event.key == "ctrl+down" or event.key == "2":
                     y.index += self._step
         except TraitError:
             pass

--- a/hyperspy/axes.py
+++ b/hyperspy/axes.py
@@ -926,7 +926,7 @@ class AxesManager(t.HasTraits):
 
     def key_navigator(self, event):
         'Set hotkeys for controlling the indices of the navigator plot'
-        if s.axes_manager.navigation_dimension == 0:
+        if self.axes_manager.navigation_dimension == 0:
             # No need for current hotkeys
             return
         x = self.navigation_axes[0]
@@ -940,7 +940,7 @@ class AxesManager(t.HasTraits):
             elif event.key == "pagedown":
                 if self._step > 1:
                     self._step -= 1
-            elif len(self.navigation_axes) == 2:
+            elif len(self.navigation_axes) >= 2:
                 y = self.navigation_axes[1]
                 if event.key == "up" or event.key == "8":
                     y.index -= self._step

--- a/hyperspy/axes.py
+++ b/hyperspy/axes.py
@@ -925,6 +925,7 @@ class AxesManager(t.HasTraits):
             axis.navigate = tl.pop(0)
 
     def key_navigator(self, event):
+        'Set hotkeys for controlling the indices of the navigator plot'
         if len(self.navigation_axes) not in (1, 2):
             return
         x = self.navigation_axes[0]

--- a/hyperspy/axes.py
+++ b/hyperspy/axes.py
@@ -926,7 +926,7 @@ class AxesManager(t.HasTraits):
 
     def key_navigator(self, event):
         'Set hotkeys for controlling the indices of the navigator plot'
-        if self.axes_manager.navigation_dimension == 0:
+        if self.navigation_dimension == 0:
             # No need for current hotkeys
             return
         x = self.navigation_axes[0]
@@ -940,7 +940,7 @@ class AxesManager(t.HasTraits):
             elif event.key == "pagedown":
                 if self._step > 1:
                     self._step -= 1
-            elif len(self.navigation_axes) >= 2:
+            elif len(self.navigation_axes) == 2:
                 y = self.navigation_axes[1]
                 if event.key == "up" or event.key == "8":
                     y.index -= self._step


### PR DESCRIPTION
### Description of the change
Before this PR, for higher dimension (>2) navigators, the hotkeys (left, right, 4, 6 etc...) did not work.
The PR adds additional support for moving in X and Y with **Ctrl** + arrow keys / 2468 to avoid the error reported in #1866.

Also, `Shift + (arrows or 2468)` now controls dimensions `(2, 3)` and` Ctrl + Alt + (arrows or 2468)` now controls dimensions `(4, 5)` for a total of hotkey control of six dimensions of navigation space.

Note: I originally went for Ctrl + Shift to control 2,3, but Ctrl + Shift + Numpad keys does not work on Windows in matplotlib (for some unknown reason).

If people are happy with these changes I will update the user guide.

*Did you know? You can use PageUp/PageDown to increase the number of steps taken by the hotkeys!*

### Progress of the PR
- [x] Change implemented (can be split into several points),
- [ ] update user guide
- [ ] ready for review.