### PR TITLE
Fix blit signal tool

### DIFF
--- a/hyperspy/drawing/_widgets/range.py
+++ b/hyperspy/drawing/_widgets/range.py
@@ -378,18 +378,19 @@ class ModifiableSpanSelector(SpanSelector):
         if initial_range is not None:
             self.range = initial_range
 
-        for cid in self.cids:
-            self.canvas.mpl_disconnect(cid)
+        self.disconnect_events()
         # And connect to the new ones
-        self.cids.append(
-            self.canvas.mpl_connect('button_press_event', self.mm_on_press))
-        self.cids.append(
-            self.canvas.mpl_connect('button_release_event',
-                                    self.mm_on_release))
-        self.cids.append(
-            self.canvas.mpl_connect('draw_event', self.update_background))
+        self.connect_event('button_press_event', self.mm_on_press)
+        self.connect_event('button_release_event', self.mm_on_release)
+        self.connect_event('draw_event', self.update_background)
+
         self.rect.set_visible(True)
         self.rect.contains = self.contains
+
+    def update(self, *args):
+        # Override the SpanSelector `update` method to blit properly all 
+        # artirts before we go to "modify mode" in `set_initial`.
+        self.draw_patch()
 
     def draw_patch(self, *args):
         """Update the patch drawing.
@@ -591,9 +592,8 @@ class ModifiableSpanSelector(SpanSelector):
         self.on_move_cid = None
 
     def turn_off(self):
-        for cid in self.cids:
-            self.canvas.mpl_disconnect(cid)
+        self.disconnect_events()
         if self.on_move_cid is not None:
-            self.canvas.mpl_disconnect(cid)
+            self.canvas.mpl_disconnect(self.on_move_cid)
         self.ax.patches.remove(self.rect)
         self.ax.figure.canvas.draw_idle()

--- a/hyperspy/drawing/signal1d.py
+++ b/hyperspy/drawing/signal1d.py
@@ -143,7 +143,7 @@ class Signal1DFigure(BlittedFigure):
             marker.update()
         for line in self.ax_lines + self.right_ax_lines:
             # save on figure rendering and do it at the end
-            line.update(render_figure=False)
+            line._auto_update_line(render_figure=False)
         if self.ax.figure.canvas.supports_blit:
             self.ax.hspy_fig._update_animated()
         else:
@@ -327,9 +327,10 @@ class Signal1DLine(object):
 
         """
         if self.auto_update:
-            # if markers are plotted, we don't render the figure now but when
-            # once the markers have been updated
-            kwargs['render_figure'] = (len(self.ax.hspy_fig.ax_markers) == 0)
+            if 'render_figure' not in kwargs.keys():
+                # if markers are plotted, we don't render the figure now but 
+                # when once the markers have been updated
+                kwargs['render_figure'] = (len(self.ax.hspy_fig.ax_markers) == 0)
             self.update(self, *args, **kwargs)
 
     def update(self, force_replot=False, render_figure=True):

--- a/hyperspy/drawing/signal1d.py
+++ b/hyperspy/drawing/signal1d.py
@@ -329,7 +329,7 @@ class Signal1DLine(object):
         if self.auto_update:
             if 'render_figure' not in kwargs.keys():
                 # if markers are plotted, we don't render the figure now but 
-                # when once the markers have been updated
+                # once the markers have been updated
                 kwargs['render_figure'] = (len(self.ax.hspy_fig.ax_markers) == 0)
             self.update(self, *args, **kwargs)
 

--- a/hyperspy/signal_tools.py
+++ b/hyperspy/signal_tools.py
@@ -920,14 +920,15 @@ class SpikesRemoval(SpanSelectorInSignal1D):
         self._reset_line()
         ncoordinates = len(self.coordinates)
         spike = self.detect_spike()
-        while not spike and (
-                (self.index < ncoordinates - 1 and back is False) or
-                (self.index > 0 and back is True)):
-            if back is False:
-                self.index += 1
-            else:
-                self.index -= 1
-            spike = self.detect_spike()
+        with self.signal.axes_manager.events.indices_changed.suppress():
+            while not spike and (
+                    (self.index < ncoordinates - 1 and back is False) or
+                    (self.index > 0 and back is True)):
+                if back is False:
+                    self.index += 1
+                else:
+                    self.index -= 1
+                spike = self.detect_spike()
 
         if spike is False:
             m = SimpleMessage()

--- a/hyperspy/signal_tools.py
+++ b/hyperspy/signal_tools.py
@@ -75,9 +75,14 @@ class SpanSelectorInSignal1D(t.HasTraits):
     def update_span_selector_traits(self, *args, **kwargs):
         if not self.signal._plot.is_active:
             return
-        self.ss_left_value = self.span_selector.rect.get_x()
-        self.ss_right_value = self.ss_left_value + \
-            self.span_selector.rect.get_width()
+        x0 = self.span_selector.rect.get_x()
+        if x0 < self.axis.low_value:
+            x0 = self.axis.low_value
+        self.ss_left_value = x0
+        x1 = self.ss_left_value + self.span_selector.rect.get_width()
+        if x1 > self.axis.high_value:
+            x1 = self.axis.high_value
+        self.ss_right_value = x1
 
     def reset_span_selector(self):
         self.span_selector_switch(False)


### PR DESCRIPTION
A few bug fixes.

### Progress of the PR
- [x] Use `_auto_update_line` instead of `update` for `Signal1DLine`,
- [x] suppress indices_changed event when detecting spikes,
- [x] fix disconnect `on_move_cid` event of `ModifiableSpanSelector`,
- [x] fix blit for `SpanSelectorInSignal1D` (introduced in #2010 where blit was enabled),
- [x] limit left and right values of `SpanSelectorInSignal1D` to axis min and max values,
- [x] ready for review.


