### PR TITLE
OneView_IS Reader

### DIFF
--- a/hyperspy/api_nogui.py
+++ b/hyperspy/api_nogui.py
@@ -74,6 +74,7 @@ del docstrings
 from hyperspy.Release import version as __version__
 from hyperspy import signals
 from hyperspy.io import load
+from hyperspy.io import oneview_is_reader
 from hyperspy.defaults_parser import preferences
 from hyperspy.utils import *
 from hyperspy import datasets


### PR DESCRIPTION
Adding a function to io.py to read Gatan OneView_IS datasets.

OneView_IS (in-situ) datasets are saved as nested folders with the following format:
`Example_OneView_IS/Hour_00/Minute_00/Second_00/Example_OneView_IS_Hour_00_Minute_00_Second_00_Frame_0000.dm4`
In each `Second_xx` folder as many frames taken per second are populated. The camera captures continuously in this mode. 

files changed:
```
hyperspy/api_nogui.py
hyperspy/io.py
```

This is a first and very basic attempt. `oneview_is_reader` gets the folder location of the dataset and loads the data as a `Signal2D` image stack lazily. As these datasets are generally large only lazy loading is performed.

Sharing to get feedback form watchers as to where to take this.

### Progress of the PR
- [x] Initial changes implemented,
- [ ] Accommodate K2-IS datasets,
- [ ] update docstring,
- [ ] update user guide (if appropriate),
- [ ] add tests,
- [ ] ready for review.

### Minimal example of the bug fix or the new feature
```python
>>> import hyperspy.api as hs
>>> s = hs.oneview_is_reader('/Documents/data/OneView_IS_example')


