### PR TITLE
Hyperlink DOIs against preferred resolver

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -57,4 +57,4 @@ Cite
 |DOI|_
 
 .. |DOI| image:: https://zenodo.org/badge/doi/10.5281/zenodo.1221347.svg
-.. _DOI: http://dx.doi.org/10.5281/zenodo.1221347
+.. _DOI: https://doi.org/10.5281/zenodo.1221347

--- a/doc/_static/articles_using_hyperspy.bib
+++ b/doc/_static/articles_using_hyperspy.bib
@@ -108,7 +108,7 @@
         year = "2014",
         note = "",
         issn = "1359-6462",
-        doi = "http://dx.doi.org/10.1016/j.scriptamat.2013.11.007",
+        doi = "https://doi.org/10.1016/j.scriptamat.2013.11.007",
         url = "http://www.sciencedirect.com/science/article/pii/S1359646213005642",
         author = "Sigurd Wenner and Calin D. Marioara and Quentin M. Ramasse and Despoina-Maria Kepaptsoglou and Fredrik S. Hage and Randi Holmestad",
         keywords = "Aluminum alloys",

--- a/doc/citing.rst
+++ b/doc/citing.rst
@@ -7,4 +7,4 @@ publication, please acknowledge that fact by citing the software. Click on
 the DOI badge below for formatted citation formats.
 
 .. image:: https://zenodo.org/badge/doi/10.5281/zenodo.1221347.svg
-   :target: http://dx.doi.org/10.5281/zenodo.1221347
+   :target: https://doi.org/10.5281/zenodo.1221347

--- a/doc/user_guide/model.rst
+++ b/doc/user_guide/model.rst
@@ -1084,7 +1084,7 @@ when fitting multi-dimensional datasets.
 The algorithm will be described in full when accompanying paper is published,
 but we are making the implementation available now, with additional details
 available in the following `conference proceeding
-<http://doi.org/10.1002/9783527808465.EMC2016.6233>`_.
+<https://doi.org/10.1002/9783527808465.EMC2016.6233>`_.
 
 The idea
 ^^^^^^^^

--- a/hyperspy/misc/example_signals_loading.py
+++ b/hyperspy/misc/example_signals_loading.py
@@ -60,10 +60,10 @@ def load_object_hologram():
     - Sample: Fe needle with YOx nanoparticle inclusions [Migunov, V. et al.
     Model-independent measurement of the charge density distribution along an Fe atom probe needle using
     off-axis electron holography without mean inner potential effects. Journal of Applied Physics 117, 134301 (2015).
-    http://dx.doi.org/10.1063/1.4916609]
+    https://doi.org/10.1063/1.4916609]
     - TEM Microscope: FEI Titan G2 60-300 HOLO [Boothroyd, C. et al. FEI Titan G2 60-300 HOLO.
     Journal of large-scale research facilities JLSRF 2, 44 (2016).
-    http://dx.doi.org/10.17815/jlsrf-2-70]
+    https://doi.org/10.17815/jlsrf-2-70]
     """
     from hyperspy.io import load
     file_path = os.sep.join([os.path.dirname(__file__), 'holography',
@@ -80,10 +80,10 @@ def load_reference_hologram():
     - Sample: Fe needle with YOx nanoparticle inclusions [Migunov, V. et al.
     Model-independent measurement of the charge density distribution along an Fe atom probe needle using
     off-axis electron holography without mean inner potential effects. Journal of Applied Physics 117, 134301 (2015).
-    http://dx.doi.org/10.1063/1.4916609]
+    https://doi.org/10.1063/1.4916609]
     - TEM Microscope: FEI Titan G2 60-300 HOLO [Boothroyd, C. et al. FEI Titan G2 60-300 HOLO.
     Journal of large-scale research facilities JLSRF 2, 44 (2016).
-    http://dx.doi.org/10.17815/jlsrf-2-70]
+    https://doi.org/10.17815/jlsrf-2-70]
     """
     from hyperspy.io import load
     file_path = os.sep.join([os.path.dirname(__file__), 'holography',


### PR DESCRIPTION
### Description of the change

The DOI foundation recommends [this new, secure resolver](https://www.doi.org/doi_handbook/3_Resolution.html#3.8) and Zenodo started using it for its badges as well. Accordingly, this PR updates all DOI links.

### Progress of the PR
- [x] Change implemented (can be split into several points),
- ~~update docstring (if appropriate),~~
- ~~update user guide (if appropriate),~~
- ~~add tests,~~
- [x] ready for review.


PS: Please let me know if some of [your other repos](https://github.com/search?q=org%3Ahyperspy+dx.doi&type=Code) are auto-generated from this one? If you merge this PR, I was planning to apply also `sed` through your other repos in the same way. Hence, it would be helpful to know which ones I could ignore then. Thanks & greetings :-)