### PR TITLE
Not just any Python 3.x version is supported - update readme

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -41,7 +41,7 @@ HyperSpy is released under the GPL v3 license.
 
 .. warning::
 
-    **Since version 0.8.4 HyperSpy only supports Python 3. If you need to install
+    **Since version 0.8.4 HyperSpy only supports Python 3.5 and later. If you need to install
     HyperSpy in Python 2.7 install HyperSpy 0.8.3.**
 
 


### PR DESCRIPTION
### Description of the change
As shown in #2083, Python 3.4 does not support the syntax used in this project. Therefore, I propose to update the readme file to mention that explicitly. Fixing the code to make it work in 3.4 is way too much pointless work, but a simple readme change might save some users (like myself) from the trouble of trying to make it work.  
Due to the trivial nature of this change, I took the liberty of skipping some sections of the PR template.

### Minimal example of the bug

Execute the following shell command:  
`python3.4 -c "import hyperspy.api"`