### PR TITLE
BUGFIX: Remove illegal filename characters from window titles

### DIFF
--- a/hyperspy/drawing/utils.py
+++ b/hyperspy/drawing/utils.py
@@ -28,6 +28,7 @@ import matplotlib as mpl
 import hyperspy as hs
 from distutils.version import LooseVersion
 import logging
+import re
 
 from hyperspy.defaults_parser import preferences
 
@@ -125,6 +126,8 @@ def create_figure(window_title=None,
     """
     fig = plt.figure(**kwargs)
     if window_title is not None:
+        # remove non-alphanumeric characters to prevent file saving problems
+        window_title = re.sub('[^\w\-_\. ]', '_', window_title)
         fig.canvas.set_window_title(window_title)
     if _on_figure_window_close is not None:
         on_figure_window_close(fig, _on_figure_window_close)

--- a/hyperspy/drawing/utils.py
+++ b/hyperspy/drawing/utils.py
@@ -126,6 +126,8 @@ def create_figure(window_title=None,
     fig = plt.figure(**kwargs)
     if window_title is not None:
         # remove non-alphanumeric characters to prevent file saving problems
+        # This is a workaround for: 
+        #   https://github.com/matplotlib/matplotlib/issues/9056
         reserved_characters = '<>"/\|?*'
         for c in reserved_characters:
             window_title = window_title.replace(c, '')

--- a/hyperspy/drawing/utils.py
+++ b/hyperspy/drawing/utils.py
@@ -28,7 +28,6 @@ import matplotlib as mpl
 import hyperspy as hs
 from distutils.version import LooseVersion
 import logging
-import re
 
 from hyperspy.defaults_parser import preferences
 
@@ -127,7 +126,11 @@ def create_figure(window_title=None,
     fig = plt.figure(**kwargs)
     if window_title is not None:
         # remove non-alphanumeric characters to prevent file saving problems
-        window_title = re.sub('[^\w\-_\. ]', '_', window_title)
+        reserved_characters = '<>"/\|?*'
+        for c in reserved_characters:
+            window_title = window_title.replace(c, '')
+        window_title = window_title.replace('\n', ' ')
+        window_title = window_title.replace(':', ' -')
         fig.canvas.set_window_title(window_title)
     if _on_figure_window_close is not None:
         on_figure_window_close(fig, _on_figure_window_close)


### PR DESCRIPTION
Fixes #1884. 

This is a bit of a workaround, but will prevent issues like #1884 from popping up in the future. Ideally, the backends of `matplotlib` would handle this more elegantly, but instead we can be careful about what filenames we pass in.

`matplotlib` automatically uses the current window title to create a suggested filename when you click the "Save figure" button.  The only place we can control this is in the window title. This PR replaces illegal non-standard characters in the window title with underscores. We lose a little bit of "prettiness" in the opened windows, for the benefit of being able to save those figures interactively.