### PR TITLE
Fix default value of `rcond` in `numpy.linalg.lstsq` for numpy<1.14

### DIFF
--- a/hyperspy/learn/onmf.py
+++ b/hyperspy/learn/onmf.py
@@ -20,8 +20,8 @@ import logging
 from itertools import chain
 
 import numpy as np
-import scipy.linalg
 from scipy.stats import halfnorm
+
 from hyperspy.external.progressbar import progressbar
 
 _logger = logging.getLogger(__name__)
@@ -43,7 +43,10 @@ def _mrdivide(B, A):
             # square array
             return np.linalg.solve(A.T, B.T).T
         else:
-            return np.linalg.lstsq(A.T, B.T, rcond=None)[0].T
+            # Set rcond default value to match numpy 1.14 default value with
+            # previous numpy version
+            rcond = np.finfo(float).eps * max(A.shape)
+            return np.linalg.lstsq(A.T, B.T, rcond=rcond)[0].T
     else:
         return B / A
 


### PR DESCRIPTION
### Description of the change
Following #1799, the `rcond` parameters of `numpy.linalg.lstsq` can't be `None` for numpy<0.14 and it breaks onmf. See https://docs.scipy.org/doc/numpy/reference/generated/numpy.linalg.lstsq.html.

### Progress of the PR
- [x] Change `rcond` to a value matching the one in numpy>=1.14,
- [x] onmf tests now pass with numpy<1.13,
- [x] ready for review.
