### PR TITLE
bug-fix: wrong metadata used for scale in ZEISS tifs

### DIFF
--- a/hyperspy/io_plugins/tiff.py
+++ b/hyperspy/io_plugins/tiff.py
@@ -339,7 +339,7 @@ def _parse_scale_unit(tiff, op, shape, force_read_resolution):
     elif 'sem_metadata' in op:
         _logger.debug("Reading Zeiss tif metadata")
         if 'ap_pixel_size' in op['sem_metadata']:
-            (ps, units0) = op['sem_metadata']['ap_pixel_size'][1:]
+            (ps, units0) = op['sem_metadata']['ap_image_pixel_size'][1:]
             for key in ['x', 'y']:
                 scales[key] = ps
                 units[key] = units0


### PR DESCRIPTION
### Current problem
Currently loading 0.5k, 2k and 3k resolution zeiss tif files gets wrong scale.

### Detailed description
Zeiss SEM can produce different resolution images. There is one unfortunate detail, tag contains two parameters for resolution: `AP_pixel_size` and `AP_image_pixel_size`, where currently first one is used in hyperspy. If image is taken at 1k resolution, both parameters are the same, however if 0.5k, 2k or 3k, those attributes differ (2x, 0.5x, 0.(3)x). `AP_pixel_size` does not represent the real pixel size of the image, but only physical pixel size on physical monitor.  `AP_image_pixel_size` however presents the real pixel size.

### Description of the change
Change the attribute for scale from  `AP_pixel_size` to `AP_image_pixel_size` so that 2k and 3k images could be load with the right scale.

### Progress of the PR
- [ ] Change implemented,
- [ ] ready for review.

_I am not sure it would be good to upload 2k zeiss image (additional 3MB) to the test folder, current test should be enough._