### PR TITLE
ADD note to UG, for users that cannot install dependencies from source

### DIFF
--- a/doc/user_guide/install.rst
+++ b/doc/user_guide/install.rst
@@ -31,7 +31,7 @@ Bundle. This is a customised `WinPython <http://winpython.github.io/>`_
 distribution that includes HyperSpy, all its dependencies and many other
 scientific Python packages.
 
-For details and download links go to https://github.com/hyperspy/hyperspy-bundle 
+For details and download links go to https://github.com/hyperspy/hyperspy-bundle
 
 .. _quick-anaconda-install:
 
@@ -256,6 +256,13 @@ HyperSpy using ``pip`` (see :ref:`install-with-python-installers`), if HyperSpy
 is going to be installed from  source, Cython is also required. Also, to
 compile the documentation sphinxcontrib-napoleon and sphinx_rtd_theme are
 required.
+
+In case some of the required libraries are not automatically installed when
+installing from source in a conda environment, these can be obtained beforehand.
+
+.. code-block:: bash
+    $ conda install hyperspy --only-deps -c conda-forge
+    $ sudo pip install -e ./
 
 .. _known-issues:
 

--- a/doc/user_guide/install.rst
+++ b/doc/user_guide/install.rst
@@ -258,10 +258,12 @@ compile the documentation sphinxcontrib-napoleon and sphinx_rtd_theme are
 required.
 
 In case some of the required libraries are not automatically installed when
-installing from source in a conda environment, these can be obtained beforehand.
+installing from source in a conda environment, these can be obtained beforehand
+by installing and removing hyperspy from that environment;
 
 .. code-block:: bash
-    $ conda install hyperspy --only-deps -c conda-forge
+    $ conda install hyperspy
+    $ conda remove hyperspy
     $ sudo pip install -e ./
 
 .. _known-issues:


### PR DESCRIPTION
### Description of the change
Fixes #1950 by adding a note to the UG for users that install from source but are not able to get the required libraries installed. For this reason I have added the note to the "Installing the required libraries" section.

### Progress of the PR
- [x] update user guide
- [x] ready for review.