### PR TITLE
Fix axis argument in call to sum() when scaling SI to normalize Poisson noise during lazy decomp

### DIFF
--- a/hyperspy/_signals/lazy.py
+++ b/hyperspy/_signals/lazy.py
@@ -761,8 +761,8 @@ class LazySignal(BaseSignal):
                 ndim = self.axes_manager.navigation_dimension
                 sdim = self.axes_manager.signal_dimension
                 bH, aG = da.compute(
-                    data.sum(axis=range(ndim)),
-                    data.sum(axis=range(ndim, ndim + sdim)))
+                    data.sum(axis=tuple(range(ndim))),
+                    data.sum(axis=tuple(range(ndim, ndim + sdim))))
                 bH = da.where(sm, bH, 1)
                 aG = da.where(nm, aG, 1)
 


### PR DESCRIPTION
### Progress of the PR
- [ ] Change implemented,
- [ ] add tests,
- [ ] ready for review.

### Minimal example of the bug fix
Running
```python
>>> import hyperspy.api as hs
>>> s = hs.load(diffraction_patterns, lazy=True)
>>> s.change_dtype('float')
>>> s.decomposition(algorithm='PCA', output_dimension=200, normalize_poissonian_noise=True)
```
does no longer throw
```python
Traceback (most recent call last):

  File "<ipython-input-1-88d7158fb358>", line 32, in <module>
    normalize_poissonian_noise=poisson_noise)

  File "/home/hakon/miniconda3/envs/pxm/lib/python3.6/site-packages/hyperspy/_signals/lazy.py", line 764, in decomposition
    data.sum(axis=range(ndim)),
[...]
  File "/home/hakon/miniconda3/envs/pxm/lib/python3.6/site-packages/dask/array/utils.py", line 144, in validate_axis
    raise TypeError("Axis value must be an integer, got %s" % axis)

TypeError: Axis value must be an integer, got range(0, 2)
```
since the it now reads `tuple(range(ndim))` instead of just `range(ndim)`.