### PR TITLE
Fix bug smooth savitzky golay

### DIFF
--- a/hyperspy/drawing/mpl_he.py
+++ b/hyperspy/drawing/mpl_he.py
@@ -146,8 +146,9 @@ class MPL_HyperExplorer(object):
         if self.navigator_plot:
             self.navigator_plot.close()
 
+    @property
     def is_active(self):
-        if self.signal_plot and self.signal_plot.figure:
+        if self.signal_plot and self.signal_plot.figure is not None:
             return True
         else:
             return False

--- a/hyperspy/model.py
+++ b/hyperspy/model.py
@@ -548,7 +548,7 @@ class BaseModel(list):
 
     @property
     def _plot_active(self):
-        if self._plot is not None and self._plot.is_active() is True:
+        if self._plot is not None and self._plot.is_active:
             return True
         else:
             return False

--- a/hyperspy/models/model1d.py
+++ b/hyperspy/models/model1d.py
@@ -53,11 +53,8 @@ class ComponentFit(SpanSelectorInSignal1D):
         self.fit_kwargs = kwargs
         self.only_current = only_current
         if signal_range == "interactive":
-            if not hasattr(self.model, '_plot'):
-                self.model.plot()
-            elif self.model._plot is None:
-                self.model.plot()
-            elif self.model._plot.is_active() is False:
+            if (not hasattr(self.model, '_plot') or self.model._plot is None or
+                not self.model._plot.is_active):
                 self.model.plot()
             self.span_selector_switch(on=True)
 
@@ -781,8 +778,7 @@ class Model1D(BaseModel):
         disable_adjust_position
 
         """
-        if (self._plot is None or
-                self._plot.is_active() is False):
+        if self._plot is None or not self._plot.is_active:
             self.plot()
         if self._position_widgets:
             self.disable_adjust_position()

--- a/hyperspy/signal.py
+++ b/hyperspy/signal.py
@@ -2138,12 +2138,12 @@ class BaseSignal(FancySlicing,
 
     def _replot(self):
         if self._plot is not None:
-            if self._plot.is_active() is True:
+            if self._plot.is_active:
                 self.plot()
 
     def update_plot(self):
         if self._plot is not None:
-            if self._plot.is_active() is True:
+            if self._plot.is_active:
                 if self._plot.signal_plot is not None:
                     self._plot.signal_plot.update()
                 if self._plot.navigator_plot is not None:

--- a/hyperspy/signal_tools.py
+++ b/hyperspy/signal_tools.py
@@ -57,7 +57,7 @@ class SpanSelectorInSignal1D(t.HasTraits):
         pass
 
     def span_selector_switch(self, on):
-        if not self.signal._plot.is_active():
+        if not self.signal._plot.is_active:
             return
 
         if on is True:
@@ -73,7 +73,7 @@ class SpanSelectorInSignal1D(t.HasTraits):
             self.span_selector = None
 
     def update_span_selector_traits(self, *args, **kwargs):
-        if not self.signal._plot.is_active():
+        if not self.signal._plot.is_active:
             return
         self.ss_left_value = self.span_selector.rect.get_x()
         self.ss_right_value = self.ss_left_value + \
@@ -135,7 +135,7 @@ class LineInSignal1D(t.HasTraits):
         self.signal._plot.signal_plot.figure.canvas.draw_idle()
 
     def switch_on_off(self, obj, trait_name, old, new):
-        if not self.signal._plot.is_active():
+        if not self.signal._plot.is_active:
             return
 
         if new is True and old is False:
@@ -152,7 +152,7 @@ class LineInSignal1D(t.HasTraits):
             self.draw()
 
     def update_position(self, *args, **kwargs):
-        if not self.signal._plot.is_active():
+        if not self.signal._plot.is_active:
             return
         self.position = self.axes_manager.coordinates[0]
 
@@ -269,8 +269,7 @@ class Smoothing(t.HasTraits):
         self.plot()
 
     def plot(self):
-        if self.signal._plot is None or not \
-                self.signal._plot.is_active():
+        if self.signal._plot is None or not self.signal._plot.is_active:
             self.signal.plot()
         hse = self.signal._plot
         l1 = hse.signal_plot.ax_lines[0]
@@ -343,7 +342,7 @@ class Smoothing(t.HasTraits):
         return smoothed
 
     def close(self):
-        if self.signal._plot.is_active():
+        if self.signal._plot.is_active:
             if self.differential_order != 0:
                 self.turn_diff_line_off()
             self.smooth_line.close()
@@ -608,11 +607,8 @@ class IntegrateArea(SpanSelectorInSignal1D):
         self.signal = signal
         self.axis = self.signal.axes_manager.signal_axes[0]
         self.span_selector = None
-        if not hasattr(self.signal, '_plot'):
-            self.signal.plot()
-        elif self.signal._plot is None:
-            self.signal.plot()
-        elif self.signal._plot.is_active() is False:
+        if (not hasattr(self.signal, '_plot') or self.signal._plot is None or 
+            not self.signal._plot.is_active):
             self.signal.plot()
         self.span_selector_switch(on=True)
 

--- a/hyperspy/signal_tools.py
+++ b/hyperspy/signal_tools.py
@@ -334,7 +334,12 @@ class Smoothing(t.HasTraits):
         if self.smooth_diff_line is not None:
             self.smooth_diff_line.line_properties = {
                 'color': self.line_color_rgb}
-        self.update_lines()
+        try:
+            # it seems that changing the properties can be done before the
+            # first rendering event, which can cause issue with blitting
+            self.update_lines()
+        except AttributeError:
+            pass
 
     def diff_model2plot(self, axes_manager=None):
         smoothed = np.diff(self.model2plot(axes_manager),
@@ -607,8 +612,8 @@ class IntegrateArea(SpanSelectorInSignal1D):
         self.signal = signal
         self.axis = self.signal.axes_manager.signal_axes[0]
         self.span_selector = None
-        if (not hasattr(self.signal, '_plot') or self.signal._plot is None or 
-            not self.signal._plot.is_active):
+        if (not hasattr(self.signal, '_plot') or self.signal._plot is None or
+                not self.signal._plot.is_active):
             self.signal.plot()
         self.span_selector_switch(on=True)
 

--- a/hyperspy/signal_tools.py
+++ b/hyperspy/signal_tools.py
@@ -299,13 +299,13 @@ class Smoothing(t.HasTraits):
 
         self.signal._plot.signal_plot.create_right_axis()
         self.smooth_diff_line = drawing.signal1d.Signal1DLine()
+        self.smooth_diff_line.axes_manager = self.signal.axes_manager
         self.smooth_diff_line.data_function = self.diff_model2plot
         self.smooth_diff_line.set_line_properties(
             color=self.line_color_rgb,
             type='line')
         self.signal._plot.signal_plot.add_line(self.smooth_diff_line,
                                                ax='right')
-        self.smooth_diff_line.axes_manager = self.signal.axes_manager
 
     def _line_color_ipy_changed(self):
         if hasattr(self, "line_color"):
@@ -320,13 +320,14 @@ class Smoothing(t.HasTraits):
         self.smooth_diff_line = None
 
     def _differential_order_changed(self, old, new):
-        if old == 0:
-            self.turn_diff_line_on(new)
-            self.smooth_diff_line.plot()
         if new == 0:
             self.turn_diff_line_off()
             return
-        self.smooth_diff_line.update(force_replot=False)
+        if old == 0:
+            self.turn_diff_line_on(new)
+            self.smooth_diff_line.plot()
+        else:
+            self.smooth_diff_line.update(force_replot=False)
 
     def _line_color_changed(self, old, new):
         self.smooth_line.line_properties = {


### PR DESCRIPTION
This PR fixes two bugs, which makes the tests fail for https://github.com/hyperspy/hyperspy_gui_ipywidgets

### Progress of the PR
- [x] Fix setting the `axes_manager` of the `smooth_diff_line` of the `SmoothingSavitzkyGolay` tool,
- [x] make `is_active` a property of `MPL_HyperExplorer`.
- [x] catch an matplotlib blit error when changing the color of the smooth_line from a script.
- [x] ready for review.

