### PR TITLE
Disable a couple of CI builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,13 +18,14 @@ matrix:
   - env: export PYTHON=3.7; FAIL_ON_EXTERNAL_DEPRECATION='False'; MINIMAL_ENV='False'
     os: osx
     language: generic
-    # Uncomment these build to generate wheels
-  # - env: export PYTHON=3.6; FAIL_ON_EXTERNAL_DEPRECATION='False'; MINIMAL_ENV='False'
-  #  os: osx
-  #  language: generic
-  #- env: export PYTHON=3.5; FAIL_ON_EXTERNAL_DEPRECATION='False'; MINIMAL_ENV='False'
-  #  os: osx
-  #  language: generic
+  - env: export PYTHON=3.6; FAIL_ON_EXTERNAL_DEPRECATION='False'; MINIMAL_ENV='False'
+    os: osx
+    language: generic
+    if: tag IS present
+  - env: export PYTHON=3.5; FAIL_ON_EXTERNAL_DEPRECATION='False'; MINIMAL_ENV='False'
+    os: osx
+    language: generic
+    if: tag IS present
   allow_failures:
     # Only test for the latest supported version as chances are that it'll
     # contain the most up-to-date external libraries.

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,12 +18,13 @@ matrix:
   - env: export PYTHON=3.7; FAIL_ON_EXTERNAL_DEPRECATION='False'; MINIMAL_ENV='False'
     os: osx
     language: generic
-  - env: export PYTHON=3.6; FAIL_ON_EXTERNAL_DEPRECATION='False'; MINIMAL_ENV='False'
-    os: osx
-    language: generic
-  - env: export PYTHON=3.5; FAIL_ON_EXTERNAL_DEPRECATION='False'; MINIMAL_ENV='False'
-    os: osx
-    language: generic
+    # Uncomment these build to generate wheels
+  # - env: export PYTHON=3.6; FAIL_ON_EXTERNAL_DEPRECATION='False'; MINIMAL_ENV='False'
+  #  os: osx
+  #  language: generic
+  #- env: export PYTHON=3.5; FAIL_ON_EXTERNAL_DEPRECATION='False'; MINIMAL_ENV='False'
+  #  os: osx
+  #  language: generic
   allow_failures:
     # Only test for the latest supported version as chances are that it'll
     # contain the most up-to-date external libraries.

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -10,12 +10,12 @@ environment:
 
 
   matrix:
-    # Pre-installed Python versions, which Appveyor may upgrade to
-    # a later point release.
-    # Uncomment python35 build only to generate python35 wheels for a new release. This saves significant amount to time when testing. 
-    # - PYTHON: "C:\\Miniconda35"
-    # - PYTHON: "C:\\Miniconda35-x64"
-    # - PYTHON: "C:\\Miniconda36"
+     - PYTHON: "C:\\Miniconda35"
+       skip_non_tags: true
+     - PYTHON: "C:\\Miniconda35-x64"
+       skip_non_tags: true
+     - PYTHON: "C:\\Miniconda36"
+       skip_non_tags: true
      - PYTHON: "C:\\Miniconda36-x64"
      - PYTHON: "C:\\Miniconda37"
      - PYTHON: "C:\\Miniconda37-x64"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -11,14 +11,23 @@ environment:
 
   matrix:
      - PYTHON: "C:\\Miniconda35"
-       skip_non_tags: true
+       TAG_SCENARIO: true
      - PYTHON: "C:\\Miniconda35-x64"
-       skip_non_tags: true
+       TAG_SCENARIO: true
      - PYTHON: "C:\\Miniconda36"
-       skip_non_tags: true
+       TAG_SCENARIO: true
      - PYTHON: "C:\\Miniconda36-x64"
      - PYTHON: "C:\\Miniconda37"
      - PYTHON: "C:\\Miniconda37-x64"
+
+for:
+-
+  # tagged scenario
+  matrix:
+    only:
+      - TAG_SCENARIO: true
+
+  skip_non_tags: true
 
 
 init:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,65 +5,30 @@ environment:
 
   global:
     TEST_DEPS: "pytest pytest-cov pytest-mpl wheel"
+    DEPS: "numpy scipy matplotlib=2.2.3 ipython h5py sympy scikit-learn dill setuptools natsort scikit-image cython ipyparallel dask numexpr sparse numba"
     MPLBACKEND: "agg"
 
 
   matrix:
-
     # Pre-installed Python versions, which Appveyor may upgrade to
     # a later point release.
-     - PYTHON: "C:\\Miniconda35"
-       PYTHON_VERSION: "3.5.x"
-       PYTHON_MAJOR: 3
-       PYTHON_ARCH: "32"
-       CONDA_PY: "35"
-       DEPS: "numpy scipy matplotlib=2.2.3 ipython h5py sympy scikit-learn dill setuptools natsort scikit-image cython ipyparallel dask numexpr sparse numba"
-
-     - PYTHON: "C:\\Miniconda35-x64"
-       PYTHON_VERSION: "3.5.x"
-       PYTHON_MAJOR: 3
-       PYTHON_ARCH: "64"
-       CONDA_PY: "35"
-       DEPS: "numpy scipy matplotlib=2.2.3 ipython h5py sympy scikit-learn dill setuptools natsort scikit-image cython ipyparallel dask numexpr sparse numba"
-
+    # Uncomment python35 build only to generate python35 wheels for a new release. This saves significant amount to time when testing. 
+    # - PYTHON: "C:\\Miniconda35"
+    # - PYTHON: "C:\\Miniconda35-x64"
      - PYTHON: "C:\\Miniconda36"
-       PYTHON_VERSION: "3.6.x"
-       PYTHON_MAJOR: 3
-       PYTHON_ARCH: "32"
-       CONDA_PY: "36"
-       DEPS: "numpy scipy matplotlib=2.2.3 ipython h5py sympy scikit-learn dill setuptools natsort scikit-image cython ipyparallel dask numexpr sparse numba"
-
      - PYTHON: "C:\\Miniconda36-x64"
-       PYTHON_VERSION: "3.6.x"
-       PYTHON_MAJOR: 3
-       PYTHON_ARCH: "64"
-       CONDA_PY: "36"
-       DEPS: "numpy scipy matplotlib=2.2.3 ipython h5py sympy scikit-learn dill setuptools natsort scikit-image cython ipyparallel dask numexpr sparse numba"
-
      - PYTHON: "C:\\Miniconda37"
-       PYTHON_VERSION: "3.7.x"
-       PYTHON_MAJOR: 3
-       PYTHON_ARCH: "32"
-       CONDA_PY: "37"
-       DEPS: "numpy scipy matplotlib=2.2.3 ipython h5py sympy scikit-learn dill setuptools natsort scikit-image cython ipyparallel dask numexpr sparse numba"
-
      - PYTHON: "C:\\Miniconda37-x64"
-       PYTHON_VERSION: "3.7.x"
-       PYTHON_MAJOR: 3
-       PYTHON_ARCH: "64"
-       CONDA_PY: "37"
-       DEPS: "numpy scipy matplotlib=2.2.3 ipython h5py sympy scikit-learn dill setuptools natsort scikit-image cython ipyparallel dask numexpr sparse numba"
 
 
 init:
-  - "ECHO %PYTHON% %PYTHON_VERSION% %PYTHON_ARCH%"
+  - "ECHO %PYTHON%"
   - "ECHO %APPVEYOR_BUILD_FOLDER%"
   - "ECHO %CMD_IN_ENV%"
 
 install:
   - ps: Add-AppveyorMessage "Starting install..."
-  # Prepend Python to the PATH
-  - "SET ORIGPATH=%PATH%"
+  # Prepend miniconda Python to the PATH
   - "SET PATH=%PYTHON%;%PYTHON%\\Scripts;%PATH%"
 
   # Check that we have the expected version and architecture for Python

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -15,7 +15,7 @@ environment:
     # Uncomment python35 build only to generate python35 wheels for a new release. This saves significant amount to time when testing. 
     # - PYTHON: "C:\\Miniconda35"
     # - PYTHON: "C:\\Miniconda35-x64"
-     - PYTHON: "C:\\Miniconda36"
+    # - PYTHON: "C:\\Miniconda36"
      - PYTHON: "C:\\Miniconda36-x64"
      - PYTHON: "C:\\Miniconda37"
      - PYTHON: "C:\\Miniconda37-x64"


### PR DESCRIPTION
At the moment, the appveyor build takes more 2h to complete, because we are testing 6 different builds and there are run sequentially. The situation is significantly with travis, which is running 5 builds at the same but I would also suggest to disable the python 3.5 and python 3.6 mac osx build to save CI time.

The idea is to continuously test python 3.5 and python 3.6 support with linux and to other disable build for a release when the build will be enabled to generate the wheels. This should be a good compromise between testing across different platform and python version and saving CI time.

On a side node, conda-forge is not packaging for python 3.5 anymore (only python 3.6 and python 3.7).

### Progress of the PR
- [x] Disable python 3.5 build in appveyor,
- [x] enable one win32 build,
- [x] disable python 3.5 and python 3.6 on mac osx,
- [x] ready for review.


