### PR TITLE
direct dict2dict mapping (moving toward independence of io_plugins)

### DIFF
--- a/hyperspy/io.py
+++ b/hyperspy/io.py
@@ -32,6 +32,7 @@ from hyperspy.misc.utils import stack as stack_method
 from hyperspy.io_plugins import io_plugins, default_write_ext
 from hyperspy.exceptions import VisibleDeprecationWarning
 from hyperspy.ui_registry import get_gui
+from hyperspy.misc.io.dict_tools import map_dict_to_dict
 
 _logger = logging.getLogger(__name__)
 
@@ -318,6 +319,10 @@ def load_with_reader(filename, reader, signal_type=None, convert_units=False,
     objects = []
 
     for signal_dict in file_data_list:
+        if "mapping" in signal_dict:
+            map_dict_to_dict(signal_dict["metadata"],
+                             signal_dict["original_metadata"],
+                             signal_dict["mapping"])
         if 'metadata' in signal_dict:
             if "Signal" not in signal_dict["metadata"]:
                 signal_dict["metadata"]["Signal"] = {}
@@ -450,14 +455,6 @@ def dict2signal(signal_dict, lazy=False):
     if "post_process" in signal_dict:
         for f in signal_dict['post_process']:
             signal = f(signal)
-    if "mapping" in signal_dict:
-        for opattr, (mpattr, function) in signal_dict["mapping"].items():
-            if opattr in signal.original_metadata:
-                value = signal.original_metadata.get_item(opattr)
-                if function is not None:
-                    value = function(value)
-                if value is not None:
-                    signal.metadata.set_item(mpattr, value)
     if "metadata" in signal_dict and "Markers" in mp:
         markers_dict = markers_metadata_dict_to_markers(
             mp['Markers'],

--- a/hyperspy/io_plugins/emd.py
+++ b/hyperspy/io_plugins/emd.py
@@ -1095,7 +1095,7 @@ class FeiEMDReader(object):
         return mapping
 
     def _convert_element_list(self, d):
-        atomic_number_list = d[d.keys()[0]]['elementSelection']
+        atomic_number_list = d[list(d)[0]]['elementSelection']
         return [atomic_number2name[int(atomic_number)]
                 for atomic_number in atomic_number_list]
 

--- a/hyperspy/misc/io/dict_tools.py
+++ b/hyperspy/misc/io/dict_tools.py
@@ -34,8 +34,13 @@ def interpret(string):
 
 
 def dictionarize(et):
-    """translate and return the python dictionary/list tree
-    from xml.etree.ElementTree.ElementTree instance"""
+    """
+    Translate and return the python dictionary/list tree
+    from xml.etree.ElementTree.ElementTree instance.
+    The nodes containing longer than 32 chars text are 
+    not evaluated and placed into dictionary as etree
+    objects of the node, for eventual further processing.
+    """
     d = {et.tag: {} if et.attrib else None}
     children = et.getchildren()
     if children:

--- a/hyperspy/misc/io/dict_tools.py
+++ b/hyperspy/misc/io/dict_tools.py
@@ -10,11 +10,15 @@ def return_item(dictionary, path,  sep='.'):
     """
     current_level = dictionary
     path_list = path.split(sep)
-    for i in path_list:
-        if type(current_level) == dict and i in current_level:         
+    for i in path_list[:-1]:
+        if isinstance(current_level, dict) and i in current_level:         
             current_level = current_level[i]
         else:
             return
+    if path_list[-1] in current_level:
+        current_level = current_level[path_list[-1]]
+    else:
+        return
     return current_level
 
 
@@ -59,11 +63,13 @@ Can't set the value at node '{0}' as the key '{1}' is already preocupied
 with dictionary""".format(path, sub_paths[-1]))
 
 
-def map_dict_to_dict(dict_to, dict_from, mapping_dict):
+def map_dict_to_dict(dict_to, dict_from, mapping_dict, sep='.',
+                     force_overwrite=False):
     for path_from, (path_to, function) in mapping_dict.items():
-        value = return_node(dict_from, path_from)
+        value = return_item(dict_from, path_from, sep=sep)
         if value:
             if function is not None:
                 value = function(value)
             if value is not None:
-                set_item(dict_to, path_to, value) 
+                set_item(dict_to, path_to, value, sep=sep,
+                         force_overwrite=force_overwrite) 

--- a/hyperspy/misc/io/dict_tools.py
+++ b/hyperspy/misc/io/dict_tools.py
@@ -1,0 +1,69 @@
+def return_item(dictionary, path,  sep='.'):
+    """return the node/item from the (nested/tree-like) dictionary
+    at given path.
+    -------------
+    args:
+    dictionary -- dictionary to parse
+    path -- string of path with separator
+            e.g. 'Signal.Detector.Type'
+    sep -- separator (default: '.')
+    """
+    current_level = dictionary
+    path_list = path.split(sep)
+    for i in path_list:
+        if type(current_level) == dict and i in current_level:         
+            current_level = current_level[i]
+        else:
+            return
+    return current_level
+
+
+def _create_dict_path(path_list, dictionary, force_overwrite=False):
+    """(create if missing and) return the branch of hierachical tree-like
+    dictionary
+    ----------
+    args:
+    path_list -- the list with nodes (e.g. ['Signal','Type','Whatever']).
+    dictionary -- dictionary where branch will be created.
+    force_overwrite -- should the already preocupied branch with value
+      be overwriten with dictionary branch (bool; default: False).
+    """
+    current_level = dictionary
+    for i in path_list:
+        if i not in current_level:
+            current_level[i] = {}
+        elif type(current_level[i]) != dict:
+            if force_overwrite:
+                current_level[i] = {}
+            else:
+                raise TypeError("""
+Can't intiate the dict node '{0}' as the key {1} is already preocupied
+with {2} type value""".format('.'.join(path_list[:path_list.index(i)+1]),
+                              i, type(current_level[i])))
+        current_level = current_level[i]
+    return current_level
+
+
+def set_item(dictionary, path, value, sep='.', force_overwrite=False):
+    current_level = dictionary
+    if (type(path) == str) and (sep is not None): 
+        sub_paths = path.split(sep)
+    else:
+        sub_paths = path
+    node = _create_dict_path(sub_paths[:-1], current_level, force_overwrite)
+    if (sub_paths[-1] not in node) or (type(node[sub_paths[-1]]) != dict):
+        node[sub_paths[-1]] = value
+    else:
+        raise RuntimeError("""
+Can't set the value at node '{0}' as the key '{1}' is already preocupied
+with dictionary""".format(path, sub_paths[-1]))
+
+
+def map_dict_to_dict(dict_to, dict_from, mapping_dict):
+    for path_from, (path_to, function) in mapping_dict.items():
+        value = return_node(dict_from, path_from)
+        if value:
+            if function is not None:
+                value = function(value)
+            if value is not None:
+                set_item(dict_to, path_to, value) 

--- a/hyperspy/misc/utils.py
+++ b/hyperspy/misc/utils.py
@@ -219,11 +219,8 @@ class DictionaryTreeBrowser(object):
 
     """
 
-    def __init__(self, dictionary=None, double_lines=False):
+    def __init__(self, dictionary={}, double_lines=False):
         self._double_lines = double_lines
-        if not dictionary:
-            dictionary = {}
-        super(DictionaryTreeBrowser, self).__init__()
         self.add_dictionary(dictionary, double_lines=double_lines)
 
     def add_dictionary(self, dictionary, double_lines=False):

--- a/hyperspy/tests/io/test_bruker.py
+++ b/hyperspy/tests/io/test_bruker.py
@@ -205,7 +205,8 @@ def test_fast_bcf():
 
 
 def test_decimal_regex():
-    from hyperspy.io_plugins.bruker import fix_dec_patterns
+    # The health of bruker reader depends from this passing
+    from hyperspy.misc.io.dict_tools import fix_msxml
     dummy_xml_positive = [b'<dummy_tag>85,658</dummy_tag>',
                           b'<dummy_tag>85,658E-8</dummy_tag>',
                           b'<dummy_tag>-85,658E-8</dummy_tag>',
@@ -214,9 +215,9 @@ def test_decimal_regex():
     dummy_xml_negative = [b'<dum_tag>12,25,23,45,56,12,45</dum_tag>',
                           b'<dum_tag>12e1,23,-24E-5</dum_tag>']
     for i in dummy_xml_positive:
-        assert b'85.658' in fix_dec_patterns.sub(b'\\1.\\2', i)
+        assert b'85.658' in fix_msxml(i)
     for j in dummy_xml_negative:
-        assert b'.' not in fix_dec_patterns.sub(b'\\1.\\2', j)
+        assert b'.' not in fix_msxml(j)
 
 def test_all_spx_loads():
     for spxfile in spx_files:


### PR DESCRIPTION
### Description of the change
1. This PR adds more efficient dictionary mapping, which is used in io_plugins. This PR aims removing any usage of DictionaryTreeBrowser (DTB) from io_plugins. Many io_plugins are creating and destroying DTB only to map one dictionary structure to the another, which is highly inefficient and makes io_plugins to depend directly to hyperspy. New `map_dict_to_dict` is going to be drop-in replacement, and needs no changes to currently used io_plugin mapping dictionaries.

2. looks that some other plugins uses xml sparingly. The MSXML bug-workaround methods and dictionarization of etree is moved to separate file accessible by all io_plugins (`dict_tools.py`). The path of this collection of tools should be discussed. (currently it is `misc/io/dict_tools.py`)

3. Bruker.py is refactored – that is getting rid of step-by-step building of `metadata` dictionaries (often using if-else) into parsing only `original_metadata`, and moving the `metadata` generation to be done completely by `mapping` mechanism. That simplifies code, and removes duplicate code (i.e. separate (bcf and spx) dict building.

4. **to be filled later...**


### Progress of the PR
- [x] New `map_dict_to_dict` function implemented
- [ ] refactor/simplyfy bruker.py heavy using mapping, making it more universal and showcase the simplicity of the mapping.
- [ ] refactor currently used DTB for mapping in `io_plugins` and replace with new function.
- [ ] update docstring (if appropriate), (?)
- [ ] update user guide (if appropriate), (?)
- [ ] update tests,
- [ ] ready for review.