### PR TITLE
Fix rebin

### DIFF
--- a/hyperspy/_signals/eds.py
+++ b/hyperspy/_signals/eds.py
@@ -188,12 +188,17 @@ class EDS_mixin:
         aimd = m.metadata.Acquisition_instrument
         if "Acquisition_instrument.SEM.Detector.EDS.real_time" in m.metadata:
             aimd.SEM.Detector.EDS.real_time *= time_factor
+        elif "Acquisition_instrument.TEM.Detector.EDS.real_time" in m.metadata:
+            aimd.TEM.Detector.EDS.real_time *= time_factor
+        else:
+            warnings.warn("real_time could not be found in the metadata and has not been updated.")
         if "Acquisition_instrument.SEM.Detector.EDS.live_time" in m.metadata:
             aimd.SEM.Detector.EDS.live_time *= time_factor
-        if "Acquisition_instrument.TEM.Detector.EDS.real_time" in m.metadata:
-            aimd.TEM.Detector.EDS.real_time *= time_factor
-        if "Acquisition_instrument.TEM.Detector.EDS.live_time" in m.metadata:
+        elif "Acquisition_instrument.TEM.Detector.EDS.live_time" in m.metadata:
             aimd.TEM.Detector.EDS.live_time *= time_factor
+        else: 
+            warnings.warn("real_time could not be found in the metadata and has not been updated.")
+
         if out is None:
             return m
         else:

--- a/hyperspy/_signals/eds.py
+++ b/hyperspy/_signals/eds.py
@@ -191,13 +191,13 @@ class EDS_mixin:
         elif "Acquisition_instrument.TEM.Detector.EDS.real_time" in m.metadata:
             aimd.TEM.Detector.EDS.real_time *= time_factor
         else:
-            warnings.warn("real_time could not be found in the metadata and has not been updated.")
+            _logger.info("real_time could not be found in the metadata and has not been updated.")
         if "Acquisition_instrument.SEM.Detector.EDS.live_time" in m.metadata:
             aimd.SEM.Detector.EDS.live_time *= time_factor
         elif "Acquisition_instrument.TEM.Detector.EDS.live_time" in m.metadata:
             aimd.TEM.Detector.EDS.live_time *= time_factor
-        else: 
-            warnings.warn("real_time could not be found in the metadata and has not been updated.")
+        else:
+            _logger.info("Live_time could not be found in the metadata and has not been updated.")
 
         if out is None:
             return m

--- a/hyperspy/_signals/eels.py
+++ b/hyperspy/_signals/eels.py
@@ -1352,10 +1352,12 @@ class EELSSpectrum_mixin:
         m.get_dimensions_from_data()
         if "Acquisition_instrument.TEM.Detector.EELS.dwell_time" in m.metadata:
             mdeels.EELS.dwell_time *= time_factor
-        if "Acquisition_instrument.TEM.Detector.EELS.exposure" in m.metadata:
+        elif "Acquisition_instrument.TEM.Detector.EELS.exposure" in m.metadata:
             mdeels.EELS.exposure *= time_factor
-        if "Acquisition_instrument.TEM.Detector.Camera.exposure" in m.metadata:
+        elif "Acquisition_instrument.TEM.Detector.Camera.exposure" in m.metadata:
             mdeels.Camera.exposure *= time_factor
+        else:
+            warnings.warn('No dwell_time could be found in the metadata so this has not been updated.') 
         if out is None:
             return m
         else:

--- a/hyperspy/_signals/eels.py
+++ b/hyperspy/_signals/eels.py
@@ -1357,7 +1357,7 @@ class EELSSpectrum_mixin:
         elif "Acquisition_instrument.TEM.Detector.Camera.exposure" in m.metadata:
             mdeels.Camera.exposure *= time_factor
         else:
-            _logger.info('No dwell_time could be found in the metadata so this has not been updated.') 
+            _logger.info('No dwell_time could be found in the metadata so this has not been updated.')
         if out is None:
             return m
         else:

--- a/hyperspy/_signals/eels.py
+++ b/hyperspy/_signals/eels.py
@@ -1348,14 +1348,20 @@ class EELSSpectrum_mixin:
         m = out or m
         time_factor = np.prod([factors[axis.index_in_array]
                                for axis in m.axes_manager.navigation_axes])
-        mdeels = m.metadata.Acquisition_instrument.TEM.Detector
+        mdeels = m.metadata
         m.get_dimensions_from_data()
-        if "Acquisition_instrument.TEM.Detector.EELS.dwell_time" in m.metadata:
-            mdeels.EELS.dwell_time *= time_factor
-        elif "Acquisition_instrument.TEM.Detector.EELS.exposure" in m.metadata:
-            mdeels.EELS.exposure *= time_factor
-        elif "Acquisition_instrument.TEM.Detector.Camera.exposure" in m.metadata:
-            mdeels.Camera.exposure *= time_factor
+        if "Acquisition_instrument" in m.metadata:
+            mdeels = m.metadat.Acquisition_instrument
+            if "Acquisition_instrument.TEM.Detector.EELS.dwell_time" in m.metadata:
+                mdeels.TEM.Detector.EELS.dwell_time *= time_factor
+            elif "Acquisition_instrument.TEM.Detector.EELS.exposure" in m.metadata:
+                mdeels.TEM.Detector.EELS.exposure *= time_factor
+            elif "Acquisition_instrument.TEM.Detector.Camera.exposure" in m.metadata:
+                mdeels.TEM.Detector.Camera.exposure *= time_factor
+        elif "dwell_time" in m.metadata:
+            m.metadata.dwell_time *= time_factor
+        elif "exposure" in m.metadata:
+            m.metadata.exposure *= time_factor
         else:
             _logger.info('No dwell_time could be found in the metadata so this has not been updated.')
         if out is None:

--- a/hyperspy/_signals/eels.py
+++ b/hyperspy/_signals/eels.py
@@ -1357,7 +1357,7 @@ class EELSSpectrum_mixin:
         elif "Acquisition_instrument.TEM.Detector.Camera.exposure" in m.metadata:
             mdeels.Camera.exposure *= time_factor
         else:
-            warnings.warn('No dwell_time could be found in the metadata so this has not been updated.') 
+            _logger.info('No dwell_time could be found in the metadata so this has not been updated.') 
         if out is None:
             return m
         else:

--- a/hyperspy/_signals/eels.py
+++ b/hyperspy/_signals/eels.py
@@ -1350,20 +1350,15 @@ class EELSSpectrum_mixin:
                                for axis in m.axes_manager.navigation_axes])
         mdeels = m.metadata
         m.get_dimensions_from_data()
-        if "Acquisition_instrument" in m.metadata:
-            mdeels = m.metadat.Acquisition_instrument
-            if "Acquisition_instrument.TEM.Detector.EELS.dwell_time" in m.metadata:
-                mdeels.TEM.Detector.EELS.dwell_time *= time_factor
-            elif "Acquisition_instrument.TEM.Detector.EELS.exposure" in m.metadata:
-                mdeels.TEM.Detector.EELS.exposure *= time_factor
-            elif "Acquisition_instrument.TEM.Detector.Camera.exposure" in m.metadata:
-                mdeels.TEM.Detector.Camera.exposure *= time_factor
-        elif "dwell_time" in m.metadata:
-            m.metadata.dwell_time *= time_factor
-        elif "exposure" in m.metadata:
-            m.metadata.exposure *= time_factor
+        if m.metadata.get_item("Acquisition_instrument.TEM.Detector.EELS"):
+            mdeels = m.metadata.Acquisition_instrument.TEM.Detector.EELS
+            if "dwell_time" in mdeels:
+                mdeels.dwell_time *= time_factor
+            if "exposure" in mdeels:
+                mdeels.exposure *= time_factor
         else:
-            _logger.info('No dwell_time could be found in the metadata so this has not been updated.')
+            _logger.info('No dwell_time could be found in the metadata so '
+                         'this has not been updated.')
         if out is None:
             return m
         else:

--- a/hyperspy/_signals/eels.py
+++ b/hyperspy/_signals/eels.py
@@ -1348,12 +1348,14 @@ class EELSSpectrum_mixin:
         m = out or m
         time_factor = np.prod([factors[axis.index_in_array]
                                for axis in m.axes_manager.navigation_axes])
-        mdeels = m.metadata.Acquisition_instrument.TEM.Detector.EELS
+        mdeels = m.metadata.Acquisition_instrument.TEM.Detector
         m.get_dimensions_from_data()
         if "Acquisition_instrument.TEM.Detector.EELS.dwell_time" in m.metadata:
-            mdeels.dwell_time *= time_factor
+            mdeels.EELS.dwell_time *= time_factor
         if "Acquisition_instrument.TEM.Detector.EELS.exposure" in m.metadata:
-            mdeels.exposure *= time_factor
+            mdeels.EELS.exposure *= time_factor
+        if "Acquisition_instrument.TEM.Detector.Camera.exposure" in m.metadata:
+            mdeels.Camera.exposure *= time_factor
         if out is None:
             return m
         else:

--- a/hyperspy/misc/array_tools.py
+++ b/hyperspy/misc/array_tools.py
@@ -308,7 +308,7 @@ def _linear_bin(dat, scale, crop=True):
         # The new dimension size is old_size/step, this is rounded down normally
         # but if crop is switched off it is rounded up to the nearest whole
         # number.
-        if not np.issubdtype(s, float):
+        if not np.issubdtype(s, np.floating):
             s = float(s)
 
         dim = (math.floor(dat.shape[0] / s) if crop

--- a/hyperspy/misc/array_tools.py
+++ b/hyperspy/misc/array_tools.py
@@ -167,9 +167,9 @@ def rebin(a, new_shape=None, scale=None, crop=True):
     if _requires_linear_rebin(arr=a, scale=scale):
         _logger.debug("Using linear_bin")
         if np.issubdtype(a.dtype, np.integer):
-            # The operations below require a float dtype with the default
-            # numpy casting rule ('same_kind')
-            a.astype("float")
+            # The _linear_bin function below requires a float dtype
+            # because of the default numpy casting rule ('same_kind').
+            a.astype("float", castin="safe", copy=False)
         return _linear_bin(a, scale, crop)
     else:
         _logger.debug("Using standard rebin with lazy support")
@@ -308,7 +308,7 @@ def _linear_bin(dat, scale, crop=True):
         # The new dimension size is old_size/step, this is rounded down normally
         # but if crop is switched off it is rounded up to the nearest whole
         # number.
-        if type(s) != float:
+        if not np.issubtype(s, float):
             s = float(s)
 
         dim = (math.floor(dat.shape[0] / s) if crop

--- a/hyperspy/misc/array_tools.py
+++ b/hyperspy/misc/array_tools.py
@@ -163,6 +163,11 @@ def rebin(a, new_shape=None, scale=None, crop=True):
     # check whether or not interpolation is needed.
     if _requires_linear_rebin(arr=a, scale=scale):
         _logger.debug("Using linear_bin")
+        print("Using linear_bin")
+        if np.issubdtype(a.dtype, np.integer):
+            # The operations below require a float dtype with the default
+            # numpy casting rule ('same_kind')
+            a.astype("float")
         return _linear_bin(a, scale, crop)
     else:
         _logger.debug("Using standard rebin with lazy support")
@@ -301,6 +306,9 @@ def _linear_bin(dat, scale, crop=True):
         # The new dimension size is old_size/step, this is rounded down normally
         # but if crop is switched off it is rounded up to the nearest whole
         # number.
+        if type(s) != 'float':
+            raise TypeError('Scale should be provided as floats values not integers.')
+
         dim = (math.floor(dat.shape[0] / s) if crop
                else math.ceil(dat.shape[0] / s))
         # check function wont bin to zero.

--- a/hyperspy/misc/array_tools.py
+++ b/hyperspy/misc/array_tools.py
@@ -169,7 +169,7 @@ def rebin(a, new_shape=None, scale=None, crop=True):
         if np.issubdtype(a.dtype, np.integer):
             # The _linear_bin function below requires a float dtype
             # because of the default numpy casting rule ('same_kind').
-            a.astype("float", casting="safe", copy=False)
+            a = a.astype("float", casting="safe", copy=False)
         return _linear_bin(a, scale, crop)
     else:
         _logger.debug("Using standard rebin with lazy support")
@@ -200,7 +200,7 @@ def rebin(a, new_shape=None, scale=None, crop=True):
             try:
                 return da.coarsen(np.sum, a, {i: int(f)
                                               for i, f in enumerate(scale)})
-            # we provide slightly better error message in hypersy context
+            # we provide slightly better error message in hyperspy context
             except ValueError:
                 raise ValueError("Rebinning does not align with data dask chunks."
                                  " Rebin fewer dimensions at a time to avoid this"
@@ -296,10 +296,6 @@ def _linear_bin(dat, scale, crop=True):
 
     if not hasattr(_linear_bin_loop, "__numba__"):
         _logger.warning("Install numba to speed up the computation of `rebin`")
-
-    all_integer = np.all([isinstance(n, numbers.Integral) for n in scale])
-    dtype = (dat.dtype if (all_integer or "complex" in dat.dtype.name)
-             else "float")
 
     for axis, s in enumerate(scale):
         # For each iteration of linear_bin the axis being interated over has to

--- a/hyperspy/misc/array_tools.py
+++ b/hyperspy/misc/array_tools.py
@@ -169,7 +169,7 @@ def rebin(a, new_shape=None, scale=None, crop=True):
         if np.issubdtype(a.dtype, np.integer):
             # The _linear_bin function below requires a float dtype
             # because of the default numpy casting rule ('same_kind').
-            a.astype("float", castin="safe", copy=False)
+            a.astype("float", casting="safe", copy=False)
         return _linear_bin(a, scale, crop)
     else:
         _logger.debug("Using standard rebin with lazy support")
@@ -320,7 +320,7 @@ def _linear_bin(dat, scale, crop=True):
             avoid this.")
         # Set up the result np.array to have a new axis[0] size for after
         # cropping.
-        result = np.zeros((dim,) + dat.shape[1:], dtype=dtype)
+        result = np.zeros((dim,) + dat.shape[1:])
         # Carry out binning over axis[0]
         _linear_bin_loop(result=result, data=dat, scale=s)
         # Swap axis[0] back to the original axis location.

--- a/hyperspy/misc/array_tools.py
+++ b/hyperspy/misc/array_tools.py
@@ -163,7 +163,6 @@ def rebin(a, new_shape=None, scale=None, crop=True):
     # check whether or not interpolation is needed.
     if _requires_linear_rebin(arr=a, scale=scale):
         _logger.debug("Using linear_bin")
-        print("Using linear_bin")
         if np.issubdtype(a.dtype, np.integer):
             # The operations below require a float dtype with the default
             # numpy casting rule ('same_kind')
@@ -306,8 +305,8 @@ def _linear_bin(dat, scale, crop=True):
         # The new dimension size is old_size/step, this is rounded down normally
         # but if crop is switched off it is rounded up to the nearest whole
         # number.
-        if type(s) != 'float':
-            raise TypeError('Scale should be provided as floats values not integers.')
+        if type(s) != float:
+            s = float(s)
 
         dim = (math.floor(dat.shape[0] / s) if crop
                else math.ceil(dat.shape[0] / s))

--- a/hyperspy/misc/array_tools.py
+++ b/hyperspy/misc/array_tools.py
@@ -143,6 +143,9 @@ def rebin(a, new_shape=None, scale=None, crop=True):
     Notes
     -----
     Fast re_bin function Adapted from scipy cookbook
+    If rebin function fails with error stating that the function is 'not binned
+    and therefore cannot be rebinned', add binned to metadata with:
+    >>> s.metadata.Signal.binned = True
 
     """
     # Series of if statements to check that only one out of new_shape or scale

--- a/hyperspy/misc/array_tools.py
+++ b/hyperspy/misc/array_tools.py
@@ -308,7 +308,7 @@ def _linear_bin(dat, scale, crop=True):
         # The new dimension size is old_size/step, this is rounded down normally
         # but if crop is switched off it is rounded up to the nearest whole
         # number.
-        if not np.issubtype(s, float):
+        if not np.issubdtype(s, float):
             s = float(s)
 
         dim = (math.floor(dat.shape[0] / s) if crop

--- a/hyperspy/signal.py
+++ b/hyperspy/signal.py
@@ -2376,7 +2376,7 @@ class BaseSignal(FancySlicing,
             s.data = data
         s.get_dimensions_from_data()
         for i, factor in enumerate(factors):
-            s.axes_manager[i].offset = (factor - 1)/2*s.axes_manager[i].scale
+            s.axes_manager[i].offset = (factor - 1)/2*s.axes_manager[i].scale + s.axes_manager[i].offset
         for axis, axis_src in zip(s.axes_manager._axes,
                                   self.axes_manager._axes):
             axis.scale = axis_src.scale * factors[axis.index_in_array]

--- a/hyperspy/signal.py
+++ b/hyperspy/signal.py
@@ -2376,7 +2376,7 @@ class BaseSignal(FancySlicing,
             s.data = data
         s.get_dimensions_from_data()
         for i, factor in enumerate(factors):
-            s.axes_manager[i].offset = (factor - 1)/2*s.axes_manager[i].scale + s.axes_manager[i].offset
+            s.axes_manager[i].offset += ((factor-1) * s.axes_manager[i].scale)/2
         for axis, axis_src in zip(s.axes_manager._axes,
                                   self.axes_manager._axes):
             axis.scale = axis_src.scale * factors[axis.index_in_array]

--- a/hyperspy/signal.py
+++ b/hyperspy/signal.py
@@ -2360,6 +2360,9 @@ class BaseSignal(FancySlicing,
         Sum =  164.0
 
         """
+        if self.metadata.Signal.binned == False:
+            raise TypeError('The signal is not binned, hence cannot be rebinned.\
+            Change using s.metadata.Signal.binned = True')
         factors = self._validate_rebin_args_and_get_factors(
             new_shape=new_shape,
             scale=scale,)
@@ -2375,6 +2378,8 @@ class BaseSignal(FancySlicing,
         else:
             s.data = data
         s.get_dimensions_from_data()
+        for i, factor in enumerate(factors):
+            s.axes_manager[i].offset = (factor - 1)/2*s.axes_manager[i].scale
         for axis, axis_src in zip(s.axes_manager._axes,
                                   self.axes_manager._axes):
             axis.scale = axis_src.scale * factors[axis.index_in_array]

--- a/hyperspy/signal.py
+++ b/hyperspy/signal.py
@@ -2360,9 +2360,6 @@ class BaseSignal(FancySlicing,
         Sum =  164.0
 
         """
-        if self.metadata.Signal.binned == False:
-            raise TypeError('The signal is not binned, hence cannot be rebinned.\
-            Change using s.metadata.Signal.binned = True')
         factors = self._validate_rebin_args_and_get_factors(
             new_shape=new_shape,
             scale=scale,)

--- a/hyperspy/tests/signal/test_eds_tem.py
+++ b/hyperspy/tests/signal/test_eds_tem.py
@@ -85,6 +85,16 @@ class Test_metadata:
         assert (old_metadata.as_dictionary() ==
                 self.signal.metadata.as_dictionary()), "Source metadata changed"
 
+    def test_offset_after_rebin(self):
+        s = self.signal
+        s.axesmanager[0].offset = 1
+        s.axesmanager[1].offset = 2
+        s.axesmanager[2].offset = 3
+        s2 = s.rebin(scale(2, 2, 1)
+        assert(s2.axesmanager[0].offset == 1.5)
+        assert(s2.axesmanager[1].offset == 2.5)
+        assert(s2.axesmanager[2].offset == s.axesmanager[2].offset)
+
     def test_add_elements(self):
         s = self.signal
         s.add_elements(['Al', 'Ni'])

--- a/hyperspy/tests/signal/test_eds_tem.py
+++ b/hyperspy/tests/signal/test_eds_tem.py
@@ -87,13 +87,13 @@ class Test_metadata:
 
     def test_offset_after_rebin(self):
         s = self.signal
-        s.axesmanager[0].offset = 1
-        s.axesmanager[1].offset = 2
-        s.axesmanager[2].offset = 3
+        s.axes_manager[0].offset = 1
+        s.axes_manager[1].offset = 2
+        s.axes_manager[2].offset = 3
         s2 = s.rebin(scale(2, 2, 1))
-        assert s2.axesmanager[0].offset == 1.5
-        assert s2.axesmanager[1].offset == 2.5
-        assert s2.axesmanager[2].offset == s.axesmanager[2].offset
+        assert s2.axes_manager[0].offset == 1.5
+        assert s2.axes_manager[1].offset == 2.5
+        assert s2.axes_manager[2].offset == s.axes_manager[2].offset
 
     def test_add_elements(self):
         s = self.signal

--- a/hyperspy/tests/signal/test_eds_tem.py
+++ b/hyperspy/tests/signal/test_eds_tem.py
@@ -90,7 +90,7 @@ class Test_metadata:
         s.axes_manager[0].offset = 1
         s.axes_manager[1].offset = 2
         s.axes_manager[2].offset = 3
-        s2 = s.rebin(scale(2, 2, 1))
+        s2 = s.rebin(scale = (2, 2, 1))
         assert s2.axes_manager[0].offset == 1.5
         assert s2.axes_manager[1].offset == 2.5
         assert s2.axes_manager[2].offset == s.axes_manager[2].offset

--- a/hyperspy/tests/signal/test_eds_tem.py
+++ b/hyperspy/tests/signal/test_eds_tem.py
@@ -90,10 +90,10 @@ class Test_metadata:
         s.axesmanager[0].offset = 1
         s.axesmanager[1].offset = 2
         s.axesmanager[2].offset = 3
-        s2 = s.rebin(scale(2, 2, 1)
+        s2 = s.rebin(scale(2, 2, 1))
         assert s2.axesmanager[0].offset == 1.5
         assert s2.axesmanager[1].offset == 2.5
-        assert s2.axesmanager[2].offset == s.axesmanager[2].offset 
+        assert s2.axesmanager[2].offset == s.axesmanager[2].offset
 
     def test_add_elements(self):
         s = self.signal

--- a/hyperspy/tests/signal/test_eds_tem.py
+++ b/hyperspy/tests/signal/test_eds_tem.py
@@ -91,9 +91,9 @@ class Test_metadata:
         s.axesmanager[1].offset = 2
         s.axesmanager[2].offset = 3
         s2 = s.rebin(scale(2, 2, 1)
-        assert(s2.axesmanager[0].offset == 1.5)
-        assert(s2.axesmanager[1].offset == 2.5)
-        assert(s2.axesmanager[2].offset == s.axesmanager[2].offset)
+        assert s2.axesmanager[0].offset == 1.5
+        assert s2.axesmanager[1].offset == 2.5
+        assert s2.axesmanager[2].offset == s.axesmanager[2].offset 
 
     def test_add_elements(self):
         s = self.signal

--- a/hyperspy/tests/signal/test_eels.py
+++ b/hyperspy/tests/signal/test_eels.py
@@ -250,7 +250,7 @@ class TestFourierRatioDeconvolution:
 class TestRebin:
     def setup_method(self, method):
         # Create an empty spectrum
-        s = EELSSpectrum(np.ones((4, 2, 1024)))
+        s = signals.EELSSpectrum(np.ones((4, 2, 1024)))
         self.signal = s
 
     def test_rebin_without_dwell_time(self):
@@ -267,10 +267,10 @@ class TestRebin:
 
     def test_offset_after_rebin(self):
         s = self.signal
-        s.axesmanager[0].offset = 1
-        s.axesmanager[1].offset = 2
-        s.axesmanager[2].offset = 3
+        s.axes_manager[0].offset = 1
+        s.axes_manager[1].offset = 2
+        s.axes_manager[2].offset = 3
         s2 = s.rebin(scale(2, 2, 1))
-        assert s2.axesmanager[0].offset == 1.5
-        assert s2.axesmanager[1].offset == 2.5
-        assert s2.axesmanager[2].offset == s.axesmanager[2].offset
+        assert s2.axes_manager[0].offset == 1.5
+        assert s2.axes_manager[1].offset == 2.5
+        assert s2.axes_manager[2].offset == s.axes_manager[2].offset

--- a/hyperspy/tests/signal/test_eels.py
+++ b/hyperspy/tests/signal/test_eels.py
@@ -262,8 +262,8 @@ class TestRebin:
         s.metadata.dwell_time = 5.3
         s.metadata.exposure = 10.2
         s2 = s.rebin(scale(2, 2, 8)
-        assert(s2.metadata.dwell_time == 5.3 * 2 * 2)
-        assert(s2.metadata.dwell_time == 10.2 * 2 * 2)
+        assert s2.metadata.dwell_time == (5.3 * 2 * 2)
+        assert s2.metadata.dwell_time == (10.2 * 2 * 2)
 
     def test_offset_after_rebin(self):
         s = self.signal
@@ -271,6 +271,6 @@ class TestRebin:
         s.axesmanager[1].offset = 2
         s.axesmanager[2].offset = 3
         s2 = s.rebin(scale(2, 2, 1)
-        assert(s2.axesmanager[0].offset == 1.5)
-        assert(s2.axesmanager[1].offset == 2.5)
-        assert(s2.axesmanager[2].offset == s.axesmanager[2].offset)
+        assert s2.axesmanager[0].offset == 1.5
+        assert s2.axesmanager[1].offset == 2.5
+        assert s2.axesmanager[2].offset == s.axesmanager[2].offset

--- a/hyperspy/tests/signal/test_eels.py
+++ b/hyperspy/tests/signal/test_eels.py
@@ -247,3 +247,30 @@ class TestFourierRatioDeconvolution:
         s_ll.axes_manager[0].offset = -50
         s.fourier_ratio_deconvolution(s_ll,
                                       extrapolate_lowloss=extrapolate_lowloss)
+class TestRebin:
+    def setup_method(self, method):
+        # Create an empty spectrum
+        s = EELSSpectrum(np.ones((4, 2, 1024)))
+        self.signal = s
+
+    def test_rebin_without_dwell_time(self):
+        s = self.signal
+        s.rebin(scale=(2,2,1))
+
+    def test_rebin_dwell_time(self):
+        s = self.signal
+        s.metadata.dwell_time = 5.3
+        s.metadata.exposure = 10.2
+        s2 = s.rebin(scale(2, 2, 8)
+        assert(s2.metadata.dwell_time == 5.3 * 2 * 2)
+        assert(s2.metadata.dwell_time == 10.2 * 2 * 2)
+
+    def test_offset_after_rebin(self):
+        s = self.signal
+        s.axesmanager[0].offset = 1
+        s.axesmanager[1].offset = 2
+        s.axesmanager[2].offset = 3
+        s2 = s.rebin(scale(2, 2, 1)
+        assert(s2.axesmanager[0].offset == 1.5)
+        assert(s2.axesmanager[1].offset == 2.5)
+        assert(s2.axesmanager[2].offset == s.axesmanager[2].offset)

--- a/hyperspy/tests/signal/test_eels.py
+++ b/hyperspy/tests/signal/test_eels.py
@@ -259,9 +259,14 @@ class TestRebin:
 
     def test_rebin_dwell_time(self):
         s = self.signal
-        s.metadata.dwell_time = 5.3
+        s.metadata.add_node("Acquisition_instrument.TEM.Detector.EELS")
+        s_mdEELS = s.metadata.Acquisition_instrument.TEM.Detector.EELS
+        s_mdEELS.dwell_time = 0.1
+        s_mdEELS.exposure = 0.5
         s2 = s.rebin(scale = (2, 2, 8))
-        assert s2.metadata.dwell_time == (5.3 * 2 * 2)
+        s2_mdEELS = s2.metadata.Acquisition_instrument.TEM.Detector.EELS
+        assert s2_mdEELS.dwell_time == (0.1 * 2 * 2)
+        assert s2_mdEELS.exposure == (0.5 * 2 * 2)
 
         def test_rebin_exposure(self):
             s = self.signal

--- a/hyperspy/tests/signal/test_eels.py
+++ b/hyperspy/tests/signal/test_eels.py
@@ -261,7 +261,7 @@ class TestRebin:
         s = self.signal
         s.metadata.dwell_time = 5.3
         s.metadata.exposure = 10.2
-        s2 = s.rebin(scale(2, 2, 8))
+        s2 = s.rebin(scale = (2, 2, 8))
         assert s2.metadata.dwell_time == (5.3 * 2 * 2)
         assert s2.metadata.dwell_time == (10.2 * 2 * 2)
 
@@ -270,7 +270,7 @@ class TestRebin:
         s.axes_manager[0].offset = 1
         s.axes_manager[1].offset = 2
         s.axes_manager[2].offset = 3
-        s2 = s.rebin(scale(2, 2, 1))
+        s2 = s.rebin(scale = (2, 2, 1))
         assert s2.axes_manager[0].offset == 1.5
         assert s2.axes_manager[1].offset == 2.5
         assert s2.axes_manager[2].offset == s.axes_manager[2].offset

--- a/hyperspy/tests/signal/test_eels.py
+++ b/hyperspy/tests/signal/test_eels.py
@@ -263,7 +263,7 @@ class TestRebin:
         s.metadata.exposure = 10.2
         s2 = s.rebin(scale = (2, 2, 8))
         assert s2.metadata.dwell_time == (5.3 * 2 * 2)
-        assert s2.metadata.dwell_time == (10.2 * 2 * 2)
+        assert s2.metadata.exposure == (10.2 * 2 * 2)
 
     def test_offset_after_rebin(self):
         s = self.signal

--- a/hyperspy/tests/signal/test_eels.py
+++ b/hyperspy/tests/signal/test_eels.py
@@ -260,10 +260,14 @@ class TestRebin:
     def test_rebin_dwell_time(self):
         s = self.signal
         s.metadata.dwell_time = 5.3
-        s.metadata.exposure = 10.2
         s2 = s.rebin(scale = (2, 2, 8))
         assert s2.metadata.dwell_time == (5.3 * 2 * 2)
-        assert s2.metadata.exposure == (10.2 * 2 * 2)
+
+        def test_rebin_exposure(self):
+            s = self.signal
+            s.metadata.exposure = 10.2
+            s2 = s.rebin(scale = (2, 2, 8))
+            assert s2.metadata.exposure == (10.2 * 2 * 2)
 
     def test_offset_after_rebin(self):
         s = self.signal

--- a/hyperspy/tests/signal/test_eels.py
+++ b/hyperspy/tests/signal/test_eels.py
@@ -261,7 +261,7 @@ class TestRebin:
         s = self.signal
         s.metadata.dwell_time = 5.3
         s.metadata.exposure = 10.2
-        s2 = s.rebin(scale(2, 2, 8)
+        s2 = s.rebin(scale(2, 2, 8))
         assert s2.metadata.dwell_time == (5.3 * 2 * 2)
         assert s2.metadata.dwell_time == (10.2 * 2 * 2)
 
@@ -270,7 +270,7 @@ class TestRebin:
         s.axesmanager[0].offset = 1
         s.axesmanager[1].offset = 2
         s.axesmanager[2].offset = 3
-        s2 = s.rebin(scale(2, 2, 1)
+        s2 = s.rebin(scale(2, 2, 1))
         assert s2.axesmanager[0].offset == 1.5
         assert s2.axesmanager[1].offset == 2.5
         assert s2.axesmanager[2].offset == s.axesmanager[2].offset

--- a/hyperspy/tests/signal/test_tools.py
+++ b/hyperspy/tests/signal/test_tools.py
@@ -336,7 +336,7 @@ class Test3D:
         assert new_s.metadata.Signal.Noise_properties.variance == 0.3
 
     def test_rebin_dtype(self):
-        s = hs.signals.Signal1D(np.arange(1000).reshape(10, 10, 10))
+        s = signals.Signal1D(np.arange(1000).reshape(10, 10, 10))
         s.change_dtype(np.uint8)
         s2 = s.rebin(scale=(3, 3, 1), crop=False)
         assert s.sum() == s2.sum()

--- a/hyperspy/tests/signal/test_tools.py
+++ b/hyperspy/tests/signal/test_tools.py
@@ -339,7 +339,7 @@ class Test3D:
         s = hs.signals.Signal1D(np.arange(1000).reshape(10, 10, 10))
         s.change_dtype(np.uint8)
         s2 = s.rebin(scale=(3, 3, 1), crop=False)
-        assert s.sum() = s2.sum()
+        assert s.sum() == s2.sum()
 
     def test_swap_axes_simple(self):
         s = self.signal

--- a/hyperspy/tests/signal/test_tools.py
+++ b/hyperspy/tests/signal/test_tools.py
@@ -252,7 +252,7 @@ class Test3D:
         self.signal.axes_manager[1].name = "y"
         self.signal.axes_manager[2].name = "E"
         self.signal.axes_manager[0].scale = 0.5
-        self.metadata.Signal.binned = True
+        self.signal.metadata.Signal.binned = True
         self.data = self.signal.data.copy()
 
     def test_indexmin(self):

--- a/hyperspy/tests/signal/test_tools.py
+++ b/hyperspy/tests/signal/test_tools.py
@@ -252,7 +252,6 @@ class Test3D:
         self.signal.axes_manager[1].name = "y"
         self.signal.axes_manager[2].name = "E"
         self.signal.axes_manager[0].scale = 0.5
-        self.signal.metadata.Signal.binned = True
         self.data = self.signal.data.copy()
 
     def test_indexmin(self):

--- a/hyperspy/tests/signal/test_tools.py
+++ b/hyperspy/tests/signal/test_tools.py
@@ -335,6 +335,12 @@ class Test3D:
         new_s = self.signal.rebin(scale=(2, 2, 1))
         assert new_s.metadata.Signal.Noise_properties.variance == 0.3
 
+    def test_rebin_dtype(self):
+        s = hs.signals.Signal1D(np.arange(1000).reshape(10, 10, 10))
+        s.change_dtype(np.uint8)
+        s2 = s.rebin(scale=(3, 3, 1), crop=False)
+        assert s.sum() = s2.sum()
+
     def test_swap_axes_simple(self):
         s = self.signal
         if s._lazy:

--- a/hyperspy/tests/signal/test_tools.py
+++ b/hyperspy/tests/signal/test_tools.py
@@ -252,6 +252,7 @@ class Test3D:
         self.signal.axes_manager[1].name = "y"
         self.signal.axes_manager[2].name = "E"
         self.signal.axes_manager[0].scale = 0.5
+        self.metadata.Signal.binned = True
         self.data = self.signal.data.copy()
 
     def test_indexmin(self):


### PR DESCRIPTION
### Description of the change
- Function now checks for dwell_time or live_time and doesn't break if not found in the metadata but does raise a warning to clarify that it has not been changed. #1957 
- Checks for dtype of array if using the linear_bin method and converts to float if found to be an integer. #1923 
- Checks dtype of scale or new_shape, if using linear_bin method and raises Error if integer. #1923 

Still needs
- [x] Update to fix checking whether or not spectrum is binned (and so can be rebinned).
- [x] Update to fix rebinned axes offsets #1846  
