### PR TITLE
Fixes installation instructions for `hyperspy-gui-traitsui` in anaconda.

### DIFF
--- a/doc/user_guide/install.rst
+++ b/doc/user_guide/install.rst
@@ -80,14 +80,14 @@ MKL libraries) and the easiest installation. The academic license is free.
         As of traitsui v5.1.0, traitsui does not support Qt5 and, therefore,
         in order to use the Qt backend it is necessary to
         downgrade pyqt. With the standard Anaconda installation this causes
-        a conflict with the anaconda-navigator package and, therefore,
-        it is necessary to remove it in order to install hyperspy_gui_traitsui
-        as follows:
+        a conflict with the anaconda-navigator and the navigator-updater packages, 
+	therefore, it is necessary to remove it in order to install 
+	hyperspy_gui_traitsui as follows:
 
         .. code-block:: bash
 
-            $ conda uninstall anaconda-navigator -y
-            $ conda install hyperspy_gui_traitsui -c conda-forge
+            $ conda remove anaconda-navigator navigator-updater
+            $ conda install hyperspy-gui-traitsui -c conda-forge
 
 
 .. note::


### PR DESCRIPTION
### Progress of the PR
- [x] Fixes installation instructions for `hyperspy-gui-traitsui` in anaconda,
- [x] update README.md of `hyperspy-gui-traitsui`, see https://github.com/hyperspy/hyperspy_gui_traitsui/pull/4.
- [x] ready for review.
