### PR TITLE
Fix lazy fei edx memory issue

### DIFF
--- a/doc/user_guide/io.rst
+++ b/doc/user_guide/io.rst
@@ -776,9 +776,13 @@ Note also that loading a spectrum image can be slow if `numba
 
 .. note::
 
-    To enable lazy loading of spectrum images in this format it may be
+    To enable lazy loading of EDX spectrum images in this format it may be
     necessary to install `sparse <http://sparse.pydata.org/en/latest/>`_. See
-    See also :ref:`install-with-python-installers`.
+    See also :ref:`install-with-python-installers`. Note also that currently
+    only lazy uncompression rather than lazy loading is implemented. This
+    means that it is not currently possible to read EDX SI FEI EMD files with
+    size bigger than the available memory.
+
 
 
 .. warning::

--- a/hyperspy/misc/io/fei_stream_readers.py
+++ b/hyperspy/misc/io/fei_stream_readers.py
@@ -83,7 +83,8 @@ def _stream_to_sparse_COO_array_sum_frames(
             navigation_index += 1
             data = 0
 
-    # Store data  at the end if any (there is no final 65535 to mark the end of the stream)
+    # Store data  at the end if any (there is no final 65535 to mark the end
+    # of the stream)
     if data:  # Only store coordinates if the spectrum was not empty
         coords_list.append((
             int(navigation_index // xsize),
@@ -161,7 +162,8 @@ def _stream_to_sparse_COO_array(
             navigation_index += 1
             data = 0
 
-    # Store data at the end if any (there is no final 65535 to mark the end of the stream)
+    # Store data at the end if any (there is no final 65535 to mark the end of
+    # the stream)
     if data:  # Only store coordinates if the spectrum was not empty
         coords.append((
             frame_number - first_frame,

--- a/hyperspy/misc/io/fei_stream_readers.py
+++ b/hyperspy/misc/io/fei_stream_readers.py
@@ -83,6 +83,15 @@ def _stream_to_sparse_COO_array_sum_frames(
             navigation_index += 1
             data = 0
 
+    # Store data  at the end if any (there is no final 65535 to mark the end of the stream)
+    if data:  # Only store coordinates if the spectrum was not empty
+        coords_list.append((
+            int(navigation_index // xsize),
+            int(navigation_index % xsize),
+            int(count_channel // rebin_energy))
+        )
+        data_list.append(data)
+
     final_shape = (ysize, xsize, channels // rebin_energy)
     coords = np.array(coords_list).T
     data = np.array(data_list)
@@ -152,6 +161,16 @@ def _stream_to_sparse_COO_array(
             navigation_index += 1
             data = 0
 
+    # Store data at the end if any (there is no final 65535 to mark the end of the stream)
+    if data:  # Only store coordinates if the spectrum was not empty
+        coords.append((
+            frame_number - first_frame,
+            int(navigation_index // xsize),
+            int(navigation_index % xsize),
+            int(count_channel // rebin_energy))
+        )
+        data_list.append(data)
+
     final_shape = (last_frame - first_frame, ysize, xsize,
                    channels // rebin_energy)
     coords = np.array(coords).T
@@ -182,9 +201,6 @@ def stream_to_sparse_COO_array(
             "The python-sparse package is not installed and it is required "
             "for lazy loading of SIs stored in FEI EMD stream format."
         )
-    # The stream format does not add a final mark. We add to simplify the
-    # reading code in this case
-    stream_data = np.hstack((stream_data, 65535))
     if sum_frames:
         coords, data, shape = _stream_to_sparse_COO_array_sum_frames(
             stream_data=stream_data,


### PR DESCRIPTION
The lazy code for reading FEI EMD SIs was taking 2x the memory required. This fixes it and improves the UG lazy FEI EMD SI note.