### PR TITLE
Enhancement: select and replot one axis in plot_images

### DIFF
--- a/doc/user_guide/visualisation.rst
+++ b/doc/user_guide/visualisation.rst
@@ -635,12 +635,12 @@ __ plot.spectra_
     instead set the ``colorbar`` argument to ``None``.
 
 .. versionadd: 1.4
-    By default or by setting the ``axes_replot`` bool argument to ``True``, adds
-    the possibility to select and re-plot and axis in ``plot_images``. This is
-    achieved by double clicking into this axis. Each click triggers a plot
-    event, in which the selected signal is presented. This helps navigating
-    through a panel with many figures by enlarging some of them and allowing
-    comfortable zooming.
+    Double-clicking into an axis in the panel created by ``plot_images``
+    triggers a plot event, creating a new figure in which the selected signal is
+    presented alone. This helps navigating through panels with many figures by
+    selecting and enlarging some of them and allowing comfortable zooming. This
+    functionality is only enabled if a ``matplotlib`` backend that supports the
+    ``button_press_event`` in the figure canvas is being used.
 
 .. _plot.spectra:
 

--- a/doc/user_guide/visualisation.rst
+++ b/doc/user_guide/visualisation.rst
@@ -290,7 +290,7 @@ can be used as an external signal for the navigator.
 
 .. code-block:: python
 
-    >>> im = hs.load('Ni_superalloy_0*.tif', stack=True) 
+    >>> im = hs.load('Ni_superalloy_0*.tif', stack=True)
     >>> s = hs.load('Ni_superalloy_0*.rpl', stack=True).as_signal1D(0)
     >>> dim = s.axes_manager.navigation_shape
     >>> #Rebin the image
@@ -633,6 +633,14 @@ __ plot.spectra_
     other iterable type for the ``cmap`` argument together with ``'single'``
     for the ``colorbar`` argument. Such an input will cause a warning and
     instead set the ``colorbar`` argument to ``None``.
+
+.. versionadd: 1.4
+    By default or by setting the ``axes_replot`` bool argument to ``True``, adds
+    the possibility to select and re-plot and axis in ``plot_images``. This is
+    achieved by double clicking into this axis. Each click triggers a plot
+    event, in which the selected signal is presented. This helps navigating
+    through a panel with many figures by enlarging some of them and allowing
+    comfortable zooming.
 
 .. _plot.spectra:
 
@@ -1170,7 +1178,7 @@ Permanent markers are stored in the HDF5 file if the signal is saved:
 
     >>> s = hs.signals.Signal2D(np.arange(100).reshape(10, 10))
     >>> marker = hs.markers.point(2, 1, color='red')
-    >>> s.add_marker(marker, plot_marker=False, permanent=True) 
+    >>> s.add_marker(marker, plot_marker=False, permanent=True)
     >>> s.metadata.Markers
     └── point = <marker.Point, point (x=2,y=1,color=red,size=20)>
     >>> s.save("storing_marker.hdf5")

--- a/hyperspy/drawing/utils.py
+++ b/hyperspy/drawing/utils.py
@@ -1350,7 +1350,7 @@ def animate_legend(figure='last'):
 
 def replot_axes(figure='last'):
     """Select and replot an axis from a figure. The axis can be selected by
-    clicking, this triggers a replotting of the axis in a new figure.
+    double clicking, this triggers a replotting of the axis in a new figure.
 
     Parameters
     ----------
@@ -1366,11 +1366,12 @@ def replot_axes(figure='last'):
     else:
         fig = figure
 
-    def on_click(event):
+    def on_dblclick(event):
         from pickle import dump, load
         from io import BytesIO
 
         if not event.inaxes: return
+        if not event.dblclick: return
         inx = list(fig.axes).index(event.inaxes)
         buf = BytesIO()
         dump(fig, buf)
@@ -1388,7 +1389,7 @@ def replot_axes(figure='last'):
         dummy.remove()
         fig2.show()
 
-    fig.canvas.mpl_connect('button_press_event', on_click)
+    fig.canvas.mpl_connect('button_press_event', on_dblclick)
 
 def plot_histograms(signal_list,
                     bins='freedman',

--- a/hyperspy/drawing/utils.py
+++ b/hyperspy/drawing/utils.py
@@ -1034,11 +1034,17 @@ def plot_images(images,
             cm = subplots[inx].images[0].get_cmap()
             clim = subplots[inx].images[0].get_clim()
 
+            sbar = False
+            if (scalelist and inx in scalebar) or scalebar is 'all':
+                sbar = True
+
             im.plot(colorbar=bool(colorbar),
                     vmin=clim[0],
                     vmax=clim[1],
                     no_nans=no_nans,
-                    aspect=aspect,
+                    aspect=asp,
+                    scalebar=sbar,
+                    scalebar_color=scalebar_color,
                     cmap=cm)
 
         f.canvas.mpl_connect('button_press_event', on_dblclick)

--- a/hyperspy/drawing/utils.py
+++ b/hyperspy/drawing/utils.py
@@ -820,6 +820,11 @@ def plot_images(images,
 
     idx = 0
     ax_im_list = [0] * len(isrgb)
+
+    # If replot is selected create a list to store references to the images
+    if axes_replot:
+        replot_ims = []
+
     # Loop through each image, adding subplot for each one
     for i, ims in enumerate(images):
         # Get handles for the signal axes and axes_manager
@@ -966,6 +971,10 @@ def plot_images(images,
                     units=axes[0].units,
                     color=scalebar_color,
                 )
+            # Store references to the images
+            if axes_replot:
+                replot_ims.append(im)
+
             idx += 1
 
     # If using a single colorbar, add it, and do tight_layout, ensuring that
@@ -1019,17 +1028,8 @@ def plot_images(images,
             if not event.dblclick: return
             subplots = [axi for axi in f.axes if type(axi) is mpl.axes.Subplot]
             inx = list(subplots).index(event.inaxes)
-            # Loop through each image in the list, till we find the good one!
-            idx = 0
-            done = False
-            for ims in images:
-                for im in ims:
-                    if idx == inx:
-                        done = True
-                        break
-                    idx += 1
-                if done:
-                    break
+            im = replot_ims[inx]
+
             # Use some of the info in the subplot
             cm = subplots[inx].images[0].get_cmap()
             clim = subplots[inx].images[0].get_clim()

--- a/hyperspy/drawing/utils.py
+++ b/hyperspy/drawing/utils.py
@@ -415,7 +415,6 @@ def plot_images(images,
                 aspect='auto',
                 min_asp=0.1,
                 namefrac_thresh=0.4,
-                axes_replot=True,
                 fig=None,
                 vmin=None,
                 vmax=None,
@@ -524,9 +523,6 @@ def plot_images(images,
             encourage shortening of titles by auto-labeling, while larger
             values will require more overlap in titles before activing the
             auto-label code.
-        axes_replot : bool, optional
-            If True, allows to select and replot an axis from the figure. This
-            creates a new figure with only this axis. True by default.
         fig : mpl figure, optional
             If set, the images will be plotted to an existing MPL figure
         vmin, vmax : scalar or list of scalar, optional, default: None
@@ -821,9 +817,8 @@ def plot_images(images,
     idx = 0
     ax_im_list = [0] * len(isrgb)
 
-    # If replot is selected create a list to store references to the images
-    if axes_replot:
-        replot_ims = []
+    # Replot: create a list to store references to the images
+    replot_ims = []
 
     # Loop through each image, adding subplot for each one
     for i, ims in enumerate(images):
@@ -971,9 +966,8 @@ def plot_images(images,
                     units=axes[0].units,
                     color=scalebar_color,
                 )
-            # Store references to the images
-            if axes_replot:
-                replot_ims.append(im)
+            # Replot: store references to the images
+            replot_ims.append(im)
 
             idx += 1
 
@@ -1021,33 +1015,33 @@ def plot_images(images,
     if padding is not None:
         plt.subplots_adjust(**padding)
 
-    if axes_replot:
-        def on_dblclick(event):
-            # On the event of a double click, replot the selected subplot
-            if not event.inaxes: return
-            if not event.dblclick: return
-            subplots = [axi for axi in f.axes if type(axi) is mpl.axes.Subplot]
-            inx = list(subplots).index(event.inaxes)
-            im = replot_ims[inx]
+    # Replot: connect function
+    def on_dblclick(event):
+        # On the event of a double click, replot the selected subplot
+        if not event.inaxes: return
+        if not event.dblclick: return
+        subplots = [axi for axi in f.axes if type(axi) is mpl.axes.Subplot]
+        inx = list(subplots).index(event.inaxes)
+        im = replot_ims[inx]
 
-            # Use some of the info in the subplot
-            cm = subplots[inx].images[0].get_cmap()
-            clim = subplots[inx].images[0].get_clim()
+        # Use some of the info in the subplot
+        cm = subplots[inx].images[0].get_cmap()
+        clim = subplots[inx].images[0].get_clim()
 
-            sbar = False
-            if (scalelist and inx in scalebar) or scalebar is 'all':
-                sbar = True
+        sbar = False
+        if (scalelist and inx in scalebar) or scalebar is 'all':
+            sbar = True
 
-            im.plot(colorbar=bool(colorbar),
-                    vmin=clim[0],
-                    vmax=clim[1],
-                    no_nans=no_nans,
-                    aspect=asp,
-                    scalebar=sbar,
-                    scalebar_color=scalebar_color,
-                    cmap=cm)
+        im.plot(colorbar=bool(colorbar),
+                vmin=clim[0],
+                vmax=clim[1],
+                no_nans=no_nans,
+                aspect=asp,
+                scalebar=sbar,
+                scalebar_color=scalebar_color,
+                cmap=cm)
 
-        f.canvas.mpl_connect('button_press_event', on_dblclick)
+    f.canvas.mpl_connect('button_press_event', on_dblclick)
 
     return axes_list
 

--- a/hyperspy/drawing/utils.py
+++ b/hyperspy/drawing/utils.py
@@ -1038,6 +1038,7 @@ def plot_images(images,
                     vmin=clim[0],
                     vmax=clim[1],
                     no_nans=no_nans,
+                    aspect=aspect,
                     cmap=cm)
 
         f.canvas.mpl_connect('button_press_event', on_dblclick)

--- a/hyperspy/tests/drawing/test_plot_signal2d.py
+++ b/hyperspy/tests/drawing/test_plot_signal2d.py
@@ -353,7 +353,8 @@ def test_plot_images_multi_signal_w_axes_replot(mpl_cleanup):
     img_list = [imgs, imgs.inav[:2], imgs.inav[0]]
     subplots=hs.plot.plot_images(img_list, axes_replot=True)
     f = plt.gcf()
-    plt.pause(0.01) # this pause is important somehow
+    f.canvas.draw()
+    f.canvas.flush_events()
 
     tests = []
     for axi in subplots:

--- a/hyperspy/tests/drawing/test_plot_signal2d.py
+++ b/hyperspy/tests/drawing/test_plot_signal2d.py
@@ -351,7 +351,7 @@ def test_plot_images_multi_signal_w_axes_replot(mpl_cleanup):
     imdata = np.random.rand(3, 5, 5)
     imgs = hs.signals.Signal2D(imdata)
     img_list = [imgs, imgs.inav[:2], imgs.inav[0]]
-    subplots=hs.plot.plot_images(img_lists, axes_decor=None)
+    subplots=hs.plot.plot_images(img_list, axes_decor=None)
     f = plt.gcf()
     f.canvas.draw()
     f.canvas.flush_events()

--- a/hyperspy/tests/drawing/test_plot_signal2d.py
+++ b/hyperspy/tests/drawing/test_plot_signal2d.py
@@ -347,6 +347,27 @@ def test_plot_images_single_image(mpl_cleanup):
     ax = hs.plot.plot_images(image0, saturated_pixels=0.1)
     return ax[0].figure
 
+def test_plot_images_multi_signal_w_axes_replot(mpl_cleanup):
+    imdata = np.random.rand(3, 5, 5)
+    imgs = hs.signals.Signal2D(imdata)
+    img_list = [imgs, imgs.inav[:2], imgs.inav[0]]
+    subplots=hs.plot.plot_images(img_list, axes_replot=True)
+    f = plt.gcf()
+    plt.pause(0.01) # this pause is important somehow
+
+    tests = []
+    for axi in subplots:
+        imi = axi.images[0].get_array()
+        x, y = axi.transData.transform((2, 2))
+        # Calling base class method because of backends
+        plt.matplotlib.backends.backend_agg.FigureCanvasBase.button_press_event(
+                                                  f.canvas, x, y, 'left',  True)
+        fn = plt.gcf()
+        tests.append(
+            np.allclose(imi, fn.axes[0].images[0].get_array().data) )
+        plt.close(fn)
+    assert np.alltrue(tests)
+    return f
 
 @pytest.mark.parametrize("saturated_pixels", [5.0, [0.0, 20.0, 40.0],
                                               [10.0, 20.0], [10.0, None, 20.0]])

--- a/hyperspy/tests/drawing/test_plot_signal2d.py
+++ b/hyperspy/tests/drawing/test_plot_signal2d.py
@@ -351,7 +351,7 @@ def test_plot_images_multi_signal_w_axes_replot(mpl_cleanup):
     imdata = np.random.rand(3, 5, 5)
     imgs = hs.signals.Signal2D(imdata)
     img_list = [imgs, imgs.inav[:2], imgs.inav[0]]
-    subplots=hs.plot.plot_images(img_list, axes_replot=True)
+    subplots=hs.plot.plot_images(img_lists, axes_decor=None)
     f = plt.gcf()
     f.canvas.draw()
     f.canvas.flush_events()


### PR DESCRIPTION
### Description
This enhancement proposal adds the possibility to select and replot and axis in plot_images. This is done by clicking into this axis. Each click triggers a plot event, in which the selected axis alone is presented in a figure. 

This helps navigating through a panel with many figures by enlarging some of them and allowing comfortable zooming. I use this trick a lot and thought about contributing it. 

### Progress of the PR
- [x] Change implemented 
- [x] update docstring
- [x] ready for review
- [x] update user guide (if appropriate)
- [x] add tests

### Minimal example of new feature
```python
>>> import hyperspy.api as hs
>>> import numpy as np
>>> imgdata = np.random.rand(20, 512, 512)
>>> imgs = hs.signals.Signal2D(imgdata)
>>> hs.plot.plot_images(imgs, axes_decor='off', axes_replot=True)
>>> # Double click on one axis and get a new plot
```