### PR TITLE
Parse more metadata dm

### DIFF
--- a/hyperspy/io_plugins/digital_micrograph.py
+++ b/hyperspy/io_plugins/digital_micrograph.py
@@ -854,7 +854,9 @@ class ImageObject(object):
             "{}.Microscope Info.Voltage".format(tags_path): (
                 "Acquisition_instrument.TEM.beam_energy", lambda x: x / 1e3),
             "{}.Microscope Info.Stage Position.Stage Alpha".format(tags_path): (
-                "Acquisition_instrument.TEM.Stage.tilt_alpha", None),
+                "Acquisition_instrument.TEM.Stage.tilt_alpha", lambda x: round(x, 2)),
+            "{}.Microscope Info.Stage Position.Stage Beta".format(tags_path): (
+                "Acquisition_instrument.TEM.Stage.tilt_beta", lambda x: round(x, 2)),
             "{}.Microscope Info.Stage Position.Stage X".format(tags_path): (
                 "Acquisition_instrument.TEM.Stage.x", lambda x: x * 1e-3),
             "{}.Microscope Info.Stage Position.Stage Y".format(tags_path): (

--- a/hyperspy/io_plugins/digital_micrograph.py
+++ b/hyperspy/io_plugins/digital_micrograph.py
@@ -826,7 +826,7 @@ class ImageObject(object):
         # only present for single spectrum acquisition;  for maps we need to
         # compute exposure * number of frames
         if 'Integration_time_s' in tags.keys():
-            return float(tags["Integration time (s)"])
+            return float(tags["Integration_time_s"])
         elif 'Exposure_s' in tags.keys():
             frame_number = 1
             if "Number_of_frames" in tags.keys():
@@ -853,9 +853,9 @@ class ImageObject(object):
             "{}.Microscope Info.Voltage".format(tags_path): (
                 "Acquisition_instrument.TEM.beam_energy", lambda x: x / 1e3),
             "{}.Microscope Info.Stage Position.Stage Alpha".format(tags_path): (
-                "Acquisition_instrument.TEM.Stage.tilt_alpha", lambda x: round(x, 2)),
+                "Acquisition_instrument.TEM.Stage.tilt_alpha", None),
             "{}.Microscope Info.Stage Position.Stage Beta".format(tags_path): (
-                "Acquisition_instrument.TEM.Stage.tilt_beta", lambda x: round(x, 2)),
+                "Acquisition_instrument.TEM.Stage.tilt_beta", None),
             "{}.Microscope Info.Stage Position.Stage X".format(tags_path): (
                 "Acquisition_instrument.TEM.Stage.x", lambda x: x * 1e-3),
             "{}.Microscope Info.Stage Position.Stage Y".format(tags_path): (

--- a/hyperspy/io_plugins/digital_micrograph.py
+++ b/hyperspy/io_plugins/digital_micrograph.py
@@ -825,15 +825,14 @@ class ImageObject(object):
         # for GMS 2 and quantum/enfinium, the  "Integration time (s)" tag is
         # only present for single spectrum acquisition;  for maps we need to
         # compute exposure * number of frames
-        try:
-            if 'Integration_time_s' in tags.keys():
-                return float(tags["Integration time (s)"])
-            else:
-                frame_number = 1
-                if "Number_of_frames" in tags.keys():
-                    frame_number = float(tags["Number_of_frames"])
-                return float(tags["Exposure_s"]) * frame_number
-        except AttributeError:
+        if 'Integration_time_s' in tags.keys():
+            return float(tags["Integration time (s)"])
+        elif 'Exposure_s' in tags.keys():
+            frame_number = 1
+            if "Number_of_frames" in tags.keys():
+                frame_number = float(tags["Number_of_frames"])
+            return float(tags["Exposure_s"]) * frame_number
+        else:
             _logger.info("EELS exposure time can't be read.")
 
     def get_mapping(self):

--- a/hyperspy/io_plugins/digital_micrograph.py
+++ b/hyperspy/io_plugins/digital_micrograph.py
@@ -821,6 +821,21 @@ class ImageObject(object):
         else:
             return tag
 
+    def _get_EELS_exposure_time(self, tags):
+        # for GMS 2 and quantum/enfinium, the  "Integration time (s)" tag is
+        # only present for single spectrum acquisition;  for maps we need to
+        # compute exposure * number of frames
+        try:
+            if 'Integration_time_s' in tags.keys():
+                return float(tags["Integration time (s)"])
+            else:
+                frame_number = 1
+                if "Number_of_frames" in tags.keys():
+                    frame_number = float(tags["Number_of_frames"])
+                return float(tags["Exposure_s"]) * frame_number
+        except AttributeError:
+            _logger.info("EELS exposure time can't be read.")
+
     def get_mapping(self):
         if 'source' in self.imdict.ImageTags.keys():
             # For stack created with the stack builder plugin
@@ -915,9 +930,9 @@ class ImageObject(object):
                 "Convergence semi-angle (mrad)": (
                     "Acquisition_instrument.TEM.convergence_angle",
                     None),
-                "{}.EELS.Acquisition.Integration time (s)".format(tags_path): (
+                "{}.EELS.Acquisition".format(tags_path): (
                     "Acquisition_instrument.TEM.Detector.EELS.%s" % mapped_attribute,
-                    None),
+                    self._get_EELS_exposure_time),
                 "{}.EELS.Acquisition.Number_of_frames".format(tags_path): (
                     "Acquisition_instrument.TEM.Detector.EELS.frame_number",
                     None),


### PR DESCRIPTION
Partially fix #1859. It seems that the integration time is used for single spectrum while exposure is used for mapping. When using the exposure metadata, it needs to be multiplied by the number of frames: integration time = exposure * number of frames.

### Progress of the PR
- [x] parse the EELS dwell time of DM files to metadata,
- [x] add beta tilt,
- [x] ready for review.

