### PR TITLE
Fix issue when loading decomposition results

### DIFF
--- a/hyperspy/learn/mva.py
+++ b/hyperspy/learn/mva.py
@@ -1281,6 +1281,9 @@ class LearningResults(object):
         for key, value in decomposition.items():
             if value.dtype == np.dtype('object'):
                 value = None
+            # Unwrap values stored as 0D numpy arrays to raw datatypes
+            if isinstance(value, np.ndarray) and value.shape == ():
+                value = value.item()
             setattr(self, key, value)
         _logger.info("\n%s loaded correctly" % filename)
         # For compatibility with old version ##################
@@ -1318,11 +1321,6 @@ class LearningResults(object):
         if hasattr(self, 'ica_factors'):
             self.bss_factors = self.ica_factors
             del self.ica_factors
-        #
-        # Output_dimension is an array after loading, convert it to int
-        if hasattr(self, 'output_dimension') and self.output_dimension \
-                is not None:
-            self.output_dimension = int(self.output_dimension)
         _logger.info(self._summary())
 
     def summary(self):

--- a/hyperspy/learn/mva.py
+++ b/hyperspy/learn/mva.py
@@ -1282,7 +1282,7 @@ class LearningResults(object):
             if value.dtype == np.dtype('object'):
                 value = None
             # Unwrap values stored as 0D numpy arrays to raw datatypes
-            if isinstance(value, np.ndarray) and value.shape == ():
+            if isinstance(value, np.ndarray) and value.ndim == 0:
                 value = value.item()
             setattr(self, key, value)
         _logger.info("\n%s loaded correctly" % filename)


### PR DESCRIPTION
Fix bug causing attributes to be saved as 0D numpy arrays.

Fix by converting the attributes to their original Python datatype.

### Progress of the PR
- [x] Change implemented
- [x] Add tests
- [x] Ready for review

### Minimal example of the bug fix or the new feature
```python
>>> import hyperspy.api as hs
>>> s = hs.load(multidimensional_eds_signal)
>>> s.change_dtype('float64')
>>> s.decomposition()
>>> s.learning_results.save('results.npz')
>>> s.learning_results.load('results.npz')
>>> s.save('out.hspy')
```

This does no longer cause an error.