### PR TITLE
User guide: remove (DRAFT) from the title

### DIFF
--- a/doc/user_guide/index.rst
+++ b/doc/user_guide/index.rst
@@ -3,9 +3,9 @@
    You can adapt this file completely to your liking, but it should at least
    contain the root `toctree` directive.
 
-###########################
-HyperSpy User Guide (DRAFT)
-###########################
+###################
+HyperSpy User Guide
+###################
 
 .. toctree::
     :maxdepth: 2


### PR DESCRIPTION
This pull request changes the title of the user guide from "HyperSpy User Guide (DRAFT)" to "HyperSpy User Guide".

https://github.com/hyperspy/hyperspy/issues/1956