### PR TITLE
Set hyperspy-*-gui requirement to last version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -68,10 +68,10 @@ install_req = ['scipy>=0.15',
 
 extras_require = {
     "learning": ['scikit-learn'],
-    "gui-jupyter": ["hyperspy_gui_ipywidgets"],
-    "gui-traitsui": ["hyperspy_gui_traitsui"],
+    "gui-jupyter": ["hyperspy_gui_ipywidgets>=1.1.0"],
+    "gui-traitsui": ["hyperspy_gui_traitsui>=1.1.0"],
     "mrcz": ["blosc>=1.5", 'mrcz>=0.3.6'],
-    "test": ["pytest>=3", "pytest-mpl", "matplotlib>=2.0.2"],
+    "test": ["pytest>=3", "pytest-mpl"],
     "doc": ["sphinx>=1.7", "sphinx_rtd_theme"],
     "speed": ["numba<0.39"],
 


### PR DESCRIPTION
Set hyperspy-*-gui requirement to last version to have the plot tab in preferences, as documented in the user guide.
Even if this is not strictly required, this is fairly convenient and doesn't cost nothing in term of dependency. It may also be worth updating the hyperspy conda recipe.

### Progress of the PR
- [x] Change implemented,
- [x] ready for review.

