### PR TITLE
Fix coveralls badge pointer to the wrong branch.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -8,8 +8,8 @@
 .. |AppVeyor| image:: https://ci.appveyor.com/api/projects/status/github/hyperspy/hyperspy?svg=true&branch=RELEASE_next_minor
 .. _AppVeyor: https://ci.appveyor.com/project/hyperspy/hyperspy/branch/RELEASE_next_minor
 
-.. |Coveralls| image:: https://coveralls.io/repos/hyperspy/hyperspy/badge.svg
-.. _Coveralls: https://coveralls.io/r/hyperspy/hyperspy
+.. |Coveralls| image:: https://coveralls.io/repos/github/hyperspy/hyperspy/badge.svg?branch=RELEASE_next_minor
+.. _Coveralls: https://coveralls.io/github/hyperspy/hyperspy?branch=RELEASE_next_minor
 
 .. |pypi_version| image:: http://img.shields.io/pypi/v/hyperspy.svg?style=flat
 .. _pypi_version: https://pypi.python.org/pypi/hyperspy


### PR DESCRIPTION
The coveralls badge is pointing to the wrong branch -the master branch which doesn't exist anymore. The proper fix would change the default branch in coveralls, but it seems that there are issues with doing that.
See https://github.com/lemurheavy/coveralls-public/issues/862 and https://github.com/lemurheavy/coveralls-public/issues/36.

### Progress of the PR
- [x] Update coveralls badge, now pointing to RELEASE_next_minor,
- [x] ready for review.
