### PR TITLE
Add add_powerlaw argument to get_core_loss_eels_signal/model

### DIFF
--- a/hyperspy/datasets/artificial_data.py
+++ b/hyperspy/datasets/artificial_data.py
@@ -49,6 +49,9 @@ def get_core_loss_eels_signal(add_powerlaw=False):
 
     Similar to a Mn-L32 edge from a perovskite oxide.
 
+    Some random noise is also added to the spectrum, to simulate
+    experimental noise.
+
     Parameters
     ----------
     add_powerlaw : bool
@@ -69,6 +72,16 @@ def get_core_loss_eels_signal(add_powerlaw=False):
 
     >>> s = ad.get_core_loss_eels_signal(add_powerlaw=True)
     >>> s.plot()
+
+    To make the noise the same for multiple spectra, which can
+    be useful for testing fitting routines
+
+    >>> np.random.seed(seed=10)
+    >>> s1 = ad.get_core_loss_eels_signal()
+    >>> np.random.seed(seed=10)
+    >>> s2 = ad.get_core_loss_eels_signal()
+    >>> (s1.data == s2.data).all()
+    True
 
     See also
     --------

--- a/hyperspy/datasets/artificial_data.py
+++ b/hyperspy/datasets/artificial_data.py
@@ -44,10 +44,16 @@ def get_low_loss_eels_signal():
     return s
 
 
-def get_core_loss_eels_signal():
+def get_core_loss_eels_signal(add_powerlaw=False):
     """Get an artificial core loss electron energy loss spectrum.
 
     Similar to a Mn-L32 edge from a perovskite oxide.
+
+    Parameters
+    ----------
+    add_powerlaw : bool
+        If True, adds a powerlaw background to the spectrum.
+        Default False.
 
     Returns
     -------
@@ -55,7 +61,13 @@ def get_core_loss_eels_signal():
 
     Example
     -------
-    >>> s = hs.datasets.artificial_data.get_core_loss_eels_signal()
+    >>> import hs.datasets.artifical_data as ad
+    >>> s = ad.get_core_loss_eels_signal()
+    >>> s.plot()
+
+    With the powerlaw background
+
+    >>> s = ad.get_core_loss_eels_signal(add_powerlaw=True)
     >>> s.plot()
 
     See also
@@ -76,6 +88,10 @@ def get_core_loss_eels_signal():
     data += mn_l3_g.function(x)
     data += mn_l2_g.function(x)
     data += np.random.random(size=len(x))*0.7
+
+    if add_powerlaw:
+        powerlaw = components1d.PowerLaw(A=10e8, r=3, origin=0)
+        data += powerlaw.function(x)
 
     s = EELSSpectrum(data)
     s.axes_manager[0].offset = x[0]
@@ -187,10 +203,16 @@ def get_core_loss_eels_line_scan_signal():
     return s
 
 
-def get_core_loss_eels_model():
+def get_core_loss_eels_model(add_powerlaw=False):
     """Get an artificial core loss electron energy loss model.
 
     Similar to a Mn-L32 edge from a perovskite oxide.
+
+    Parameters
+    ----------
+    add_powerlaw : bool
+        If True, adds a powerlaw background to the spectrum.
+        Default False.
 
     Returns
     -------
@@ -198,7 +220,13 @@ def get_core_loss_eels_model():
 
     Example
     -------
-    >>> s = hs.datasets.artificial_data.get_core_loss_eels_model()
+    >>> import hs.datasets.artifical_data as ad
+    >>> s = ad.get_core_loss_eels_model()
+    >>> s.plot()
+
+    With the powerlaw background
+
+    >>> s = ad.get_core_loss_eels_model(add_powerlaw=True)
     >>> s.plot()
 
     See also
@@ -207,9 +235,8 @@ def get_core_loss_eels_model():
     get_core_loss_eels_signal : get a model instead of a signal
 
     """
-    s = get_core_loss_eels_signal()
+    s = get_core_loss_eels_signal(add_powerlaw=add_powerlaw)
     m = s.create_model(auto_background=False, GOS='hydrogenic')
-    m.fit()
     return m
 
 

--- a/hyperspy/tests/datasets/test_artificial_data.py
+++ b/hyperspy/tests/datasets/test_artificial_data.py
@@ -1,3 +1,4 @@
+import numpy as np
 import hyperspy.datasets.artificial_data as ad
 
 
@@ -12,6 +13,12 @@ def test_get_core_loss_eels_signal():
     s1 = ad.get_core_loss_eels_signal(add_powerlaw=True)
     assert s1.metadata.Signal.signal_type == 'EELS'
     assert s1.data.sum() > s.data.sum()
+
+    np.random.seed(seed=10)
+    s2 = ad.get_core_loss_eels_signal()
+    np.random.seed(seed=10)
+    s3 = ad.get_core_loss_eels_signal()
+    assert (s2.data == s3.data).all()
 
 
 def test_get_core_loss_eels_model():

--- a/hyperspy/tests/datasets/test_artificial_data.py
+++ b/hyperspy/tests/datasets/test_artificial_data.py
@@ -7,13 +7,19 @@ def test_get_low_loss_eels_signal():
 
 
 def test_get_core_loss_eels_signal():
-    s = ad.get_core_loss_eels_signal()
+    s = ad.get_core_loss_eels_signal(add_powerlaw=False)
     assert s.metadata.Signal.signal_type == 'EELS'
+    s1 = ad.get_core_loss_eels_signal(add_powerlaw=True)
+    assert s1.metadata.Signal.signal_type == 'EELS'
+    assert s1.data.sum() > s.data.sum()
 
 
 def test_get_core_loss_eels_model():
-    m = ad.get_core_loss_eels_model()
+    m = ad.get_core_loss_eels_model(add_powerlaw=False)
     assert m.signal.metadata.Signal.signal_type == 'EELS'
+    m1 = ad.get_core_loss_eels_model(add_powerlaw=True)
+    assert m1.signal.metadata.Signal.signal_type == 'EELS'
+    assert m1.signal.data.sum() > m.signal.data.sum()
 
 
 def test_get_low_loss_eels_line_scan_signal():


### PR DESCRIPTION
The `artificial_data.get_core_loss_eels_signal` and `artificial_data.get_core_loss_eels_model` currently returns an artificial core less EEL spectrum without a power law background. This is fine for some cases, but for others (like https://github.com/hyperspy/hyperspy/pull/2003#issuecomment-403091405) having it would be nice.
 
So this pull requests add a new `add_powerlaw` argument to the `artificial_data.get_core_loss_eels_signal` and `artificial_data.get_core_loss_eels_model` functions.

### Progress of the PR
- [x] Add `add_powerlaw` argument to both functions
- [x] Update docstring
- [ ] Update user guide
- [x] add tests,
- [ ] ready for review.

### Minimal example
```python
import hyperspy.api as hs
s = hs.datasets.artificial_data.get_core_loss_eels_signal(add_powerlaw=True)
s.plot()
```

![with_powerlaw](https://user-images.githubusercontent.com/1690979/43078519-02251f10-8e8b-11e8-9c78-306c6c64a977.png)

Without the power law

```python
import hyperspy.api as hs
s = hs.datasets.artificial_data.get_core_loss_eels_signal(add_powerlaw=True)
s.plot()
```

![without_powerlaw](https://user-images.githubusercontent.com/1690979/43078563-2a5690cc-8e8b-11e8-89a6-d6d2ef408d7b.png)