### PR TITLE
Fix eds set microscope parameters

### DIFF
--- a/hyperspy/_signals/eds.py
+++ b/hyperspy/_signals/eds.py
@@ -912,7 +912,7 @@ class EDS_mixin:
                         only_one=only_one,
                         only_lines=only_lines)
                 else:
-                    raise ValueError(
+                    _logger.warning(
                         "No elements defined, set them with `add_elements`")
             xray_lines, xray_not_here = self._get_xray_lines_in_spectral_range(
                 xray_lines)

--- a/hyperspy/_signals/eds.py
+++ b/hyperspy/_signals/eds.py
@@ -917,7 +917,7 @@ class EDS_mixin:
             xray_lines, xray_not_here = self._get_xray_lines_in_spectral_range(
                 xray_lines)
             for xray in xray_not_here:
-                _logger.warn("%s is not in the data energy range." % xray)
+                _logger.warning("%s is not in the data energy range." % xray)
             xray_lines = np.unique(xray_lines)
             self.add_xray_lines_markers(xray_lines)
             if background_windows is not None:

--- a/hyperspy/io_plugins/blockfile.py
+++ b/hyperspy/io_plugins/blockfile.py
@@ -168,7 +168,7 @@ def file_reader(filename, endianess='<', mmap_mode=None,
         header['Note'] = note.decode("latin1").strip("\x00")
     except:
         # Not sure about the encoding so, if it fails, we carry on
-        _logger.warn(
+        _logger.warning(
             "Reading the Note metadata of this file failed. "
             "You can help improving "
             "HyperSpy by reporting the issue in "

--- a/hyperspy/io_plugins/mrc.py
+++ b/hyperspy/io_plugins/mrc.py
@@ -150,7 +150,7 @@ def file_reader(filename, endianess='<', **kwds):
     if f.tell() == 1024 + std_header['NEXT']:
         _logger.debug("The FEI header was correctly loaded")
     else:
-        _logger.warn("There was a problem reading the extended header")
+        _logger.warning("There was a problem reading the extended header")
         f.seek(1024 + std_header['NEXT'])
         fei_header = None
     NX, NY, NZ = std_header['NX'], std_header['NY'], std_header['NZ']

--- a/hyperspy/io_plugins/msa.py
+++ b/hyperspy/io_plugins/msa.py
@@ -232,13 +232,13 @@ def parse_msa_string(string, filename=None):
             mapped.set_item('General.time', time.time().isoformat())
         except:
             if 'TIME' in parameters and parameters['TIME']:
-                _logger.warn('The time information could not be retrieved')
+                _logger.warning('The time information could not be retrieved')
         try:
             date = dt.strptime(parameters['DATE'], "%d-%b-%Y")
             mapped.set_item('General.date', date.date().isoformat())
         except:
             if 'DATE' in parameters and parameters['DATE']:
-                _logger.warn('The date information could not be retrieved')
+                _logger.warning('The date information could not be retrieved')
     except:
         warnings.warn("I couldn't read the date information due to"
                       "an unexpected error. Please report this error to "

--- a/hyperspy/io_plugins/netcdf.py
+++ b/hyperspy/io_plugins/netcdf.py
@@ -130,8 +130,8 @@ def nc_hyperspy_reader_0dot1(ncfile, filename, *args, **kwds):
             else:
                 calibration_dict[attrib[0]] = value
         else:
-            _logger.warn("Warning: the attribute '%s' is not defined in the "
-                         "file '%s'", attrib[0], filename)
+            _logger.warning("Warning: the attribute '%s' is not defined in "
+                            "the file '%s'", attrib[0], filename)
     for attrib in acquisition2netcdf.items():
         if hasattr(dc, attrib[1]):
             value = eval('dc.' + attrib[1])
@@ -140,14 +140,14 @@ def nc_hyperspy_reader_0dot1(ncfile, filename, *args, **kwds):
             else:
                 acquisition_dict[attrib[0]] = value
         else:
-            _logger.warn("Warning: the attribute '%s' is not defined in the "
-                         "file '%s'", attrib[0], filename)
+            _logger.warning("Warning: the attribute '%s' is not defined in "
+                            "the file '%s'", attrib[0], filename)
     for attrib in treatments2netcdf.items():
         if hasattr(dc, attrib[1]):
             treatments_dict[attrib[0]] = eval('dc.' + attrib[1])
         else:
-            _logger.warn("Warning: the attribute '%s' is not defined in the "
-                         "file '%s'", attrib[0], filename)
+            _logger.warning("Warning: the attribute '%s' is not defined in "
+                            "the file '%s'", attrib[0], filename)
     original_metadata = {'record_by': ncfile.type,
                          'calibration': calibration_dict,
                          'acquisition': acquisition_dict,

--- a/hyperspy/signal_tools.py
+++ b/hyperspy/signal_tools.py
@@ -211,12 +211,12 @@ class Signal1DCalibration(SpanSelectorInSignal1D):
 
     def apply(self):
         if np.isnan(self.ss_left_value) or np.isnan(self.ss_right_value):
-            _logger.warn("Select a range by clicking on the signal figure "
-                         "and dragging before pressing Apply.")
+            _logger.warning("Select a range by clicking on the signal figure "
+                            "and dragging before pressing Apply.")
             return
         elif self.left_value is t.Undefined or self.right_value is t.Undefined:
-            _logger.warn("Select the new left and right values before "
-                         "pressing apply.")
+            _logger.warning("Select the new left and right values before "
+                            "pressing apply.")
             return
         axis = self.axis
         axis.scale = self.scale
@@ -387,13 +387,13 @@ class SmoothingSavitzkyGolay(Smoothing):
         if nwl > self.polynomial_order:
             self.window_length = nwl
         else:
-            _logger.warn(
+            _logger.warning(
                 "The window length must be greater than the polynomial order")
 
     def _polynomial_order_changed(self, old, new):
         if self.window_length <= new:
             self.window_length = new + 2 if new % 2 else new + 1
-            _logger.warn(
+            _logger.warning(
                 "Polynomial order must be < window length. "
                 "Window length set to %i.", self.window_length)
         self.update_lines()
@@ -404,7 +404,7 @@ class SmoothingSavitzkyGolay(Smoothing):
     def _differential_order_changed(self, old, new):
         if new > self.polynomial_order:
             self.polynomial_order += 1
-            _logger.warn(
+            _logger.warning(
                 "Differential order must be <= polynomial order. "
                 "Polynomial order set to %i.", self.polynomial_order)
         super(

--- a/hyperspy/tests/drawing/test_plot_markers.py
+++ b/hyperspy/tests/drawing/test_plot_markers.py
@@ -464,6 +464,7 @@ def test_plot_line_markers(mpl_cleanup):
 def test_plot_line_markers_close():
     return _test_plot_line_markers()
 
+
 @pytest.mark.mpl_image_compare(
     baseline_dir=baseline_dir, tolerance=default_tol, style=style_pytest_mpl)
 def test_plot_eds_lines():
@@ -472,4 +473,16 @@ def test_plot_eds_lines():
     s.plot(True)
     s.axes_manager.navigation_axes[0].index = 1
     return s._plot.signal_plot.figure
-    
+
+
+@update_close_figure
+def test_plot_eds_markers_close():
+    s = EDS_TEM_Spectrum()
+    s.plot(True)
+    return s
+
+
+def test_plot_eds_markers_no_energy():
+    s = EDS_TEM_Spectrum()
+    del s.metadata.Acquisition_instrument.TEM.beam_energy
+    s.plot(True)


### PR DESCRIPTION
### Description of the change
When plotting X-rays markers without the beam energy present, hyperspy raise an AttributeError requesting to use `set microscope parameters` to set the beam energy. It should be possible to plot markers without the beam energy in the metadata.

### Progress of the PR
- [x] Catch `AttributeError` when plotting X-rays marker lines and beam energy is not present,
- [x] `_logger.warn` is deprecated, use `_logger.warning` instead.,
- [x] add tests,
- [x] ready for review.

### Minimal example of the bug fix or the new feature
```python
import hyperspy.api as hs
s = hs.datasets.example_signals.EDS_TEM_Spectrum()
del s.metadata.Acquisition_instrument.TEM.beam_energy
s.plot(True)
```
