### PR TITLE
Bug-fix: plotting markers was not working for Jupyter Notebooks

### DIFF
--- a/hyperspy/signal.py
+++ b/hyperspy/signal.py
@@ -4384,8 +4384,10 @@ class BaseSignal(FancySlicing,
             self.metadata.Markers = markers_dict
         if plot_marker:
             if self._plot.signal_plot:
+                self._plot.signal_plot.ax.hspy_fig._on_blit_draw()
                 self._plot.signal_plot.ax.hspy_fig._update_animated()
             if self._plot.navigator_plot:
+                self._plot.navigator_plot.ax.hspy_fig._on_blit_draw()
                 self._plot.navigator_plot.ax.hspy_fig._update_animated()
 
     def _plot_permanent_markers(self):
@@ -4400,8 +4402,10 @@ class BaseSignal(FancySlicing,
                     self._plot.navigator_plot.add_marker(marker)
                 marker.plot(update_plot=False)
         if self._plot.signal_plot:
+            self._plot.signal_plot.ax.hspy_fig._on_blit_draw()
             self._plot.signal_plot.ax.hspy_fig._update_animated()
         if self._plot.navigator_plot:
+            self._plot.navigator_plot.ax.hspy_fig._on_blit_draw()
             self._plot.navigator_plot.ax.hspy_fig._update_animated()
 
     def add_poissonian_noise(self, keep_dtype=True):


### PR DESCRIPTION
The HyperSpy 1.3.1 release broke plotting of markers when using Jupyter Notebook + `%matplotlib nbagg`. This was due to a change in `BlittedFigure`, where `BlittedFigure._background` was set to `None`, which `matplotlib` did not like:

```python
hyperspy/hyperspy/drawing/figure.py in _update_animated(self)
     83         canvas = self.ax.figure.canvas
     84         # As the background haven't changed, we can simply restore it.
---> 85         canvas.restore_region(self._background)
     86         # Now it is when we draw the animated elements using the blit method
     87         self._draw_animated()
```

This is fixed by calling `BlittedFigure._on_blit_draw()` before calling `_update_animated()`.

To test this (in a Jupyter Notebook):
```python
%matplotlib nbagg
import numpy as np
import hyperspy.api as hs
s = hs.signals.Signal2D(np.random.random((50, 50)))
point0 = hs.markers.point(20, 20, color='red')
s.add_marker(point0)
```

For some reason this did not break the plotting when using `%matplotlib qt`, which I guess is the reason the unit tests didn't catch it... So the bigger question is how do we make sure things don't break silently in for example the notebooks? Only reason I noticed this is due to the Atomap notebooks suddenly failing: https://gitlab.com/atomap/atomap_demos/-/jobs/64306264

- [x] Bug fixed
- [x] Ready for review