### PR TITLE
Friendler testing guide to new users

### DIFF
--- a/doc/dev_guide.rst
+++ b/doc/dev_guide.rst
@@ -164,18 +164,26 @@ outputs when coding. Writing tests can seem laborious but you'll probably
 soon find that they're very important as they force you to sanity check all
 you do.
 
-HyperSpy uses the `py.test <http://doc.pytest.org/>`_ library for testing. The
-tests reside in the ``hyperspy.tests`` module. To run them:
+HyperSpy uses the `pytest <http://doc.pytest.org/>`_ library for testing. The
+tests reside in the ``hyperspy.tests`` module. 
+
+First ensure pytest and its plugins are installed:
 
 .. code:: bash
 
-   py.test --pyargs hyperspy
+   conda install pytest pytest-mpl freetype 
+
+To run them:
+
+.. code:: bash
+
+   pytest --pyargs hyperspy
 
 Or, from HyperSpy's project folder simply:
 
 .. code:: bash
 
-   py.test
+   pytest
 
 
 Useful hints on testing:
@@ -207,7 +215,7 @@ Useful hints on testing:
   PR page. This service can help you to find how well your code is being tested
   and exactly which part is not currently tested.
 * `pytest-sugar <https://pypi.python.org/pypi/pytest-sugar>`_ can be installed
-  to have a nicer look and feel of py.test in the console (encoding issue have
+  to have a nicer look and feel of pytest in the console (encoding issue have
   been reported in the Windows console).
 
 
@@ -234,7 +242,7 @@ If you need to add or change some plots, follow the workflow below:
     1. Write the tests using appropriate decorator such as
        ``@pytest.mark.mpl_image_compare``.
     2. If you need to generate new reference image in the folder
-       ``plot_test_dir``, for example, run: ``py.test
+       ``plot_test_dir``, for example, run: ``pytest
        --mpl-generate-path=plot_test_dir``
     3. Run again the tests and this time they should pass.
     4. Use ``git add`` to put the new file in the git repository.
@@ -259,7 +267,21 @@ variable and set accordingly the backend.
 
 See `pytest-mpl <https://pypi.python.org/pypi/pytest-mpl>`_ for more details.
 
+Exporting pytest results as HTML
+^^^^^^^^^^^^
+With ``pytest-html`` it is possible to export the results of running pytest 
+for easier viewing. I can be installed by conda:
 
+.. code:: bash
+
+   conda install pytest-html
+   
+and run by:
+
+.. code:: bash
+
+   pytest --mpl --html=report.html
+   
 Write documentation
 ^^^^^^^^^^^^^^^^^^^
 

--- a/doc/dev_guide.rst
+++ b/doc/dev_guide.rst
@@ -167,10 +167,13 @@ you do.
 HyperSpy uses the `pytest <http://doc.pytest.org/>`_ library for testing. The
 tests reside in the ``hyperspy.tests`` module. 
 
-First ensure pytest and its plugins are installed:
+First ensure pytest and its plugins are installed by:
 
 .. code:: bash
-
+   
+   # Either
+   pip install hyperspy[test]
+   # Or
    conda install pytest pytest-mpl freetype 
 
 To run them:

--- a/doc/dev_guide.rst
+++ b/doc/dev_guide.rst
@@ -176,7 +176,7 @@ First ensure pytest and its plugins are installed by:
    # Or, from a hyperspy local development directory
    pip install -e .[test]
    # Or just installing the dependencies using conda
-   conda install pytest pytest-mpl freetype
+   conda install -c conda-forge pytest pytest-mpl
 
 To run them:
 

--- a/doc/dev_guide.rst
+++ b/doc/dev_guide.rst
@@ -182,7 +182,7 @@ To run them:
 
 .. code:: bash
 
-   pytest --pyargs hyperspy
+   pytest --mpl --pyargs hyperspy
 
 Or, from HyperSpy's project folder simply:
 

--- a/doc/dev_guide.rst
+++ b/doc/dev_guide.rst
@@ -171,10 +171,12 @@ First ensure pytest and its plugins are installed by:
 
 .. code:: bash
    
-   # Either
+   # If using a standard hyperspy install
    pip install hyperspy[test]
-   # Or
-   conda install pytest pytest-mpl freetype 
+   # Or, from a hyperspy local development directory
+   pip install -e .[test]
+   # Or just installing the dependencies using conda
+   conda install pytest pytest-mpl 
 
 To run them:
 

--- a/doc/dev_guide.rst
+++ b/doc/dev_guide.rst
@@ -176,7 +176,7 @@ First ensure pytest and its plugins are installed by:
    # Or, from a hyperspy local development directory
    pip install -e .[test]
    # Or just installing the dependencies using conda
-   conda install pytest pytest-mpl 
+   conda install pytest pytest-mpl freetype
 
 To run them:
 


### PR DESCRIPTION
- Replaced py.test with pytest, as the website only uses the latter nowadays (and I was confused initially a to whether the hs docs were speaking about one or two different packages)
- Added install commands for pytest and pytest-mpl (the latter of which pytest will fail without). 
- Also added a reference to pytest-html for easier reading of the test results.