### PR TITLE
Fix numpy indexing deprecation warning. Add lazy test for tiff io.

### DIFF
--- a/hyperspy/io_plugins/tiff.py
+++ b/hyperspy/io_plugins/tiff.py
@@ -261,7 +261,7 @@ def _load_data(TF, filename, is_rgb, sl=None, memmap=False, **kwds):
         if is_rgb:
             dc = rgb_tools.regular_array2rgbx(dc)
         if sl is not None:
-            dc = dc[sl]
+            dc = dc[tuple(sl)]
         return dc
 
 

--- a/hyperspy/tests/io/test_tiff.py
+++ b/hyperspy/tests/io/test_tiff.py
@@ -4,6 +4,7 @@ import tempfile
 import numpy as np
 import traits.api as t
 from numpy.testing import assert_allclose
+import pytest
 
 import hyperspy.api as hs
 from hyperspy.misc.test_utils import assert_deep_almost_equal
@@ -90,10 +91,11 @@ def test_read_unit_from_imagej_stack():
     assert_allclose(s.axes_manager[2].scale, 0.16867, atol=1E-5)
 
 
-def test_read_unit_from_DM_stack():
+@pytest.mark.parametrize("lazy", [True, False])
+def test_read_unit_from_DM_stack(lazy):
     fname = os.path.join(MY_PATH, 'tiff_files',
                          'test_loading_image_saved_with_DM_stack.tif')
-    s = hs.load(fname)
+    s = hs.load(fname, lazy=lazy)
     assert s.data.shape == (2, 68, 68)
     assert s.axes_manager[0].units == 's'
     assert s.axes_manager[1].units == 'µm'


### PR DESCRIPTION
### Progress of the PR
- [x] Fixes numpy deprecation warning which makes io tiff tests fail,
- [x] add lazy test for tiff io,
- [x] ready for review.


