### PR TITLE
Fix 1864 and add kwargs to GaussianHF's constructor

### DIFF
--- a/hyperspy/_components/expression.py
+++ b/hyperspy/_components/expression.py
@@ -196,9 +196,10 @@ class Expression(Component):
                            modules=module, dummify=False)
 
         if self._is2D:
-            f = lambda x, y: self._f(x, y, *[p.value for p in self.parameters])
+            def f(x, y): return self._f(
+                x, y, *[p.value for p in self.parameters])
         else:
-            f = lambda x: self._f(x, *[p.value for p in self.parameters])
+            def f(x): return self._f(x, *[p.value for p in self.parameters])
         setattr(self, "function", f)
         parnames = [symbol.name for symbol in parameters]
         self._parameter_strings = parnames

--- a/hyperspy/_components/expression.py
+++ b/hyperspy/_components/expression.py
@@ -126,9 +126,8 @@ class Expression(Component):
         Component.__init__(self, self._parameter_strings)
         # When creating components using Expression (for example GaussianHF)
         # we shouldn't add anything else to the _whitelist as the
-        # component should be initizialize with its own kwargs
-        # To implement this, we check if a "no_whitelist" kwarg exists.
-        if "no_whitelist" not in kwargs:
+        # component should be initizialized with its own kwargs
+        if self.__class__ is Expression:
             self._whitelist['expression'] = ('init', expression)
             self._whitelist['name'] = ('init', name)
             self._whitelist['position'] = ('init', position)
@@ -136,8 +135,6 @@ class Expression(Component):
             if self._is2D:
                 self._whitelist['add_rotation'] = ('init', self._add_rotation)
                 self._whitelist['rotation_center'] = ('init', rotation_center)
-        else:
-            del kwargs["no_whitelist"]
         self.name = name
         # Set the position parameter
         if position:

--- a/hyperspy/_components/expression.py
+++ b/hyperspy/_components/expression.py
@@ -124,13 +124,20 @@ class Expression(Component):
             self.compile_function(module=module, position=rotation_center)
         # Initialise component
         Component.__init__(self, self._parameter_strings)
-        self._whitelist['expression'] = ('init', expression)
-        self._whitelist['name'] = ('init', name)
-        self._whitelist['position'] = ('init', position)
-        self._whitelist['module'] = ('init', module)
-        if self._is2D:
-            self._whitelist['add_rotation'] = ('init', self._add_rotation)
-            self._whitelist['rotation_center'] = ('init', rotation_center)
+        # When creating components using Expression (for example GaussianHF)
+        # we shouldn't add anything else to the _whitelist as the
+        # component should be initizialize with its own kwargs
+        # To implement this, we check if a "no_whitelist" kwarg exists.
+        if "no_whitelist" not in kwargs:
+            self._whitelist['expression'] = ('init', expression)
+            self._whitelist['name'] = ('init', name)
+            self._whitelist['position'] = ('init', position)
+            self._whitelist['module'] = ('init', module)
+            if self._is2D:
+                self._whitelist['add_rotation'] = ('init', self._add_rotation)
+                self._whitelist['rotation_center'] = ('init', rotation_center)
+        else:
+            del kwargs["no_whitelist"]
         self.name = name
         # Set the position parameter
         if position:

--- a/hyperspy/_components/expression.py
+++ b/hyperspy/_components/expression.py
@@ -126,12 +126,13 @@ class Expression(Component):
         Component.__init__(self, self._parameter_strings)
         # When creating components using Expression (for example GaussianHF)
         # we shouldn't add anything else to the _whitelist as the
-        # component should be initizialized with its own kwargs
+        # component should be initizialized with its own kwargs.
+        # An exception is "module"
+        self._whitelist['module'] = ('init', module)
         if self.__class__ is Expression:
             self._whitelist['expression'] = ('init', expression)
             self._whitelist['name'] = ('init', name)
             self._whitelist['position'] = ('init', position)
-            self._whitelist['module'] = ('init', module)
             if self._is2D:
                 self._whitelist['add_rotation'] = ('init', self._add_rotation)
                 self._whitelist['rotation_center'] = ('init', rotation_center)

--- a/hyperspy/_components/gaussianhf.py
+++ b/hyperspy/_components/gaussianhf.py
@@ -51,6 +51,11 @@ class GaussianHF(Expression):
         fwhm: float
             The full width half maximum value, i.e. the width of the gaussian
             at half the value of gaussian peak (at centre).
+        **kwargs
+            Extra keyword arguments are passes to the ``Expression`` component.
+            An useful keyword argument that can be used to speed up the
+            component is `module`. See the ``Expression`` component
+            documentation for details.
 
     The helper properties `sigma` and `A` are also defined for compatibility
     with `Gaussian` component.
@@ -61,7 +66,7 @@ class GaussianHF(Expression):
 
     """
 
-    def __init__(self, height=1., fwhm=1., centre=0.):
+    def __init__(self, height=1., fwhm=1., centre=0., **kwargs):
         super(GaussianHF, self).__init__(
             expression="height * exp(-(x - centre)**2 * 4 * log(2)/fwhm**2)",
             name="GaussianHF",
@@ -70,6 +75,7 @@ class GaussianHF(Expression):
             centre=centre,
             position="centre",
             autodoc=False,
+            **kwargs,
         )
 
         # Boundaries

--- a/hyperspy/_components/gaussianhf.py
+++ b/hyperspy/_components/gaussianhf.py
@@ -70,7 +70,6 @@ class GaussianHF(Expression):
             centre=centre,
             position="centre",
             autodoc=False,
-            no_whitelist=True,
         )
 
         # Boundaries

--- a/hyperspy/_components/gaussianhf.py
+++ b/hyperspy/_components/gaussianhf.py
@@ -70,6 +70,7 @@ class GaussianHF(Expression):
             centre=centre,
             position="centre",
             autodoc=False,
+            no_whitelist=True,
         )
 
         # Boundaries

--- a/hyperspy/tests/model/test_model_storing.py
+++ b/hyperspy/tests/model/test_model_storing.py
@@ -26,7 +26,7 @@ import pytest
 
 from hyperspy._signals.signal1d import Signal1D
 from hyperspy.io import load
-from hyperspy.components1d import Gaussian
+from hyperspy.components1d import Gaussian, Expression, GaussianHF
 
 
 def clean_model_dictionary(d):
@@ -144,21 +144,23 @@ class TestModelSaving:
     def setup_method(self, method):
         s = Signal1D(range(100))
         m = s.create_model()
-        m.append(Gaussian())
-        m[-1].A.value = 13
+        m.append(Gaussian(A=13))
         m[-1].name = 'something'
-        m.append(Gaussian())
-        m[-1].A.value = 3
+        m.append(GaussianHF())
+        m[-1].height.value = 3
+        m.append(Expression(name="Line", expression="a * x + b", a=1, b=0))
         self.m = m
 
     def test_save_and_load_model(self):
         m = self.m
         m.save('tmp.hdf5', overwrite=True)
-        l = load('tmp.hdf5')
-        assert hasattr(l.models, 'a')
-        n = l.models.restore('a')
-        assert n.components.something.A.value == 13
-        assert n.components.Gaussian.A.value == 3
+        s = load('tmp.hdf5')
+        assert hasattr(s.models, 'a')
+        mr = s.models.restore('a')
+        assert mr.components.something.A.value == 13
+        assert mr.components.GaussianHF.height.value == 3
+        assert mr.components.Line.a.value == 1
+        assert mr.components.Line.function(10) == 10
 
     def teardown_method(self, method):
         gc.collect()        # Make sure any memmaps are closed first!

--- a/hyperspy/tests/model/test_model_storing.py
+++ b/hyperspy/tests/model/test_model_storing.py
@@ -146,7 +146,7 @@ class TestModelSaving:
         m = s.create_model()
         m.append(Gaussian(A=13))
         m[-1].name = 'something'
-        m.append(GaussianHF())
+        m.append(GaussianHF(module="numpy"))
         m[-1].height.value = 3
         m.append(Expression(name="Line", expression="a * x + b", a=1, b=0))
         self.m = m


### PR DESCRIPTION
When using the ``GaussianHF`` component several operations raised errors because the component is created using the ``Expression`` component, that was adding extra kwargs to the whitelist. This fixes the issue.

This also adds ``**kwargs`` to ``GaussianHF``'s constructor to enable passing keyword arguments to ``Expression``. See the example below.

### Progress of the PR
- [x] Change implemented (can be split into several points),
- [x] add tests,
- [x] ready for review.

### Minimal example of the bug fix or the new feature

The following example (completed from 1864) no longer raises an error.

```python
%matplotlib qt

import numpy as np
import hyperspy.api as hs

s = hs.signals.Signal1D(np.random.random((200, 200, 100)))

model = s.create_model()
g = hs.model.components1D.GaussianHF(module="numexpr")
model.append(g)
sm = model.as_signal()
```


