### PR TITLE
Update appveyor and coveralls badge to point to the correct branch.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -2,14 +2,14 @@
 
 |Travis|_ |AppVeyor|_ |Coveralls|_ |pypi_version|_  |rtd|_ |gitter|_ |saythanks|_
 
-.. |Travis| image:: https://api.travis-ci.org/hyperspy/hyperspy.png?branch=RELEASE_next_minor
+.. |Travis| image:: https://api.travis-ci.org/hyperspy/hyperspy.png?branch=RELEASE_next_patch
 .. _Travis: https://travis-ci.org/hyperspy/hyperspy
 
-.. |AppVeyor| image:: https://ci.appveyor.com/api/projects/status/github/hyperspy/hyperspy?svg=true&branch=RELEASE_next_minor
-.. _AppVeyor: https://ci.appveyor.com/project/hyperspy/hyperspy/branch/RELEASE_next_minor
+.. |AppVeyor| image:: https://ci.appveyor.com/api/projects/status/github/hyperspy/hyperspy?svg=true&branch=RELEASE_next_patch
+.. _AppVeyor: https://ci.appveyor.com/project/hyperspy/hyperspy/branch/RELEASE_next_patch
 
-.. |Coveralls| image:: https://coveralls.io/repos/hyperspy/hyperspy/badge.svg
-.. _Coveralls: https://coveralls.io/r/hyperspy/hyperspy
+.. |Coveralls| image:: https://coveralls.io/repos/github/hyperspy/hyperspy/badge.svg?branch=RELEASE_next_patch
+.. _Coveralls: https://coveralls.io/github/hyperspy/hyperspy?branch=RELEASE_next_patch
 
 .. |pypi_version| image:: http://img.shields.io/pypi/v/hyperspy.svg?style=flat
 .. _pypi_version: https://pypi.python.org/pypi/hyperspy


### PR DESCRIPTION
Same as #2015.

### Progress of the PR
- [x] Update coveralls badge, now pointing to RELEASE_next_patch
- [x] Update appveyor badge, now pointing to RELEASE_next_patch
- [x] Update travis badge, now pointing to RELEASE_next_patch
- [x] ready for review.
