### PR TITLE
Update mrcz version requirement to 0.3.6

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -62,7 +62,7 @@ install_req = ['scipy>=0.15',
                'scikit-image>=0.13',
                'pint>=0.8',
                'statsmodels',
-               'mrcz>0.3.4',
+               'mrcz>=0.3.6',
                ]
 
 extras_require = {


### PR DESCRIPTION
The import mrcz was also importing matplotlib.pyplot and setting backend at the same time, which in turn create an issue in hyperspyUI https://github.com/hyperspy/hyperspyUI/issues/155
This has been fixed in the last version of mrcz (0.3.6) but we just need to change the version requirement in hyperspy.
