### PR TITLE
Flake8 configuration and flake8 fixes

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -14,8 +14,30 @@ exclude =
     hyperspy/utils/plot.py
     hyperspy/utils/roi.py
     hyperspy/utils/eds.py
+    hyperspy/datasets/example_signals.py
+    hyperspy/misc/machine_learning/import_sklearn.py
+    hyperspy/samfire_utils/fit_tests.py
     # Ignore files which contains constants or physical values
     hyperspy/misc/eds/ffast_mac.py
     hyperspy/misc/elements.py
-    hyperspy/datasets/example_signals.py
-    hyperspy/misc/machine_learning/import_sklearn.py
+    # Files with unresolved issues
+    hyperspy/misc/eels/tools.py
+    hyperspy/misc/eels/eelsdb.py
+    hyperspy/misc/io/tools.py
+    hyperspy/misc/example_signals_loading.py
+    hyperspy/misc/utils.py
+    hyperspy/misc/material.py
+    hyperspy/_components/lorentzian.py
+    hyperspy/_components/gaussianhf.py
+    hyperspy/_components/expression.py
+    hyperspy/_components/gaussian.py
+    hyperspy/io_plugins/protochips.py
+    hyperspy/io_plugins/msa.py
+    hyperspy/io_plugins/bcf.py
+    hyperspy/io_plugins/digital_micrograph.py
+    hyperspy/io_plugins/tiff.py
+    hyperspy/io_plugins/ripple.py
+    hyperspy/io_plugins/blockfile.py
+    hyperspy/samfire_utils/samfire_kernel.py
+    hyperspy/samfire_utils/samfire_worker.py
+    hyperspy/external/mpfit/test_mpfit.py

--- a/.flake8
+++ b/.flake8
@@ -18,3 +18,4 @@ exclude =
     hyperspy/misc/eds/ffast_mac.py
     hyperspy/misc/elements.py
     hyperspy/datasets/example_signals.py
+    hyperspy/misc/machine_learning/import_sklearn.py

--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,20 @@
+[flake8]
+exclude =
+    .git
+    .cache
+    examples
+    doc
+    # Ignore files which just import functions
+    hyperspy/drawing/widgets.py
+    hyperspy/utils/model.py
+    hyperspy/utils/markers.py
+    hyperspy/utils/__init__.py
+    hyperspy/utils/samfire.py
+    hyperspy/utils/material.py
+    hyperspy/utils/plot.py
+    hyperspy/utils/roi.py
+    hyperspy/utils/eds.py
+    # Ignore files which contains constants or physical values
+    hyperspy/misc/eds/ffast_mac.py
+    hyperspy/misc/elements.py
+    hyperspy/datasets/example_signals.py

--- a/hyperspy/_components/arctan.py
+++ b/hyperspy/_components/arctan.py
@@ -75,7 +75,7 @@ class Arctan(Component):
         k = self.k.value
         x0 = self.x0.value
         if self.minimum_at_zero:
-            return offset + np.arctan(k * (x - x0))
+            return math.pi / 2 + np.arctan(k * (x - x0))
         else:
             return np.arctan(k * (x - x0))
 

--- a/hyperspy/_components/bleasdale.py
+++ b/hyperspy/_components/bleasdale.py
@@ -18,7 +18,7 @@
 
 import numpy as np
 
-from hyperspy.component import Component, Parameter
+from hyperspy.component import Component
 
 
 class Bleasdale(Component):

--- a/hyperspy/_components/eels_vignetting.py
+++ b/hyperspy/_components/eels_vignetting.py
@@ -56,8 +56,8 @@ class Vignetting(Component):
         period = self.period.value
         la = self.left_slope.value
         ra = self.right_slope.value
-        l = self.left.value
-        r = self.right.value
+        lv = self.left.value
+        rv = self.right.value
         ex = self.extension_nch
         if self.side_vignetting is True:
 
@@ -66,11 +66,11 @@ class Vignetting(Component):
                 list(range(int(x[-1]) + 1, int(x[-1]) + ex + 1))
             x = np.array(x)
             v1 = A * np.cos((x - x0) / (2 * np.pi * period)) ** 4
-            v2 = np.where(x < l,
-                          1. - (l - x) * la,
-                          np.where(x < r,
+            v2 = np.where(x < lv,
+                          1. - (lv - x) * la,
+                          np.where(x < rv,
                                    1.,
-                                   1. - (x - r) * ra))
+                                   1. - (x - rv) * ra))
             self.gaussian.sigma.value = sigma
             self.gaussian.origin.value = (x[-1] + x[0]) / 2
             result = np.convolve(self.gaussian.function(x), v1 * v2, 'same')

--- a/hyperspy/_components/expression.py
+++ b/hyperspy/_components/expression.py
@@ -32,7 +32,7 @@ def _parse_substitutions(string):
     splits = map(str.strip, string.split(';'))
     expr = sympy.sympify(next(splits))
     # We substitute one by one manually, as passing all at the same time does
-    # not work as we want (subsitutions inside other substitutions do not work)
+    # not work as we want (substitutions inside other substitutions do not work)
     for sub in splits:
         t = tuple(map(str.strip, sub.split('=')))
         expr = expr.subs(t[0], sympy.sympify(t[1]))
@@ -66,7 +66,7 @@ class Expression(Component):
             Name of the component.
         position: str, optional
             The parameter name that defines the position of the component if
-            applicable. It enables interative adjustment of the position of the
+            applicable. It enables interactive adjustment of the position of the
             component in the model. For 2D components, a tuple must be passed
             with the name of the two parameters e.g. `("x0", "y0")`.
         module: {"numpy", "numexpr"}, default "numpy"
@@ -76,17 +76,17 @@ class Expression(Component):
             This is only relevant for 2D components. If `True` it automatically
             adds `rotation_angle` parameter.
         rotation_center: {None, tuple}
-            If None, the rotation center is the center i.e. (0, 0) if `position`
-            is not defined, otherwise the center is the coordinates specified
-            by `position`. Alternatively a tuple with the (x, y) coordinates
-            of the center can be provided.
+            If None, the rotation center is the center i.e. (0, 0) if
+            `position` is not defined, otherwise the center is the coordinates
+            specified by `position`. Alternatively a tuple with the (x, y)
+            coordinates of the center can be provided.
         **kwargs
              Keyword arguments can be used to initialise the value of the
              parameters.
 
         Methods
         -------
-        recompile: useful to recompile the function and gradient with a
+        recompile: useful to recompile the function and gradient with
             a different module.
 
         Examples

--- a/hyperspy/_components/gaussianhf.py
+++ b/hyperspy/_components/gaussianhf.py
@@ -41,21 +41,21 @@ class GaussianHF(Expression):
 
 
     Parameters
-    -----------
-        height: float
-            The height of the peak. If there is no binning, this corresponds
-            directly to the maximum, otherwise the maximum divided by
-            signal_axis.scale
-        centre: float
-            Location of the gaussian maximum, also the mean position.
-        fwhm: float
-            The full width half maximum value, i.e. the width of the gaussian
-            at half the value of gaussian peak (at centre).
-        **kwargs
-            Extra keyword arguments are passes to the ``Expression`` component.
-            An useful keyword argument that can be used to speed up the
-            component is `module`. See the ``Expression`` component
-            documentation for details.
+    ----------
+    height: float
+        The height of the peak. If there is no binning, this corresponds
+        directly to the maximum, otherwise the maximum divided by
+        signal_axis.scale
+    centre: float
+        Location of the gaussian maximum, also the mean position.
+    fwhm: float
+        The full width half maximum value, i.e. the width of the gaussian
+        at half the value of gaussian peak (at centre).
+    **kwargs
+        Extra keyword arguments are passes to the ``Expression`` component.
+        An useful keyword argument that can be used to speed up the
+        component is `module`. See the ``Expression`` component
+        documentation for details.
 
     The helper properties `sigma` and `A` are also defined for compatibility
     with `Gaussian` component.

--- a/hyperspy/_components/lorentzian.py
+++ b/hyperspy/_components/lorentzian.py
@@ -80,8 +80,11 @@ class Lorentzian(Component):
     def grad_gamma(self, x):
         """
         """
-        return self.A.value / (np.pi * (self.gamma.value ** 2 + (x - self.centre.value) ** 2)) - (
-            (2 * self.A.value * self.gamma.value ** 2) / (np.pi * (self.gamma.value ** 2 + (x - self.centre.value) ** 2) ** 2))
+        part1 = self.A.value / (np.pi * (
+            self.gamma.value ** 2 + (x - self.centre.value) ** 2))
+        part2 = ((2 * self.A.value * self.gamma.value ** 2) / (
+            np.pi * (self.gamma.value ** 2 + (x - self.centre.value) ** 2) ** 2))
+        return part1 - part2
 
     def grad_centre(self, x):
         """

--- a/hyperspy/_components/pes_core_line_shape.py
+++ b/hyperspy/_components/pes_core_line_shape.py
@@ -87,16 +87,20 @@ class PESCoreLineShape(Component):
         a1 = self.origin.value
         a2 = self.FWHM.value
         a3 = self.ab.value
-        return self.factor * (2 * math.log(2) * a0 * (x + a3 - a1) ** 2 *
-                              np.exp(-(math.log(2) * (x + a3 - a1) ** 2) / a2 ** 2)) / a2 ** 3
+        a4 = self.factor
+        l2 = math.log(2)
+        return a4 * (2 * l2 * a0 * (x + a3 - a1) ** 2 *
+                     np.exp(-(l2 * (x + a3 - a1) ** 2) / a2 ** 2)) / a2 ** 3
 
     def grad_origin(self, x):
         a0 = self.A.value
         a1 = self.origin.value
         a2 = self.FWHM.value
         a3 = self.ab.value
-        return self.factor * (2 * math.log(2) * a0 * (x + a3 - a1) *
-                              np.exp(-(math.log(2) * (x + a3 - a1) ** 2) / a2 ** 2)) / a2 ** 2
+        a4 = self.factor
+        l2 = math.log(2)
+        return a4 * (2 * l2 * a0 * (x + a3 - a1) *
+                     np.exp(-(l2 * (x + a3 - a1) ** 2) / a2 ** 2)) / a2 ** 2
 
     def grad_ab(self, x):
         return -self.grad_origin(x)

--- a/hyperspy/_components/volume_plasmon_drude.py
+++ b/hyperspy/_components/volume_plasmon_drude.py
@@ -23,7 +23,7 @@ from hyperspy.component import Component
 
 class VolumePlasmonDrude(Component):
 
-    r"""Drude volume plasmon energy loss function component, the energy loss 
+    r"""Drude volume plasmon energy loss function component, the energy loss
     function is defined as:
 
     .. math::

--- a/hyperspy/_signals/common_signal1d.py
+++ b/hyperspy/_signals/common_signal1d.py
@@ -28,7 +28,7 @@ class CommonSignal1D(object):
     def to_signal2D(self, optimize=True):
         """Returns the one dimensional signal as a two dimensional signal.
 
-        By default ensures the data is stored optimally, hence often making a 
+        By default ensures the data is stored optimally, hence often making a
         copy of the data. See `transpose` for a more general method with more
         options.
 

--- a/hyperspy/_signals/complex_signal.py
+++ b/hyperspy/_signals/complex_signal.py
@@ -103,9 +103,10 @@ class ComplexSignal_mixin:
         Parameters
         ----------
         dtype : str or dtype
-            Typecode or data-type to which the array is cast. For complex signals only other
-            complex dtypes are allowed. If real valued properties are required use `real`,
-            `imag`, `amplitude` and `phase` instead.
+            Typecode or data-type to which the array is cast. For complex
+             signals only other complex dtypes are allowed. If real valued
+             properties are required use `real`,`imag`, `amplitude` and
+             `phase` instead.
         """
         if np.issubdtype(dtype, np.complexfloating):
             self.data = self.data.astype(dtype)
@@ -115,8 +116,9 @@ class ComplexSignal_mixin:
 
     @format_title('angle')
     def angle(self, angle, deg=False):
-        r"""Return the angle (also known as phase or argument). If the data is real, the angle is 0
-        for positive values and :math:`2\pi` for negative values.
+        r"""Return the angle (also known as phase or argument).
+        If the data is real, the angle is 0 for positive values and
+        :math:`2\pi` for negative values.
 
         Parameters
         ----------
@@ -141,13 +143,13 @@ class ComplexSignal_mixin:
         ----------
         wrap_around : bool or sequence of bool, optional
             When an element of the sequence is  `True`, the unwrapping process
-            will regard the edges along the corresponding axis of the image to be
-            connected and use this connectivity to guide the phase unwrapping
-            process. If only a single boolean is given, it will apply to all axes.
-            Wrap around is not supported for 1D arrays.
+            will regard the edges along the corresponding axis of the image to
+            be connected and use this connectivity to guide the phase
+            unwrapping process. If only a single boolean is given, it will
+            apply to all axes. Wrap around is not supported for 1D arrays.
         seed : int, optional
-            Unwrapping 2D or 3D images uses random initialization. This sets the
-            seed of the PRNG to achieve deterministic behavior.
+            Unwrapping 2D or 3D images uses random initialization. This sets
+            the seed of the PRNG to achieve deterministic behavior.
         show_progressbar : None or bool
             If True, display a progress bar. If None the default is set in
             `preferences`.
@@ -161,11 +163,12 @@ class ComplexSignal_mixin:
 
         Notes
         -----
-        Uses the :func:`~skimage.restoration.unwrap_phase` function from `skimage`.
-        The algorithm is based on Miguel Arevallilo Herraez, David R. Burton, Michael J. Lalor,
-        and Munther A. Gdeisat, “Fast two-dimensional phase-unwrapping algorithm based on sorting
-        by reliability following a noncontinuous path”, Journal Applied Optics,
-        Vol. 41, No. 35, pp. 7437, 2002
+        Uses the :func:`~skimage.restoration.unwrap_phase` function from
+        `skimage`. The algorithm is based on Miguel Arevallilo Herraez,
+        David R. Burton, Michael J. Lalor, and Munther A. Gdeisat,
+        “Fast two-dimensional phase-unwrapping algorithm based on sorting
+        by reliability following a noncontinuous path”,
+        Journal Applied Optics, Vol. 41, No. 35, pp. 7437, 2002
 
         """
         from skimage.restoration import unwrap_phase
@@ -213,7 +216,8 @@ class ComplexSignal_mixin:
                     **kwargs)
         else:
             raise ValueError('{}'.format(representation) +
-                             'is not a valid input for representation (use "cartesian" or "polar")!')
+                             'is not a valid input for representation "
+                             "(use "cartesian" or "polar")!')
     plot.__doc__ %= BASE_PLOT_DOCSTRING, COMPLEX_DOCSTRING, KWARGS_DOCSTRING
 
 

--- a/hyperspy/_signals/complex_signal.py
+++ b/hyperspy/_signals/complex_signal.py
@@ -112,7 +112,7 @@ class ComplexSignal_mixin:
             self.data = self.data.astype(dtype)
         else:
             raise AttributeError(
-                'Complex data can only be converted into other complex dtypes!')
+                'Complex data can only be converted into other complex dtypes')
 
     @format_title('angle')
     def angle(self, angle, deg=False):
@@ -128,8 +128,8 @@ class ComplexSignal_mixin:
         Returns
         -------
         angle : HyperSpy signal
-            The counterclockwise angle from the positive real axis on the complex plane,
-            with dtype as numpy.float64.
+            The counterclockwise angle from the positive real axis on the
+            complex plane, with dtype as numpy.float64.
 
         """
         angle.set_signal_type('')
@@ -215,9 +215,9 @@ class ComplexSignal_mixin:
                     axes_manager=self.axes_manager,
                     **kwargs)
         else:
-            raise ValueError('{}'.format(representation) +
-                             'is not a valid input for representation "
-                             "(use "cartesian" or "polar")!')
+            raise ValueError(
+                    '{0} is not a valid input for representation '
+                    '(use "cartesian" or "polar")'.format(representation))
     plot.__doc__ %= BASE_PLOT_DOCSTRING, COMPLEX_DOCSTRING, KWARGS_DOCSTRING
 
 

--- a/hyperspy/_signals/dielectric_function.py
+++ b/hyperspy/_signals/dielectric_function.py
@@ -37,15 +37,15 @@ class DielectricFunction_mixin:
         The Bethe f-sum rule gives rise to two definitions of the effective
         number (see [Egerton2011]_), neff1 and neff2:
 
-            .. math::
+        .. math::
 
-                n_{\mathrm{eff_{1}}} = n_{\mathrm{eff}}\left(-\Im\left(\epsilon^{-1}\right)\right)
+            n_{\mathrm{eff_{1}}} = n_{\mathrm{eff}}\left(-\Im\left(\epsilon^{-1}\right)\right)
 
         and:
 
-            .. math::
+        .. math::
 
-                n_{\mathrm{eff_{2}}} = n_{\mathrm{eff}}\left(\epsilon_{2}\right)
+            n_{\mathrm{eff_{2}}} = n_{\mathrm{eff}}\left(\epsilon_{2}\right)
 
         This method computes and return both.
 

--- a/hyperspy/_signals/eds_tem.py
+++ b/hyperspy/_signals/eds_tem.py
@@ -580,7 +580,8 @@ class EDSTEM_mixin:
         beam_current: float
             Probe current in nA
         live_time: float
-            Acquisiton time in s, compensated for the dead time of the detector.
+            Acquisiton time in s, compensated for the dead time of the
+            detector.
         probe_area: float
             The illumination area of the electron beam in nm\xB2.
             If not set the value is extracted from the scale axes_manager.

--- a/hyperspy/_signals/eels.py
+++ b/hyperspy/_signals/eels.py
@@ -299,9 +299,9 @@ class EELSSpectrum_mixin:
         for signal in also_align + [self]:
             shift_array = -zlpc.data + mean_
             if zlpc._lazy:
-                # We must compute right now because otherwise any changes to the
-                # axes_manager of the signal later in the workflow may result in
-                # a wrong shift_array
+                # We must compute right now because otherwise any changes to
+                # the axes_manager of the signal later in the workflow may
+                # result in a wrong shift_array
                 shift_array = shift_array.compute()
             signal.shift1D(
                 shift_array, crop=crop, show_progressbar=show_progressbar)
@@ -807,8 +807,8 @@ class EELSSpectrum_mixin:
             If True, display a progress bar. If None the default is set in
             `preferences`.
         parallel : {None,bool,int}
-            if True, the deconvolution will be performed in a threaded (parallel)
-            manner.
+            if True, the deconvolution will be performed in a threaded
+            (parallel) manner.
 
         Notes:
         -----
@@ -823,7 +823,6 @@ class EELSSpectrum_mixin:
         self._check_signal_dimension_equals_one()
         psf_size = psf.axes_manager.signal_axes[0].size
         kernel = psf()
-        imax = kernel.argmax()
         maxval = self.axes_manager.navigation_size
         show_progressbar = show_progressbar and (maxval > 0)
 
@@ -849,7 +848,7 @@ class EELSSpectrum_mixin:
                 '_after_R-L_deconvolution_%iiter' % iterations)
         return ds
 
-    def _are_microscope_parameters_missing(self, ignore_parameters=[]):
+    def _are_microscope_parameters_missing(self, ignore_parameters=None):
         """
         Check if the EELS parameters necessary to calculate the GOS
         are defined in metadata. If not, in interactive mode
@@ -860,10 +859,12 @@ class EELSSpectrum_mixin:
             'Acquisition_instrument.TEM.convergence_angle',
             'Acquisition_instrument.TEM.beam_energy',
             'Acquisition_instrument.TEM.Detector.EELS.collection_angle',)
+        if ignore_paramters is None:
+            ignore_parameters = []
         missing_parameters = []
         for item in must_exist:
-            exists = self.metadata.has_item(item)
-            if exists is False and item.split('.')[-1] not in ignore_parameters:
+            exist = self.metadata.has_item(item)
+            if exist is False and item.split('.')[-1] not in ignore_parameters:
                 missing_parameters.append(item)
         if missing_parameters:
             _logger.info("Missing parameters {}".format(missing_parameters))

--- a/hyperspy/_signals/eels.py
+++ b/hyperspy/_signals/eels.py
@@ -859,7 +859,7 @@ class EELSSpectrum_mixin:
             'Acquisition_instrument.TEM.convergence_angle',
             'Acquisition_instrument.TEM.beam_energy',
             'Acquisition_instrument.TEM.Detector.EELS.collection_angle',)
-        if ignore_paramters is None:
+        if ignore_paramaters is None:
             ignore_parameters = []
         missing_parameters = []
         for item in must_exist:

--- a/hyperspy/_signals/hologram_image.py
+++ b/hyperspy/_signals/hologram_image.py
@@ -208,7 +208,8 @@ class HologramImage(Signal2D):
             Sideband radius of the aperture in corresponding unit (see
             'sb_unit'). If None, the radius of the aperture is set to 1/3 of
             the distance between sideband and center band.
-        sb_smoothness : float, ndarray, :class:`~hyperspy.signals.BaseSignal, None
+        sb_smoothness : float, ndarray, :class:`~hyperspy.signals.BaseSignal,
+                        None
             Smoothness of the aperture in the same unit as sb_size.
         sb_unit : str, None
             Unit of the two sideband parameters 'sb_size' and 'sb_smoothness'.
@@ -285,7 +286,8 @@ class HologramImage(Signal2D):
                              'reference holograms do not match')
 
         signal_shape = self.axes_manager.signal_shape
-        if reference and not reference.axes_manager.signal_shape == signal_shape:
+        if reference and not (
+                reference.axes_manager.signal_shape == signal_shape):
 
             raise ValueError('The signal dimensions of object and reference'
                              ' holograms do not match')

--- a/hyperspy/_signals/hologram_image.py
+++ b/hyperspy/_signals/hologram_image.py
@@ -38,7 +38,8 @@ def _first_nav_pixel_data(s):
 
 
 class HologramImage(Signal2D):
-    """Image subclass for holograms acquired via off-axis electron holography."""
+    """Image subclass for holograms acquired via off-axis electron holography.
+    """
 
     _signal_type = 'hologram'
 
@@ -98,13 +99,15 @@ class HologramImage(Signal2D):
         sb : str, optional
             Chooses which sideband is taken. 'lower' or 'upper'
         show_progressbar : boolean
-            Shows progressbar while iterating over different slices of the signal (passes the parameter to map method).
+            Shows progressbar while iterating over different slices of the
+            signal (passes the parameter to map method).
         parallel : bool
             Estimate the positions in parallel
 
         Returns
         -------
-        Signal1D instance of sideband positions (y, x), referred to the unshifted FFT.
+        Signal1D instance of sideband positions (y, x), referred to the
+        unshifted FFT.
 
         Examples
         --------
@@ -145,7 +148,8 @@ class HologramImage(Signal2D):
         sb_position : :class:`~hyperspy.signals.BaseSignal
             The sideband position (y, x), referred to the non-shifted FFT.
         show_progressbar: boolean
-            Shows progressbar while iterating over different slices of the signal (passes the parameter to map method).
+            Shows progressbar while iterating over different slices of the
+            signal (passes the parameter to map method).
         parallel : bool
             Estimate the sizes in parallel
 
@@ -243,7 +247,8 @@ class HologramImage(Signal2D):
         >>> sb_position = s.estimate_sideband_position()
         >>> sb_size = s.estimate_sideband_size(sb_position)
         >>> sb_size.data
-        >>> wave = s.reconstruct_phase(sb_position=sb_position, sb_size=sb_size)
+        >>> wave = s.reconstruct_phase(
+        ...     sb_position=sb_position, sb_size=sb_size)
 
         """
 
@@ -279,7 +284,8 @@ class HologramImage(Signal2D):
             raise ValueError('The navigation dimensions of object and '
                              'reference holograms do not match')
 
-        if reference and not reference.axes_manager.signal_shape == self.axes_manager.signal_shape:
+        signal_shape = self.axes_manager.signal_shape
+        if reference and not reference.axes_manager.signal_shape == signal_shape:
 
             raise ValueError('The signal dimensions of object and reference'
                              ' holograms do not match')
@@ -309,7 +315,8 @@ class HologramImage(Signal2D):
             if not sb_position.axes_manager.signal_size == 2:
                 raise ValueError('sb_position should to have signal size of 2')
 
-        if sb_position.axes_manager.navigation_size != self.axes_manager.navigation_size:
+        nav_size = self.axes_manager.navigation_size
+        if sb_position.axes_manager.navigation_size != nav_size:
             if sb_position.axes_manager.navigation_size:
                 raise ValueError('Sideband position dimensions do not match'
                                  ' neither reference nor hologram dimensions.')
@@ -340,7 +347,7 @@ class HologramImage(Signal2D):
                 if isinstance(sb_size.data, daArray):
                     sb_size = sb_size.as_lazy()
 
-        if sb_size.axes_manager.navigation_size != self.axes_manager.navigation_size:
+        if sb_size.axes_manager.navigation_size != nav_size:
             if sb_size.axes_manager.navigation_size:
                 raise ValueError('Sideband size dimensions do not match '
                                  'neither reference nor hologram dimensions.')
@@ -364,7 +371,7 @@ class HologramImage(Signal2D):
                 if isinstance(sb_smoothness.data, daArray):
                     sb_smoothness = sb_smoothness.as_lazy()
 
-        if sb_smoothness.axes_manager.navigation_size != self.axes_manager.navigation_size:
+        if sb_smoothness.axes_manager.navigation_size != nav_size:
             if sb_smoothness.axes_manager.navigation_size:
                 raise ValueError('Sideband smoothness dimensions do not match'
                                  ' neither reference nor hologram '
@@ -397,7 +404,7 @@ class HologramImage(Signal2D):
             )
             try:
                 ht = self.metadata.Acquisition_instrument.TEM.beam_energy
-            except:
+            except AttributeError:
                 raise AttributeError("Please define the beam energy."
                                      "You can do this e.g. by using the "
                                      "set_microscope_parameters method")
@@ -415,9 +422,11 @@ class HologramImage(Signal2D):
         if output_shape is None:
             # Future improvement will give a possibility to choose
             # if sb_size.axes_manager.navigation_size > 0:
-            #     output_shape = (np.int(sb_size.inav[0].data*2), np.int(sb_size.inav[0].data*2))
+            #     output_shape = (np.int(sb_size.inav[0].data*2),
+            #                     np.int(sb_size.inav[0].data*2))
             # else:
-            #     output_shape = (np.int(sb_size.data*2), np.int(sb_size.data*2))
+            #     output_shape = (np.int(sb_size.data*2),
+            #                     np.int(sb_size.data*2))
             output_shape = self.axes_manager.signal_shape
             output_shape = output_shape[::-1]
 
@@ -449,7 +458,7 @@ class HologramImage(Signal2D):
         if reference is None:
             wave_reference = 1
         # case when reference is 1d
-        elif reference.axes_manager.navigation_size != self.axes_manager.navigation_size:
+        elif reference.axes_manager.navigation_size != nav_size:
 
             # Prepare parameters for reconstruction of the reference wave:
 
@@ -524,11 +533,11 @@ class HologramImage(Signal2D):
             rec_param_dict = OrderedDict(
                 [('sb_position', sb_position_temp), ('sb_size', sb_size_temp),
                  ('sb_units', sb_unit), ('sb_smoothness', sb_smoothness_temp)])
-            wave_image.metadata.Signal.add_node('Holography')
-            wave_image.metadata.Signal.Holography.add_node(
-                'Reconstruction_parameters')
-            wave_image.metadata.Signal.Holography.Reconstruction_parameters.add_dictionary(
-                rec_param_dict)
+            md_sig = wave_image.metadata.Signal
+            md_sig.add_node('Holography')
+            md_sig.Holography.add_node('Reconstruction_parameters')
+            md_sig.Holography.Reconstruction_parameters.add_dictionary(
+                    rec_param_dict)
             _logger.info('Reconstruction parameters stored in metadata')
 
         return wave_image

--- a/hyperspy/_signals/lazy.py
+++ b/hyperspy/_signals/lazy.py
@@ -268,8 +268,8 @@ class LazySignal(BaseSignal):
                     "(10| 6), new_shape=(5| 3) is valid, (3 | 4) is not.")
             else:
                 raise NotImplementedError(
-                    "Lazy rebin requires scale to be integer and divisor of the "
-                    "original signal shape")
+                    "Lazy rebin requires scale to be integer and divisor of "
+                    "the original signal shape")
         axis = {ax.index_in_array: ax
                 for ax in self.axes_manager._axes}[factors.argmax()]
         self._make_lazy(axis=axis, rechunk=rechunk)
@@ -425,7 +425,8 @@ class LazySignal(BaseSignal):
     # def _get_navigation_signal(self, data=None, dtype=None):
     # return super()._get_navigation_signal(data=data, dtype=dtype).as_lazy()
 
-    # _get_navigation_signal.__doc__ = BaseSignal._get_navigation_signal.__doc__
+    # get_nav_sig_doc = BaseSignal._get_navigation_signal.__doc__
+    # _get_navigation_signal.__doc__ = get_nav_sig_doc
 
     # def _get_signal_signal(self, data=None, dtype=None):
     #     return super()._get_signal_signal(data=data, dtype=dtype).as_lazy()

--- a/hyperspy/_signals/signal1d.py
+++ b/hyperspy/_signals/signal1d.py
@@ -799,8 +799,8 @@ _spikes_diagnosis,
         from hyperspy.misc.utils import deprecation_warning
         msg = (
             "The `Signal1D.integrate_in_range` method is deprecated and will "
-            "be removed in v2.0. Use a `roi.SpanRoi` followed by `integrate1D` "
-            "instead.")
+            "be removed in v2.0. Use a `roi.SpanRoi` followed by "
+            "`integrate1D` instead.")
         deprecation_warning(msg)
         signal_range = signal_range_from_roi(signal_range)
 
@@ -1099,7 +1099,8 @@ _spikes_diagnosis,
         >>> s.remove_background() #doctest: +SKIP
 
         Using command line, returns a spectrum
-        >>> s1 = s.remove_background(signal_range=(400,450), background_type='PowerLaw')
+        >>> s1 = s.remove_background(
+        ...     signal_range=(400,450), background_type='PowerLaw')
 
         Using a full model to fit the background
         >>> s1 = s.remove_background(signal_range=(400,450), fast=False)

--- a/hyperspy/_signals/signal2d.py
+++ b/hyperspy/_signals/signal2d.py
@@ -273,11 +273,13 @@ class Signal2D(BaseSignal, CommonSignal2D):
 
     def create_model(self, dictionary=None):
         """Create a model for the current signal
+
         Parameters
-        __________
+        ----------
         dictionary : {None, dict}, optional
-            A dictionary to be used to recreate a model. Usually generated using
-            :meth:`hyperspy.model.as_dictionary`
+            A dictionary to be used to recreate a model.
+            Usually generated using :meth:`hyperspy.model.as_dictionary`
+
         Returns
         -------
         A Model class
@@ -632,11 +634,12 @@ class Signal2D(BaseSignal, CommonSignal2D):
             Slope of the ramp in y-direction.
         offset: float, optional
             Offset of the ramp at the signal fulcrum.
+
         Notes
         -----
-            The fulcrum of the linear ramp is at the origin and the slopes are given in units of
-            the axis with the according scale taken into account. Both are available via the
-            `axes_manager` of the signal.
+        The fulcrum of the linear ramp is at the origin and the slopes are
+        given in units of the axis with the according scale taken into account.
+        Both are available via the `axes_manager` of the signal.
 
         """
         yy, xx = np.indices(self.axes_manager._signal_shape_in_array)

--- a/hyperspy/docstrings/plot.py
+++ b/hyperspy/docstrings/plot.py
@@ -82,8 +82,9 @@ PLOT2D_DOCSTRING = \
 
 COMPLEX_DOCSTRING = \
     """representation : {'cartesian' or 'polar'}
-            Determines if the real and imaginary part of the complex data is plotted ('cartesian',
-            default), or if the amplitude and phase should be used ('polar').
+            Determines if the real and imaginary part of the complex data is
+            plotted ('cartesian', default), or if the amplitude and phase
+            should be used ('polar').
         same_axes : bool, default True
             If True (default) plot the real and
             imaginary parts (or amplitude and phase) in the same figure if

--- a/hyperspy/docstrings/signal.py
+++ b/hyperspy/docstrings/signal.py
@@ -42,4 +42,5 @@ OPTIMIZE_ARG = \
 RECHUNK_ARG = \
     """rechunk: bool
            Only has effect when operating on lazy signal. If `True` (default),
-           the data may be automatically rechunked before performing this operation."""
+           the data may be automatically rechunked before performing this
+           operation."""

--- a/hyperspy/docstrings/signal1d.py
+++ b/hyperspy/docstrings/signal1d.py
@@ -5,4 +5,5 @@
 
 CROP_PARAMETER_DOC = \
     """crop : bool
-            If True automatically crop the signal axis at both ends if needed."""
+            If True automatically crop the signal axis at both ends if needed.
+            """

--- a/hyperspy/drawing/_widgets/circle.py
+++ b/hyperspy/drawing/_widgets/circle.py
@@ -154,7 +154,7 @@ class CircleWidget(Widget2DBase, ResizersMixin):
             if ri > 0:
                 # Add the inner circle
                 if len(self.patch) == 1:
-                    # Need to remove the previous patch before using 
+                    # Need to remove the previous patch before using
                     # `_add_patch_to`
                     self.ax.artists.remove(self.patch[0])
                     self.patch = []

--- a/hyperspy/drawing/_widgets/range.py
+++ b/hyperspy/drawing/_widgets/range.py
@@ -64,7 +64,7 @@ class RangeWidget(ResizableDraggableWidgetBase):
                 self.disconnect()
             try:
                 self.ax.figure.canvas.draw_idle()
-            except:  # figure does not exist
+            except AttributeError:  # figure does not exist
                 pass
             if value is False:
                 self.ax = None

--- a/hyperspy/drawing/_widgets/range.py
+++ b/hyperspy/drawing/_widgets/range.py
@@ -156,8 +156,8 @@ class RangeWidget(ResizableDraggableWidgetBase):
         def warn(obj, parameter, value):
             global already_warn_out_of_range
             if not already_warn_out_of_range:
-                _logger.info('{}: {} is out of range. It is therefore set '
-                             'to the value of {}'.format(obj, parameter, value))
+                _logger.info('{}: {} is out of range. It is therefore set to '
+                             'the value of {}'.format(obj, parameter, value))
                 already_warn_out_of_range = True
 
         x, w = self._parse_bounds_args(args, kwargs)

--- a/hyperspy/drawing/_widgets/rectangles.py
+++ b/hyperspy/drawing/_widgets/rectangles.py
@@ -152,8 +152,8 @@ class RectangleWidget(SquareWidget, ResizersMixin):
         def warn(obj, parameter, value):
             global already_warn_out_of_range
             if not already_warn_out_of_range:
-                _logger.info('{}: {} is out of range. It is therefore set '
-                             'to the value of {}'.format(obj, parameter, value))
+                _logger.info('{}: {} is out of range. It is therefore set to '
+                             'the value of {}'.format(obj, parameter, value))
                 already_warn_out_of_range = True
 
         scale = [axis.scale for axis in self.axes]

--- a/hyperspy/drawing/marker.py
+++ b/hyperspy/drawing/marker.py
@@ -177,8 +177,8 @@ class MarkerBase(object):
         render_figure : bool, optional, default True
             If True, will render the figure after adding the marker.
             If False, the marker will be added to the plot, but will the figure
-            will not be rendered. This is useful when plotting many markers, 
-            since rendering the figure after adding each marker will slow 
+            will not be rendered. This is useful when plotting many markers,
+            since rendering the figure after adding each marker will slow
             things down.
         """
         if self.ax is None:

--- a/hyperspy/drawing/mpl_he.py
+++ b/hyperspy/drawing/mpl_he.py
@@ -21,7 +21,6 @@ import logging
 from traits.api import Undefined
 
 from hyperspy.drawing import widgets, signal1d, image
-from hyperspy.ui_registry import get_gui
 
 
 _logger = logging.getLogger(__name__)
@@ -70,7 +69,8 @@ class MPL_HyperExplorer(object):
         if self.navigator_data_function is "slider":
             self._get_navigation_sliders()
             return
-        title = title or self.signal_title + " Navigator" if self.signal_title else ""
+        signal_title = self.signal_title
+        title = title or signal_title + " Navigator" if signal_title else ""
         if self.navigator_plot is not None:
             self.navigator_plot.plot()
             return

--- a/hyperspy/drawing/mpl_hie.py
+++ b/hyperspy/drawing/mpl_hie.py
@@ -16,7 +16,7 @@
 # You should have received a copy of the GNU General Public License
 # along with  HyperSpy.  If not, see <http://www.gnu.org/licenses/>.
 
-from hyperspy.drawing import image, utils
+from hyperspy.drawing import image
 from hyperspy.drawing.mpl_he import MPL_HyperExplorer
 
 

--- a/hyperspy/drawing/mpl_hse.py
+++ b/hyperspy/drawing/mpl_hse.py
@@ -23,7 +23,7 @@ import numpy as np
 from traits.api import Undefined
 
 from hyperspy.drawing.mpl_he import MPL_HyperExplorer
-from hyperspy.drawing import signal1d, utils
+from hyperspy.drawing import signal1d
 
 
 class MPL_HyperSignal1D_Explorer(MPL_HyperExplorer):

--- a/hyperspy/drawing/signal1d.py
+++ b/hyperspy/drawing/signal1d.py
@@ -314,11 +314,11 @@ class Signal1DLine(object):
                 self.text.remove()
             self.text = self.ax.text(
                     *self.text_position,
-                     s=str(self.axes_manager.indices),
-                     transform=self.ax.transAxes,
-                     fontsize=12,
-                     color=self.line.get_color(),
-                     animated=self.ax.figure.canvas.supports_blit)
+                    s=str(self.axes_manager.indices),
+                    transform=self.ax.transAxes,
+                    fontsize=12,
+                    color=self.line.get_color(),
+                    animated=self.ax.figure.canvas.supports_blit)
         self.ax.figure.canvas.draw_idle()
 
     def _auto_update_line(self, *args, **kwargs):

--- a/hyperspy/drawing/signal1d.py
+++ b/hyperspy/drawing/signal1d.py
@@ -312,12 +312,13 @@ class Signal1DLine(object):
         if self.plot_indices is True:
             if self.text is not None:
                 self.text.remove()
-            self.text = self.ax.text(*self.text_position,
-                                     s=str(self.axes_manager.indices),
-                                     transform=self.ax.transAxes,
-                                     fontsize=12,
-                                     color=self.line.get_color(),
-                                     animated=self.ax.figure.canvas.supports_blit)
+            self.text = self.ax.text(
+                    *self.text_position,
+                     s=str(self.axes_manager.indices),
+                     transform=self.ax.transAxes,
+                     fontsize=12,
+                     color=self.line.get_color(),
+                     animated=self.ax.figure.canvas.supports_blit)
         self.ax.figure.canvas.draw_idle()
 
     def _auto_update_line(self, *args, **kwargs):

--- a/hyperspy/drawing/tiles.py
+++ b/hyperspy/drawing/tiles.py
@@ -23,7 +23,6 @@ import numpy as np
 import matplotlib.pyplot as plt
 
 from hyperspy.drawing.figure import BlittedFigure
-from hyperspy.drawing import utils
 
 
 class HistogramTilePlot(BlittedFigure):
@@ -78,7 +77,8 @@ class HistogramTilePlot(BlittedFigure):
                         **kwargs)
                     width = bin_edges[-1] - bin_edges[0]
                     ax.set_xlim(
-                        bin_edges[0] - width * 0.1, bin_edges[-1] + width * 0.1)
+                        bin_edges[0] - width * 0.1,
+                        bin_edges[-1] + width * 0.1)
                     ax.set_ylim(0, np.max(hist) * 1.1)
                     # ax.set_title(c_n + ' ' + p_n)
         self.figure.canvas.draw_idle()

--- a/hyperspy/drawing/utils.py
+++ b/hyperspy/drawing/utils.py
@@ -242,7 +242,8 @@ def plot_signals(signal_list, sync=True, navigator="auto",
         If True: the signals will share navigation, all the signals
         must have the same navigation shape for this to work, but not
         necessarily the same signal shape.
-    navigator : {"auto", None, "spectrum", "slider", BaseSignal}, default "auto"
+    navigator : {"auto", None, "spectrum", "slider", BaseSignal},
+                default "auto"
         See signal.plot docstring for full description
     navigator_list : {List of navigator arguments, None}, default None
         Set different navigator options for the signals. Must use valid

--- a/hyperspy/drawing/utils.py
+++ b/hyperspy/drawing/utils.py
@@ -458,8 +458,8 @@ def plot_images(images,
             Control the title labeling of the plotted images.
             If None, no titles will be shown.
             If 'auto' (default), function will try to determine suitable titles
-            using Signal2D titles, falling back to the 'titles' option if no good
-            short titles are detected.
+            using Signal2D titles, falling back to the 'titles' option if no
+            good short titles are detected.
             Works best if all images to be plotted have the same beginning
             to their titles.
             If 'titles', the title from each image's metadata.General.title
@@ -612,9 +612,9 @@ def plot_images(images,
     def _check_arg(arg, default_value, arg_name):
         if isinstance(arg, list):
             if len(arg) != n:
-                _logger.warning('The provided {} values are ignored because the '
-                                'length of the list does not match the number of '
-                                'images'.format(arg_name))
+                _logger.warning('The provided {} values are ignored because '
+                                'the length of the list does not match the '
+                                'number of images'.format(arg_name))
                 arg = [default_value] * n
         else:
             arg = [arg] * n
@@ -1079,9 +1079,9 @@ def plot_spectra(
             This parameter controls where the legend is placed on the
             figure; see the pyplot.legend docstring for valid values
         """
-        l = ax_.get_legend()
-        labels = [lb.get_text() for lb in list(l.get_texts())]
-        handles = l.legendHandles
+        legend = ax_.get_legend()
+        labels = [lb.get_text() for lb in list(legend.get_texts())]
+        handles = legend.legendHandles
         ax_.legend(handles[::-1], labels[::-1], loc=legend_loc_)
 
     # Before v1.3 default would read the value from prefereces.

--- a/hyperspy/external/mpfit/mpfit.py
+++ b/hyperspy/external/mpfit/mpfit.py
@@ -1,31 +1,31 @@
 """
 Perform Levenberg-Marquardt least-squares minimization, based on MINPACK-1.
 
-								   AUTHORS
+                                                                   AUTHORS
   The original version of this software, called LMFIT, was written in FORTRAN
   as part of the MINPACK-1 package by XXX.
 
   Craig Markwardt converted the FORTRAN code to IDL.  The information for the
   IDL version is:
-	 Craig B. Markwardt, NASA/GSFC Code 662, Greenbelt, MD 20770
-	 craigm@lheamail.gsfc.nasa.gov
-	 UPDATED VERSIONs can be found on my WEB PAGE:
-		http://cow.physics.wisc.edu/~craigm/idl/idl.html
+         Craig B. Markwardt, NASA/GSFC Code 662, Greenbelt, MD 20770
+         craigm@lheamail.gsfc.nasa.gov
+         UPDATED VERSIONs can be found on my WEB PAGE:
+                http://cow.physics.wisc.edu/~craigm/idl/idl.html
 
   Mark Rivers created this Python version from Craig's IDL version.
-	Mark Rivers, University of Chicago
-	Building 434A, Argonne National Laboratory
-	9700 South Cass Avenue, Argonne, IL 60439
-	rivers@cars.uchicago.edu
-	Updated versions can be found at http://cars.uchicago.edu/software
+        Mark Rivers, University of Chicago
+        Building 434A, Argonne National Laboratory
+        9700 South Cass Avenue, Argonne, IL 60439
+        rivers@cars.uchicago.edu
+        Updated versions can be found at http://cars.uchicago.edu/software
 
  Sergey Koposov converted the Mark's Python version from Numeric to numpy
-	Sergey Koposov, University of Cambridge, Institute of Astronomy,
-	Madingley road, CB3 0HA, Cambridge, UK
-	koposov@ast.cam.ac.uk
-	Updated versions can be found at http://code.google.com/p/astrolibpy/source/browse/trunk/
+        Sergey Koposov, University of Cambridge, Institute of Astronomy,
+        Madingley road, CB3 0HA, Cambridge, UK
+        koposov@ast.cam.ac.uk
+        Updated versions can be found at http://code.google.com/p/astrolibpy/source/browse/trunk/
 
-								 DESCRIPTION
+                                                                 DESCRIPTION
 
  MPFIT uses the Levenberg-Marquardt technique to solve the
  least-squares problem.  In its typical use, MPFIT will be used to
@@ -79,7 +79,7 @@ Perform Levenberg-Marquardt least-squares minimization, based on MINPACK-1.
  least-squares minimization problem.
 
 
-							   USER FUNCTION
+                                                           USER FUNCTION
 
  The user must define a function which returns the appropriate
  values as specified above.  The function should return the weighted
@@ -89,15 +89,15 @@ Perform Levenberg-Marquardt least-squares minimization, based on MINPACK-1.
  function should be declared in the following way:
 
    def myfunct(p, fjac=None, x=None, y=None, err=None)
-	# Parameter values are passed in "p"
-	# If fjac==None then partial derivatives should not be
-	# computed.  It will always be None if MPFIT is called with default
-	# flag.
-	model = F(x, p)
-	# Non-negative status value means MPFIT should continue, negative means
-	# stop the calculation.
-	status = 0
-	return([status, (y-model)/err]
+        # Parameter values are passed in "p"
+        # If fjac==None then partial derivatives should not be
+        # computed.  It will always be None if MPFIT is called with default
+        # flag.
+        model = F(x, p)
+        # Non-negative status value means MPFIT should continue, negative means
+        # stop the calculation.
+        status = 0
+        return([status, (y-model)/err]
 
  See below for applications with analytical derivatives.
 
@@ -116,7 +116,7 @@ Perform Levenberg-Marquardt least-squares minimization, based on MINPACK-1.
  -15 and -1 then MPFIT will stop the calculation and return to the caller.
 
 
-							ANALYTIC DERIVATIVES
+                                                        ANALYTIC DERIVATIVES
 
  In the search for the best-fit solution, MPFIT by default
  calculates derivatives numerically via a finite difference
@@ -131,21 +131,21 @@ Perform Levenberg-Marquardt least-squares minimization, based on MINPACK-1.
  FJAC, and if FJAC!=None then return the partial derivative array in the
  return list.
    def myfunct(p, fjac=None, x=None, y=None, err=None)
-	# Parameter values are passed in "p"
-	# If FJAC!=None then partial derivatives must be comptuer.
-	# FJAC contains an array of len(p), where each entry
-	# is 1 if that parameter is free and 0 if it is fixed.
-	model = F(x, p)
-	Non-negative status value means MPFIT should continue, negative means
-	# stop the calculation.
-	status = 0
-	if (dojac):
-	   pderiv = zeros([len(x), len(p)], Float)
-	   for j in range(len(p)):
-		 pderiv[:,j] = FGRAD(x, p, j)
-	else:
-	   pderiv = None
-	return([status, (y-model)/err, pderiv]
+        # Parameter values are passed in "p"
+        # If FJAC!=None then partial derivatives must be comptuer.
+        # FJAC contains an array of len(p), where each entry
+        # is 1 if that parameter is free and 0 if it is fixed.
+        model = F(x, p)
+        Non-negative status value means MPFIT should continue, negative means
+        # stop the calculation.
+        status = 0
+        if (dojac):
+           pderiv = zeros([len(x), len(p)], Float)
+           for j in range(len(p)):
+                 pderiv[:,j] = FGRAD(x, p, j)
+        else:
+           pderiv = None
+        return([status, (y-model)/err, pderiv]
 
  where FGRAD(x, p, i) is a user function which must compute the
  derivative of the model with respect to parameter P[i] at X.  When
@@ -170,7 +170,7 @@ Perform Levenberg-Marquardt least-squares minimization, based on MINPACK-1.
  50x50 image, "dp" should be 50x50xNPAR.
 
 
-		   CONSTRAINING PARAMETER VALUES WITH THE PARINFO KEYWORD
+                   CONSTRAINING PARAMETER VALUES WITH THE PARINFO KEYWORD
 
  The behavior of MPFIT can be modified with respect to each
  parameter to be fitted.  A parameter value can be fixed; simple
@@ -186,72 +186,72 @@ Perform Levenberg-Marquardt least-squares minimization, based on MINPACK-1.
  numerical order.  The dictionary can have the following keys
  (none are required, keys are case insensitive):
 
-	'value' - the starting parameter value (but see the START_PARAMS
-			 parameter for more information).
+        'value' - the starting parameter value (but see the START_PARAMS
+                         parameter for more information).
 
-	'fixed' - a boolean value, whether the parameter is to be held
-			 fixed or not.  Fixed parameters are not varied by
-			 MPFIT, but are passed on to MYFUNCT for evaluation.
+        'fixed' - a boolean value, whether the parameter is to be held
+                         fixed or not.  Fixed parameters are not varied by
+                         MPFIT, but are passed on to MYFUNCT for evaluation.
 
-	'limited' - a two-element boolean array.  If the first/second
-			   element is set, then the parameter is bounded on the
-			   lower/upper side.  A parameter can be bounded on both
-			   sides.  Both LIMITED and LIMITS must be given
-			   together.
+        'limited' - a two-element boolean array.  If the first/second
+                           element is set, then the parameter is bounded on the
+                           lower/upper side.  A parameter can be bounded on both
+                           sides.  Both LIMITED and LIMITS must be given
+                           together.
 
-	'limits' - a two-element float array.  Gives the
-			  parameter limits on the lower and upper sides,
-			  respectively.  Zero, one or two of these values can be
-			  set, depending on the values of LIMITED.  Both LIMITED
-			  and LIMITS must be given together.
+        'limits' - a two-element float array.  Gives the
+                          parameter limits on the lower and upper sides,
+                          respectively.  Zero, one or two of these values can be
+                          set, depending on the values of LIMITED.  Both LIMITED
+                          and LIMITS must be given together.
 
-	'parname' - a string, giving the name of the parameter.  The
-			   fitting code of MPFIT does not use this tag in any
-			   way.  However, the default iterfunct will print the
-			   parameter name if available.
+        'parname' - a string, giving the name of the parameter.  The
+                           fitting code of MPFIT does not use this tag in any
+                           way.  However, the default iterfunct will print the
+                           parameter name if available.
 
-	'step' - the step size to be used in calculating the numerical
-			derivatives.  If set to zero, then the step size is
-			computed automatically.  Ignored when AUTODERIVATIVE=0.
+        'step' - the step size to be used in calculating the numerical
+                        derivatives.  If set to zero, then the step size is
+                        computed automatically.  Ignored when AUTODERIVATIVE=0.
 
-	'mpside' - the sidedness of the finite difference when computing
-			  numerical derivatives.  This field can take four
-			  values:
+        'mpside' - the sidedness of the finite difference when computing
+                          numerical derivatives.  This field can take four
+                          values:
 
-				 0 - one-sided derivative computed automatically
-				 1 - one-sided derivative (f(x+h) - f(x)  )/h
-				-1 - one-sided derivative (f(x)   - f(x-h))/h
-				 2 - two-sided derivative (f(x+h) - f(x-h))/(2*h)
+                                 0 - one-sided derivative computed automatically
+                                 1 - one-sided derivative (f(x+h) - f(x)  )/h
+                                -1 - one-sided derivative (f(x)   - f(x-h))/h
+                                 2 - two-sided derivative (f(x+h) - f(x-h))/(2*h)
 
-			 Where H is the STEP parameter described above.  The
-			 "automatic" one-sided derivative method will chose a
-			 direction for the finite difference which does not
-			 violate any constraints.  The other methods do not
-			 perform this check.  The two-sided method is in
-			 principle more precise, but requires twice as many
-			 function evaluations.  Default: 0.
+                         Where H is the STEP parameter described above.  The
+                         "automatic" one-sided derivative method will chose a
+                         direction for the finite difference which does not
+                         violate any constraints.  The other methods do not
+                         perform this check.  The two-sided method is in
+                         principle more precise, but requires twice as many
+                         function evaluations.  Default: 0.
 
-	'mpmaxstep' - the maximum change to be made in the parameter
-				 value.  During the fitting process, the parameter
-				 will never be changed by more than this value in
-				 one iteration.
+        'mpmaxstep' - the maximum change to be made in the parameter
+                                 value.  During the fitting process, the parameter
+                                 will never be changed by more than this value in
+                                 one iteration.
 
-				 A value of 0 indicates no maximum.  Default: 0.
+                                 A value of 0 indicates no maximum.  Default: 0.
 
-	'tied' - a string expression which "ties" the parameter to other
-			free or fixed parameters.  Any expression involving
-			constants and the parameter array P are permitted.
-			Example: if parameter 2 is always to be twice parameter
-			1 then use the following: parinfo(2).tied = '2 * p(1)'.
-			Since they are totally constrained, tied parameters are
-			considered to be fixed; no errors are computed for them.
-			[ NOTE: the PARNAME can't be used in expressions. ]
+        'tied' - a string expression which "ties" the parameter to other
+                        free or fixed parameters.  Any expression involving
+                        constants and the parameter array P are permitted.
+                        Example: if parameter 2 is always to be twice parameter
+                        1 then use the following: parinfo(2).tied = '2 * p(1)'.
+                        Since they are totally constrained, tied parameters are
+                        considered to be fixed; no errors are computed for them.
+                        [ NOTE: the PARNAME can't be used in expressions. ]
 
-	'mpprint' - if set to 1, then the default iterfunct will print the
-			   parameter value.  If set to 0, the parameter value
-			   will not be printed.  This tag can be used to
-			   selectively print only a few parameter values out of
-			   many.  Default: 1 (all parameters printed)
+        'mpprint' - if set to 1, then the default iterfunct will print the
+                           parameter value.  If set to 0, the parameter value
+                           will not be printed.  This tag can be used to
+                           selectively print only a few parameter values out of
+                           many.  Default: 1 (all parameters printed)
 
 
  Future modifications to the PARINFO structure, if any, will involve
@@ -262,7 +262,7 @@ Perform Levenberg-Marquardt least-squares minimization, based on MINPACK-1.
 
  PARINFO Example:
  parinfo = [{'value':0., 'fixed':0, 'limited':[0,0], 'limits':[0.,0.]}
- 												for i in range(5)]
+                                                                                                for i in range(5)]
  parinfo[0]['fixed'] = 1
  parinfo[4]['limited'][0] = 1
  parinfo[4]['limits'][0]  = 50.
@@ -275,14 +275,14 @@ Perform Levenberg-Marquardt least-squares minimization, based on MINPACK-1.
  constrained to be above 50.
 
 
-								   EXAMPLE
+                                                                   EXAMPLE
 
    import mpfit
    import numpy.oldnumeric as Numeric
    x = arange(100, float)
    p0 = [5.7, 2.2, 500., 1.5, 2000.]
    y = ( p[0] + p[1]*[x] + p[2]*[x**2] + p[3]*sqrt(x) +
-		 p[4]*log(x))
+                 p[4]*log(x))
    fa = {'x':x, 'y':y, 'err':err}
    m = mpfit('myfunct', p0, functkw=fa)
    print('status = ', m.status)
@@ -294,16 +294,16 @@ Perform Levenberg-Marquardt least-squares minimization, based on MINPACK-1.
    results can be obtained from the returned object m.
 
 
-							THEORY OF OPERATION
+                                                        THEORY OF OPERATION
 
    There are many specific strategies for function minimization.  One
    very popular technique is to use function gradient information to
    realize the local structure of the function.  Near a local minimum
    the function value can be taylor expanded about x0 as follows:
 
-	  f(x) = f(x0) + f'(x0) . (x-x0) + (1/2) (x-x0) . f''(x0) . (x-x0)
-			 -----   ---------------   -------------------------------  (1)
-	 Order	0th		  1st					  2nd
+          f(x) = f(x0) + f'(x0) . (x-x0) + (1/2) (x-x0) . f''(x0) . (x-x0)
+                         -----   ---------------   -------------------------------  (1)
+         Order  0th               1st                                     2nd
 
    Here f'(x) is the gradient vector of f at x, and f''(x) is the
    Hessian matrix of second derivatives of f at x.  The vector x is
@@ -311,7 +311,7 @@ Perform Levenberg-Marquardt least-squares minimization, based on MINPACK-1.
    can find the minimum of f, f(xm) using Newton's method, and
    arrives at the following linear equation:
 
-	  f''(x0) . (xm-x0) = - f'(x0)							(2)
+          f''(x0) . (xm-x0) = - f'(x0)                                                  (2)
 
    If an inverse can be found for f''(x0) then one can solve for
    (xm-x0), the step vector from the current position x0 to the new
@@ -323,7 +323,7 @@ Perform Levenberg-Marquardt least-squares minimization, based on MINPACK-1.
    It adds an additional diagonal term to the equation which may aid the
    convergence properties:
 
-	  (f''(x0) + nu I) . (xm-x0) = -f'(x0)				  (2a)
+          (f''(x0) + nu I) . (xm-x0) = -f'(x0)                            (2a)
 
    where I is the identity matrix.  When nu is large, the overall
    matrix is diagonally dominant, and the iterations follow steepest
@@ -341,14 +341,14 @@ Perform Levenberg-Marquardt least-squares minimization, based on MINPACK-1.
    which assist in solving eqn (2).  The function to be minimized is
    a sum of squares:
 
-	   f = Sum(hi^2)										 (3)
+           f = Sum(hi^2)                                                                                 (3)
 
    where hi is the ith residual out of m residuals as described
    above.  This can be substituted back into eqn (2) after computing
    the derivatives:
 
-	   f'  = 2 Sum(hi  hi')
-	   f'' = 2 Sum(hi' hj') + 2 Sum(hi hi'')				(4)
+           f'  = 2 Sum(hi  hi')
+           f'' = 2 Sum(hi' hj') + 2 Sum(hi hi'')                                (4)
 
    If one assumes that the parameters are already close enough to a
    minimum, then one typically finds that the second term in f'' is
@@ -358,7 +358,7 @@ Perform Levenberg-Marquardt least-squares minimization, based on MINPACK-1.
 
    In matrix notation, the combination of eqns (2) and (4) becomes:
 
-		hT' . h' . dx = - hT' . h						  (5)
+                hT' . h' . dx = - hT' . h                                                 (5)
 
    Where h is the residual vector (length m), hT is its transpose, h'
    is the Jacobian matrix (dimensions n x m), and dx is (xm-x0).  The
@@ -374,9 +374,9 @@ Perform Levenberg-Marquardt least-squares minimization, based on MINPACK-1.
    Q = I, and R is upper right triangular.  Using h' = Q . R and the
    ortogonality of Q, eqn (5) becomes
 
-		(RT . QT) . (Q . R) . dx = - (RT . QT) . h
-					 RT . R . dx = - RT . QT . h		 (6)
-						  R . dx = - QT . h
+                (RT . QT) . (Q . R) . dx = - (RT . QT) . h
+                                         RT . R . dx = - RT . QT . h             (6)
+                                                  R . dx = - QT . h
 
    where the last statement follows because R is upper triangular.
    Here, R, QT and h are known so this is a matter of solving for dx.
@@ -384,17 +384,17 @@ Perform Levenberg-Marquardt least-squares minimization, based on MINPACK-1.
    pivoting, and MPFIT_QRSOLV provides the solution for dx.
 
 
-								 REFERENCES
+                                                                 REFERENCES
 
    MINPACK-1, Jorge More', available from netlib (www.netlib.org).
    "Optimization Software Guide," Jorge More' and Stephen Wright,
-	 SIAM, *Frontiers in Applied Mathematics*, Number 14.
+         SIAM, *Frontiers in Applied Mathematics*, Number 14.
    More', Jorge J., "The Levenberg-Marquardt Algorithm:
-	 Implementation and Theory," in *Numerical Analysis*, ed. Watson,
-	 G. A., Lecture Notes in Mathematics 630, Springer-Verlag, 1977.
+         Implementation and Theory," in *Numerical Analysis*, ed. Watson,
+         G. A., Lecture Notes in Mathematics 630, Springer-Verlag, 1977.
 
 
-						   MODIFICATION HISTORY
+                                                   MODIFICATION HISTORY
 
    Translated from MINPACK-1 in FORTRAN, Apr-Jul 1998, CM
  Copyright (C) 1997-2002, Craig Markwardt
@@ -413,188 +413,187 @@ import numpy
 import types
 import scipy.linalg
 
-#	 Original FORTRAN documentation
-#	 **********
-#
-#	 subroutine lmdif
-#
-#	 the purpose of lmdif is to minimize the sum of the squares of
-#	 m nonlinear functions in n variables by a modification of
-#	 the levenberg-marquardt algorithm. the user must provide a
-#	 subroutine which calculates the functions. the jacobian is
-#	 then calculated by a forward-difference approximation.
-#
-#	 the subroutine statement is
-#
-#	   subroutine lmdif(fcn,m,n,x,fvec,ftol,xtol,gtol,maxfev,epsfcn,
-#						diag,mode,factor,nprint,info,nfev,fjac,
-#						ldfjac,ipvt,qtf,wa1,wa2,wa3,wa4)
-#
-#	 where
-#
-#	   fcn is the name of the user-supplied subroutine which
-#		 calculates the functions. fcn must be declared
-#		 in an external statement in the user calling
-#		 program, and should be written as follows.
-#
-#		 subroutine fcn(m,n,x,fvec,iflag)
-#		 integer m,n,iflag
-#		 double precision x(n),fvec(m)
-#		 ----------
-#		 calculate the functions at x and
-#		 return this vector in fvec.
-#		 ----------
-#		 return
-#		 end
-#
-#		 the value of iflag should not be changed by fcn unless
-#		 the user wants to terminate execution of lmdif.
-#		 in this case set iflag to a negative integer.
-#
-#	   m is a positive integer input variable set to the number
-#		 of functions.
-#
-#	   n is a positive integer input variable set to the number
-#		 of variables. n must not exceed m.
-#
-#	   x is an array of length n. on input x must contain
-#		 an initial estimate of the solution vector. on output x
-#		 contains the final estimate of the solution vector.
-#
-#	   fvec is an output array of length m which contains
-#		 the functions evaluated at the output x.
-#
-#	   ftol is a nonnegative input variable. termination
-#		 occurs when both the actual and predicted relative
-#		 reductions in the sum of squares are at most ftol.
-#		 therefore, ftol measures the relative error desired
-#		 in the sum of squares.
-#
-#	   xtol is a nonnegative input variable. termination
-#		 occurs when the relative error between two consecutive
-#		 iterates is at most xtol. therefore, xtol measures the
-#		 relative error desired in the approximate solution.
-#
-#	   gtol is a nonnegative input variable. termination
-#		 occurs when the cosine of the angle between fvec and
-#		 any column of the jacobian is at most gtol in absolute
-#		 value. therefore, gtol measures the orthogonality
-#		 desired between the function vector and the columns
-#		 of the jacobian.
-#
-#	   maxfev is a positive integer input variable. termination
-#		 occurs when the number of calls to fcn is at least
-#		 maxfev by the end of an iteration.
-#
-#	   epsfcn is an input variable used in determining a suitable
-#		 step length for the forward-difference approximation. this
-#		 approximation assumes that the relative errors in the
-#		 functions are of the order of epsfcn. if epsfcn is less
-#		 than the machine precision, it is assumed that the relative
-#		 errors in the functions are of the order of the machine
-#		 precision.
-#
-#	   diag is an array of length n. if mode = 1 (see
-#		 below), diag is internally set. if mode = 2, diag
-#		 must contain positive entries that serve as
-#		 multiplicative scale factors for the variables.
-#
-#	   mode is an integer input variable. if mode = 1, the
-#		 variables will be scaled internally. if mode = 2,
-#		 the scaling is specified by the input diag. other
-#		 values of mode are equivalent to mode = 1.
-#
-#	   factor is a positive input variable used in determining the
-#		 initial step bound. this bound is set to the product of
-#		 factor and the euclidean norm of diag*x if nonzero, or else
-#		 to factor itself. in most cases factor should lie in the
-#		 interval (.1,100.). 100. is a generally recommended value.
-#
-#	   nprint is an integer input variable that enables controlled
-#		 printing of iterates if it is positive. in this case,
-#		 fcn is called with iflag = 0 at the beginning of the first
-#		 iteration and every nprint iterations thereafter and
-#		 immediately prior to return, with x and fvec available
-#		 for printing. if nprint is not positive, no special calls
-#		 of fcn with iflag = 0 are made.
-#
-#	   info is an integer output variable. if the user has
-#		 terminated execution, info is set to the (negative)
-#		 value of iflag. see description of fcn. otherwise,
-#		 info is set as follows.
-#
-#		 info = 0  improper input parameters.
-#
-#		 info = 1  both actual and predicted relative reductions
-#				   in the sum of squares are at most ftol.
-#
-#		 info = 2  relative error between two consecutive iterates
-#				   is at most xtol.
-#
-#		 info = 3  conditions for info = 1 and info = 2 both hold.
-#
-#		 info = 4  the cosine of the angle between fvec and any
-#				   column of the jacobian is at most gtol in
-#				   absolute value.
-#
-#		 info = 5  number of calls to fcn has reached or
-#				   exceeded maxfev.
-#
-#		 info = 6  ftol is too small. no further reduction in
-#				   the sum of squares is possible.
-#
-#		 info = 7  xtol is too small. no further improvement in
-#				   the approximate solution x is possible.
-#
-#		 info = 8  gtol is too small. fvec is orthogonal to the
-#				   columns of the jacobian to machine precision.
-#
-#	   nfev is an integer output variable set to the number of
-#		 calls to fcn.
-#
-#	   fjac is an output m by n array. the upper n by n submatrix
-#		 of fjac contains an upper triangular matrix r with
-#		 diagonal elements of nonincreasing magnitude such that
-#
-#				t	 t		   t
-#			   p *(jac *jac)*p = r *r,
-#
-#		 where p is a permutation matrix and jac is the final
-#		 calculated jacobian. column j of p is column ipvt(j)
-#		 (see below) of the identity matrix. the lower trapezoidal
-#		 part of fjac contains information generated during
-#		 the computation of r.
-#
-#	   ldfjac is a positive integer input variable not less than m
-#		 which specifies the leading dimension of the array fjac.
-#
-#	   ipvt is an integer output array of length n. ipvt
-#		 defines a permutation matrix p such that jac*p = q*r,
-#		 where jac is the final calculated jacobian, q is
-#		 orthogonal (not stored), and r is upper triangular
-#		 with diagonal elements of nonincreasing magnitude.
-#		 column j of p is column ipvt(j) of the identity matrix.
-#
-#	   qtf is an output array of length n which contains
-#		 the first n elements of the vector (q transpose)*fvec.
-#
-#	   wa1, wa2, and wa3 are work arrays of length n.
-#
-#	   wa4 is a work array of length m.
-#
-#	 subprograms called
-#
-#	   user-supplied ...... fcn
-#
-#	   minpack-supplied ... dpmpar,enorm,fdjac2,,qrfac
-#
-#	   fortran-supplied ... dabs,dmax1,dmin1,dsqrt,mod
-#
-#	 argonne national laboratory. minpack project. march 1980.
-#	 burton s. garbow, kenneth e. hillstrom, jorge j. more
-#
-#	 **********
+"""
+Original FORTRAN documentation
+**********
 
+subroutine lmdif
+
+the purpose of lmdif is to minimize the sum of the squares of
+m nonlinear functions in n variables by a modification of
+the levenberg-marquardt algorithm. the user must provide a
+subroutine which calculates the functions. the jacobian is
+then calculated by a forward-difference approximation.
+
+the subroutine statement is
+
+  subroutine lmdif(fcn,m,n,x,fvec,ftol,xtol,gtol,maxfev,epsfcn,
+                                       diag,mode,factor,nprint,info,nfev,fjac,
+                                       ldfjac,ipvt,qtf,wa1,wa2,wa3,wa4)
+
+where
+
+  fcn is the name of the user-supplied subroutine which
+        calculates the functions. fcn must be declared
+        in an external statement in the user calling
+        program, and should be written as follows.
+
+        subroutine fcn(m,n,x,fvec,iflag)
+        integer m,n,iflag
+        double precision x(n),fvec(m)
+        ----------
+        calculate the functions at x and
+        return this vector in fvec.
+        ----------
+        return
+        end
+
+        the value of iflag should not be changed by fcn unless
+        the user wants to terminate execution of lmdif.
+        in this case set iflag to a negative integer.
+
+  m is a positive integer input variable set to the number
+        of functions.
+
+  n is a positive integer input variable set to the number
+        of variables. n must not exceed m.
+
+  x is an array of length n. on input x must contain
+        an initial estimate of the solution vector. on output x
+        contains the final estimate of the solution vector.
+
+  fvec is an output array of length m which contains
+        the functions evaluated at the output x.
+
+  ftol is a nonnegative input variable. termination
+        occurs when both the actual and predicted relative
+        reductions in the sum of squares are at most ftol.
+        therefore, ftol measures the relative error desired
+        in the sum of squares.
+
+  xtol is a nonnegative input variable. termination
+        occurs when the relative error between two consecutive
+        iterates is at most xtol. therefore, xtol measures the
+        relative error desired in the approximate solution.
+
+  gtol is a nonnegative input variable. termination
+        occurs when the cosine of the angle between fvec and
+        any column of the jacobian is at most gtol in absolute
+        value. therefore, gtol measures the orthogonality
+        desired between the function vector and the columns
+        of the jacobian.
+
+  maxfev is a positive integer input variable. termination
+        occurs when the number of calls to fcn is at least
+        maxfev by the end of an iteration.
+
+  epsfcn is an input variable used in determining a suitable
+        step length for the forward-difference approximation. this
+        approximation assumes that the relative errors in the
+        functions are of the order of epsfcn. if epsfcn is less
+        than the machine precision, it is assumed that the relative
+        errors in the functions are of the order of the machine
+        precision.
+
+  diag is an array of length n. if mode = 1 (see
+        below), diag is internally set. if mode = 2, diag
+        must contain positive entries that serve as
+        multiplicative scale factors for the variables.
+
+  mode is an integer input variable. if mode = 1, the
+        variables will be scaled internally. if mode = 2,
+        the scaling is specified by the input diag. other
+        values of mode are equivalent to mode = 1.
+
+  factor is a positive input variable used in determining the
+        initial step bound. this bound is set to the product of
+        factor and the euclidean norm of diag*x if nonzero, or else
+        to factor itself. in most cases factor should lie in the
+        interval (.1,100.). 100. is a generally recommended value.
+
+  nprint is an integer input variable that enables controlled
+        printing of iterates if it is positive. in this case,
+        fcn is called with iflag = 0 at the beginning of the first
+        iteration and every nprint iterations thereafter and
+        immediately prior to return, with x and fvec available
+        for printing. if nprint is not positive, no special calls
+        of fcn with iflag = 0 are made.
+
+  info is an integer output variable. if the user has
+        terminated execution, info is set to the (negative)
+        value of iflag. see description of fcn. otherwise,
+        info is set as follows.
+
+        info = 0  improper input parameters.
+
+        info = 1  both actual and predicted relative reductions
+                          in the sum of squares are at most ftol.
+
+        info = 2  relative error between two consecutive iterates
+                          is at most xtol.
+
+        info = 3  conditions for info = 1 and info = 2 both hold.
+
+        info = 4  the cosine of the angle between fvec and any
+                          column of the jacobian is at most gtol in
+                          absolute value.
+
+        info = 5  number of calls to fcn has reached or
+                          exceeded maxfev.
+
+        info = 6  ftol is too small. no further reduction in
+                          the sum of squares is possible.
+
+        info = 7  xtol is too small. no further improvement in
+                          the approximate solution x is possible.
+
+        info = 8  gtol is too small. fvec is orthogonal to the
+                          columns of the jacobian to machine precision.
+
+  nfev is an integer output variable set to the number of
+        calls to fcn.
+
+  fjac is an output m by n array. the upper n by n submatrix
+        of fjac contains an upper triangular matrix r with
+        diagonal elements of nonincreasing magnitude such that
+
+                       t        t                 t
+                  p *(jac *jac)*p = r *r,
+
+        where p is a permutation matrix and jac is the final
+        calculated jacobian. column j of p is column ipvt(j)
+        (see below) of the identity matrix. the lower trapezoidal
+        part of fjac contains information generated during
+        the computation of r.
+
+  ldfjac is a positive integer input variable not less than m
+        which specifies the leading dimension of the array fjac.
+
+  ipvt is an integer output array of length n. ipvt
+        defines a permutation matrix p such that jac*p = q*r,
+        where jac is the final calculated jacobian, q is
+        orthogonal (not stored), and r is upper triangular
+        with diagonal elements of nonincreasing magnitude.
+        column j of p is column ipvt(j) of the identity matrix.
+
+  qtf is an output array of length n which contains
+        the first n elements of the vector (q transpose)*fvec.
+
+  wa1, wa2, and wa3 are work arrays of length n.
+
+  wa4 is a work array of length m.
+
+subprograms called
+
+  user-supplied ...... fcn
+
+  minpack-supplied ... dpmpar,enorm,fdjac2,,qrfac
+
+  fortran-supplied ... dabs,dmax1,dmin1,dsqrt,mod
+
+argonne national laboratory. minpack project. march 1980.
+burton s. garbow, kenneth e. hillstrom, jorge j. more
+"""
 
 class mpfit:
 
@@ -679,12 +678,12 @@ Keywords:
         and QUIET).
 
         myfunct:  The user-supplied function to be minimized,
-        p:		The current set of model parameters
-        iter:	 The iteration number
+        p:              The current set of model parameters
+        iter:    The iteration number
         functkw:  The arguments to be passed to myfunct.
-        fnorm:	The chi-squared value.
-        quiet:	Set when no textual output should be printed.
-        dof:	  The number of degrees of freedom, normally the number of points
+        fnorm:  The chi-squared value.
+        quiet:  Set when no textual output should be printed.
+        dof:      The number of degrees of freedom, normally the number of points
                           less the number of free parameters.
         See below for documentation of parinfo.
 
@@ -1362,7 +1361,7 @@ Outputs:
                 if ~numpy.all(numpy.isfinite(wa1) & numpy.isfinite(wa2) &
                               numpy.isfinite(x)) or ~numpy.isfinite(ratio):
                     errmsg = ('''ERROR: parameter or function value(s) have become
-						'infinite; check model function for over- 'and underflow''')
+                                                'infinite; check model function for over- 'and underflow''')
                     self.status = -16
                     break
                 # wh = where(finite(wa1) EQ 0 OR finite(wa2) EQ 0 OR finite(x) EQ 0, ct)
@@ -1465,18 +1464,18 @@ Outputs:
 
     #  DO_ITERSTOP:
     #  if keyword_set(iterstop) then begin
-    #	  k = get_kbrd(0)
-    #	  if k EQ string(byte(7)) then begin
-    #		  message, 'WARNING: minimization not complete', /info
-    #		  print, 'Do you want to terminate this procedure? (y/n)', $
-    #			format='(A,$)'
-    #		  k = ''
-    #		  read, k
-    #		  if strupcase(strmid(k,0,1)) EQ 'Y' then begin
-    #			  message, 'WARNING: Procedure is terminating.', /info
-    #			  mperr = -1
-    #		  endif
-    #	  endif
+    #     k = get_kbrd(0)
+    #     if k EQ string(byte(7)) then begin
+    #             message, 'WARNING: minimization not complete', /info
+    #             print, 'Do you want to terminate this procedure? (y/n)', $
+    #                   format='(A,$)'
+    #             k = ''
+    #             read, k
+    #             if strupcase(strmid(k,0,1)) EQ 'Y' then begin
+    #                     message, 'WARNING: Procedure is terminating.', /info
+    #                     mperr = -1
+    #             endif
+    #     endif
     #  endif
 
     # Procedure to parse the parameter values in PARINFO, which is a list of
@@ -1578,8 +1577,8 @@ Outputs:
 
             # This definition is consistent with CURVEFIT
             # Sign error found (thanks Jesus Fernandez <fernande@irm.chu-caen.fr>)
-#			fjac.shape = [m,nall]
-#			fjac = -fjac
+#                       fjac.shape = [m,nall]
+#                       fjac = -fjac
 
             # Select only the free parameters
             if len(ifree) < nall:
@@ -1646,82 +1645,82 @@ Outputs:
                 fjac[0:, j] = (fp - fm) / (2 * h[j])
         return fjac
 
-    #	 Original FORTRAN documentation
-    #	 **********
+    #    Original FORTRAN documentation
+    #    **********
     #
-    #	 subroutine qrfac
+    #    subroutine qrfac
     #
-    #	 this subroutine uses householder transformations with column
-    #	 pivoting (optional) to compute a qr factorization of the
-    #	 m by n matrix a. that is, qrfac determines an orthogonal
-    #	 matrix q, a permutation matrix p, and an upper trapezoidal
-    #	 matrix r with diagonal elements of nonincreasing magnitude,
-    #	 such that a*p = q*r. the householder transformation for
-    #	 column k, k = 1,2,...,min(m,n), is of the form
+    #    this subroutine uses householder transformations with column
+    #    pivoting (optional) to compute a qr factorization of the
+    #    m by n matrix a. that is, qrfac determines an orthogonal
+    #    matrix q, a permutation matrix p, and an upper trapezoidal
+    #    matrix r with diagonal elements of nonincreasing magnitude,
+    #    such that a*p = q*r. the householder transformation for
+    #    column k, k = 1,2,...,min(m,n), is of the form
     #
-    #						t
-    #		i - (1/u(k))*u*u
+    #                                           t
+    #           i - (1/u(k))*u*u
     #
-    #	 where u has zeros in the first k-1 positions. the form of
-    #	 this transformation and the method of pivoting first
-    #	 appeared in the corresponding linpack subroutine.
+    #    where u has zeros in the first k-1 positions. the form of
+    #    this transformation and the method of pivoting first
+    #    appeared in the corresponding linpack subroutine.
     #
-    #	 the subroutine statement is
+    #    the subroutine statement is
     #
-    #	subroutine qrfac(m,n,a,lda,pivot,ipvt,lipvt,rdiag,acnorm,wa)
+    #   subroutine qrfac(m,n,a,lda,pivot,ipvt,lipvt,rdiag,acnorm,wa)
     #
-    #	 where
+    #    where
     #
-    #	m is a positive integer input variable set to the number
-    #	  of rows of a.
+    #   m is a positive integer input variable set to the number
+    #     of rows of a.
     #
-    #	n is a positive integer input variable set to the number
-    #	  of columns of a.
+    #   n is a positive integer input variable set to the number
+    #     of columns of a.
     #
-    #	a is an m by n array. on input a contains the matrix for
-    #	  which the qr factorization is to be computed. on output
-    #	  the strict upper trapezoidal part of a contains the strict
-    #	  upper trapezoidal part of r, and the lower trapezoidal
-    #	  part of a contains a factored form of q (the non-trivial
-    #	  elements of the u vectors described above).
+    #   a is an m by n array. on input a contains the matrix for
+    #     which the qr factorization is to be computed. on output
+    #     the strict upper trapezoidal part of a contains the strict
+    #     upper trapezoidal part of r, and the lower trapezoidal
+    #     part of a contains a factored form of q (the non-trivial
+    #     elements of the u vectors described above).
     #
-    #	lda is a positive integer input variable not less than m
-    #	  which specifies the leading dimension of the array a.
+    #   lda is a positive integer input variable not less than m
+    #     which specifies the leading dimension of the array a.
     #
-    #	pivot is a logical input variable. if pivot is set true,
-    #	  then column pivoting is enforced. if pivot is set false,
-    #	  then no column pivoting is done.
+    #   pivot is a logical input variable. if pivot is set true,
+    #     then column pivoting is enforced. if pivot is set false,
+    #     then no column pivoting is done.
     #
-    #	ipvt is an integer output array of length lipvt. ipvt
-    #	  defines the permutation matrix p such that a*p = q*r.
-    #	  column j of p is column ipvt(j) of the identity matrix.
-    #	  if pivot is false, ipvt is not referenced.
+    #   ipvt is an integer output array of length lipvt. ipvt
+    #     defines the permutation matrix p such that a*p = q*r.
+    #     column j of p is column ipvt(j) of the identity matrix.
+    #     if pivot is false, ipvt is not referenced.
     #
-    #	lipvt is a positive integer input variable. if pivot is false,
-    #	  then lipvt may be as small as 1. if pivot is true, then
-    #	  lipvt must be at least n.
+    #   lipvt is a positive integer input variable. if pivot is false,
+    #     then lipvt may be as small as 1. if pivot is true, then
+    #     lipvt must be at least n.
     #
-    #	rdiag is an output array of length n which contains the
-    #	  diagonal elements of r.
+    #   rdiag is an output array of length n which contains the
+    #     diagonal elements of r.
     #
-    #	acnorm is an output array of length n which contains the
-    #	  norms of the corresponding columns of the input matrix a.
-    #	  if this information is not needed, then acnorm can coincide
-    #	  with rdiag.
+    #   acnorm is an output array of length n which contains the
+    #     norms of the corresponding columns of the input matrix a.
+    #     if this information is not needed, then acnorm can coincide
+    #     with rdiag.
     #
-    #	wa is a work array of length n. if pivot is false, then wa
-    #	  can coincide with rdiag.
+    #   wa is a work array of length n. if pivot is false, then wa
+    #     can coincide with rdiag.
     #
-    #	 subprograms called
+    #    subprograms called
     #
-    #	minpack-supplied ... dpmpar,enorm
+    #   minpack-supplied ... dpmpar,enorm
     #
-    #	fortran-supplied ... dmax1,dsqrt,min0
+    #   fortran-supplied ... dmax1,dsqrt,min0
     #
-    #	 argonne national laboratory. minpack project. march 1980.
-    #	 burton s. garbow, kenneth e. hillstrom, jorge j. more
+    #    argonne national laboratory. minpack project. march 1980.
+    #    burton s. garbow, kenneth e. hillstrom, jorge j. more
     #
-    #	 **********
+    #    **********
     #
     # PIVOTING / PERMUTING:
     #
@@ -1742,37 +1741,37 @@ Outputs:
     # output.
     #
     #  EXAMPLE:  decompose the matrix [[9.,2.,6.],[4.,8.,7.]]
-    #	aa = [[9.,2.,6.],[4.,8.,7.]]
-    #	mpfit_qrfac, aa, aapvt, rdiag, aanorm
-    #	 IDL> print, aa
-    #		  1.81818*	 0.181818*	 0.545455*
-    #		 -8.54545+	  1.90160*	 0.432573*
-    #	 IDL> print, rdiag
-    #		 -11.0000+	 -7.48166+
+    #   aa = [[9.,2.,6.],[4.,8.,7.]]
+    #   mpfit_qrfac, aa, aapvt, rdiag, aanorm
+    #    IDL> print, aa
+    #             1.81818*       0.181818*       0.545455*
+    #            -8.54545+        1.90160*       0.432573*
+    #    IDL> print, rdiag
+    #            -11.0000+       -7.48166+
     #
     # The components marked with a * are the components of the
     # reflectors, and those marked with a + are components of R.
     #
     # To reconstruct Q and R we proceed as follows.  First R.
-    #	r = fltarr(m, n)
+    #   r = fltarr(m, n)
     # for i = 0, n-1 do r(0:i,i) = aa(0:i,i)  # fill in lower diag
-    #	r(lindgen(n)*(m+1)) = rdiag
+    #   r(lindgen(n)*(m+1)) = rdiag
     #
     # Next, Q, which are composed from the reflectors.  Each reflector v
     # is taken from the upper trapezoid of aa, and converted to a matrix
     # via (I - 2 vT . v / (v . vT)).
     #
-    # hh = ident									# identity matrix
+    # hh = ident                                                                        # identity matrix
     #   for i = 0, n-1 do begin
-    # v = aa(*,i) & if i GT 0 then v(0:i-1) = 0	# extract reflector
+    # v = aa(*,i) & if i GT 0 then v(0:i-1) = 0 # extract reflector
     # hh = hh # (ident - 2*(v # v)/total(v * v))  # generate matrix
     #   endfor
     #
     # Test the result:
     # IDL> print, hh # transpose(r)
-    #		  9.00000	  4.00000
-    #		  2.00000	  8.00000
-    #		  6.00000	  7.00000
+    #             9.00000         4.00000
+    #             2.00000         8.00000
+    #             6.00000         7.00000
     #
     # Note that it is usually never necessary to form the Q matrix
     # explicitly, and MPFIT does not.
@@ -1856,82 +1855,82 @@ Outputs:
             rdiag[j] = -ajnorm
         return [a, ipvt, rdiag, acnorm]
 
-    #	 Original FORTRAN documentation
-    #	 **********
+    #    Original FORTRAN documentation
+    #    **********
     #
-    #	 subroutine qrsolv
+    #    subroutine qrsolv
     #
-    #	 given an m by n matrix a, an n by n diagonal matrix d,
-    #	 and an m-vector b, the problem is to determine an x which
-    #	 solves the system
+    #    given an m by n matrix a, an n by n diagonal matrix d,
+    #    and an m-vector b, the problem is to determine an x which
+    #    solves the system
     #
-    #		   a*x = b ,	 d*x = 0 ,
+    #              a*x = b ,     d*x = 0 ,
     #
-    #	 in the least squares sense.
+    #    in the least squares sense.
     #
-    #	 this subroutine completes the solution of the problem
-    #	 if it is provided with the necessary information from the
-    #	 factorization, with column pivoting, of a. that is, if
-    #	 a*p = q*r, where p is a permutation matrix, q has orthogonal
-    #	 columns, and r is an upper triangular matrix with diagonal
-    #	 elements of nonincreasing magnitude, then qrsolv expects
-    #	 the full upper triangle of r, the permutation matrix p,
-    #	 and the first n components of (q transpose)*b. the system
-    #	 a*x = b, d*x = 0, is then equivalent to
+    #    this subroutine completes the solution of the problem
+    #    if it is provided with the necessary information from the
+    #    factorization, with column pivoting, of a. that is, if
+    #    a*p = q*r, where p is a permutation matrix, q has orthogonal
+    #    columns, and r is an upper triangular matrix with diagonal
+    #    elements of nonincreasing magnitude, then qrsolv expects
+    #    the full upper triangle of r, the permutation matrix p,
+    #    and the first n components of (q transpose)*b. the system
+    #    a*x = b, d*x = 0, is then equivalent to
     #
-    #				  t	   t
-    #		   r*z = q *b ,  p *d*p*z = 0 ,
+    #                             t        t
+    #              r*z = q *b ,  p *d*p*z = 0 ,
     #
-    #	 where x = p*z. if this system does not have full rank,
-    #	 then a least squares solution is obtained. on output qrsolv
-    #	 also provides an upper triangular matrix s such that
+    #    where x = p*z. if this system does not have full rank,
+    #    then a least squares solution is obtained. on output qrsolv
+    #    also provides an upper triangular matrix s such that
     #
-    #			t   t			   t
-    #		   p *(a *a + d*d)*p = s *s .
+    #                   t   t                      t
+    #              p *(a *a + d*d)*p = s *s .
     #
-    #	 s is computed within qrsolv and may be of separate interest.
+    #    s is computed within qrsolv and may be of separate interest.
     #
-    #	 the subroutine statement is
+    #    the subroutine statement is
     #
-    #	   subroutine qrsolv(n,r,ldr,ipvt,diag,qtb,x,sdiag,wa)
+    #      subroutine qrsolv(n,r,ldr,ipvt,diag,qtb,x,sdiag,wa)
     #
-    #	 where
+    #    where
     #
-    #	   n is a positive integer input variable set to the order of r.
+    #      n is a positive integer input variable set to the order of r.
     #
-    #	   r is an n by n array. on input the full upper triangle
-    #		 must contain the full upper triangle of the matrix r.
-    #		 on output the full upper triangle is unaltered, and the
-    #		 strict lower triangle contains the strict upper triangle
-    #		 (transposed) of the upper triangular matrix s.
+    #      r is an n by n array. on input the full upper triangle
+    #            must contain the full upper triangle of the matrix r.
+    #            on output the full upper triangle is unaltered, and the
+    #            strict lower triangle contains the strict upper triangle
+    #            (transposed) of the upper triangular matrix s.
     #
-    #	   ldr is a positive integer input variable not less than n
-    #		 which specifies the leading dimension of the array r.
+    #      ldr is a positive integer input variable not less than n
+    #            which specifies the leading dimension of the array r.
     #
-    #	   ipvt is an integer input array of length n which defines the
-    #		 permutation matrix p such that a*p = q*r. column j of p
-    #		 is column ipvt(j) of the identity matrix.
+    #      ipvt is an integer input array of length n which defines the
+    #            permutation matrix p such that a*p = q*r. column j of p
+    #            is column ipvt(j) of the identity matrix.
     #
-    #	   diag is an input array of length n which must contain the
-    #		 diagonal elements of the matrix d.
+    #      diag is an input array of length n which must contain the
+    #            diagonal elements of the matrix d.
     #
-    #	   qtb is an input array of length n which must contain the first
-    #		 n elements of the vector (q transpose)*b.
+    #      qtb is an input array of length n which must contain the first
+    #            n elements of the vector (q transpose)*b.
     #
-    #	   x is an output array of length n which contains the least
-    #		 squares solution of the system a*x = b, d*x = 0.
+    #      x is an output array of length n which contains the least
+    #            squares solution of the system a*x = b, d*x = 0.
     #
-    #	   sdiag is an output array of length n which contains the
-    #		 diagonal elements of the upper triangular matrix s.
+    #      sdiag is an output array of length n which contains the
+    #            diagonal elements of the upper triangular matrix s.
     #
-    #	   wa is a work array of length n.
+    #      wa is a work array of length n.
     #
-    #	 subprograms called
+    #    subprograms called
     #
-    #	   fortran-supplied ... dabs,dsqrt
+    #      fortran-supplied ... dabs,dsqrt
     #
-    #	 argonne national laboratory. minpack project. march 1980.
-    #	 burton s. garbow, kenneth e. hillstrom, jorge j. more
+    #    argonne national laboratory. minpack project. march 1980.
+    #    burton s. garbow, kenneth e. hillstrom, jorge j. more
     #
     def qrsolv(self, r, ipvt, diag, qtb, sdiag):
         if self.debug:
@@ -2008,98 +2007,98 @@ Outputs:
         x[ipvt] = wa
         return r, x, sdiag
 
-    #	 Original FORTRAN documentation
+    #    Original FORTRAN documentation
     #
-    #	 subroutine lmpar
+    #    subroutine lmpar
     #
-    #	 given an m by n matrix a, an n by n nonsingular diagonal
-    #	 matrix d, an m-vector b, and a positive number delta,
-    #	 the problem is to determine a value for the parameter
-    #	 par such that if x solves the system
+    #    given an m by n matrix a, an n by n nonsingular diagonal
+    #    matrix d, an m-vector b, and a positive number delta,
+    #    the problem is to determine a value for the parameter
+    #    par such that if x solves the system
     #
-    #		a*x = b ,	 sqrt(par)*d*x = 0 ,
+    #           a*x = b ,        sqrt(par)*d*x = 0 ,
     #
-    #	 in the least squares sense, and dxnorm is the euclidean
-    #	 norm of d*x, then either par is zero and
+    #    in the least squares sense, and dxnorm is the euclidean
+    #    norm of d*x, then either par is zero and
     #
-    #		(dxnorm-delta) .le. 0.1*delta ,
+    #           (dxnorm-delta) .le. 0.1*delta ,
     #
-    #	 or par is positive and
+    #    or par is positive and
     #
-    #		abs(dxnorm-delta) .le. 0.1*delta .
+    #           abs(dxnorm-delta) .le. 0.1*delta .
     #
-    #	 this subroutine completes the solution of the problem
-    #	 if it is provided with the necessary information from the
-    #	 qr factorization, with column pivoting, of a. that is, if
-    #	 a*p = q*r, where p is a permutation matrix, q has orthogonal
-    #	 columns, and r is an upper triangular matrix with diagonal
-    #	 elements of nonincreasing magnitude, then lmpar expects
-    #	 the full upper triangle of r, the permutation matrix p,
-    #	 and the first n components of (q transpose)*b. on output
-    #	 lmpar also provides an upper triangular matrix s such that
+    #    this subroutine completes the solution of the problem
+    #    if it is provided with the necessary information from the
+    #    qr factorization, with column pivoting, of a. that is, if
+    #    a*p = q*r, where p is a permutation matrix, q has orthogonal
+    #    columns, and r is an upper triangular matrix with diagonal
+    #    elements of nonincreasing magnitude, then lmpar expects
+    #    the full upper triangle of r, the permutation matrix p,
+    #    and the first n components of (q transpose)*b. on output
+    #    lmpar also provides an upper triangular matrix s such that
     #
-    #		 t   t				   t
-    #		p *(a *a + par*d*d)*p = s *s .
+    #            t   t                             t
+    #           p *(a *a + par*d*d)*p = s *s .
     #
-    #	 s is employed within lmpar and may be of separate interest.
+    #    s is employed within lmpar and may be of separate interest.
     #
-    #	 only a few iterations are generally needed for convergence
-    #	 of the algorithm. if, however, the limit of 10 iterations
-    #	 is reached, then the output par will contain the best
-    #	 value obtained so far.
+    #    only a few iterations are generally needed for convergence
+    #    of the algorithm. if, however, the limit of 10 iterations
+    #    is reached, then the output par will contain the best
+    #    value obtained so far.
     #
-    #	 the subroutine statement is
+    #    the subroutine statement is
     #
-    #	subroutine lmpar(n,r,ldr,ipvt,diag,qtb,delta,par,x,sdiag,
-    #					 wa1,wa2)
+    #   subroutine lmpar(n,r,ldr,ipvt,diag,qtb,delta,par,x,sdiag,
+    #                                    wa1,wa2)
     #
-    #	 where
+    #    where
     #
-    #	n is a positive integer input variable set to the order of r.
+    #   n is a positive integer input variable set to the order of r.
     #
-    #	r is an n by n array. on input the full upper triangle
-    #	  must contain the full upper triangle of the matrix r.
-    #	  on output the full upper triangle is unaltered, and the
-    #	  strict lower triangle contains the strict upper triangle
-    #	  (transposed) of the upper triangular matrix s.
+    #   r is an n by n array. on input the full upper triangle
+    #     must contain the full upper triangle of the matrix r.
+    #     on output the full upper triangle is unaltered, and the
+    #     strict lower triangle contains the strict upper triangle
+    #     (transposed) of the upper triangular matrix s.
     #
-    #	ldr is a positive integer input variable not less than n
-    #	  which specifies the leading dimension of the array r.
+    #   ldr is a positive integer input variable not less than n
+    #     which specifies the leading dimension of the array r.
     #
-    #	ipvt is an integer input array of length n which defines the
-    #	  permutation matrix p such that a*p = q*r. column j of p
-    #	  is column ipvt(j) of the identity matrix.
+    #   ipvt is an integer input array of length n which defines the
+    #     permutation matrix p such that a*p = q*r. column j of p
+    #     is column ipvt(j) of the identity matrix.
     #
-    #	diag is an input array of length n which must contain the
-    #	  diagonal elements of the matrix d.
+    #   diag is an input array of length n which must contain the
+    #     diagonal elements of the matrix d.
     #
-    #	qtb is an input array of length n which must contain the first
-    #	  n elements of the vector (q transpose)*b.
+    #   qtb is an input array of length n which must contain the first
+    #     n elements of the vector (q transpose)*b.
     #
-    #	delta is a positive input variable which specifies an upper
-    #	  bound on the euclidean norm of d*x.
+    #   delta is a positive input variable which specifies an upper
+    #     bound on the euclidean norm of d*x.
     #
-    #	par is a nonnegative variable. on input par contains an
-    #	  initial estimate of the levenberg-marquardt parameter.
-    #	  on output par contains the final estimate.
+    #   par is a nonnegative variable. on input par contains an
+    #     initial estimate of the levenberg-marquardt parameter.
+    #     on output par contains the final estimate.
     #
-    #	x is an output array of length n which contains the least
-    #	  squares solution of the system a*x = b, sqrt(par)*d*x = 0,
-    #	  for the output par.
+    #   x is an output array of length n which contains the least
+    #     squares solution of the system a*x = b, sqrt(par)*d*x = 0,
+    #     for the output par.
     #
-    #	sdiag is an output array of length n which contains the
-    #	  diagonal elements of the upper triangular matrix s.
+    #   sdiag is an output array of length n which contains the
+    #     diagonal elements of the upper triangular matrix s.
     #
-    #	wa1 and wa2 are work arrays of length n.
+    #   wa1 and wa2 are work arrays of length n.
     #
-    #	 subprograms called
+    #    subprograms called
     #
-    #	minpack-supplied ... dpmpar,enorm,qrsolv
+    #   minpack-supplied ... dpmpar,enorm,qrsolv
     #
-    #	fortran-supplied ... dabs,dmax1,dmin1,dsqrt
+    #   fortran-supplied ... dabs,dmax1,dmin1,dsqrt
     #
-    #	 argonne national laboratory. minpack project. march 1980.
-    #	 burton s. garbow, kenneth e. hillstrom, jorge j. more
+    #    argonne national laboratory. minpack project. march 1980.
+    #    burton s. garbow, kenneth e. hillstrom, jorge j. more
     #
     def lmpar(self, r, ipvt, diag, qtb, delta, x, sdiag, par=None):
 
@@ -2229,72 +2228,72 @@ Outputs:
             exec(cmd)
         return p
 
-    #	 Original FORTRAN documentation
-    #	 **********
+    #    Original FORTRAN documentation
+    #    **********
     #
-    #	 subroutine covar
+    #    subroutine covar
     #
-    #	 given an m by n matrix a, the problem is to determine
-    #	 the covariance matrix corresponding to a, defined as
+    #    given an m by n matrix a, the problem is to determine
+    #    the covariance matrix corresponding to a, defined as
     #
-    #					t
-    #		   inverse(a *a) .
+    #                                   t
+    #              inverse(a *a) .
     #
-    #	 this subroutine completes the solution of the problem
-    #	 if it is provided with the necessary information from the
-    #	 qr factorization, with column pivoting, of a. that is, if
-    #	 a*p = q*r, where p is a permutation matrix, q has orthogonal
-    #	 columns, and r is an upper triangular matrix with diagonal
-    #	 elements of nonincreasing magnitude, then covar expects
-    #	 the full upper triangle of r and the permutation matrix p.
-    #	 the covariance matrix is then computed as
+    #    this subroutine completes the solution of the problem
+    #    if it is provided with the necessary information from the
+    #    qr factorization, with column pivoting, of a. that is, if
+    #    a*p = q*r, where p is a permutation matrix, q has orthogonal
+    #    columns, and r is an upper triangular matrix with diagonal
+    #    elements of nonincreasing magnitude, then covar expects
+    #    the full upper triangle of r and the permutation matrix p.
+    #    the covariance matrix is then computed as
     #
-    #					  t	 t
-    #		   p*inverse(r *r)*p  .
+    #                                     t      t
+    #              p*inverse(r *r)*p  .
     #
-    #	 if a is nearly rank deficient, it may be desirable to compute
-    #	 the covariance matrix corresponding to the linearly independent
-    #	 columns of a. to define the numerical rank of a, covar uses
-    #	 the tolerance tol. if l is the largest integer such that
+    #    if a is nearly rank deficient, it may be desirable to compute
+    #    the covariance matrix corresponding to the linearly independent
+    #    columns of a. to define the numerical rank of a, covar uses
+    #    the tolerance tol. if l is the largest integer such that
     #
-    #		   abs(r(l,l)) .gt. tol*abs(r(1,1)) ,
+    #              abs(r(l,l)) .gt. tol*abs(r(1,1)) ,
     #
-    #	 then covar computes the covariance matrix corresponding to
-    #	 the first l columns of r. for k greater than l, column
-    #	 and row ipvt(k) of the covariance matrix are set to zero.
+    #    then covar computes the covariance matrix corresponding to
+    #    the first l columns of r. for k greater than l, column
+    #    and row ipvt(k) of the covariance matrix are set to zero.
     #
-    #	 the subroutine statement is
+    #    the subroutine statement is
     #
-    #	   subroutine covar(n,r,ldr,ipvt,tol,wa)
+    #      subroutine covar(n,r,ldr,ipvt,tol,wa)
     #
-    #	 where
+    #    where
     #
-    #	   n is a positive integer input variable set to the order of r.
+    #      n is a positive integer input variable set to the order of r.
     #
-    #	   r is an n by n array. on input the full upper triangle must
-    #		 contain the full upper triangle of the matrix r. on output
-    #		 r contains the square symmetric covariance matrix.
+    #      r is an n by n array. on input the full upper triangle must
+    #            contain the full upper triangle of the matrix r. on output
+    #            r contains the square symmetric covariance matrix.
     #
-    #	   ldr is a positive integer input variable not less than n
-    #		 which specifies the leading dimension of the array r.
+    #      ldr is a positive integer input variable not less than n
+    #            which specifies the leading dimension of the array r.
     #
-    #	   ipvt is an integer input array of length n which defines the
-    #		 permutation matrix p such that a*p = q*r. column j of p
-    #		 is column ipvt(j) of the identity matrix.
+    #      ipvt is an integer input array of length n which defines the
+    #            permutation matrix p such that a*p = q*r. column j of p
+    #            is column ipvt(j) of the identity matrix.
     #
-    #	   tol is a nonnegative input variable used to define the
-    #		 numerical rank of a in the manner described above.
+    #      tol is a nonnegative input variable used to define the
+    #            numerical rank of a in the manner described above.
     #
-    #	   wa is a work array of length n.
+    #      wa is a work array of length n.
     #
-    #	 subprograms called
+    #    subprograms called
     #
-    #	   fortran-supplied ... dabs
+    #      fortran-supplied ... dabs
     #
-    #	 argonne national laboratory. minpack project. august 1980.
-    #	 burton s. garbow, kenneth e. hillstrom, jorge j. more
+    #    argonne national laboratory. minpack project. august 1980.
+    #    burton s. garbow, kenneth e. hillstrom, jorge j. more
     #
-    #	 **********
+    #    **********
     def calc_covar(self, rr, ipvt=None, tol=1.e-14):
 
         if self.debug:

--- a/hyperspy/external/mpfit/test_mpfit.py
+++ b/hyperspy/external/mpfit/test_mpfit.py
@@ -59,8 +59,11 @@ def test_linfit():
 
 def myfunctrosenbrock(p, fjac=None):
     # rosenbrock function
-    res = N.array(
-        [1 - p[0], -(1 - p[0]), 10 * (p[1] - p[0] ** 2), -10 * (p[1] - p[0] ** 2)])
+    res = N.array([
+        1 - p[0], -(1 - p[0]),
+        10 * (p[1] - p[0] ** 2),
+        -10 * (p[1] - p[0] ** 2)
+        ])
     status = 0
     return [status, res]
 
@@ -75,6 +78,7 @@ def test_rosenbrock():
     assert N.allclose(m.params, pactual)
     assert N.allclose(m.fnorm, 0)
     return
+
 
 if __name__ == "__main__":
     run_module_suite()

--- a/hyperspy/io_plugins/blockfile.py
+++ b/hyperspy/io_plugins/blockfile.py
@@ -25,7 +25,8 @@ import datetime
 import dateutil
 
 from hyperspy.misc.array_tools import sarray2dict, dict2sarray
-from hyperspy.misc.date_time_tools import serial_date_to_ISO_format, datetime_to_serial_date
+from hyperspy.misc.date_time_tools import (
+        serial_date_to_ISO_format, datetime_to_serial_date)
 
 _logger = logging.getLogger(__name__)
 

--- a/hyperspy/io_plugins/digital_micrograph.py
+++ b/hyperspy/io_plugins/digital_micrograph.py
@@ -29,7 +29,8 @@ import numpy as np
 import traits.api as t
 
 import hyperspy.misc.io.utils_readfile as iou
-from hyperspy.exceptions import DM3TagIDError, DM3DataTypeError, DM3TagTypeError
+from hyperspy.exceptions import (
+        DM3TagIDError, DM3DataTypeError, DM3TagTypeError)
 import hyperspy.misc.io.tools
 from hyperspy.misc.utils import DictionaryTreeBrowser
 from hyperspy.docstrings.signal import OPTIMIZE_ARG

--- a/hyperspy/io_plugins/edax.py
+++ b/hyperspy/io_plugins/edax.py
@@ -83,7 +83,8 @@ def get_spd_dtype_list(endianess='<'):
      - countBytes: 4 byte long;    *Number of count bytes per channel*
      - dataOffset: 4 byte long;    *File offset in bytes for data start*
      - nFrames: 4 byte long;       *Number of frames in live spectrum mapping*
-     - fName: 120 byte char array; *File name of electron image acquired during mapping*
+     - fName: 120 byte char array; *File name of electron image acquired during
+                                    mapping*
 
 
     Parameters
@@ -174,16 +175,19 @@ def get_spc_dtype_list(load_all=False, endianess='<', version=0.61):
     Table of header tags:
         - fVersion: 4 byte float; *File format Version*
         - aVersion: 4 byte float; *Application Version*
-        - fileName: 8 array of 1 byte char; *File name w/o '.spc' extension (OLD)*
+        - fileName: 8 array of 1 byte char; *File name w/o '.spc'
+                                            extension (OLD)*
         - collectDateYear: 2 byte short; *Year the spectrum was collected*
         - collectDateDay: 1 byte char; *Day the spectrum was collected*
         - collectDateMon: 1 byte char; *Month the spectrum was collected*
         - collectTimeMin: 1 byte char; *Minute the spectrum was collected*
         - collectTimeHour: 1 byte char; *Hour the spectrum was collected*
-        - collectTimeHund: 1 byte char; *Hundredth second the spectrum was collected*
+        - collectTimeHund: 1 byte char; *Hundredth second the spectrum was
+                                        collected*
         - collectTimeSec: 1 byte char; *Second the spectrum was collected*
         - fileSize: 4 byte long; *Size of spectrum file in bytes*
-        - dataStart: 4 byte long; *Start of spectrum data in bytes offset from 0 of file*
+        - dataStart: 4 byte long; *Start of spectrum data in bytes offset
+                                  from 0 of file*
         - numPts: 2 byte short; *Number of spectrum pts*
         - intersectingDist: 2 byte short; *Intersecting distance * 100 (mm)*
         - workingDist: 2 byte short; *Working distance * 100*
@@ -191,23 +195,31 @@ def get_spc_dtype_list(load_all=False, endianess='<', version=0.61):
 
         - filler1: 24 byte;
 
-        - spectrumLabel: 256 array of 1 byte char; *Type label for spectrum, 0-39=material type, 40-255=sample*
+        - spectrumLabel: 256 array of 1 byte char; *Type label for spectrum,
+                                                   0-39=material type,
+                                                   40-255=sample*
         - imageFilename: 8 array of 1 byte char; *Parent Image filename*
         - spotX: 2 byte short; *Spot X  in parent image file*
         - spotY: 2 byte short; *Spot Y in parent image file*
         - imageADC: 2 byte short; *Image ADC value 0-4095*
         - discrValues: 5 array of 4 byte long; *Analyzer Discriminator Values*
-        - discrEnabled: 5 array of 1 byte unsigned char; *Discriminator Flags (0=Disabled,1=Enabled)*
-        - pileupProcessed: 1 byte char; *Pileup Processed Flag (0=No PU,1=Static PU, 2=Dynamic PU,...)*
+        - discrEnabled: 5 array of 1 byte unsigned char; *Discriminator Flags
+                                                         (0=Disabled,1=Enabled)*
+        - pileupProcessed: 1 byte char; *Pileup Processed Flag (0=No
+                                        PU,1=Static PU, 2=Dynamic PU,...)*
         - fpgaVersion: 4 byte long; *Firmware Version.*
         - pileupProcVersion: 4 byte long; *Pileup Processing Software Version*
-        - NB5000CFG: 4 byte long; *Defines Hitachi NB5000 Dual Stage Cfg 0=None, 10=Eucentric Crossx,11= Eucentric Surface 12= Side Entry - Side 13 = Side Entry - Top*
+        - NB5000CFG: 4 byte long; *Defines Hitachi NB5000 Dual Stage Cfg
+                                  0=None, 10=Eucentric Crossx,11= Eucentric
+                                  Surface 12= Side Entry - Side
+                                  13 = Side Entry - Top*
 
         - filler2: 12 byte;
 
         - evPerChan: 4 byte long; *EV/channel*
         - ADCTimeConstant: 2 byte short; *ADC Time constant*
-        - analysisType: 2 byte short; *Preset mode 1=clock, 2=count, 3=none, 4=live, 5=resume*
+        - analysisType: 2 byte short; *Preset mode 1=clock, 2=count, 3=none,
+                                      4=live, 5=resume*
         - preset: 4 byte float; *Analysis Time Preset value*
         - maxp: 4 byte long; *Maximum counts of the spectrum*
         - maxPeakCh: 4 byte long; *Max peak channel number*
@@ -219,18 +231,27 @@ def get_spc_dtype_list(load_all=False, endianess='<', version=0.61):
         - xrayCollimator: 2 byte unsigned short; *0=None, 1=Installed*
         - xrayCapilaryType: 2 byte unsigned short; *0=Mono, 1=Poly*
         - xrayCapilarySize: 2 byte unsigned short; *Range : 20 – 5000 Microns*
-        - xrayFilterThickness: 2 byte unsigned short; *Range : 0 – 10000 Microns*
-        - spectrumSmoothed: 2 byte unsigned short; *1= Spectrum Smoothed, Else 0*
-        - detector_Size_SiLi: 2 byte unsigned short; *Eagle Detector 0=30mm, 1=80mm*
-        - spectrumReCalib: 2 byte unsigned short; *1= Peaks Recalibrated, Else 0*
-        - eagleSystem: 2 byte unsigned short; *0=None, 2=Eagle2, 3=Eagle3, 4-Xscope*
+        - xrayFilterThickness: 2 byte unsigned short; *Range :
+                                                      0 – 10000 Microns*
+        - spectrumSmoothed: 2 byte unsigned short; *1= Spectrum Smoothed,
+                                                   Else 0*
+        - detector_Size_SiLi: 2 byte unsigned short; *Eagle Detector 0=30mm,
+                                                     1=80mm*
+        - spectrumReCalib: 2 byte unsigned short; *1= Peaks Recalibrated,
+                                                  Else 0*
+        - eagleSystem: 2 byte unsigned short; *0=None, 2=Eagle2, 3=Eagle3,
+                                              4-Xscope*
         - sumPeakRemoved: 2 byte unsigned short; *1= Sum Peaks Removed, Else 0*
         - edaxSoftwareType: 2 byte unsigned short; *1= Team Spectrum, Else 0*
 
         - filler3: 6 byte;
 
-        - escapePeakRemoved: 2 byte unsigned short; *1=Escape Peak Was Removed, Else 0*
-        - analyzerType: 4 byte unsigned long; *Hardware type 1=EDI1, 2=EDI2, 3=DPP2, 31=DPP-FR, 32=DPP-FR2, 4=DPP3, 5= APOLLO XLT/XLS/DPP-4 (EDPP)*
+        - escapePeakRemoved: 2 byte unsigned short; *1=Escape Peak Was
+                                                    Removed, Else 0*
+        - analyzerType: 4 byte unsigned long; *Hardware type 1=EDI1, 2=EDI2,
+                                              3=DPP2, 31=DPP-FR, 32=DPP-FR2,
+                                              4=DPP3,
+                                              5= APOLLO XLT/XLS/DPP-4 (EDPP)*
         - startEnergy: 4 byte float; *Starting energy of spectrum*
         - endEnergy: 4 byte float; *Ending energy of spectrum*
         - liveTime: 4 byte float; *LiveTime*
@@ -238,7 +259,16 @@ def get_spc_dtype_list(load_all=False, endianess='<', version=0.61):
         - takeoff: 4 byte float; *Take off angle*
         - beamCurFact: 4 byte float; *Beam current factor*
         - detReso: 4 byte float; *Detector resolution*
-        - detectType: 4 byte unsigned long; *Detector Type: 1=Std-BE, 2=UTW, 3=Super UTW, 4=ECON 3/4 Open, 5=ECON 3/4 Closed, 6=ECON 5/6 Open, 7=ECON 5/6 Closed, 8=TEMECON; Add + 10 For Sapphire SiLi Detectors, (11-18), which started shipping in 1996. 30 = APOLLO 10 SDD, 31=APOLLO XV, 32 = APOLLO 10+, 40 = APOLLO 40 SDD ,50 = APOLLO-X, 51=APOLLO-XP, 52 = APOLLO-XL, 53 = APOLLO XL-XRF, 60 =APOLLO-XLT-LS, 61 =APOLLO-XLT-NW, 62 =APOLLO-XLT-SUTW*
+        - detectType: 4 byte unsigned long;
+                        *Detector Type: 1=Std-BE, 2=UTW, 3=Super UTW,
+                        4=ECON 3/4 Open, 5=ECON 3/4 Closed, 6=ECON 5/6 Open,
+                        7=ECON 5/6 Closed,
+                        8=TEMECON; Add + 10 For Sapphire SiLi Detectors,
+                        (11-18), which started shipping in 1996.
+                        30 = APOLLO 10 SDD, 31=APOLLO XV, 32 = APOLLO 10+,
+                        40 = APOLLO 40 SDD ,50 = APOLLO-X, 51=APOLLO-XP,
+                        52 = APOLLO-XL, 53 = APOLLO XL-XRF, 60 =APOLLO-XLT-LS,
+                        61 = APOLLO-XLT-NW, 62 =APOLLO-XLT-SUTW*
         - parThick: 4 byte float; *Parlodion light shield thickness*
         - alThick: 4 byte float; *Aluminum light shield thickness*
         - beWinThick: 4 byte float; *Be window thickness*
@@ -262,20 +292,28 @@ def get_spc_dtype_list(load_all=False, endianess='<', version=0.61):
 
         - rawDataType: 2 byte unsigned short; *TEM or SEM data*
         - totalBkgdCount: 4 byte float; *Accumulated background counts*
-        - totalSpectralCount: 4 byte unsigned long; *Accumulated spectrum counts*
+        - totalSpectralCount: 4 byte unsigned long; *Accumulated spectrum
+                                                    counts*
         - avginputCount: 4 byte float; *Average spectral counts*
-        - stdDevInputCount: 4 byte float; *Standard deviation of spectral counts*
-        - peakToBack: 2 byte unsigned short; *Peak to background setting. 0 = off, 1 = low, 2 = medium, 3 = high, 4 = user selected*
+        - stdDevInputCount: 4 byte float; *Standard deviation of spectral
+                                          counts*
+        - peakToBack: 2 byte unsigned short; *Peak to background setting.
+                                             0 = off, 1 = low, 2 = medium,
+                                             3 = high, 4 = user selected*
         - peakToBackValue: 4 byte float; *Peak to back value*
 
         - filler5: 38 byte;
 
         - numElem: 2 byte short; *Number of peak id elements 0-48*
-        - at: 48 array of 2 byte unsigned short; *atomic numbers for peak id elems*
-        - line: 48 array of 2 byte unsigned short; *line numbers for peak id elems*
+        - at: 48 array of 2 byte unsigned short; *atomic numbers for
+                                                 peak id elems*
+        - line: 48 array of 2 byte unsigned short; *line numbers for
+                                                   peak id elems*
         - energy: 48 array of 4 byte float; *float energy of identified peaks*
-        - height: 48 array of 4 byte unsigned long; *height in counts of id' ed peaks*
-        - spkht: 48 array of 2 byte short; *sorted peak height of id' ed peaks*
+        - height: 48 array of 4 byte unsigned long; *height in counts of
+                                                    id' ed peaks*
+        - spkht: 48 array of 2 byte short; *sorted peak height of
+                                           id' ed peaks*
 
         - filler5_1: 30 byte;
 
@@ -297,13 +335,16 @@ def get_spc_dtype_list(load_all=False, endianess='<', version=0.61):
         - filler6: 12 byte;
 
         - backgrdWidth: 2 byte short; *Background width*
-        - manBkgrdPerc: 4 byte float; *Percentage to move manual background down*
+        - manBkgrdPerc: 4 byte float; *Percentage to move manual background
+                                      down*
         - numBkgrdPts: 2 byte short; *Number of background points (2-64)*
-        - backMethod: 4 byte unsigned long; *Background method 1=auto, 2=manual*
+        - backMethod: 4 byte unsigned long; *Background method 1=auto,
+                                            2=manual*
         - backStEng: 4 byte float; *Starting energy of background*
         - backEndEng: 4 byte float; *Ending energy of background*
         - bg: 64 array of 2 byte short; *Channel # of background point*
-        - bgType: 4 byte unsigned long; *Background type. 1 = curve, 2 = linear.*
+        - bgType: 4 byte unsigned long; *Background type. 1 = curve,
+                                        2 = linear.*
         - concenKev1: 4 byte float; *First concentration background point*
         - concenKev2: 4 byte float; *Second concentration background point*
         - concenMethod: 2 byte short; *0 = Off, 1 = On*
@@ -312,24 +353,33 @@ def get_spc_dtype_list(load_all=False, endianess='<', version=0.61):
         - filler7: 16 byte;
 
         - numLabels: 2 byte short; *Number of displayed labels*
-        - label: (10 x 32) array 1 byte char; *32 character labels on the spectrum*
-        - labelx: 10 array of 2 byte short; *x position of label in terms of channel #*
-        - labely: 10 array of 4 byte long; *y position of label in terms of counts*
+        - label: (10 x 32) array 1 byte char; *32 character labels on the
+                                              spectrum*
+        - labelx: 10 array of 2 byte short; *x position of label in terms of
+                                            channel #*
+        - labely: 10 array of 4 byte long; *y position of label in terms of
+                                           counts*
         - zListFlag: 4 byte long; *Flag to indicate if Z List was written*
-        - bgPercents: 64 array of 4 byte float; *Percentage to move background point up and down.*
+        - bgPercents: 64 array of 4 byte float; *Percentage to move background
+                                                point up and down.*
         - IswGBg: 2 byte short; *= 1 if new backgrd pts exist*
         - BgPoints: 5 array of 4 byte float; *Background points*
         - IswGConc: 2 byte short; *= 1 if given concentrations exist*
         - numConcen: 2 byte short; *Number of elements (up to 24)*
-        - ZList: 24 array of 2 byte short; *Element list for which given concentrations exist*
-        - GivenConc: 24 array of 4 byte float; *Given concentrations for each element in Zlist*
+        - ZList: 24 array of 2 byte short; *Element list for which given
+                                        concentrations exist*
+        - GivenConc: 24 array of 4 byte float; *Given concentrations for each
+                                               element in Zlist*
 
         - filler8: 598 byte;
 
         - s: 4096 array of 4 byte long; *counts for each channel*
-        - longFileName: 256 array of 1 byte char; *Long filename for 32 bit version*
-        - longImageFileName: 256 array of 1 byte char; *Associated long image file name*
-        - ADCTimeConstantNew: 4 byte float; *Time constant: 2.5… 100 OR 1.6… 102.4 us*
+        - longFileName: 256 array of 1 byte char; *Long filename for
+                                                  32 bit version*
+        - longImageFileName: 256 array of 1 byte char; *Associated long image
+                                                       file name*
+        - ADCTimeConstantNew: 4 byte float; *Time constant:
+                                            2.5… 100 OR 1.6… 102.4 us*
 
         # the following datatypes are only included for version 0.70:
 
@@ -604,15 +654,19 @@ def get_ipr_dtype_list(endianess='<', version=333):
 
     Table of header tags:
         -  version: 2 byte unsigned short; *Current version number: 334*
-        -  imageType: 2 byte unsigned short; *0=empty; 1=electron; 2=xmap; 3=disk; 4=overlay*
+        -  imageType: 2 byte unsigned short; *0=empty; 1=electron; 2=xmap;
+                                             3=disk; 4=overlay*
         -  label: 8 byte char array; *Image label*
         -  sMin: 2 byte unsigned short; *Min collected signal*
         -  sMax: 2 byte unsigned short; *Max collected signal*
-        -  color: 2 byte unsigned short; *color: 0=gray; 1=R; 2=G; 3=B; 4=Y; 5=M; 6=C; 8=overlay*
+        -  color: 2 byte unsigned short; *color: 0=gray; 1=R; 2=G; 3=B; 4=Y;
+                                         5=M; 6=C; 8=overlay*
         -  presetMode: 2 byte unsigned short; *0=clock; 1=live*
         -  presetTime: 4 byte unsigned long; *Dwell time for x-ray (millisec)*
-        -  dataType: 2 byte unsigned short; *0=ROI;  1=Net intensity; 2=K ratio; 3=Wt%;  4=Mthin2*
-        -  timeConstantOld: 2 byte unsigned short; *Amplifier pulse processing time [usec]*
+        -  dataType: 2 byte unsigned short; *0=ROI; 1=Net intensity; 2=K ratio;
+                                            3=Wt%;  4=Mthin2*
+        -  timeConstantOld: 2 byte unsigned short; *Amplifier pulse processing
+                                                   time [usec]*
         -  reserved1: 2 byte short; *Not used*
         -  roiStartChan: 2 byte unsigned short; *ROI starting channel*
         -  roiEndChan: 2 byte unsigned short; *ROI ending channel*

--- a/hyperspy/io_plugins/fei.py
+++ b/hyperspy/io_plugins/fei.py
@@ -313,14 +313,12 @@ def load_ser_file(filename):
         # data have been acquired using a 32 or 64 bits platform.
         if header['SeriesVersion'] <= 528:
             data_offset = readLELong(f)
-            data_offset_array = np.fromfile(f,
-                                            dtype="<u4",
-                                            count=header["TotalNumberElements"][0])
+            data_offset_array = np.fromfile(
+                    f, dtype="<u4", count=header["TotalNumberElements"][0])
         else:
             data_offset = readLELongLong(f)
-            data_offset_array = np.fromfile(f,
-                                            dtype="<u8",
-                                            count=header["TotalNumberElements"][0])
+            data_offset_array = np.fromfile(
+                    f, dtype="<u8", count=header["TotalNumberElements"][0])
         data_dtype_list, shape = get_data_dtype_list(
             f,
             data_offset,

--- a/hyperspy/io_plugins/image.py
+++ b/hyperspy/io_plugins/image.py
@@ -41,13 +41,13 @@ writes = [(2, 0), ]
 def file_writer(filename, signal, file_format='png', **kwds):
     """Writes data to any format supported by PIL
 
-        Parameters
-        ----------
-        filename: str
-        signal: a Signal instance
-        file_format : str
-            The fileformat defined by its extension that is any one supported by
-            PIL.
+    Parameters
+    ----------
+    filename: str
+    signal: a Signal instance
+    file_format : str
+        The fileformat defined by its extension that is any one supported by
+        PIL.
     """
     imsave(filename, signal.data)
 

--- a/hyperspy/io_plugins/protochips.py
+++ b/hyperspy/io_plugins/protochips.py
@@ -112,13 +112,15 @@ class ProtochipsCSV(object):
 
     def _get_metadata(self, quantity):
         date, time = np.datetime_as_string(self.start_datetime).split('T')
-        return {'General': {'original_filename': os.path.split(self.filename)[1],
-                            'title': '%s (%s)' % (quantity,
-                                                  self._parse_quantity_units(quantity)),
-                            'date': date,
-                            'time': time},
-                "Signal": {'signal_type': '',
-                           'quantity': self._parse_quantity(quantity)}}
+        return {'General': {
+                    'original_filename': os.path.split(self.filename)[1],
+                    'title': '%s (%s)' % (quantity,
+                                          self._parse_quantity_units(quantity)),
+                    'date': date,
+                    'time': time},
+                "Signal": {
+                    'signal_type': '',
+                    'quantity': self._parse_quantity(quantity)}}
 
     def _get_mapping(self):
         mapping = {
@@ -138,7 +140,7 @@ class ProtochipsCSV(object):
     def _read_data(self, header_line_number):
         names = [name.replace(' ', '_') for name in self.column_name]
         # Necessary for numpy >= 1.14
-        kwargs = {'encoding':'latin1'} if np.__version__ >= LooseVersion("1.14") else {}
+        kwargs = {'encoding': 'latin1'} if np.__version__ >= LooseVersion("1.14") else {}
         data = np.genfromtxt(self.filename, delimiter=',', dtype=None,
                              names=names,
                              skip_header=header_line_number,
@@ -159,7 +161,7 @@ class ProtochipsCSV(object):
         return np.compress(arr[1] != '', arr, axis=1)
 
     def _parse_calibration_filepath(self):
-         # for the gas cell, the calibration is saved in the notes colunm
+        # for the gas cell, the calibration is saved in the notes colunm
         if hasattr(self, "calibration_file"):
             calibration_file = self.calibration_file
         else:
@@ -182,7 +184,8 @@ class ProtochipsCSV(object):
             # Once we support non-linear axis, don't forgot to update the
             # documentation of the protochips reader
             _logger.warning("The time axis is not linear, the time step is "
-                            "thus extrapolated to {0} {1}. The maximal step in time step is {2} {1}".format(
+                            "thus extrapolated to {0} {1}. The maximal step "
+                            "in time step is {2} {1}".format(
                                 scale, units, max_diff))
         else:
             warnings.warn("Time units not recognised, assuming second.")
@@ -226,7 +229,8 @@ class ProtochipsCSV(object):
             i += 1
             try:
                 param, value = self._parse_metadata_header(self.raw_header[i])
-            except ValueError:  # when the last line of header does not contain 'User'
+            except ValueError:
+                # when the last line of header does not contain 'User'
                 self.user = None
                 break
             except IndexError:

--- a/hyperspy/io_plugins/ripple.py
+++ b/hyperspy/io_plugins/ripple.py
@@ -326,7 +326,8 @@ def file_reader(filename, rpl_info=None, encoding="latin-1",
       height-name      str           # Name of the magnitude stored as height
       signal            str        # Type of the signal stored, e.g. EDS_SEM
       convergence-angle float   # TEM convergence angle in mrad
-      collection-angle  float   # EELS spectrometer collection semi-angle in mrad
+      collection-angle  float   # EELS spectrometer collection semi-angle in
+                                  mrad
       beam-energy       float   # TEM beam energy in keV
       elevation-angle   float   # Elevation angle of the EDS detector
       azimuth-angle     float   # Elevation angle of the EDS detector

--- a/hyperspy/io_plugins/semper_unf.py
+++ b/hyperspy/io_plugins/semper_unf.py
@@ -340,10 +340,12 @@ class SemperFormat(object):
             iform = 0  # byte
         elif np.issubdtype(data.dtype, np.int16):
             iform = 1  # int16
-        elif np.issubdtype(data.dtype, np.floating) and data.dtype.itemsize <= 4:
+        elif np.issubdtype(
+                data.dtype, np.floating) and data.dtype.itemsize <= 4:
             data = data.astype(np.float32)
             iform = 2  # float (4 byte or less)
-        elif np.issubdtype(data.dtype, np.complexfloating) and data.dtype.itemsize <= 8:
+        elif np.issubdtype(
+                data.dtype, np.complexfloating) and data.dtype.itemsize <= 8:
             data = data.astype(np.complex64)
             iform = 3  # complex (8 byte or less)
         elif np.issubdtype(data.dtype, np.int32):

--- a/hyperspy/io_plugins/tiff.py
+++ b/hyperspy/io_plugins/tiff.py
@@ -124,8 +124,8 @@ def file_reader(filename, record_by='image', force_read_resolution=False,
     force_read_resolution: Bool
         Default: False.
         Force reading the x_resolution, y_resolution and the resolution_unit
-        of the tiff tags.
-        See http://www.awaresystems.be/imaging/tiff/tifftags/resolutionunit.html
+        of the tiff tags. See:
+        http://www.awaresystems.be/imaging/tiff/tifftags/resolutionunit.html
     **kwds, optional
     """
 
@@ -450,7 +450,7 @@ def _get_dm_kwargs_extratag(signal, scales, units, offsets):
         extratags.extend([(65005, 's', 3, units[0], False),  # z unit
                           (65008, 'd', 1, offsets[0], False),  # z origin
                           (65011, 'd', 1, float(scales[0]), False),  # z scale
-                          #(65014, 's', 3, units[0], False), # z unit full name
+                          # (65014, 's', 3, units[0], False),# z unit full name
                           (65017, 'i', 1, 1, False)])
     return extratags
 
@@ -549,7 +549,8 @@ class Metadata:
         # mapping FEI metadata
         mapping_FEI = {
             'fei_metadata.Beam.HV':
-            ("Acquisition_instrument.SEM.beam_energy", lambda x: float(x) * 1e-3),
+            ("Acquisition_instrument.SEM.beam_energy",
+                lambda x: float(x) * 1e-3),
             'fei_metadata.Stage.StageX':
             ("Acquisition_instrument.SEM.Stage.x", None),
             'fei_metadata.Stage.StageY':
@@ -561,12 +562,13 @@ class Metadata:
             'fei_metadata.Stage.StageT':
             ("Acquisition_instrument.SEM.Stage.tilt", None),
             'fei_metadata.Stage.WorkingDistance':
-            ("Acquisition_instrument.SEM.working_distance", lambda x: float(x) * 1e3),
+            ("Acquisition_instrument.SEM.working_distance",
+                lambda x: float(x) * 1e3),
             'fei_metadata.Scan.Dwelltime':
             ("Acquisition_instrument.SEM.dwell_time", None),
             'fei_metadata.EBeam.BeamCurrent':
             ("Acquisition_instrument.SEM.beam_current",
-             self._parse_beam_current_FEI),
+                self._parse_beam_current_FEI),
             'fei_metadata.System.SystemType':
             ("Acquisition_instrument.SEM.microscope", None),
             'fei_metadata.User.Date':
@@ -582,9 +584,11 @@ class Metadata:
         # mapping Zeiss metadata
         mapping_Zeiss = {
             'sem_metadata.ap_actualkv':
-            ("Acquisition_instrument.SEM.beam_energy", self._parse_tuple_Zeiss),
+            ("Acquisition_instrument.SEM.beam_energy",
+                self._parse_tuple_Zeiss),
             'sem_metadata.ap_mag':
-            ("Acquisition_instrument.SEM.magnification", self._parse_tuple_Zeiss),
+            ("Acquisition_instrument.SEM.magnification",
+                self._parse_tuple_Zeiss),
             'sem_metadata.ap_stage_at_x':
             ("Acquisition_instrument.SEM.Stage.x", self._parse_tuple_Zeiss),
             'sem_metadata.ap_stage_at_y':
@@ -592,25 +596,31 @@ class Metadata:
             'sem_metadata.ap_stage_at_z':
             ("Acquisition_instrument.SEM.Stage.z", self._parse_tuple_Zeiss),
             'sem_metadata.ap_stage_at_r':
-            ("Acquisition_instrument.SEM.Stage.rotation", self._parse_tuple_Zeiss),
+            ("Acquisition_instrument.SEM.Stage.rotation",
+                self._parse_tuple_Zeiss),
             'sem_metadata.ap_stage_at_t':
             ("Acquisition_instrument.SEM.Stage.tilt", self._parse_tuple_Zeiss),
             'sem_metadata.ap_free_wd':
             ("Acquisition_instrument.SEM.working_distance",
-             lambda tup: self._parse_tuple_Zeiss_with_units(tup, to_units='mm')),
+             lambda tup: self._parse_tuple_Zeiss_with_units(
+                 tup, to_units='mm')),
             'sem_metadata.dp_dwell_time':
             ("Acquisition_instrument.SEM.dwell_time",
-             lambda tup: self._parse_tuple_Zeiss_with_units(tup, to_units='s')),
+             lambda tup: self._parse_tuple_Zeiss_with_units(
+                 tup, to_units='s')),
             'sem_metadata.ap_beam_current':
             ("Acquisition_instrument.SEM.beam_current",
-             lambda tup: self._parse_tuple_Zeiss_with_units(tup, to_units='nA')),
+             lambda tup: self._parse_tuple_Zeiss_with_units(
+                 tup, to_units='nA')),
             'sem_metadata.sv_serial_number':
             ("Acquisition_instrument.SEM.microscope", self._parse_tuple_Zeiss),
             # I have not find the corresponding metadata....
-            #'sem_metadata.???':
-            #("General.date", lambda tup: parser.parse(tup[1]).date().isoformat()),
-            #'sem_metadata.???':
-            #("General.time", lambda tup: parser.parse(tup[1]).time().isoformat()),
+            # 'sem_metadata.???':
+            # ("General.date", lambda tup: parser.parse(
+            #   tup[1]).date().isoformat()),
+            # 'sem_metadata.???':
+            # ("General.time", lambda tup: parser.parse(
+            #   tup[1]).time().isoformat()),
             'sem_metadata.sv_user_name':
             ("General.authors", self._parse_tuple_Zeiss),
         }
@@ -633,9 +643,10 @@ class Metadata:
             ("Acquisition_instrument.TEM.Detector.Camera.name", None),
             'tvips_metadata.exposure_time':
             ("Acquisition_instrument.TEM.Detector.Camera.exposure",
-             lambda x: float(x) * 1e-3),
+                lambda x: float(x) * 1e-3),
             'tvips_metadata.tem_high_tension':
-            ("Acquisition_instrument.TEM.beam_energy", lambda x: float(x) * 1e-3),
+            ("Acquisition_instrument.TEM.beam_energy",
+                lambda x: float(x) * 1e-3),
             'tvips_metadata.comment':
             ("General.notes", self._parse_string),
             'tvips_metadata.date':

--- a/hyperspy/learn/mva.py
+++ b/hyperspy/learn/mva.py
@@ -131,7 +131,7 @@ class MVA():
             Only has effect when using the svd of fast_svd algorithms.
         navigation_mask : boolean numpy array
             The navigation locations marked as True are not used in the
-            decompostion.
+            decomposition.
         signal_mask : boolean numpy array
             The signal locations marked as True are not used in the
             decomposition.
@@ -139,20 +139,23 @@ class MVA():
             Array of variance for the maximum likelihood PCA algorithm
         var_func : function or numpy array
             If function, it will apply it to the dataset to obtain the
-            var_array. Alternatively, it can a an array with the coefficients
+            var_array. Alternatively, it can an array with the coefficients
             of a polynomial.
         reproject : None | signal | navigation | both
             If not None, the results of the decomposition will be projected in
             the selected masked area.
         return_info: bool, default False
-            The result of the decomposition is stored internally. However, some algorithms generate some extra
-            information that is not stored. If True (the default is False) return any extra information if available
+            The result of the decomposition is stored internally.
+            However, some algorithms generate some extra information that
+            is not stored. If True (the default is False) return any extra
+            information if available
 
         Returns
         -------
         (X, E) : (numpy array, numpy array)
-            If 'algorithm' == 'RPCA_GoDec' or 'ORPCA' and 'return_info' is True,
-            returns the low-rank (X) and sparse (E) matrices from robust PCA.
+            If 'algorithm' == 'RPCA_GoDec' or 'ORPCA' and 'return_info'
+            is True, returns the low-rank (X) and sparse (E) matrices from
+            robust PCA.
 
         See also
         --------
@@ -191,9 +194,10 @@ class MVA():
                                  "output_dimension must be specified")
         if algorithm == 'RPCA_GoDec' or algorithm == 'ORPCA':
             if output_dimension is None:
-                raise ValueError("With the robust PCA algorithms ('RPCA_GoDec' "
-                                 "and 'ORPCA'), the output_dimension "
-                                 "must be specified")
+                raise ValueError(
+                        "With the robust PCA algorithms ('RPCA_GoDec' "
+                        "and 'ORPCA'), the output_dimension "
+                        "must be specified")
 
         # Apply pre-treatments
         # Transform the data in a line spectrum
@@ -230,7 +234,7 @@ class MVA():
                 signal_mask = ~signal_mask
 
             # WARNING: signal_mask and navigation_mask values are now their
-            # negaties i.e. True -> False and viceversa. However, the
+            # negatives i.e. True -> False and viceversa. However, the
             # stored value (at the end of the method) coincides with the
             # input masks
 
@@ -546,9 +550,8 @@ class MVA():
         # Check factors
         if not isinstance(factors, BaseSignal):
             raise ValueError(
-                "`factors` must be a BaseSignal instance, but an object of type "
-                "%s was provided." %
-                type(factors))
+                "`factors` must be a BaseSignal instance, but an object of "
+                "type %s was provided." % type(factors))
 
         # Check factor dimensions
         if factors.axes_manager.navigation_dimension != 1:

--- a/hyperspy/learn/rpca.py
+++ b/hyperspy/learn/rpca.py
@@ -323,8 +323,9 @@ class ORPCA:
         if self.init in ('qr', 'rand'):
             if self.init == 'qr':
                 if iterating:
-                    Y2 = np.stack([next(X) for _ in range(self.training_samples)],
-                                  axis=-1)
+                    Y2 = np.stack(
+                            [next(X) for _ in range(self.training_samples)],
+                            axis=-1)
                     X = chain(iter(Y2.T.copy()), X)
                 else:
                     Y2 = X[:self.training_samples, :].T

--- a/hyperspy/misc/array_tools.py
+++ b/hyperspy/misc/array_tools.py
@@ -195,9 +195,9 @@ def rebin(a, new_shape=None, scale=None, crop=True):
                                               for i, f in enumerate(scale)})
             # we provide slightly better error message in hypersy context
             except ValueError:
-                raise ValueError("Rebinning does not align with data dask chunks."
-                                 " Rebin fewer dimensions at a time to avoid this"
-                                 " error")
+                raise ValueError("Rebinning does not align with data dask "
+                                 "chunks. Rebin fewer dimensions at a time "
+                                 "to avoid this error")
 
 
 def jit_ifnumba(func):
@@ -221,8 +221,8 @@ def _linear_bin_loop(result, data, scale):
             # left over from it being non-integer binning e.g. when x1=1.4
             cx1 = math.ceil(x1)
             rem = cx1 - x1
-            # This will add a value of fractional pixel to the bin, eg if x1=1.4,
-            # the fist step will be to add 0.6*data[1]
+            # This will add a value of fractional pixel to the bin,
+            # eg if x1=1.4, the fist step will be to add 0.6*data[1]
             value += data[math.floor(x1)] * rem
             # Update x1 to remove the part of the bin we have just added.
             x1 = cx1
@@ -242,8 +242,8 @@ def _linear_bin_loop(result, data, scale):
                 # If our step is smaller than rounding up to the nearest whole
                 # number.
                 value += data[fx1] * (cx1 - x1)
-                x1 = cx1  # This step is needed when this particular bin straddes
-                # two neighbouring pixels.
+                x1 = cx1  # This step is needed when this particular bin
+                # straddes two neighbouring pixels.
             if x1 < x2:
                 # The standard upsampling function where each new pixel is a
                 # fraction of the original pixel.
@@ -298,9 +298,9 @@ def _linear_bin(dat, scale, crop=True):
         # For each iteration of linear_bin the axis being interated over has to
         # be switched to axis[0] in order to carry out the interation loop.
         dat = np.swapaxes(dat, 0, axis)
-        # The new dimension size is old_size/step, this is rounded down normally
-        # but if crop is switched off it is rounded up to the nearest whole
-        # number.
+        # The new dimension size is old_size/step, this is rounded down
+        # normally but if crop is switched off it is rounded up to the
+        # nearest whole number.
         dim = (math.floor(dat.shape[0] / s) if crop
                else math.ceil(dat.shape[0] / s))
         # check function wont bin to zero.

--- a/hyperspy/misc/date_time_tools.py
+++ b/hyperspy/misc/date_time_tools.py
@@ -56,7 +56,8 @@ def get_date_time_from_metadata(metadata, formatting='ISO'):
         '1991-10-01T12:00:00'
         >>> s = get_date_time_from_metadata(s.metadata, formatting='datetime')
 
-        >>> s = get_date_time_from_metadata(s.metadata, formatting='datetime64')
+        >>> s = get_date_time_from_metadata(
+        ...     s.metadata, formatting='datetime64')
 
     """
     date = metadata.get_item('General.date')
@@ -145,7 +146,9 @@ def serial_date_to_ISO_format(serial):
     """
     dt_utc = serial_date_to_datetime(serial)
     dt_local = dt_utc.astimezone(tz.tzlocal())
-    return dt_local.date().isoformat(), dt_local.time().isoformat(), dt_local.tzname()
+    local_date = dt_local.date().isoformat()
+    local_time = dt_local.time().isoformat()
+    return local_date, local_time, dt_local.tzname()
 
 
 def ISO_format_to_serial_date(date, time, timezone='UTC'):

--- a/hyperspy/misc/eels/base_gos.py
+++ b/hyperspy/misc/eels/base_gos.py
@@ -15,12 +15,14 @@ class GOSBase(object):
         if (element in elements) is not True:
             raise ValueError("The given element " + element +
                              " is not in the database.")
-        elif subshell not in elements[element]['Atomic_properties']['Binding_energies']:
+        elif subshell not in elements[element]['Atomic_properties'][
+                'Binding_energies']:
             raise ValueError(
                 "The given subshell " + subshell +
                 " is not in the database.\n" +
                 "The available subshells are:\n" +
-                str(list(elements[element]['Atomic_properties']['subshells'].keys())))
+                str(list(elements[element]['Atomic_properties'][
+                    'subshells'].keys())))
 
         self.onset_energy = \
             elements[

--- a/hyperspy/misc/eels/eelsdb.py
+++ b/hyperspy/misc/eels/eelsdb.py
@@ -27,7 +27,8 @@ def eelsdb(spectrum_type=None, title=None, author=None, element=None,
         correspond with a valid element symbol.
     formula: string
         Chemical formula of the sample.
-    edge: {'K', 'L1', 'L2,3', 'M2,3', 'M4,5', 'N2,3', 'N4,5' 'O2,3', 'O4,5'}, optional
+    edge: {'K', 'L1', 'L2,3', 'M2,3', 'M4,5', 'N2,3', 'N4,5' 'O2,3', 'O4,5'},
+          optional
         Filter for spectra with a specific class of edge.
     min_energy, max_energy: float, optional
         Minimum and maximum energy in eV.

--- a/hyperspy/misc/eels/eelsdb.py
+++ b/hyperspy/misc/eels/eelsdb.py
@@ -8,9 +8,9 @@ from hyperspy.io import dict2signal
 _logger = logging.getLogger(__name__)
 
 
-def eelsdb(spectrum_type=None, title=None, author=None, element=None, formula=None,
-           edge=None, min_energy=None, max_energy=None, resolution=None,
-           min_energy_compare="gt", max_energy_compare="lt",
+def eelsdb(spectrum_type=None, title=None, author=None, element=None,
+           formula=None, edge=None, min_energy=None, max_energy=None,
+           resolution=None, min_energy_compare="gt", max_energy_compare="lt",
            resolution_compare="lt", max_n=-1, monochromated=None, order=None,
            order_direction="ASC"):
     r"""Download spectra from the EELS Data Base.
@@ -105,8 +105,9 @@ def eelsdb(spectrum_type=None, title=None, author=None, element=None, formula=No
     # Verify arguments
     if spectrum_type is not None and spectrum_type not in {
             'coreloss', 'lowloss', 'zeroloss', 'xrayabs'}:
-        raise ValueError("spectrum_type must be one of \'coreloss\', \'lowloss\', "
-                         "\'zeroloss\', \'xrayabs\'.")
+        raise ValueError(
+                "spectrum_type must be one of \'coreloss\', \'lowloss\', "
+                "\'zeroloss\', \'xrayabs\'.")
     valid_edges = [
         'K', 'L1', 'L2,3', 'M2,3', 'M4,5', 'N2,3', 'N4,5', 'O2,3', 'O4,5']
     valid_order_keys = [
@@ -224,8 +225,8 @@ def eelsdb(spectrum_type=None, title=None, author=None, element=None, formula=No
                 (json_spectrum["title"], json_spectrum["id"]))
     if not spectra:
         _logger.info(
-            "The EELS database does not contain any spectra matching your query"
-            ". If you have some, why not submitting them "
+            "The EELS database does not contain any spectra matching your "
+            "query. If you have some, why not submitting them "
             "https://eelsdb.eu/submit-data/ ?\n")
     else:
         # Add some info from json to metadata

--- a/hyperspy/misc/eels/effective_angle.py
+++ b/hyperspy/misc/eels/effective_angle.py
@@ -37,12 +37,10 @@ def effective_angle(E0, E, alpha, beta):
     B2 = beta * beta * 1e-6
     T2 = thetaE * thetaE * 1e-6
     eta1 = math.sqrt((A2 + B2 + T2) ** 2 - 4. * A2 * B2) - A2 - B2 - T2
-    eta2 = 2. * B2 * \
-        math.log(
-            0.5 / T2 * (math.sqrt((A2 + T2 - B2) ** 2 + 4. * B2 * T2) + A2 + T2 - B2))
-    eta3 = 2. * A2 * \
-        math.log(
-            0.5 / T2 * (math.sqrt((B2 + T2 - A2) ** 2 + 4. * A2 * T2) + B2 + T2 - A2))
+    eta2 = 2. * B2 * math.log(0.5 / T2 * (
+        math.sqrt((A2 + T2 - B2) ** 2 + 4. * B2 * T2) + A2 + T2 - B2))
+    eta3 = 2. * A2 * math.log(0.5 / T2 * (
+        math.sqrt((B2 + T2 - A2) ** 2 + 4. * A2 * T2) + B2 + T2 - A2))
 #    ETA=(eta1+eta2+eta3)/A2/math.log(4./T2)
     F1 = (eta1 + eta2 + eta3) / 2 / A2 / math.log(1. + B2 / T2)
     F2 = F1

--- a/hyperspy/misc/eels/tools.py
+++ b/hyperspy/misc/eels/tools.py
@@ -52,13 +52,13 @@ def _estimate_gain(ns, cs,
         s = Signal1D(variance2fit)
         s.axes_manager.signal_axes[0].axis = average2fit
         m = Model1D(s)
-        l = Line()
-        l.a.value = fit[1]
-        l.b.value = fit[0]
-        m.append(l)
+        li = Line()
+        li.a.value = fit[1]
+        li.b.value = fit[0]
+        m.append(li)
         m.fit(weights=True)
-        fit[0] = l.b.value
-        fit[1] = l.a.value
+        fit[0] = li.b.value
+        fit[1] = li.a.value
 
     if plot_results is True:
         plt.figure()
@@ -182,7 +182,8 @@ def power_law_perc_area(E1, E2, r):
     a = E1
     b = E2
     return 100 * ((a ** r * r - a ** r) * (a / (a ** r * r - a ** r) -
-                                           (b + a) / ((b + a) ** r * r - (b + a) ** r))) / a
+                                           (b + a) / ((b + a) ** r * r -
+                                           (b + a) ** r))) / a
 
 
 def rel_std_of_fraction(a, std_a, b, std_b, corr_factor=1):
@@ -249,14 +250,14 @@ def eels_constant(s, zlp, t):
     # Mapped parameters
     try:
         e0 = s.metadata.Acquisition_instrument.TEM.beam_energy
-    except:
+    except AttributeError:
         raise AttributeError("Please define the beam energy."
                              "You can do this e.g. by using the "
                              "set_microscope_parameters method")
     try:
         beta = s.metadata.Acquisition_instrument.\
             TEM.Detector.EELS.collection_angle
-    except:
+    except AttributeError:
         raise AttributeError("Please define the collection semi-angle."
                              "You can do this e.g. by using the "
                              "set_microscope_parameters method")

--- a/hyperspy/misc/eels/tools.py
+++ b/hyperspy/misc/eels/tools.py
@@ -216,15 +216,15 @@ def eels_constant(s, zlp, t):
 
         .. math::
 
-            S(E)=\frac{I_{0}t}{\pi a_{0}m_{0}v^{2}}\ln\left[1+\left(\frac{\beta}
-            {\theta_{E}}\right)^{2}\right]\Im(\frac{-1}{\epsilon(E)})=
-            k\Im(\frac{-1}{\epsilon(E)})
+            S(E)=\frac{I_{0}t}{\pi a_{0}m_{0}v^{2}}\ln\left[1+\left(
+            \frac{\beta}{\theta_{E}}\right)^{2}\right]\Im(
+            \frac{-1}{\epsilon(E)})=k\Im(\frac{-1}{\epsilon(E)})
 
 
     Parameters
     ----------
     zlp: {number, BaseSignal}
-        If the ZLP is the same for all spectra, the intengral of the ZLP
+        If the ZLP is the same for all spectra, the integral of the ZLP
         can be provided as a number. Otherwise, if the ZLP intensity is not
         the same for all spectra, it can be provided as i) a Signal
         of the same dimensions as the current signal containing the ZLP

--- a/hyperspy/misc/example_signals_loading.py
+++ b/hyperspy/misc/example_signals_loading.py
@@ -58,10 +58,12 @@ def load_object_hologram():
     Notes
     -----
     - Sample: Fe needle with YOx nanoparticle inclusions [Migunov, V. et al.
-    Model-independent measurement of the charge density distribution along an Fe atom probe needle using
-    off-axis electron holography without mean inner potential effects. Journal of Applied Physics 117, 134301 (2015).
+    Model-independent measurement of the charge density distribution along an
+    Fe atom probe needle using off-axis electron holography without mean inner#
+    potential effects. Journal of Applied Physics 117, 134301 (2015).
     https://doi.org/10.1063/1.4916609]
-    - TEM Microscope: FEI Titan G2 60-300 HOLO [Boothroyd, C. et al. FEI Titan G2 60-300 HOLO.
+    - TEM Microscope: FEI Titan G2 60-300 HOLO [Boothroyd, C. et al. FEI Titan
+    G2 60-300 HOLO.
     Journal of large-scale research facilities JLSRF 2, 44 (2016).
     https://doi.org/10.17815/jlsrf-2-70]
     """
@@ -78,10 +80,12 @@ def load_reference_hologram():
     Notes
     -----
     - Sample: Fe needle with YOx nanoparticle inclusions [Migunov, V. et al.
-    Model-independent measurement of the charge density distribution along an Fe atom probe needle using
-    off-axis electron holography without mean inner potential effects. Journal of Applied Physics 117, 134301 (2015).
+    Model-independent measurement of the charge density distribution along an
+    Fe atom probe needle using off-axis electron holography without mean inner
+    potential effects. Journal of Applied Physics 117, 134301 (2015).
     https://doi.org/10.1063/1.4916609]
-    - TEM Microscope: FEI Titan G2 60-300 HOLO [Boothroyd, C. et al. FEI Titan G2 60-300 HOLO.
+    - TEM Microscope: FEI Titan G2 60-300 HOLO [Boothroyd, C. et al.
+    FEI Titan G2 60-300 HOLO.
     Journal of large-scale research facilities JLSRF 2, 44 (2016).
     https://doi.org/10.17815/jlsrf-2-70]
     """

--- a/hyperspy/misc/export_dictionary.py
+++ b/hyperspy/misc/export_dictionary.py
@@ -145,24 +145,24 @@ def load_from_dictionary(target, dic):
 
     Parameters
     ----------
-        target : object
-            must contain the (nested) attributes of the whitelist.keys()
-        dic : dictionary
-            A dictionary, containing field '_whitelist', which is a dictionary
-            with all keys that were exported, with values being flag strings.
-            The convention of the flags is as follows:
-            * 'init':
-                object used for initialization of the target. Will be copied to
-                the _whitelist after loading
-            * 'fn':
-                the targeted attribute is a function, and may have been pickled
-                (preferably with dill package).
-            * 'id':
-                the id of the original object was exported and the attribute
-                will not be set. The key has to be '_id_'
-            * 'sig':
-                The targeted attribute was a signal, and may have been converted
-                to a dictionary if fullcopy=True
+    target : object
+        must contain the (nested) attributes of the whitelist.keys()
+    dic : dictionary
+        A dictionary, containing field '_whitelist', which is a dictionary
+        with all keys that were exported, with values being flag strings.
+        The convention of the flags is as follows:
+        * 'init':
+            object used for initialization of the target. Will be copied to
+            the _whitelist after loading
+        * 'fn':
+            the targeted attribute is a function, and may have been pickled
+            (preferably with dill package).
+        * 'id':
+            the id of the original object was exported and the attribute
+            will not be set. The key has to be '_id_'
+        * 'sig':
+            The targeted attribute was a signal, and may have been converted
+            to a dictionary if fullcopy=True
 
     """
     new_whitelist = {}

--- a/hyperspy/misc/holography/reconstruct.py
+++ b/hyperspy/misc/holography/reconstruct.py
@@ -99,10 +99,11 @@ def estimate_sideband_size(sb_position, holo_shape, sb_size_ratio=0.5):
 
     """
 
-    h = np.array((np.asarray(sb_position) - np.asarray([0, 0]),
-                  np.asarray(sb_position) - np.asarray([0, holo_shape[1]]),
-                  np.asarray(sb_position) - np.asarray([holo_shape[0], 0]),
-                  np.asarray(sb_position) - np.asarray(holo_shape))) * sb_size_ratio
+    h = np.array((
+        np.asarray(sb_position) - np.asarray([0, 0]),
+        np.asarray(sb_position) - np.asarray([0, holo_shape[1]]),
+        np.asarray(sb_position) - np.asarray([holo_shape[0], 0]),
+        np.asarray(sb_position) - np.asarray(holo_shape))) * sb_size_ratio
     return np.min(np.linalg.norm(h, axis=1))
 
 

--- a/hyperspy/misc/holography/reconstruct.py
+++ b/hyperspy/misc/holography/reconstruct.py
@@ -49,8 +49,8 @@ def estimate_sideband_position(
 
     f_freq = freq_array(holo_data.shape, holo_sampling)
 
-    # If aperture radius of centerband is not given, it will be set to 5 % of the Nyquist
-    # frequency.
+    # If aperture radius of centerband is not given, it will be set
+    # to 5 % of the Nyquist frequency.
     if central_band_mask_radius is None:
         central_band_mask_radius = 1 / 20. * np.max(f_freq)
 
@@ -106,8 +106,9 @@ def estimate_sideband_size(sb_position, holo_shape, sb_size_ratio=0.5):
     return np.min(np.linalg.norm(h, axis=1))
 
 
-def reconstruct(holo_data, holo_sampling, sb_size, sb_position, sb_smoothness, output_shape=None,
-                plotting=False):
+def reconstruct(
+        holo_data, holo_sampling, sb_size, sb_position, sb_smoothness,
+        output_shape=None, plotting=False):
     """Core function for holographic reconstruction.
 
     Parameters
@@ -160,10 +161,10 @@ def reconstruct(holo_data, holo_sampling, sb_size, sb_position, sb_smoothness, o
             s=10,
             color='red',
             marker='x')
-        axs.set_xlim(int(holo_size[0] / 2) - sb_size / np.mean(f_sampling), int(holo_size[0] / 2) +
-                     sb_size / np.mean(f_sampling))
-        axs.set_ylim(int(holo_size[1] / 2) - sb_size / np.mean(f_sampling), int(holo_size[1] / 2) +
-                     sb_size / np.mean(f_sampling))
+        axs.set_xlim(int(holo_size[0] / 2) - sb_size / np.mean(f_sampling),
+                     int(holo_size[0] / 2) + sb_size / np.mean(f_sampling))
+        axs.set_ylim(int(holo_size[1] / 2) - sb_size / np.mean(f_sampling),
+                     int(holo_size[1] / 2) + sb_size / np.mean(f_sampling))
         plt.show()
 
     if output_shape is not None:
@@ -183,16 +184,19 @@ def reconstruct(holo_data, holo_sampling, sb_size, sb_position, sb_smoothness, o
 
 def aperture_function(r, apradius, rsmooth):
     """
-    A smooth aperture function that decays from apradius-rsmooth to apradius+rsmooth.
+    A smooth aperture function that decays from
+    apradius-rsmooth to apradius+rsmooth.
 
     Parameters
     ----------
     r : ndarray
         Array of input data (e.g. frequencies)
     apradius : float
-        Radius (center) of the smooth aperture. Decay starts at apradius - rsmooth.
+        Radius (center) of the smooth aperture. Decay starts
+        at apradius - rsmooth.
     rsmooth : float
-        Smoothness in halfwidth. rsmooth = 1 will cause a decay from 1 to 0 over 2 pixel.
+        Smoothness in halfwidth. rsmooth = 1 will cause a decay
+        from 1 to 0 over 2 pixel.
     """
 
     return 0.5 * (1. - np.tanh((np.absolute(r) - apradius) / (0.5 * rsmooth)))

--- a/hyperspy/misc/machine_learning/import_sklearn.py
+++ b/hyperspy/misc/machine_learning/import_sklearn.py
@@ -11,7 +11,7 @@ try:
         warnings.simplefilter("ignore")
         try:
             import sklearn
-        except:
+        except ModuleNotFoundError:
             import scikits.learn as sklearn
         sklearn_version = LooseVersion(sklearn.__version__)
         if sklearn_version < LooseVersion("0.9"):

--- a/hyperspy/misc/signal_tools.py
+++ b/hyperspy/misc/signal_tools.py
@@ -28,13 +28,15 @@ def _get_shapes(am, ignore_axis):
             ignore_axis = am[ignore_axis]
         except ValueError:
             pass
-    sigsh = tuple(axis.size if (ignore_axis is None or axis is not
-                                ignore_axis)
-                  else 1 for axis in am.signal_axes) if am.signal_dimension != 0 else ()
+    sig_ax = am.signal_axes
+    sigsh = tuple(axis.size if (
+        ignore_axis is None or axis is not ignore_axis)
+        else 1 for axis in sig_ax) if am.signal_dimension != 0 else ()
 
-    navsh = tuple(axis.size if (ignore_axis is None or axis is not
-                                ignore_axis)
-                  else 1 for axis in am.navigation_axes) if am.navigation_dimension != 0 else ()
+    nav_ax = am.navigation_axes
+    navsh = tuple(axis.size if (
+        ignore_axis is None or axis is not ignore_axis)
+        else 1 for axis in nav_ax) if am.navigation_dimension != 0 else ()
     return sigsh, navsh
 
 

--- a/hyperspy/misc/slicing.py
+++ b/hyperspy/misc/slicing.py
@@ -74,9 +74,9 @@ def copy_slice_from_whitelist(
         if the slicing operation is performed on navigation dimensions of the
         object
     order : tuple, None
-        if given, performs the copying in the order given. If not all attributes
-        given, the rest is random (the order a whitelist.keys() returns them).
-        If given in the object, _slicing_order is looked up.
+        if given, performs the copying in the order given. If not all
+        attributes given, the rest is random (the order a whitelist.keys()
+        returns them). If given in the object, _slicing_order is looked up.
     """
 
     def make_slice_navigation_decision(flags, isnav):

--- a/hyperspy/misc/test_utils.py
+++ b/hyperspy/misc/test_utils.py
@@ -62,7 +62,7 @@ def ignore_warning(message="", category=None):
 # WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
 # DISCLAIMED. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT,
 # INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
-#(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
 # SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
 # HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
 # STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING
@@ -145,7 +145,8 @@ def assert_warns(message=None, category=None):
     that may produce different warnings.  The behaviors can be combined.
     If you pass multiple patterns, you get an orderless "and", where all of the
     warnings must be raised.
-    If you use the "|" operator in a pattern, you can catch one of several warnings.
+    If you use the "|" operator in a pattern, you can catch one of several
+    warnings.
     Finally, you can use "|\A\Z" in a pattern to signify it as optional.
     """
     if isinstance(message, (str, re._pattern_type)):
@@ -203,7 +204,7 @@ def assert_deep_almost_equal(actual, expected, *args, **kwargs):
 
     expected: lists, dicts or tuples
     """
-    is_root = not '__trace' in kwargs
+    is_root = '__trace' not in kwargs
     trace = kwargs.pop('__trace', 'ROOT')
     try:
         if isinstance(expected, (int, float, complex)):

--- a/hyperspy/misc/utils.py
+++ b/hyperspy/misc/utils.py
@@ -24,7 +24,6 @@ import types
 from io import StringIO
 import codecs
 import collections
-import tempfile
 import unicodedata
 from contextlib import contextmanager
 from hyperspy.misc.signal_tools import broadcast_signals
@@ -792,7 +791,6 @@ def stack(signal_list, axis=None, new_axis_name='stack_element',
            [10, 11, 12, 13, 14, 15, 16, 17, 18, 19]])
 
     """
-    from itertools import zip_longest
     from hyperspy.signals import BaseSignal
     import dask.array as da
     from numbers import Number
@@ -809,7 +807,8 @@ def stack(signal_list, axis=None, new_axis_name='stack_element',
     # Get the real signal with the most axes to get metadata/class/etc
     # first = sorted(filter(lambda _s: isinstance(_s, BaseSignal), signal_list),
     #                key=lambda _s: _s.data.ndim)[-1]
-    first = next(filter(lambda _s: isinstance(_s, BaseSignal), signal_list))
+    first = next(filter(
+        lambda _s: isinstance(_s, BaseSignal), signal_list))
 
     # Cast numbers as signals. Will broadcast later
 
@@ -887,9 +886,11 @@ def stack(signal_list, axis=None, new_axis_name='stack_element',
                 s.metadata.has_item('Signal.Noise_properties.variance')
                 for s in signal_list
         ]):
-            variance = stack([
-                s.metadata.Signal.Noise_properties.variance for s in signal_list
-            ], axis)
+            variance_list = []
+            for s in signal_list:
+                variance_list.append(
+                        s.metadata.Signal.Noise_properties.variance)
+            variance = stack([variance_list], axis)
             signal.metadata.set_item(
                 'Signal.Noise_properties.variance', variance)
     else:

--- a/hyperspy/samfire_utils/goodness_of_fit_tests/information_theory.py
+++ b/hyperspy/samfire_utils/goodness_of_fit_tests/information_theory.py
@@ -30,6 +30,7 @@ def notexp_o(x):
     else:
         return 2. / ((x * x + 1.) * np.exp(1.))
 
+
 notexp = np.vectorize(notexp_o)
 
 

--- a/hyperspy/samfire_utils/goodness_of_fit_tests/red_chisq.py
+++ b/hyperspy/samfire_utils/goodness_of_fit_tests/red_chisq.py
@@ -18,7 +18,8 @@
 
 import numpy as np
 
-from hyperspy.samfire_utils.goodness_of_fit_tests.test_general import goodness_test
+from hyperspy.samfire_utils.goodness_of_fit_tests.test_general import (
+        goodness_test)
 
 
 class red_chisq_test(goodness_test):

--- a/hyperspy/signal.py
+++ b/hyperspy/signal.py
@@ -50,7 +50,8 @@ from hyperspy.drawing.marker import markers_metadata_dict_to_markers
 from hyperspy.misc.slicing import SpecialSlicers, FancySlicing
 from hyperspy.misc.utils import slugify
 from hyperspy.docstrings.signal import (
-    ONE_AXIS_PARAMETER, MANY_AXIS_PARAMETER, OUT_ARG, NAN_FUNC, OPTIMIZE_ARG, RECHUNK_ARG)
+    ONE_AXIS_PARAMETER, MANY_AXIS_PARAMETER, OUT_ARG, NAN_FUNC, OPTIMIZE_ARG,
+    RECHUNK_ARG)
 from hyperspy.docstrings.plot import BASE_PLOT_DOCSTRING, KWARGS_DOCSTRING
 from hyperspy.events import Events, Event
 from hyperspy.interactive import interactive
@@ -763,10 +764,10 @@ class MVATools(object):
         ----------
 
         comp_ids : None, int, or list of ints
-            if None (default), returns maps of all components if the output_dimension was defined when
-            executing ``decomposition``. Otherwise it raises a ValueError.
-            if int, returns maps of components with ids from 0 to
-            given int.
+            if None (default), returns maps of all components if the
+            output_dimension was defined when executing ``decomposition``.
+            Otherwise it raises a ValueError. If int, returns maps of
+            components with ids from 0 to given int.
             if list of ints, returns maps of components with ids in
             given list.
 
@@ -902,11 +903,11 @@ class MVATools(object):
         ----------
 
         comp_ids : None, int, or list of ints
-            if None (default), returns maps of all components if the output_dimension was defined when
-            executing ``decomposition``. Otherwise it raises a ValueError.
-            if int, returns maps of components with ids from 0 to
-            given int.
-            if list of ints, returns maps of components with ids in
+            if None (default), returns maps of all components if the
+            output_dimension was defined when executing ``decomposition``.
+            Otherwise it raises a ValueError. If int, returns maps of
+            components with ids from 0 to given int.
+            If list of ints, returns maps of components with ids in
             given list.
 
         calibrate : bool

--- a/hyperspy/utils/eds.py
+++ b/hyperspy/utils/eds.py
@@ -3,4 +3,5 @@ from hyperspy.misc.eds.utils import xray_range
 from hyperspy.misc.eds.utils import electron_range
 from hyperspy.misc.eds.utils import take_off_angle
 from hyperspy.misc.eds.utils import get_xray_lines_near_energy
-from hyperspy.misc.eds.utils import edx_cross_section_to_zeta, zeta_to_edx_cross_section
+from hyperspy.misc.eds.utils import (
+        edx_cross_section_to_zeta, zeta_to_edx_cross_section)

--- a/hyperspy/utils/model_selection.py
+++ b/hyperspy/utils/model_selection.py
@@ -17,7 +17,6 @@
 # along with  HyperSpy.  If not, see <http://www.gnu.org/licenses/>.
 
 import numpy as np
-from hyperspy import model
 from hyperspy.exceptions import NavigationSizeError
 
 


### PR DESCRIPTION
Currently HyperSpy is not following the python style guide (PEP8), which aims to keep the code consistent. One way of checking the code is by using `flake8`, which also checks for other things such as undefined variables and redefined variables. (I actually found a bug in the `Arctan` component while doing this). 

Ideally we want to have the code pass `flake8` without any errors, so the continuous integration system can check if new contributions add any new errors. I've been very happy with this setup in `atomap` and `pixstem`, since it really improves the code quality and several times it has helped me catch bugs before including them into the main branch.


### Changes

- Add a configuration file for flake8: `.flake8`
- Try to fix all the issues flagged by `flake8`

The last one is a pretty big task, and potentially a bit risky since it is possible to subtly break functionality.

Some files will (currently) have to be excluded through the `flake8` configuration file:

- If they simply import functions or classes
- If they contain very long lines, for example `misc/elements.py`

In addition, I've been fixing minor docstring typos or styie issue when I see them.

### Progress of the PR
- [ ] Finish config file
- [ ] Fix all flake8 issues
- [ ] Check that nothing broke
- [ ] Ready for review.

### To test flake8

Run from the HyperSpy root directory

```bash
python3 -m flake8
```