### PR TITLE
User guide: fix typos and superfluous white space

### DIFF
--- a/doc/user_guide/getting_started.rst
+++ b/doc/user_guide/getting_started.rst
@@ -542,7 +542,7 @@ Messages log
 
 HyperSpy writes messages to the `Python logger
 <https://docs.python.org/3/howto/logging.html#logging-basic-tutorial>`_. The
-deafault log level is "WARNING", meaning that only warnings and more severe
+default log level is "WARNING", meaning that only warnings and more severe
 event messages will be displayed. The default can be set in the
 :ref:`preferences <configuring-hyperspy-label>`. Alternatively, it can be set
 using :py:func:`~.logger.set_log_level` e.g.:

--- a/doc/user_guide/intro.rst
+++ b/doc/user_guide/intro.rst
@@ -26,13 +26,13 @@ file formats, add graphical user interfaces, provide
 extra blind source separation algorithms etc.
 
 There are multiple HyperSpy extensions. For a list of extensions hosted
-publicacly in GitHub search for the GitHub topic `hyperspy-extension <https://github.com/topics/hyperspy-extension>`_
+publicly in GitHub search for the GitHub topic `hyperspy-extension <https://github.com/topics/hyperspy-extension>`_
 
 .. note::
     From version 2.0, HyperSpy will be split into a core package (HyperSpy)
     that will provide the common infrastructure and a number of HyperSpy
     extensions.
-     
+
 Our vision
 ----------
 

--- a/doc/user_guide/io.rst
+++ b/doc/user_guide/io.rst
@@ -293,7 +293,7 @@ NetCDF
 ------
 
 This was the default format in HyperSpy's predecessor, EELSLab, but it has been
-superseeded by :ref:`HDF5` in HyperSpy. We provide only reading capabilities
+superseded by :ref:`HDF5` in HyperSpy. We provide only reading capabilities
 but we do not support writing to this format.
 
 Note that only NetCDF files written by EELSLab are supported.
@@ -417,9 +417,9 @@ bio-scientific imaging. See `the library webpage
 
 Currently HyperSpy has limited support for reading and saving the TIFF tags.
 However, the way that HyperSpy reads and saves the scale and the units of tiff
-files is compatible with ImageJ/Fiji and Gatan Digital Micrograph softwares.
+files is compatible with ImageJ/Fiji and Gatan Digital Micrograph software.
 HyperSpy can also import the scale and the units from tiff files saved using
-FEI and Zeiss SEM softwares.
+FEI and Zeiss SEM software.
 
 .. code-block:: python
 
@@ -458,9 +458,9 @@ us aware of the problem.
 Extra loading arguments
 ^^^^^^^^^^^^^^^^^^^^^^^
 
-optimize: bool, default is True. During loading, the data is replaced by its 
-:ref:`optimized copy <signal.transpose_optimize>` to speed up operations, 
-e. g. iteration over navigation axes. The cost of this speed improvement is to 
+optimize: bool, default is True. During loading, the data is replaced by its
+:ref:`optimized copy <signal.transpose_optimize>` to speed up operations,
+e. g. iteration over navigation axes. The cost of this speed improvement is to
 double the memory requirement during data loading.
 
 .. _edax-format:
@@ -671,8 +671,8 @@ ImportRPL Digital Micrograph plugin
 -----------------------------------
 
 
-This Digital Micrograph plugin is designed to import Ripple files into Digital Micrograph. 
-It is used to ease data transit between DigitalMicrograph and HyperSpy without losing 
+This Digital Micrograph plugin is designed to import Ripple files into Digital Micrograph.
+It is used to ease data transit between DigitalMicrograph and HyperSpy without losing
 the calibration using the extra keywords that HyperSpy adds to the standard format.
 
 When executed it will ask for 2 files:
@@ -693,7 +693,7 @@ ImportRPL was written by Luiz Fernando Zagonel.
 readHyperSpyH5 MATLAB Plugin
 ----------------------------
 
-This MATLAB script is designed to import HyperSpy's saved HDF5 files (``.hspy`` extension). 
+This MATLAB script is designed to import HyperSpy's saved HDF5 files (``.hspy`` extension).
 Like the Digital Micrograph script above, it is used to easily transfer data
 from HyperSpy to MATLAB, while retaining spatial calibration information.
 

--- a/doc/user_guide/tools.rst
+++ b/doc/user_guide/tools.rst
@@ -134,7 +134,7 @@ have used a :py:class:`~._signals.signal2d.Signal2D` instead e.g.:
 Indeed, for data analysis purposes,
 one may like to operate with an image stack as if it was a set of spectra or
 viceversa. One can easily switch between these two alternative ways of
-classifiying the dimensions of a three-dimensional dataset by
+classifying the dimensions of a three-dimensional dataset by
 :ref:`transforming between BaseSignal subclasses
 <transforming.signal>`.
 
@@ -962,7 +962,7 @@ lazily:
     <LazyEDSSEMSpectrum, title: EDS SEM Spectrum, dimensions: (|512)>
 
 
-On the other hand, the following rebining operation requires interpolation and
+On the other hand, the following rebinning operation requires interpolation and
 cannot be performed lazily:
 
 .. code-block:: python

--- a/doc/user_guide/visualisation.rst
+++ b/doc/user_guide/visualisation.rst
@@ -10,7 +10,7 @@ instance, has a :py:meth:`~.signal.BaseSignal.plot` method that is powerful and
 flexible tools to visualize n-dimensional data. In this chapter, the
 visualisation of multidimensional data  is exemplified with two experimental
 datasets: an EELS spectrum image and an EDX dataset consisting of a secondary
-electron emission image stack and a 3D hyperspectrum , both simoultaneously
+electron emission image stack and a 3D hyperspectrum , both simultaneously
 acquired by recording two signals in parallel in a FIB/SEM.
 
 
@@ -150,7 +150,7 @@ arguments are supported as well:
 
 .. versionadded:: 1.1.2
 
-Same options can be passed to the navigator, albeit separatelly, by specifying
+Same options can be passed to the navigator, albeit separately, by specifying
 them as a dictionary in ``navigator_kwds`` argument when plotting:
 
 .. code-block:: python
@@ -290,7 +290,7 @@ can be used as an external signal for the navigator.
 
 .. code-block:: python
 
-    >>> im = hs.load('Ni_superalloy_0*.tif', stack=True) 
+    >>> im = hs.load('Ni_superalloy_0*.tif', stack=True)
     >>> s = hs.load('Ni_superalloy_0*.rpl', stack=True).as_signal1D(0)
     >>> dim = s.axes_manager.navigation_shape
     >>> #Rebin the image
@@ -875,7 +875,7 @@ Markers
 
 .. versionadded:: 0.8
 
-Hyperspy provides an easy access to the main marker of matplotlib. The markers
+HyperSpy provides an easy access to the main marker of matplotlib. The markers
 can be used in a static way
 
 .. code-block:: python
@@ -1087,7 +1087,7 @@ Permanent markers are stored in the HDF5 file if the signal is saved:
 
     >>> s = hs.signals.Signal2D(np.arange(100).reshape(10, 10))
     >>> marker = hs.markers.point(2, 1, color='red')
-    >>> s.add_marker(marker, plot_marker=False, permanent=True) 
+    >>> s.add_marker(marker, plot_marker=False, permanent=True)
     >>> s.metadata.Markers
     └── point = <marker.Point, point (x=2,y=1,color=red,size=20)>
     >>> s.save("storing_marker.hdf5")


### PR DESCRIPTION
This pull request fixes various typos and remove some superfluous white space in the user guide.