### PR TITLE
Fix bug with missing metadata of EDS signal

### DIFF
--- a/hyperspy/_signals/eds.py
+++ b/hyperspy/_signals/eds.py
@@ -168,13 +168,14 @@ class EDS_mixin:
         # modify time spend per spectrum
         s = super().sum(axis=axis, out=out)
         s = out or s
-        if "Acquisition_instrument.SEM" in s.metadata:
+        mp = None
+        if s.metadata.get_item("Acquisition_instrument.SEM"):
             mp = s.metadata.Acquisition_instrument.SEM
             mp_old = self.metadata.Acquisition_instrument.SEM
-        else:
+        elif s.metadata.get_item("Acquisition_instrument.TEM"):
             mp = s.metadata.Acquisition_instrument.TEM
             mp_old = self.metadata.Acquisition_instrument.TEM
-        if mp.has_item('Detector.EDS.live_time'):
+        if mp is not None and mp.has_item('Detector.EDS.live_time'):
             mp.Detector.EDS.live_time = mp_old.Detector.EDS.live_time * \
                 self.data.size / s.data.size
         if out is None:

--- a/hyperspy/tests/component/test_components.py
+++ b/hyperspy/tests/component/test_components.py
@@ -40,6 +40,7 @@ class TestPowerLaw:
         m[0].A.value = 1000
         m[0].r.value = 4
         self.m = m
+        self.s = s
 
     @pytest.mark.parametrize(("only_current", "binned"), TRUE_FALSE_2_TUPLE)
     def test_estimate_parameters(self, only_current, binned):
@@ -61,6 +62,10 @@ class TestPowerLaw:
         assert_allclose(g.A.map["values"][1], A_value)
         assert_allclose(g.r.map["values"][1], r_value)
 
+    def test_EDS_missing_data(self):
+        g = hs.model.components1D.PowerLaw()
+        s2 = hs.signals.EDSTEMSpectrum(self.s.data)
+        g.estimate_parameters(s2, None, None)
 
 class TestDoublePowerLaw:
 

--- a/hyperspy/tests/signal/test_eds_tem.py
+++ b/hyperspy/tests/signal/test_eds_tem.py
@@ -36,6 +36,10 @@ class Test_metadata:
         s.metadata.Acquisition_instrument.TEM.beam_energy = 15.0
         self.signal = s
 
+    def test_sum_minimum_missing(self):
+        s = EDSTEMSpectrum(np.ones((4, 2, 1024)))
+        s.sum()
+
     def test_sum_live_time1(self):
         s = self.signal
         old_metadata = s.metadata.deepcopy()


### PR DESCRIPTION
The `estimate_parameter` method of the power law component on a EDS signal was raising an error if some metadata was missing.

### Progress of the PR
- [x] ignore live time metadata if not available,
- [x] add tests,
- [x] ready for review.

### Minimal example of the bug fix or the new feature
```python
s = hs.datasets.example_signals.EDS_TEM_Spectrum()
s.remove_background() # using the power law background
```

