### PR TITLE
Fix default formatting of `print_summary_statistics`

### DIFF
--- a/hyperspy/signal.py
+++ b/hyperspy/signal.py
@@ -4201,7 +4201,7 @@ class BaseSignal(FancySlicing,
         """
         self.metadata.Signal.signal_origin = origin
 
-    def print_summary_statistics(self, formatter="%.3f"):
+    def print_summary_statistics(self, formatter="%.3g"):
         """Prints the five-number summary statistics of the data, the mean and
         the standard deviation.
 


### PR DESCRIPTION
### Description of the change
Change the default formatting of `print_summary_statistics` from `"%.3f"` to `"%.3g"` to display 3 significant digits and avoid showing 0.000 when the data are <10-3.

### Progress of the PR
- [x] Change implemented,
- [x] ready for review.

### Minimal example of the bug fix
```python
>>> import hyperspy.api as hs
>>> import numpy as np
>>> s = hs.signals.Signal1D(np.arange(100)*1E-5)
>>> s.print_summary_statistics()
Summary statistics
------------------
mean:   0.000495
std:    0.000289

min:    0
Q1:     0.000247
median: 0.000495
Q3:     0.000743
max:    0.00099
```

With current HyperSpy
```python
>>> import hyperspy.api as hs
>>> import numpy as np
>>> s = hs.signals.Signal1D(np.arange(100)*1E-5)
>>> s.print_summary_statistics()
Summary statistics
------------------
mean:   0.000
std:    0.000

min:    0.000
Q1:     0.000
median: 0.000
Q3:     0.001
max:    0.001
```