### PR TITLE
Fix compatibility with dask 0.17.4

### DIFF
--- a/hyperspy/_components/gaussian.py
+++ b/hyperspy/_components/gaussian.py
@@ -49,7 +49,7 @@ def _estimate_gaussian_parameters(signal, x1, x2, only_current):
     if isinstance(data, da.Array):
         _sum = da.sum
         _sqrt = da.sqrt
-        _abs = da.numpy_compat.builtins.abs
+        _abs = abs
     else:
         _sum = np.sum
         _sqrt = np.sqrt

--- a/hyperspy/_signals/complex_signal.py
+++ b/hyperspy/_signals/complex_signal.py
@@ -265,7 +265,7 @@ class LazyComplexSignal(ComplexSignal, LazySignal):
 
     @format_title('absolute')
     def _get_amplitude(self):
-        amplitude = da.numpy_compat.builtins.abs(self)
+        amplitude = abs(self)
         return super(ComplexSignal, self)._get_amplitude(amplitude)
 
     def _get_phase(self):
@@ -293,7 +293,7 @@ class LazyComplexSignal(ComplexSignal, LazySignal):
     def _set_phase(self, phase):
         if isinstance(phase, BaseSignal):
             phase = phase.data.real
-        self.data = da.numpy_compat.builtins.abs(self.data) * \
+        self.data = abs(self.data) * \
             da.exp(1j * phase)
         self.events.data_changed.trigger(self)
 


### PR DESCRIPTION
Tests are failing since last dask release (0.17.4). See PR #https://github.com/dask/dask/pull/3429 for the detailed changes.

### Progress of the PR
- [x] builtins has been removed from dask.numpy_compat: use builtins `abs` instead of calling it throught dask,
- [x] dask bumped numpy version to 1.11 so we need to do the same,
- [x] ready for review.
