### PR TITLE
Fix cylic import artifical data.

### DIFF
--- a/hyperspy/datasets/artificial_data.py
+++ b/hyperspy/datasets/artificial_data.py
@@ -5,8 +5,6 @@ For use in things like docstrings or to test HyperSpy functionalities.
 """
 
 import numpy as np
-from hyperspy import components1d, components2d
-from hyperspy.signals import EELSSpectrum, Signal2D
 
 
 def get_low_loss_eels_signal():
@@ -31,6 +29,10 @@ def get_low_loss_eels_signal():
     get_core_loss_eels_line_scan_signal : get EELS core loss line scan
 
     """
+
+    from hyperspy.signals import EELSSpectrum
+    from hyperspy import components1d
+
     x = np.arange(-100, 400, 0.5)
     zero_loss = components1d.Gaussian(A=100, centre=4.1, sigma=1)
     plasmon = components1d.Gaussian(A=100, centre=60, sigma=20)
@@ -97,6 +99,10 @@ def get_core_loss_eels_signal(add_powerlaw=False):
     get_core_loss_eels_line_scan_signal : get EELS core loss line scan
 
     """
+
+    from hyperspy.signals import EELSSpectrum
+    from hyperspy import components1d
+
     x = np.arange(400, 800, 1)
     arctan = components1d.Arctan(A=1, k=0.2, x0=688)
     arctan.minimum_at_zero = True
@@ -143,6 +149,10 @@ def get_low_loss_eels_line_scan_signal():
     get_core_loss_eels_line_scan_signal : core loss signal with the same size
 
     """
+
+    from hyperspy.signals import EELSSpectrum
+    from hyperspy import components1d
+
     x = np.arange(-100, 400, 0.5)
     zero_loss = components1d.Gaussian(A=100, centre=4.1, sigma=1)
     plasmon = components1d.Gaussian(A=100, centre=60, sigma=20)
@@ -188,6 +198,10 @@ def get_core_loss_eels_line_scan_signal():
     get_low_loss_eels_line_scan_signal : get low loss signal with the same size
 
     """
+
+    from hyperspy.signals import EELSSpectrum
+    from hyperspy import components1d
+
     x = np.arange(400, 800, 1)
     arctan_mn = components1d.Arctan(A=1, k=0.2, x0=688)
     arctan_mn.minimum_at_zero = True
@@ -272,6 +286,9 @@ def get_atomic_resolution_tem_signal2d():
     >>> s.plot()
 
     """
+    from hyperspy.signals import Signal2D
+    from hyperspy import components2d
+    
     sX, sY = 2, 2
     x_array, y_array = np.mgrid[0:200, 0:200]
     image = np.zeros_like(x_array, dtype=np.float32)
@@ -281,5 +298,6 @@ def get_atomic_resolution_tem_signal2d():
             gaussian2d.centre_x.value = x
             gaussian2d.centre_y.value = y
             image += gaussian2d.function(x_array, y_array)
+    
     s = Signal2D(image)
     return s


### PR DESCRIPTION
As noticed in https://github.com/conda-forge/hyperspy-feedstock/pull/27/commits/951ad46425edb5943e00eb5a52a26586d8433dae, there is a cyclic import in `hyperspy.datasets.artificial_data` which breaks the import of `hyperspy._lazy_signals`.

```python
Traceback (most recent call last):

  File "<ipython-input-1-f66322193b6e>", line 1, in <module>
    import hyperspy._lazy_signals

  File "/home/eric/Dev/hyperspy/hyperspy/_lazy_signals.py", line 6, in <module>
    from hyperspy._signals.eds_sem import LazyEDSSEMSpectrum

  File "/home/eric/Dev/hyperspy/hyperspy/_signals/eds_sem.py", line 23, in <module>
    from hyperspy._signals.eds import (EDSSpectrum, LazyEDSSpectrum)

  File "/home/eric/Dev/hyperspy/hyperspy/_signals/eds.py", line 27, in <module>
    from hyperspy import utils

  File "/home/eric/Dev/hyperspy/hyperspy/utils/__init__.py", line 24, in <module>
    import hyperspy.datasets.example_signals

  File "/home/eric/Dev/hyperspy/hyperspy/datasets/__init__.py", line 21, in <module>
    from hyperspy.datasets import artificial_data

  File "/home/eric/Dev/hyperspy/hyperspy/datasets/artificial_data.py", line 9, in <module>
    from hyperspy.signals import EELSSpectrum, Signal2D

  File "/home/eric/Dev/hyperspy/hyperspy/signals.py", line 46, in <module>
    from hyperspy._signals.eds_sem import EDSSEMSpectrum

ImportError: cannot import name 'EDSSEMSpectrum' from 'hyperspy._signals.eds_sem' (/home/eric/Dev/hyperspy/hyperspy/_signals/eds_sem.py)
```
