### PR TITLE
Update user guide regarding traitsui supporting qt5 

### DIFF
--- a/doc/user_guide/install.rst
+++ b/doc/user_guide/install.rst
@@ -75,10 +75,12 @@ MKL libraries) and the easiest installation. The academic license is free.
 
         $ conda install hyperspy-gui-traitsui -c conda-forge
 
-
     .. note::
-        As of traitsui v5.1.0, traitsui does not support Qt5 and, therefore,
-        in order to use the Qt backend it is necessary to
+	As of traitsui v6.0.0, Qt5 is supported by traitsui, which resolves the 
+	conflict issue with packages depending on Qt5. 
+
+	Previous version of traitsui (v5.1.0 and below) does not support Qt5 and, 
+	therefore, in order to use the Qt backend it is necessary to
         downgrade pyqt. With the standard Anaconda installation this causes
         a conflict with the anaconda-navigator and the navigator-updater packages, 
 	therefore, it is necessary to remove it in order to install 

--- a/doc/user_guide/install.rst
+++ b/doc/user_guide/install.rst
@@ -75,23 +75,6 @@ MKL libraries) and the easiest installation. The academic license is free.
 
         $ conda install hyperspy-gui-traitsui -c conda-forge
 
-    .. note::
-	As of traitsui v6.0.0, Qt5 is supported by traitsui, which resolves the 
-	conflict issue with packages depending on Qt5. 
-
-	Previous version of traitsui (v5.1.0 and below) does not support Qt5 and, 
-	therefore, in order to use the Qt backend it is necessary to
-        downgrade pyqt. With the standard Anaconda installation this causes
-        a conflict with the anaconda-navigator and the navigator-updater packages, 
-	therefore, it is necessary to remove it in order to install 
-	hyperspy_gui_traitsui as follows:
-
-        .. code-block:: bash
-
-            $ conda remove anaconda-navigator navigator-updater
-            $ conda install hyperspy-gui-traitsui -c conda-forge
-
-
 .. note::
     Since version 0.8.4 HyperSpy only supports Python 3. If you need to
     install HyperSpy in Python 2.7 install version 0.8.3:


### PR DESCRIPTION
Add a note in the user guide explaining that as of traitsui v6.0, qt5 is supported and the conflict issue in anaconda is resolved. 

### Progress of the PR
- [x] update user guide,
- [x] ready for review.
