### PR TITLE
Change logger level from "warning" to "info" when data are made contiguous

### DIFF
--- a/hyperspy/_signals/lazy.py
+++ b/hyperspy/_signals/lazy.py
@@ -280,7 +280,7 @@ class LazySignal(BaseSignal):
     def __array__(self, dtype=None):
         return self.data.__array__(dtype=dtype)
 
-    def _make_sure_data_is_contiguous(self, log=None):
+    def _make_sure_data_is_contiguous(self):
         self._make_lazy(rechunk=True)
 
     def diff(self, axis, order=1, out=None):

--- a/hyperspy/signal.py
+++ b/hyperspy/signal.py
@@ -2692,13 +2692,11 @@ class BaseSignal(FancySlicing,
                 if isinstance(variance, BaseSignal):
                     variance.fold()
 
-    def _make_sure_data_is_contiguous(self, log=None):
+    def _make_sure_data_is_contiguous(self):
         if self.data.flags['C_CONTIGUOUS'] is False:
-            if log:
-                _logger.warning("{0!r} data is replaced by its optimized copy "
-                                ", see optimize parameter of "
-                                "``Basesignal.transpose`` for more "
-                                "information.".format(self))
+            _logger.info("{0!r} data is replaced by its optimized copy, see "
+                         "optimize parameter of ``Basesignal.transpose`` "
+                         "for more information.".format(self))
             self.data = np.ascontiguousarray(self.data)
 
     def _iterate_signal(self):
@@ -4648,7 +4646,7 @@ class BaseSignal(FancySlicing,
                                     optimize=optimize)
                 res.metadata.set_item('Signal.Noise_properties.variance', var)
         if optimize:
-            res._make_sure_data_is_contiguous(log=True)
+            res._make_sure_data_is_contiguous()
         if res.metadata.has_item('Markers'):
             # The markers might fail if the navigation dimensions are changed
             # so the safest is simply to not carry them over from the


### PR DESCRIPTION
Change the logger level to avoid getting a warning when loading DM files, which can confuse users. I suggest to try to get in the 1.3.2 release if this is fine as it is, if not we can leave it for latter. I submit it now, because I keep forgetting making this PR and I just came across it while reviewing #1995.