### PR TITLE
Fixes #1524: test time zone issue

### DIFF
--- a/hyperspy/tests/misc/test_date_time_tools.py
+++ b/hyperspy/tests/misc/test_date_time_tools.py
@@ -102,7 +102,9 @@ def test_update_date_time_in_metadata():
     md12 = dtt.update_date_time_in_metadata(dt1, md.deepcopy())
     assert_deep_almost_equal(md12.General.date, md1.General.date)
     assert_deep_almost_equal(md12.General.time, md1.General.time)
-    assert md12.General.time_zone in ('UTC', 'Coordinated Universal Time')
+    import locale
+    if locale.getlocale()[0] in ['en_GB', 'en_US']:
+        assert md12.General.time_zone in ('UTC', 'Coordinated Universal Time')
 
     md13 = dtt.update_date_time_in_metadata(iso2, md.deepcopy())
     assert_deep_almost_equal(md13.General.date, md2.General.date)


### PR DESCRIPTION
As described in #1524, a test checking the time zone is failling on system where the locale is not set to `"en_BG"` or `"en_US"`.

### Progress of the PR
- [x] Skip the test in non compliant systems,
- [x] ready for review.

