### PR TITLE
Fix lazy FEI EMD SI

### DIFF
--- a/hyperspy/misc/io/fei_stream_readers.py
+++ b/hyperspy/misc/io/fei_stream_readers.py
@@ -1,4 +1,5 @@
 import numpy as np
+import dask.array as da
 
 from hyperspy.decorators import jit_ifnumba
 
@@ -202,7 +203,9 @@ def stream_to_sparse_COO_array(
             first_frame=first_frame,
             last_frame=last_frame,
         )
-    return DenseSliceCOO(coords=coords, data=data, shape=shape)
+    dense_sparse = DenseSliceCOO(coords=coords, data=data, shape=shape)
+    dask_sparse = da.from_array(dense_sparse, chunks="auto")
+    return dask_sparse
 
 
 @jit_ifnumba()


### PR DESCRIPTION
Partially fixes hyperspy/rosettasciio#18 in the sense that there may be no need to implement the feature lazily after all.

The Signal class was actually loading the data to memory because it didn't know how to deal with the sparse array. This commits wraps the sparse array in a dask array before it gets into the Signal constructor.

