### PR TITLE
Bug kramerskronig single spectrum

### DIFF
--- a/hyperspy/_signals/dielectric_function.py
+++ b/hyperspy/_signals/dielectric_function.py
@@ -122,6 +122,7 @@ class DielectricFunction_mixin:
         data = ((-1 / self.data).imag * eels_constant(self, zlp, t).data *
                 self.axes_manager.signal_axes[0].scale)
         s = self._deepcopy_with_new_data(data)
+        s.data = s.data.real
         s.set_signal_type("EELS")
         s.metadata.General.title = ("EELS calculated from " +
                                     self.metadata.General.title)

--- a/hyperspy/_signals/eels.py
+++ b/hyperspy/_signals/eels.py
@@ -1288,19 +1288,13 @@ class EELSSpectrum_mixin:
         if 'thickness' in output:
             # As above,prevent errors if the signal is a single spectrum
             if len(te) != 1:
-                thickness = eps._get_navigation_signal(
-                    data=te[self.axes_manager._get_data_slice(
-                        [(axis.index_in_array, 0)])])
-                thickness.metadata.General.title = (
-                    self.metadata.General.title + ' thickness '
-                    '(calculated using Kramers-Kronig analysis)')
-                output['thickness'] = thickness
-            else:
-                thickness = eps._get_navigation_signal(data=te)
-                thickness.metadata.General.title = (
-                    self.metadata.General.title + ' thickness '
-                    '(calculated using Kramers-Kronig analysis)')
-                output['thickness'] = thickness
+                te = te[self.axes_manager._get_data_slice(
+                        [(axis.index_in_array, 0)])]
+            thickness = eps._get_navigation_signal(data=te)
+            thickness.metadata.General.title = (
+                self.metadata.General.title + ' thickness '
+                '(calculated using Kramers-Kronig analysis)')
+            output['thickness'] = thickness
         if full_output is False:
             return eps
         else:

--- a/hyperspy/_signals/eels.py
+++ b/hyperspy/_signals/eels.py
@@ -1295,6 +1295,12 @@ class EELSSpectrum_mixin:
                     self.metadata.General.title + ' thickness '
                     '(calculated using Kramers-Kronig analysis)')
                 output['thickness'] = thickness
+            else:
+                thickness = eps._get_navigation_signal(data=te)
+                thickness.metadata.General.title = (
+                    self.metadata.General.title + ' thickness '
+                    '(calculated using Kramers-Kronig analysis)')
+                output['thickness'] = thickness
         if full_output is False:
             return eps
         else:

--- a/hyperspy/_signals/eels.py
+++ b/hyperspy/_signals/eels.py
@@ -1204,9 +1204,11 @@ class EELSSpectrum_mixin:
                                  "thickness information, not both")
             elif n is not None:
                 # normalize using the refractive index.
-                K = (Im / eaxis).sum(axis=axis.index_in_array) * axis.scale
-                K = (K / (np.pi / 2) / (1 - 1. / n ** 2)).reshape(
-                    np.insert(K.shape, axis.index_in_array, 1))
+                K = (Im / eaxis).sum(axis=axis.index_in_array, keepdims=True) \
+                    * axis.scale
+                K = (K / (np.pi / 2) / (1 - 1. / n ** 2))
+                #K = (K / (np.pi / 2) / (1 - 1. / n ** 2)).reshape(
+                #    np.insert(K.shape, axis.index_in_array, 1))
                 # Calculate the thickness only if possible and required
                 if zlp is not None and (full_output is True or
                                         iterations > 1):
@@ -1284,13 +1286,15 @@ class EELSSpectrum_mixin:
                 self.tmp_parameters.filename +
                 '_CDF_after_Kramers_Kronig_transform')
         if 'thickness' in output:
-            thickness = eps._get_navigation_signal(
-                data=te[self.axes_manager._get_data_slice(
-                    [(axis.index_in_array, 0)])])
-            thickness.metadata.General.title = (
-                self.metadata.General.title + ' thickness '
-                '(calculated using Kramers-Kronig analysis)')
-            output['thickness'] = thickness
+            # As above,prevent errors if the signal is a single spectrum
+            if len(te) != 1:
+                thickness = eps._get_navigation_signal(
+                    data=te[self.axes_manager._get_data_slice(
+                        [(axis.index_in_array, 0)])])
+                thickness.metadata.General.title = (
+                    self.metadata.General.title + ' thickness '
+                    '(calculated using Kramers-Kronig analysis)')
+                output['thickness'] = thickness
         if full_output is False:
             return eps
         else:

--- a/hyperspy/misc/eels/tools.py
+++ b/hyperspy/misc/eels/tools.py
@@ -273,18 +273,20 @@ def eels_constant(s, zlp, t):
             if zlp.axes_manager.signal_dimension == 0:
                 i0 = zlp.data
             else:
-                i0 = zlp.data.sum(axis.index_in_array)
+                i0 = zlp.integrate1D(axis.index_in_axes_manager).data
         else:
             raise ValueError('The ZLP signal dimensions are not '
                              'compatible with the dimensions of the '
                              'low-loss signal')
-        i0 = i0.reshape(
-            np.insert(i0.shape, axis.index_in_array, 1))
+        # The following prevents errors if the signal is a single spectrum
+        if len(i0) != 1:
+            i0 = i0.reshape(
+                np.insert(i0.shape, axis.index_in_array, 1))
     elif isinstance(zlp, numbers.Number):
         i0 = zlp
     else:
-        raise ValueError('The zero-loss peak input must be a Hyperspy signal\
-                         or a number.')
+        raise ValueError('The zero-loss peak input is not valid, it must be\
+                         in the BaseSignal class or a Number.')
 
     if isinstance(t, hyperspy.signal.BaseSignal):
         if (t.axes_manager.navigation_dimension ==

--- a/hyperspy/tests/signal/test_kramers_kronig_transform.py
+++ b/hyperspy/tests/signal/test_kramers_kronig_transform.py
@@ -142,3 +142,11 @@ class Test2D:
             self.s.kramers_kronig_analysis(zlp=self.zlp,
                                            iterations=1,
                                            t=self.thickness.data)
+
+    def test_single_spectrum_dielectric(self):
+        s_in = self.s.inav[0,0]
+        z = self.zlp.inav[0,0]
+        t = self.thickness.data[0,0]
+        cdf = s_in.kramers_kronig_analysis(zlp=z, iterations=1, n=1000.)
+        s_out = cdf.get_electron_energy_loss_spectrum(z, t)
+        assert np.allclose(s_out.data, s_in.data[1:], rtol=0.01)


### PR DESCRIPTION
### Description 
Kramers Kronig analysis (KKA) with a single spectrum seems to be broken (see MEW below). I have looked into the issue, and it seems it is due to a couple of matrices (K and te) being cast to numbers in case single spectrum KKA was performed. I propose some small changes to fix this bug, by preserving the array nature of K and te.

### Progress of the PR
- [x] Change implemented.
- [x] add tests,
- [x] ready for review.

### Minimal example of the bug
```python
>>> Ne = 512
>>> Eax = {'size':Ne, 'name':'E', 'units':'eV', 'scale':0.05}
>>> axl = [Eax,]
>>> s = hs.signals.EELSSpectrum(np.random.rand(Ne), axis=axl)
>>> z = hs.signals.EELSSpectrum(np.random.rand(Ne), axis=axl)
>>> s.set_microscope_parameters(10., 10., 10.)
>>> cdf, out = s.kramers_kronig_analysis(z, 1, n=1.,full_output=True)

/home/aeljarrat/hyperspy/hyperspy/_signals/eels.py:1208: RuntimeWarning: divide by zero encountered in double_scalars
  K = (K / (np.pi / 2) / (1 - 1. / n ** 2)).reshape(

---------------------------------------------------------------------------
TypeError                                 Traceback (most recent call last)
<ipython-input-4-41bd1f068e33> in <module>()
      6 s.set_microscope_parameters(10., 10., 10.)
      7 
----> 8 cdf, out = s.kramers_kronig_analysis(z, 1, n=1.,full_output=True)

~/hyperspy/hyperspy/_signals/eels.py in kramers_kronig_analysis(self, zlp, iterations, n, t, delta, full_output)
   1207                 K = (Im / eaxis).sum(axis=axis.index_in_array) * axis.scale
   1208                 K = (K / (np.pi / 2) / (1 - 1. / n ** 2)).reshape(
-> 1209                     np.insert(K.shape, axis.index_in_array, 1))
   1210                 # Calculate the thickness only if possible and required
   1211                 if zlp is not None and (full_output is True or

TypeError: 'numpy.float64' object cannot be interpreted as an integer

```