### PR TITLE
Remove advice about the bundle

### DIFF
--- a/doc/user_guide/install.rst
+++ b/doc/user_guide/install.rst
@@ -4,8 +4,7 @@
 Installing HyperSpy
 ===================
 
-The easiest way to install HyperSpy in Microsoft Windows is installing the
-:ref:`HyperSpy Bundle <hyperspy-bundle>`.
+
 
 For quick instructions on how to install HyperSpy in Linux, MacOs or Windows
 using the `Anaconda Python distribution <http://docs.continuum.io/anaconda/>`_


### PR DESCRIPTION
Since this is no longer the way to get the latest version (if I've understood) I don't think telling people to use the bundle is a good idea.
Incidentally on the "News" page, the links to the bug fixes and enhancements seem to be wrong. They imply that none of either have occurred in this release. I wanted to change that but could not find the file about release 1.3.1.
Maybe I'm jumping the gun and this is all in hand, My apologies if so...

### Requirements
* Read the [developer guide](http://hyperspy.org/hyperspy-doc/current/dev_guide.html).
* Filling out the template; it helps the review process and it is useful to summarise the PR.
* This template can be updated during the progression of the PR to summarise its status. 

*You can delete this section after you read it.*

### Description of the change
A few sentences and/or a bulleted list to describe and motivate the change:
- Change A.
- Change B.
- etc.

### Progress of the PR
- [ ] Change implemented (can be split into several points),
- [ ] update docstring (if appropriate),
- [ ] update user guide (if appropriate),
- [ ] add tests,
- [ ] ready for review.

### Minimal example of the bug fix or the new feature
```python
>>> import hyperspy.api as hs
>>> import numpy as np
>>> s = hs.signals.Signal1D(np.arange(10))
>>> # Your new feature...
```
Note that this example can be useful to update the user guide.

