### PR TITLE
Remove edax_files.zip from distribution

### DIFF
--- a/hyperspy/tests/io/test_edax.py
+++ b/hyperspy/tests/io/test_edax.py
@@ -32,13 +32,15 @@ if not TEST_FILES_OK:
     try:
         r = requests.get(
             "https://github.com/hyperspy/hyperspy/blob/e7a323a3bb9b237c24bd9267d2cc4fcb31bb99f3/hyperspy/tests/io/edax_files.zip?raw=true")
-        with open(ZIPF, 'wb') as f:
-            SHA256SUM_GOT = hashlib.sha256(r.content).hexdigest()
-            if SHA256SUM_GOT == SHA256SUM:
-                TEST_FILES_OK = True
+        
+        SHA256SUM_GOT = hashlib.sha256(r.content).hexdigest()
+        if SHA256SUM_GOT == SHA256SUM:
+            ZIPF = os.path.join(TMP_DIR.name, "edax_files.zip")
+            with open(ZIPF, 'wb') as f:
                 f.write(r.content)
-            else:
-                REASON = "wrong sha256sum of downloaded file. Expected: %s, got: %s" % SHA256SUM, SHA256SUM_GOT
+            TEST_FILES_OK = True
+        else:
+            REASON = "wrong sha256sum of downloaded file. Expected: %s, got: %s" % SHA256SUM, SHA256SUM_GOT
     except BaseException:
         REASON = "download of EDAX test files failed"
 

--- a/hyperspy/tests/io/test_edax.py
+++ b/hyperspy/tests/io/test_edax.py
@@ -34,7 +34,7 @@ if not TEST_FILES_OK:
             "https://github.com/hyperspy/hyperspy/blob/e7a323a3bb9b237c24bd9267d2cc4fcb31bb99f3/hyperspy/tests/io/edax_files.zip?raw=true")
         with open(ZIPF, 'wb') as f:
             SHA256SUM_GOT = hashlib.sha256(r.content).hexdigest()
-            if SHA256SUM_GOT == SHA256SUM: 
+            if SHA256SUM_GOT == SHA256SUM:
                 TEST_FILES_OK = True
                 f.write(r.content)
             else:

--- a/hyperspy/tests/io/test_edax.py
+++ b/hyperspy/tests/io/test_edax.py
@@ -32,7 +32,7 @@ if not TEST_FILES_OK:
     try:
         r = requests.get(
             "https://github.com/hyperspy/hyperspy/blob/e7a323a3bb9b237c24bd9267d2cc4fcb31bb99f3/hyperspy/tests/io/edax_files.zip?raw=true")
-        
+
         SHA256SUM_GOT = hashlib.sha256(r.content).hexdigest()
         if SHA256SUM_GOT == SHA256SUM:
             ZIPF = os.path.join(TMP_DIR.name, "edax_files.zip")

--- a/hyperspy/tests/io/test_edax.py
+++ b/hyperspy/tests/io/test_edax.py
@@ -41,8 +41,8 @@ if not TEST_FILES_OK:
             TEST_FILES_OK = True
         else:
             REASON = "wrong sha256sum of downloaded file. Expected: %s, got: %s" % SHA256SUM, SHA256SUM_GOT
-    except BaseException:
-        REASON = "download of EDAX test files failed"
+    except BaseException as e:
+        REASON = "download of EDAX test files failed: %s" % e
 
 
 def setup_module():

--- a/hyperspy/tests/io/test_edax.py
+++ b/hyperspy/tests/io/test_edax.py
@@ -27,12 +27,14 @@ TEST_FILES_OK = os.path.isfile(ZIPF)
 # and skip the tests if the download fails.
 if not TEST_FILES_OK:
     try:
-        r = requests.get("https://github.com/hyperspy/hyperspy/blob/e7a323a3bb9b237c24bd9267d2cc4fcb31bb99f3/hyperspy/tests/io/edax_files.zip?raw=true")
-        with open(ZIPF, 'wb') as f:  
+        r = requests.get(
+            "https://github.com/hyperspy/hyperspy/blob/e7a323a3bb9b237c24bd9267d2cc4fcb31bb99f3/hyperspy/tests/io/edax_files.zip?raw=true")
+        with open(ZIPF, 'wb') as f:
             f.write(r.content)
             TEST_FILES_OK = os.path.isfile(ZIPF)
-    except:
+    except BaseException:
         pass
+
 
 def setup_module():
     if TEST_FILES_OK:
@@ -41,8 +43,7 @@ def setup_module():
 
 
 pytestmark = pytest.mark.skipif(not TEST_FILES_OK,
-    reason="download of EDAX test files failed")
-
+                                reason="download of EDAX test files failed")
 
 
 def teardown_module():

--- a/setup.py
+++ b/setup.py
@@ -313,7 +313,6 @@ with update_version_when_dev() as version:
                 'tests/io/dm4_2D_data/*.dm4',
                 'tests/io/dm4_3D_data/*.dm4',
                 'tests/io/dm3_locale/*.dm3',
-                'tests/io/edax_files.zip',
                 'tests/io/FEI_new/*.emi',
                 'tests/io/FEI_new/*.ser',
                 'tests/io/FEI_new/*.npy',


### PR DESCRIPTION
The ``edax_files.zip`` test files are too large and take hyperpy's distribution beyond PyPI's file size limit of 60MB. See #2048. 

This PR removes the file from the distribution. Instead, the test files are downloaded from GitHub. The tests are skipped if the download fails.