### PR TITLE
Support for loading several root groups in EMD NCEM files

### DIFF
--- a/hyperspy/io_plugins/emd.py
+++ b/hyperspy/io_plugins/emd.py
@@ -366,16 +366,17 @@ class EMD(object):
                     'sample', 'comments']:  # Nodes which are not the data!
             if key in node_list:
                 node_list.pop(node_list.index(key))  # Pop all unwanted nodes!
-        # One node should remain, the data node (named 'data', 'signals',
-        # 'experiments', ...)!
-        assert len(node_list) == 1, 'Dataset location is ambiguous!'
-        data_group = emd_file.get(node_list[0])
-        if data_group is not None:
-            for name, group in data_group.items():
-                if isinstance(group, h5py.Group):
-                    if group.attrs.get('emd_group_type') == 1:
-                        emd._read_signal_from_group(
-                            name, group, lazy)
+        if len(node_list) == 0:
+            raise IOError("No datasets found in {0}".format(filename))
+        for node in node_list:
+            data_group = emd_file.get(node)
+            if data_group is not None:
+                for group in data_group.values():
+                    name = group.name
+                    if isinstance(group, h5py.Group):
+                        if group.attrs.get('emd_group_type') == 1:
+                            emd._read_signal_from_group(
+                                name, group, lazy)
         # Close file and return EMD object:
         if not lazy:
             emd_file.close()

--- a/hyperspy/tests/io/test_emd.py
+++ b/hyperspy/tests/io/test_emd.py
@@ -53,7 +53,7 @@ user = {'name': 'John Doe', 'institution': 'TestUniversity',
 microscope = {'name': 'Titan', 'voltage': '300kV'}
 sample = {'material': 'TiO2', 'preparation': 'FIB'}
 comments = {'comment': 'Test'}
-test_title = 'This is a test!'
+test_title = '/signals/This is a test!'
 
 
 def test_signal_3d_loading():
@@ -126,6 +126,39 @@ class TestMinimalSave():
         self.signal = Signal1D([0, 1])
         with tempfile.TemporaryDirectory() as tmp:
             self.signal.save(os.path.join(tmp, 'testfile.emd'))
+
+
+class TestReadSeveralDatasets:
+
+    def setup_method(self):
+        tmpdir = tempfile.TemporaryDirectory()
+        hdf5_dataset_path = os.path.join(tmpdir.name, "test_dataset.emd")
+        f = h5py.File(hdf5_dataset_path, mode="w")
+        f.attrs.create('version_major', 0)
+        f.attrs.create('version_minor', 2)
+
+        group_path_list = ['exp/data_0', 'exp/data_1', 'calc/data_0']
+
+        for group_path in group_path_list:
+            group = f.create_group(group_path)
+            group.attrs.create('emd_group_type', 1)
+            data = np.random.random((128, 128))
+            group.create_dataset(name='data', data=data)
+            group.create_dataset(name='dim1', data=range(128))
+            group.create_dataset(name='dim2', data=range(128))
+
+        f.close()
+
+        self.group_path_list = group_path_list
+        self.hdf5_dataset_path = hdf5_dataset_path
+        self.tmpdir = tmpdir
+
+    def teardown_method(self):
+        self.tmpdir.cleanup()
+
+    def test_load_file(self):
+        s = load(self.hdf5_dataset_path)
+        assert len(s) == len(self.group_path_list)
 
 
 class TestCaseSaveAndRead():

--- a/hyperspy/tests/io/test_emd.py
+++ b/hyperspy/tests/io/test_emd.py
@@ -137,7 +137,7 @@ class TestReadSeveralDatasets:
         f.attrs.create('version_major', 0)
         f.attrs.create('version_minor', 2)
 
-        group_path_list = ['exp/data_0', 'exp/data_1', 'calc/data_0']
+        group_path_list = ['/exp/data_0', '/exp/data_1', '/calc/data_0']
 
         for group_path in group_path_list:
             group = f.create_group(group_path)
@@ -159,6 +159,8 @@ class TestReadSeveralDatasets:
     def test_load_file(self):
         s = load(self.hdf5_dataset_path)
         assert len(s) == len(self.group_path_list)
+        title_list = [s_temp.metadata.General.title for s_temp in s]
+        assert sorted(self.group_path_list) == sorted(title_list)
 
 
 class TestCaseSaveAndRead():


### PR DESCRIPTION
Currently, EMD NCEM files containing more than one non-metadata root group will not load. This pull request add support for this.

In addition, it changes how `s.metadata.General.title` is constructed for EMD NCEM files. Previously it only used the group name for the group containing `emd_group_type=1` (i.e. the group with the data). Now it includes the path to this group. So if the HDF5 file has the structure /experiment/fpd_data, the signal would get the title `fpd_data`, now it will get the name `/experiment/fpd_data`. This was necessary to avoid groups not being loaded, if the file had the same group data name (for example `/experiment/fpd_data` and `/processed/fpd_data`.

After this has been merged, I'll make a new and improved version of https://github.com/hyperspy/hyperspy/pull/1824.

### Progress of the PR
- [x] Change implemented
- [x] add tests
- [x] ready for review

### Minimal example
Generate the file
```python
import h5py               
import numpy as np        

filename = "test.emd"     
f = h5py.File(filename, mode="w")                   
f.attrs.create('version_major', 0)                  
f.attrs.create('version_minor', 2)                  

group_name_list = [       
        'experimental/data_0', 'experimental/data_1',                                                    
        'experimental/data_2', 'calculations/data_3']                                                    

for group_name in group_name_list:                  
    group = f.create_group(group_name)              
    group.attrs.create('emd_group_type', 1)         
    group.create_dataset(name='data', data=np.random.random((128, 128)))                                 
    group.create_dataset(name='dim1', data=range(128))                                                   
    group.create_dataset(name='dim2', data=range(128))                                                   

f.close()
```

Load the file:
```python
import hyperspy.api as hs
hs.load("test.emd")
```

Gives:
```python
[<Signal2D, title: /calculations/data_3, dimensions: (|128, 128)>,                                       
 <Signal2D, title: /experimental/data_0, dimensions: (|128, 128)>,                                       
 <Signal2D, title: /experimental/data_1, dimensions: (|128, 128)>,                                       
 <Signal2D, title: /experimental/data_2, dimensions: (|128, 128)>]
```