### PR TITLE
Add support for loading specific dataset from EMD NCEM files

### DIFF
--- a/doc/user_guide/io.rst
+++ b/doc/user_guide/io.rst
@@ -722,6 +722,16 @@ used to select a specific one:
     >>> s = hs.load("adatafile.emd", dataset_name="/experimental/science_data_1")
 
 
+Or several by using a list:
+
+.. code-block:: python
+
+    >>> s = hs.load("adatafile.emd",
+    ...             dataset_name=[
+    ...                 "/experimental/science_data_1",
+    ...                 "/experimental/science_data_1"])
+
+
 EMD (FEI)
 ^^^^^^^^^
 

--- a/doc/user_guide/io.rst
+++ b/doc/user_guide/io.rst
@@ -714,6 +714,13 @@ EMD (NCEM)
 This EMD format was developed by Colin Ophus at the National Center for
 Electron Microscopy (NCEM). See http://emdatasets.com/ for more information.
 
+For files containing several datasets, the `dataset_name` argument can be
+used to select a specific one:
+
+.. code-block:: python
+
+    >>> s = hs.load("adatafile.emd", dataset_name="/experimental/science_data_1")
+
 
 EMD (FEI)
 ^^^^^^^^^

--- a/hyperspy/io.py
+++ b/hyperspy/io.py
@@ -151,7 +151,7 @@ def load(filenames=None,
     load_SI_image_stack : bool (default False)
        Load the stack of STEM images acquired simultaneously as the EDS 
        spectrum image.
-    dataset_name : string
+    dataset_name : string, optional
         For filetypes which support several datasets in the same file, this
         will only load the specified dataset. Only for EMD (NCEM) files.
 

--- a/hyperspy/io.py
+++ b/hyperspy/io.py
@@ -151,7 +151,10 @@ def load(filenames=None,
     load_SI_image_stack : bool (default False)
        Load the stack of STEM images acquired simultaneously as the EDS 
        spectrum image.
-       
+    dataset_name : string
+        For filetypes which support several datasets in the same file, this
+        will only load the specified dataset. Only for EMD (NCEM) files.
+
 
     Returns
     -------

--- a/hyperspy/io.py
+++ b/hyperspy/io.py
@@ -151,9 +151,10 @@ def load(filenames=None,
     load_SI_image_stack : bool (default False)
        Load the stack of STEM images acquired simultaneously as the EDS 
        spectrum image.
-    dataset_name : string, optional
+    dataset_name : string or list, optional
         For filetypes which support several datasets in the same file, this
-        will only load the specified dataset. Only for EMD (NCEM) files.
+        will only load the specified dataset. Several datasets can be loaded
+        by using a list of strings. Only for EMD (NCEM) files.
 
 
     Returns

--- a/hyperspy/io_plugins/emd.py
+++ b/hyperspy/io_plugins/emd.py
@@ -328,6 +328,11 @@ class EMD(object):
         False : bool, optional
             If False (default) loads data to memory. If True, enables loading
             only if requested.
+        dataset_name : string, optional
+            Only add dataset with specific name. Note, this has to be the full
+            group path in the file. For example `/experimental/science_data'.
+            If the dataset is not found, an IOError with the possible
+            datasets will be raised.
 
         Returns
         -------

--- a/hyperspy/tests/io/test_emd.py
+++ b/hyperspy/tests/io/test_emd.py
@@ -161,9 +161,19 @@ class TestDatasetName:
             assert s.metadata.General.title == dataset_name
             assert s.data.shape == data_size
 
+    def test_load_with_dataset_name_several(self):
+        dataset_name = self.dataset_name_list[0:2]
+        s = load(self.hdf5_dataset_path, dataset_name=dataset_name)
+        assert len(s) == len(dataset_name)
+        assert s[0].metadata.General.title in dataset_name
+        assert s[1].metadata.General.title in dataset_name
+
     def test_wrong_dataset_name(self):
         with pytest.raises(IOError):
             load(self.hdf5_dataset_path, dataset_name='a_wrong_name')
+        with pytest.raises(IOError):
+            load(self.hdf5_dataset_path,
+                 dataset_name=[self.dataset_name_list[0], 'a_wrong_name'])
 
 
 class TestMinimalSave():


### PR DESCRIPTION
This pull request adds the functionality to select a specific dataset when loading EMD NCEM files. #1823. (Previous pull request about this: https://github.com/hyperspy/hyperspy/pull/1824)

To generate a test file:

```python
import h5py
import numpy as np

filename = "test.emd"
f = h5py.File(filename, mode="w")
f.attrs.create('version_major', 0)
f.attrs.create('version_minor', 2)

dataset_name_list = [
        '/experimental/science_data_0',
        '/experimental/science_data_1',
        '/processed/science_data_0']
data_size_list = [(120, 120), (100, 50), (30, 60)]

for dataset_name, data_size in zip(dataset_name_list, data_size_list):
    group = f.create_group(dataset_name)
    group.attrs.create('emd_group_type', 1)
    group.create_dataset(name='data', data=np.random.random(data_size), chunks=(16, 16))
    group.create_dataset(name='dim1', data=range(data_size[0]))
    group.create_dataset(name='dim2', data=range(data_size[1]))

f.close()
```

To test this:
```python
import hyperspy.api as hs
hs.load("test.emd")
[<Signal2D, title: /experimental/science_data_0, dimensions: (|120, 120)>,
 <Signal2D, title: /experimental/science_data_1, dimensions: (|50, 100)>,
 <Signal2D, title: /processed/science_data_0, dimensions: (|60, 30)>]
hs.load("test.emd", dataset_name='/experimental/science_data_1')
<Signal2D, title: /experimental/science_data_1, dimensions: (|50, 100)>
```

- [x] Add docstring
- [x] Add text in user guide
- [x] Add tests
- [x] Ready for review