### PR TITLE
Speed up reading chunked data from velox emd

### DIFF
--- a/hyperspy/io_plugins/emd.py
+++ b/hyperspy/io_plugins/emd.py
@@ -681,6 +681,8 @@ class FeiEMDReader(object):
                     chunks=h5data.chunks),
                 axes=[2, 0, 1])
         else:
+            # Workaround for a h5py bug https://github.com/h5py/h5py/issues/977
+            # Change back to standard API once issue #977 is fixed.
             # Preallocate the numpy array and use read_direct method, which is
             # much faster in case of chunked data.
             data = np.empty(h5data.shape)


### PR DESCRIPTION
Fixes #1887. Reading chunked data from hdf5 file with h5py can be slow. For the file mentioned in #1887 (chunked in 50 pieces), preallocating a numpy array and "manually" filling it with a numpy for loop is faster (~5x) as mentioned in https://github.com/h5py/h5py/issues/977 and using `read_direct` method is even much faster (~50x) and is as close as we would expect to be.

### Progress of the PR
- [x] Improve the reading speed of chunked data created by the velox software by creating the numpy array before hand and filling it with the `read_direct` method of the h5py dataset,
- [x] Improve the speed of parsing metadata in case of stack of images by reading only the first slice, instead of all the slices.
- [x] ready for review.

Benchmark using the file provided by @hentr in #1887.
On next_release_minor branch:
```python
import time
import hyperspy.api as hs

t1 = time.time()
s = hs.load('STEM HAADF 1613.emd')
print("Loading time:", time.time() - t1)
# Loading time: 30.282315492630005
```

On this PR:
```python
import time
import hyperspy.api as hs

t1 = time.time()
s = hs.load('STEM HAADF 1613.emd')
print("Loading time:", time.time() - t1)
# Loading time: 0.7876532077789307
```

