### PR TITLE
Update warning for decomposition of non-float types

### DIFF
--- a/hyperspy/learn/mva.py
+++ b/hyperspy/learn/mva.py
@@ -162,14 +162,13 @@ class MVA():
         to_return = None
         # Check if it is the wrong data type
         if self.data.dtype.char not in ['e', 'f', 'd']:  # If not float
-            _logger.error(
+            raise TypeError(
                 'To perform a decomposition the data must be of the float '
-                'type, but the current type is {}. '
+                'type, but the current type is \'{}\'. '
                 'To fix this issue, you can change the type using the '
                 'change_dtype method (e.g. s.change_dtype(\'float64\')) '
                 'and then repeat the decomposition.\n'
-                'No decomposition was performed and the data was not '
-                'changed.'.format(self.data.dtype))
+                'No decomposition was performed.'.format(self.data.dtype))
             return
 
         if self.axes_manager.navigation_size < 2:

--- a/hyperspy/learn/mva.py
+++ b/hyperspy/learn/mva.py
@@ -162,11 +162,14 @@ class MVA():
         to_return = None
         # Check if it is the wrong data type
         if self.data.dtype.char not in ['e', 'f', 'd']:  # If not float
-            _logger.warning(
+            _logger.error(
                 'To perform a decomposition the data must be of the float '
-                'type. You can change the type using the change_dtype method'
-                ' e.g. s.change_dtype(\'float64\')\n'
-                'Nothing done.')
+                'type, but the current type is {}. '
+                'To fix this issue, you can change the type using the '
+                'change_dtype method (e.g. s.change_dtype(\'float64\')) '
+                'and then repeat the decomposition.\n'
+                'No decomposition was performed and the data was not '
+                'changed.'.format(self.data.dtype))
             return
 
         if self.axes_manager.navigation_size < 2:

--- a/hyperspy/tests/mva/test_decomposition.py
+++ b/hyperspy/tests/mva/test_decomposition.py
@@ -276,3 +276,17 @@ class TestReturnInfo:
                 algorithm=algorithm,
                 return_info=False,
                 output_dimension=1) is None
+
+
+class TestNonFloatTypeError:
+
+    def setup_method(self, method):
+        self.s_int = signals.Signal1D(
+            (np.random.random((20, 100)) * 20).astype('int'))
+        self.s_float= signals.Signal1D(np.random.random((20, 100)))
+
+    def test_decomposition_error(self):
+        self.s_float.decomposition()
+        with pytest.raises(TypeError):
+            self.s_int.decomposition()
+


### PR DESCRIPTION
Per [discussion](https://gitter.im/hyperspy/hyperspy?at=5b48cba9c2d95c60f4d7777a) on gitter chat... change the warning for decomposition to a logger error, since in this situation HyperSpy does something different than what the user expects.