### PR TITLE
BUGFIX reversed line order in animated legend in plot_spectra

### DIFF
--- a/hyperspy/drawing/utils.py
+++ b/hyperspy/drawing/utils.py
@@ -1317,7 +1317,7 @@ def animate_legend(figure='last'):
         ax = plt.gca()
     else:
         ax = figure.axes[0]
-    lines = ax.lines
+    lines = ax.lines[::-1]
     lined = dict()
     leg = ax.get_legend()
     for legline, origline in zip(leg.get_lines(), lines):

--- a/hyperspy/tests/drawing/test_plot_signal1d.py
+++ b/hyperspy/tests/drawing/test_plot_signal1d.py
@@ -15,6 +15,7 @@
 # You should have received a copy of the GNU General Public License
 # along with  HyperSpy.  If not, see <http://www.gnu.org/licenses/>.
 
+import numpy as np
 import scipy.misc
 import pytest
 import matplotlib.pyplot as plt
@@ -116,6 +117,25 @@ class TestPlotSpectra():
             return s2._plot.navigator_plot.figure
         if figure == '2sig':
             return s2._plot.navigator_plot.figure
+
+    def test_plot_spectra_legend_pick(self, mpl_cleanup):
+        x = np.linspace(0., 2., 512)
+        n = np.arange(1, 5)
+        x_pow_n = x[None,:]**n[:,None]
+        s = hs.signals.Signal1D(x_pow_n)
+        my_legend = [r'x^'+str(io) for io in n]
+        f = plt.figure()
+        ax = hs.plot.plot_spectra(s, legend=my_legend, fig=f)
+        leg = ax.get_legend()
+        leg_artists = leg.get_lines()
+        click = plt.matplotlib.backend_bases.MouseEvent(
+                                   'button_press_event',f.canvas,0,0,'left')
+        for artist, li in zip(leg_artists, ax.lines[::-1]):
+            plt.matplotlib.backends.backend_agg.FigureCanvasBase.pick_event(
+                                                    f.canvas, click, artist)
+            assert not li.get_visible()
+            plt.matplotlib.backends.backend_agg.FigureCanvasBase.pick_event(
+                                                    f.canvas, click, artist)
 
 
 @update_close_figure

--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,7 @@ setup_path = os.path.dirname(__file__)
 import hyperspy.Release as Release
 
 install_req = ['scipy>=0.15',
-               'matplotlib>=1.2, !=2.1.0, !=2.1.1',
+               'matplotlib>=2.0.0, !=2.1.0, !=2.1.1',
                'numpy>=1.10, !=1.13.0',
                'traits>=4.5.0',
                'natsort',


### PR DESCRIPTION
### Description of the change
When using `hs.plot.plot_spectra` the animated legend would not work properly. Although the legend lines correspond to the plot data, when clicked, the wrong lines would disappear. This minimalist PR fixes this issue. Indeed, I have only tried this in my system, using qt and nbagg backends. Is it possible this bug only appears for me?

### Progress of the PR
- [x] Change implemented 
- [x] add tests,
- [x] ready for review.

### Minimal example of the bug fix or the new feature
```python
>>> x = np.linspace(0., 2., 512)
>>> n = np.arange(1, 5)
>>> x_pow_n = x[None,:]**n[:,None]
>>> s = hs.signals.Signal1D(x_pow_n)
>>> my_legend = [r'x^'+str(io) for io in n]
>>> hs.plot.plot_spectra(s, legend=my_legend)
### wrong line dissapears when clicking the legend
```

