### PR TITLE
Obtain X-ray lines from incoming arguments rather than metadata

### DIFF
--- a/hyperspy/_signals/eds_tem.py
+++ b/hyperspy/_signals/eds_tem.py
@@ -357,7 +357,7 @@ class EDSTEM_mixin:
             navigation_mask = self.vacuum_mask(navigation_mask, closing).data
         elif navigation_mask is not None:
             navigation_mask = navigation_mask.data
-        xray_lines = self.metadata.Sample.xray_lines
+        xray_lines = [intensity.metadata.Sample.xray_lines[0] for intensity in intensities]
         composition = utils.stack(intensities, lazy=False)
         if method == 'CL':
             composition.data = utils_eds.quantification_cliff_lorimer(

--- a/hyperspy/tests/signal/test_eds_tem.py
+++ b/hyperspy/tests/signal/test_eds_tem.py
@@ -267,6 +267,21 @@ class Test_quantification:
         res = utils_eds.zeta_to_edx_cross_section(factors, elements)
         np.testing.assert_allclose(res, [3, 6], atol=1e-3)
 
+    def test_quant_element_order(self):
+        s = self.signal
+        s.set_elements([])
+        s.set_lines([])
+        lines = ['Zn_Ka', 'Al_Ka']
+        kfactors = [2.0009344042484134, 1]
+        intensities = s.get_lines_intensity(xray_lines=lines)
+        res = s.quantification(intensities, method='CL', factors=kfactors,
+                               composition_units='weight')
+        assert res[0].metadata.Sample.xray_lines[0] == 'Zn_Ka'
+        assert res[1].metadata.Sample.xray_lines[0] == 'Al_Ka'
+        np.testing.assert_allclose(res[1].data, np.array([
+            [22.70779, 22.70779],
+            [22.70779, 22.70779]]), atol=1e-3)
+
 
 @lazifyTestClass
 class Test_vacum_mask:


### PR DESCRIPTION
### Description of the change
Obtain X-ray lines from the intensity signals, rather than from metadata.

### Progress of the PR
- [x] Change implemented
- [x] add tests
- [x] ready for review

### Minimal example of the bug fix or the new feature
```python
>>> import hyperspy.api as hs
>>> s = hs.load(some_eds_signal, signal_type='EDS_TEM')
>>> s.set_elements(['Al', 'Zn'])
>>> s.add_lines(only_one=False)
>>> s.quantification(s.get_lines_intensity(xray_lines=['Al_Ka', 'Zn_Ka'], method='CL', factors=[1, 1])
```
This does no longer raise an exception.

My first attempt on bugfix here, hope it works :-)

Should fix #2061 