### PR TITLE
Fix issue with applying function on masked data

### DIFF
--- a/hyperspy/signal.py
+++ b/hyperspy/signal.py
@@ -2756,6 +2756,7 @@ class BaseSignal(FancySlicing,
         # the axes since the function will consume it/them.
         if not np.iterable(ar_axes):
             ar_axes = (ar_axes,)
+
         ar_axes = sorted(ar_axes)
         new_shape = list(self.data.shape)
         for index in ar_axes[1:]:
@@ -2782,11 +2783,22 @@ class BaseSignal(FancySlicing,
         axes = self.axes_manager[axes]
         if not np.iterable(axes):
             axes = (axes,)
+
         # Use out argument in numpy function when available for operations that
         # do not return scalars in numpy.
         np_out = not len(self.axes_manager._axes) == len(axes)
         ar_axes = tuple(ax.index_in_array for ax in axes)
-        if len(ar_axes) == 1:
+
+        if len(ar_axes) == 0:
+            # no axes is provided, so no operation needs to be done but we 
+            # still need to finished the execution of the function properly.
+            if out:
+                out.data[:] = self.data
+                out.events.data_changed.trigger(obj=out)
+                return
+            else:
+                return self
+        elif len(ar_axes) == 1:
             ar_axes = ar_axes[0]
 
         s = out or self._deepcopy_with_new_data(None)

--- a/hyperspy/tests/signal/test_tools.py
+++ b/hyperspy/tests/signal/test_tools.py
@@ -745,6 +745,17 @@ class TestOutArg:
         sr = s.sum(axis=('x', 'z',))
         np.testing.assert_array_equal(sr.data.sum(), (~mask).sum())
 
+    @pytest.mark.parametrize('mask', (True, False))
+    def test_sum_no_navigation_axis(self, mask):
+        s = signals.Signal1D(np.arange(100))
+        if mask:
+            s.data = np.ma.masked_array(s.data, mask=(s < 50))
+        # Since s haven't any navigation axis, it returns the same signal as
+        # default
+        np.testing.assert_array_equal(s, s.sum())
+        # When we specify an axis, it actually takes the sum.
+        np.testing.assert_array_equal(s.data.sum(), s.sum(axis=0))
+
     def test_masked_arrays_out(self):
         s = self.s
         if s._lazy:


### PR DESCRIPTION
This PR is an attempt to fix an issue with applying function on masked data, when no navigation axis is present and no axis is provided to the function. At the moment, it will raise an error. This PR fixes the error and makes masked data and non-masked data behaving consistently.
I am not really sure if this is the correct way to fix this.

### Progress of the PR
- [x] Make signals with masked data and non-masked data behaving in the same way,
- [x] add tests,
- [x] ready for review.

### Minimal example of the bug fix
```python
import hyperspy.api as hs
import numpy as np

s = hs.signals.Signal1D(np.arange(100))
s.data = np.ma.masked_array(s.data, mask=(s<50))
s.sum() # now works with masked array 
# it doesn't do anything since no navigation axis is present and no axis is provided as argument.
```
Traceback
```python
---------------------------------------------------------------------------
IndexError                                Traceback (most recent call last)
<ipython-input-2-4c2eb35e000d> in <module>()
      1 s = hs.signals.Signal1D(np.arange(100))
      2 s.data = np.ma.masked_array(s.data, mask=(s<50))
----> 3 s.sum()
      4 

/opt/anaconda3/lib/python3.6/site-packages/hyperspy/signal.py in sum(self, axis, out)
   2842             axis = self.axes_manager.navigation_axes
   2843         return self._apply_function_on_data_and_remove_axis(np.sum, axis,
-> 2844                                                             out=out)
   2845     sum.__doc__ %= (MANY_AXIS_PARAMETER, OUT_ARG)
   2846 

/opt/anaconda3/lib/python3.6/site-packages/hyperspy/signal.py in _apply_function_on_data_and_remove_axis(self, function, axes, out)
   2794         if np.ma.is_masked(self.data):
   2795             return self._ma_workaround(s=s, function=function, axes=axes,
-> 2796                                        ar_axes=ar_axes, out=out)
   2797         if out:
   2798             if np_out:

/opt/anaconda3/lib/python3.6/site-packages/hyperspy/signal.py in _ma_workaround(self, s, function, axes, ar_axes, out)
   2761         for index in ar_axes[1:]:
   2762             new_shape[index] = 1
-> 2763         new_shape[ar_axes[0]] = -1
   2764         data = self.data.reshape(new_shape).squeeze()
   2765 

IndexError: list index out of range
```