### PR TITLE
Bug  in powerlaw when numexpr is not installed

### DIFF
--- a/hyperspy/_components/power_law.py
+++ b/hyperspy/_components/power_law.py
@@ -39,7 +39,7 @@ class PowerLaw(Expression):
 
     """
 
-    def __init__(self, A=10e5, r=3., origin=0., module="numexpr", **kwargs):
+    def __init__(self, A=10e5, r=3., origin=0., module="numpy", **kwargs):
         super(PowerLaw, self).__init__(
             expression="A *( x - origin) ** -r",
             name="PowerLaw",


### PR DESCRIPTION
The PowerLaw component (found in `_components/power_law.py`) cannot be imported without having the`numexpr` package installed. This package is a new requirement of hyperspy, however, it is stated in the docstring that the default and safer behavior of the function is to use `numpy`. I have changed the default option to `numpy` as corresponds to this rationale.

### Description of the change
- Changed the default option of power law component to "numpy"

### Progress of the PR
- [x] Change implemented.
- [x] ready for review.

### Minimal example of the bug fix:
```python
## If numexpr is not installed, this fails
s = hs.signals.EELSSpectrum(np.random.random(1000))
s.power_law_extrapolation(window_size=20, 
                          extrapolation_size=24)
```

