### PR TITLE
Corrected typo in warning when hyperspy_gui_traitsui is not installed

### DIFF
--- a/hyperspy/api.py
+++ b/hyperspy/api.py
@@ -21,4 +21,4 @@ except ImportError:
     if preferences.GUIs.warn_if_guis_are_missing:
         _logger.warning(
             "The traitsui GUI elements are not available, probably because the "
-            "hyperspy_gui_traitui package is not installed.")
+            "hyperspy_gui_traitsui package is not installed.")


### PR DESCRIPTION
### Description of the change
'traitsui' was missing the 's' in the warning printed when  hyperspy_gui_traitsui is not installed

### Progress of the PR
- [X ] Change implemented (can be split into several points),
- [X ] ready for review.

