### PR TITLE
Fix pytest parametrize deprecation warning.

### DIFF
--- a/hyperspy/tests/model/test_model.py
+++ b/hyperspy/tests/model/test_model.py
@@ -1030,19 +1030,22 @@ class TestAsSignal:
                                   show_progressbar=False, parallel=False)
             np.testing.assert_allclose(s1.data, s.data)
 
-    @pytest.mark.parametrize('parallel', [pytest.mark.parallel(True), False])
+    @pytest.mark.parametrize('parallel',
+                             [pytest.param(True, marks=pytest.mark.parallel), False])
     def test_all_components_simple(self, parallel):
         s = self.m.as_signal(show_progressbar=False, parallel=parallel)
         assert np.all(s.data == 4.)
 
-    @pytest.mark.parametrize('parallel', [pytest.mark.parallel(True), False])
+    @pytest.mark.parametrize('parallel',
+                             [pytest.param(True, marks=pytest.mark.parallel), False])
     def test_one_component_simple(self, parallel):
         s = self.m.as_signal(component_list=[0], show_progressbar=False,
                              parallel=parallel)
         assert np.all(s.data == 2.)
         assert self.m[1].active
 
-    @pytest.mark.parametrize('parallel', [pytest.mark.parallel(True), False])
+    @pytest.mark.parametrize('parallel',
+                             [pytest.param(True, marks=pytest.mark.parallel), False])
     def test_all_components_multidim(self, parallel):
         self.m[0].active_is_multidimensional = True
 
@@ -1055,7 +1058,8 @@ class TestAsSignal:
             s.data, np.array([np.ones((2, 5)) * 2, np.ones((2, 5)) * 4]))
         assert self.m[0].active_is_multidimensional
 
-    @pytest.mark.parametrize('parallel', [pytest.mark.parallel(True), False])
+    @pytest.mark.parametrize('parallel',
+                             [pytest.param(True, marks=pytest.mark.parallel), False])
     def test_one_component_multidim(self, parallel):
         self.m[0].active_is_multidimensional = True
 

--- a/hyperspy/tests/signal/test_1D_tools.py
+++ b/hyperspy/tests/signal/test_1D_tools.py
@@ -299,7 +299,8 @@ class TestSmoothing:
         self.rtol = 1e-7
         self.atol = 0
 
-    @pytest.mark.parametrize('parallel', [pytest.mark.parallel(True), False])
+    @pytest.mark.parametrize('parallel',
+                             [pytest.param(True, marks=pytest.mark.parallel), False])
     def test_lowess(self, parallel):
         pytest.importorskip("statsmodels")
         from statsmodels.nonparametric.smoothers_lowess import lowess
@@ -321,7 +322,8 @@ class TestSmoothing:
         np.testing.assert_allclose(self.s.data, data,
                                    rtol=self.rtol, atol=self.atol)
 
-    @pytest.mark.parametrize('parallel', [pytest.mark.parallel(True), False])
+    @pytest.mark.parametrize('parallel',
+                             [pytest.param(True, marks=pytest.mark.parallel), False])
     def test_tv(self, parallel):
         weight = 1
         data = np.asanyarray(self.s.data, dtype='float')

--- a/hyperspy/tests/signal/test_map_method.py
+++ b/hyperspy/tests/signal/test_map_method.py
@@ -15,7 +15,8 @@ class TestImage:
         self.im = hs.signals.Signal2D(np.arange(0., 18).reshape((2, 3, 3)))
         self.ragged = None
 
-    @pytest.mark.parametrize('parallel', [pytest.mark.parallel(True), False])
+    @pytest.mark.parametrize('parallel',
+                             [pytest.param(True, marks=pytest.mark.parallel), False])
     def test_constant_sigma(self, parallel):
         s = self.im
         s.map(gaussian_filter, sigma=1, show_progressbar=None,
@@ -29,7 +30,8 @@ class TestImage:
               [12.42207377, 13., 13.57792623],
               [14.15585247, 14.7337787, 15.31170493]]]))
 
-    @pytest.mark.parametrize('parallel', [pytest.mark.parallel(True), False])
+    @pytest.mark.parametrize('parallel',
+                             [pytest.param(True, marks=pytest.mark.parallel), False])
     def test_constant_sigma_navdim0(self, parallel):
         s = self.im.inav[0]
         s.map(gaussian_filter, sigma=1, show_progressbar=None,
@@ -39,7 +41,8 @@ class TestImage:
              [3.42207377, 4., 4.57792623],
              [5.15585247, 5.7337787, 6.31170493]]))
 
-    @pytest.mark.parametrize('parallel', [pytest.mark.parallel(True), False])
+    @pytest.mark.parametrize('parallel',
+                             [pytest.param(True, marks=pytest.mark.parallel), False])
     def test_variable_sigma(self, parallel):
         s = self.im
 
@@ -58,7 +61,8 @@ class TestImage:
               [12.42207377, 13., 13.57792623],
               [14.15585247, 14.7337787, 15.31170493]]]))
 
-    @pytest.mark.parametrize('parallel', [pytest.mark.parallel(True), False])
+    @pytest.mark.parametrize('parallel',
+                             [pytest.param(True, marks=pytest.mark.parallel), False])
     def test_axes_argument(self, parallel):
         s = self.im
         s.map(rotate, angle=45, reshape=False, show_progressbar=None,
@@ -72,7 +76,8 @@ class TestImage:
               [9.46446609, 13., 16.53553391],
               [0., 14.76776695, 0.]]]))
 
-    @pytest.mark.parametrize('parallel', [pytest.mark.parallel(True), False])
+    @pytest.mark.parametrize('parallel',
+                             [pytest.param(True, marks=pytest.mark.parallel), False])
     def test_different_shapes(self, parallel):
         s = self.im
         angles = hs.signals.BaseSignal([0, 45])
@@ -103,7 +108,8 @@ class TestSignal1D:
         self.s = hs.signals.Signal1D(np.arange(0., 6).reshape((2, 3)))
         self.ragged = None
 
-    @pytest.mark.parametrize('parallel', [pytest.mark.parallel(True), False])
+    @pytest.mark.parametrize('parallel',
+                             [pytest.param(True, marks=pytest.mark.parallel), False])
     def test_constant_sigma(self, parallel):
         s = self.s
         m = mock.Mock()
@@ -115,7 +121,8 @@ class TestSignal1D:
               [3.42207377, 4., 4.57792623]])))
         assert m.data_changed.called
 
-    @pytest.mark.parametrize('parallel', [pytest.mark.parallel(True), False])
+    @pytest.mark.parametrize('parallel',
+                             [pytest.param(True, marks=pytest.mark.parallel), False])
     def test_dtype(self, parallel):
         s = self.s
         s.map(lambda data: np.sqrt(np.complex128(data)),
@@ -132,7 +139,8 @@ class TestSignal0D:
         self.s.axes_manager.set_signal_dimension(0)
         self.ragged = None
 
-    @pytest.mark.parametrize('parallel', [pytest.mark.parallel(True), False])
+    @pytest.mark.parametrize('parallel',
+                             [pytest.param(True, marks=pytest.mark.parallel), False])
     def test(self, parallel):
         s = self.s
         m = mock.Mock()
@@ -143,7 +151,8 @@ class TestSignal0D:
             s.data, (np.arange(0., 6) ** 2).reshape((2, 3)))
         assert m.data_changed.called
 
-    @pytest.mark.parametrize('parallel', [pytest.mark.parallel(True), False])
+    @pytest.mark.parametrize('parallel',
+                             [pytest.param(True, marks=pytest.mark.parallel), False])
     def test_nav_dim_1(self, parallel):
         s = self.s.inav[1, 1]
         m = mock.Mock()
@@ -166,7 +175,8 @@ class TestChangingAxes:
         for ax, name in zip(self.base.axes_manager._axes, _alphabet):
             ax.name = name
 
-    @pytest.mark.parametrize('parallel', [pytest.mark.parallel(True), False])
+    @pytest.mark.parametrize('parallel',
+                             [pytest.param(True, marks=pytest.mark.parallel), False])
     def test_one_nav_reducing(self, parallel):
         s = self.base.transpose(signal_axes=4).inav[0, 0]
         s.map(np.mean, axis=1, parallel=parallel, ragged=self.ragged)
@@ -177,7 +187,8 @@ class TestChangingAxes:
         assert ['f'] == [ax.name for ax in s.axes_manager._axes]
         assert 0 == len(s.axes_manager.navigation_axes)
 
-    @pytest.mark.parametrize('parallel', [pytest.mark.parallel(True), False])
+    @pytest.mark.parametrize('parallel',
+                             [pytest.param(True, marks=pytest.mark.parallel), False])
     def test_one_nav_increasing(self, parallel):
         s = self.base.transpose(signal_axes=4).inav[0, 0]
         s.map(np.tile, reps=(2, 1, 1, 1, 1),
@@ -188,7 +199,8 @@ class TestChangingAxes:
         assert 0 == len(s.axes_manager.navigation_axes)
         assert s.data.shape == (2, 4, 5, 6, 7)
 
-    @pytest.mark.parametrize('parallel', [pytest.mark.parallel(True), False])
+    @pytest.mark.parametrize('parallel',
+                             [pytest.param(True, marks=pytest.mark.parallel), False])
     def test_reducing(self, parallel):
         s = self.base.transpose(signal_axes=4)
         s.map(np.mean, axis=1, parallel=parallel, ragged=self.ragged)
@@ -202,7 +214,8 @@ class TestChangingAxes:
                               s.axes_manager.navigation_axes]
         assert 2 == len(s.axes_manager.navigation_axes)
 
-    @pytest.mark.parametrize('parallel', [pytest.mark.parallel(True), False])
+    @pytest.mark.parametrize('parallel',
+                             [pytest.param(True, marks=pytest.mark.parallel), False])
     def test_increasing(self, parallel):
         s = self.base.transpose(signal_axes=4)
         s.map(np.tile, reps=(2, 1, 1, 1, 1),
@@ -216,7 +229,8 @@ class TestChangingAxes:
         assert s.data.shape == (2, 3, 2, 4, 5, 6, 7)
 
 
-@pytest.mark.parametrize('parallel', [pytest.mark.parallel(True), False])
+@pytest.mark.parametrize('parallel',
+                         [pytest.param(True, marks=pytest.mark.parallel), False])
 def test_new_axes(parallel):
     s = hs.signals.Signal1D(np.empty((10, 10)))
     s.axes_manager.navigation_axes[0].name = 'a'


### PR DESCRIPTION
### Description of the change
Fix pytest parametrize deprecation warning to get the test suite pass in the winpython build.

### Progress of the PR
- [x] update the `pytest.mark.parallel(True)` to the recommanded `pytest.param(True, marks=pytest.mark.parallel)`
- [x] ready for review.

