### PR TITLE
Use imageio instead of deprecated scipy functions to read and write images.

### DIFF
--- a/hyperspy/io_plugins/image.py
+++ b/hyperspy/io_plugins/image.py
@@ -18,9 +18,10 @@
 
 import os
 
-from scipy.misc import imread, imsave
+from imageio import imread, imwrite
 
-from hyperspy.misc.rgb_tools import regular_array2rgbx
+
+from hyperspy.misc import rgb_tools
 
 # Plugin characteristics
 # ----------------------
@@ -47,7 +48,10 @@ def file_writer(filename, signal, file_format='png', **kwds):
             The fileformat defined by its extension that is any one supported by
             PIL.
     """
-    imsave(filename, signal.data)
+    data = signal.data
+    if rgb_tools.is_rgbx(data):
+        data = rgb_tools.rgbx2regular_array(data)
+    imwrite(filename, data)
 
 
 def file_reader(filename, **kwds):
@@ -86,5 +90,5 @@ def _read_data(filename):
                 (dc[:, :, 1] == dc[:, :, 2]).all():
             dc = dc[:, :, 0]
         else:
-            dc = regular_array2rgbx(dc)
+            dc = rgb_tools.regular_array2rgbx(dc)
     return dc

--- a/hyperspy/tests/io/test_edax.py
+++ b/hyperspy/tests/io/test_edax.py
@@ -2,7 +2,6 @@ import os.path
 import os
 import tempfile
 import gc
-import urllib.request
 import zipfile
 import hashlib
 
@@ -13,7 +12,6 @@ import requests
 
 from hyperspy.io import load
 from hyperspy import signals
-from hyperspy.misc.test_utils import assert_deep_almost_equal
 
 
 MY_PATH = os.path.dirname(__file__)

--- a/hyperspy/tests/io/test_image.py
+++ b/hyperspy/tests/io/test_image.py
@@ -1,0 +1,54 @@
+# -*- coding: utf-8 -*-
+# Copyright 2007-2016 The HyperSpy developers
+#
+# This file is part of  HyperSpy.
+#
+#  HyperSpy is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+#  HyperSpy is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with  HyperSpy.  If not, see <http://www.gnu.org/licenses/>.
+
+import os
+import numpy as np
+import tempfile
+import pytest
+
+import hyperspy.api as hs
+
+
+@pytest.mark.parametrize(("dtype"), ['uint8', 'uint32'])
+@pytest.mark.parametrize(("ext"), ['png', 'bmp', 'gif', 'jpg'])
+def test_save_load_cycle_grayscale(dtype, ext):
+    s = hs.signals.Signal2D(np.arange(128*128).reshape(128, 128).astype(dtype))
+    with tempfile.TemporaryDirectory() as tmpdir:
+        print('Saving-loading cycle for the extension:', ext)
+        filename = os.path.join(tmpdir, 'test_image.'+ext)
+        s.save(filename)
+        hs.load(filename)
+
+
+@pytest.mark.parametrize(("color"), ['rgb8', 'rgba8', 'rgb16', 'rgba16'])
+@pytest.mark.parametrize(("ext"), ['png', 'bmp', 'gif', 'jpeg'])
+def test_save_load_cycle_color(color, ext):
+    dim = 4 if "rgba" in color else 3
+    dtype = 'uint8' if "8" in color else 'uint16'
+    if dim == 4 and ext == 'jpeg':
+        # JPEG does not support alpha channel.
+        return
+    print('color:', color, '; dim:', dim, '; dtype:', dtype)
+    s = hs.signals.Signal1D(np.arange(128*128*dim).reshape(128, 128, dim).astype(dtype))
+    s.change_dtype(color)
+    with tempfile.TemporaryDirectory() as tmpdir:
+        print('Saving-loading cycle for the extension:', ext)
+        filename = os.path.join(tmpdir, 'test_image.'+ext)
+        s.save(filename)
+        hs.load(filename)
+

--- a/setup.py
+++ b/setup.py
@@ -64,6 +64,7 @@ install_req = ['scipy>=0.15',
                'statsmodels',
                'numexpr',
                'sparse',
+               'imageio',
                ]
 
 extras_require = {


### PR DESCRIPTION
See https://docs.scipy.org/doc/scipy/reference/release.1.0.0.html#deprecated-features
Reading and saving images will break with the coming scipy 1.2 release.

### Progress of the PR
- [x] replace imread and imsave functions from scipy with imageio imread and imwrite,
- [x] add imageio dependency,
- [x] add support for saving color image,
- [x] add tests,
- [x] ready for review.

