### PR TITLE
Fix scale as quantity

### DIFF
--- a/hyperspy/axes.py
+++ b/hyperspy/axes.py
@@ -186,7 +186,7 @@ class UnitConversion:
                 self.__dict__[other] = float(other_quantity.magnitude)
 
             self.units = '{:~}'.format(value.units)
-            self.__dict__[attribute] = float(value.magnitude)
+            setattr(self, attribute, float(value.magnitude))
         else:
             raise ValueError('`attribute` argument can only take the `scale` '
                              'or the `offset` value.')

--- a/hyperspy/axes.py
+++ b/hyperspy/axes.py
@@ -165,7 +165,7 @@ class UnitConversion:
             units = self.units
             if units == t.Undefined:
                 units = ''
-            return self.__dict__[attribute] * _ureg(units)
+            return getattr(self, attribute) * _ureg(units)
         else:
             raise ValueError('`attribute` argument can only take the `scale` '
                              'or the `offset` value.')
@@ -183,7 +183,7 @@ class UnitConversion:
             if value.units != units and value.units != '' and units != '':
                 other = 'offset' if attribute == 'scale' else 'scale'
                 other_quantity = self._get_quantity(other).to(value.units)
-                self.__dict__[other] = float(other_quantity.magnitude)
+                setattr(self, other, float(other_quantity.magnitude))
 
             self.units = '{:~}'.format(value.units)
             setattr(self, attribute, float(value.magnitude))

--- a/hyperspy/tests/axes/test_conversion_units.py
+++ b/hyperspy/tests/axes/test_conversion_units.py
@@ -200,6 +200,8 @@ class TestDataAxis:
         assert self.axis.scale == 2.5
         nt.assert_almost_equal(self.axis.offset, 5.0)
         assert self.axis.units == 'nm'
+        # Test that the axis array has been recomputed
+        nt.assert_almost_equal(self.axis.axis[1], 7.5)
 
     def test_scale_as_quantity_setter_string_no_previous_units(self):
         axis = DataAxis(size=2048, scale=12E-12, offset=5.0)


### PR DESCRIPTION
Fixes #2117.

The issue was that ``DataAxis.scale_as_quantity`` and ``DataAxis.offset_as_quantity`` was setting the class attributes using ``__dict__`` instead of ``setattr``, what was not triggering the automatic update of other attributes.