### PR TITLE
Fix appveyor

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -47,9 +47,10 @@ install:
     else DEPS="pip ipython numpy scipy matplotlib>2.2.3 h5py sympy scikit-image numexpr";
     fi
   - conda update -y conda;
+    conda config --append channels conda-forge;
     conda create -n testenv --yes python=$PYTHON;
     source activate testenv;
-    conda install -y -c conda-forge $DEPS pytest-cov;
+    conda install -y $DEPS pytest-cov;
   - if [[ $MINIMAL_ENV == 'False' ]] ; then
       pip install .[tests] mrcz;
     else pip install .[tests];

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ env:
   global:
     - DISPLAY=99.0
     - MPLBACKEND="agg"
+    - TEST_DEPS="pytest pytest-cov pytest-mpl wheel"
 
 matrix:
   include:
@@ -50,10 +51,10 @@ install:
     conda config --append channels conda-forge;
     conda create -n testenv --yes python=$PYTHON;
     source activate testenv;
-    conda install -y $DEPS pytest-cov;
+    conda install -y $DEPS $TEST_DEPS;
   - if [[ $MINIMAL_ENV == 'False' ]] ; then
-      pip install .[tests] mrcz;
-    else pip install .[tests];
+      pip install .[mrcz];
+    else pip install .;
     fi
 
 before_script: # configure a headless display to test plot generation

--- a/.travis.yml
+++ b/.travis.yml
@@ -49,9 +49,9 @@ install:
   - conda update -y conda;
     conda create -n testenv --yes python=$PYTHON;
     source activate testenv;
-    conda install -y -c conda-forge $DEPS;
+    conda install -y -c conda-forge $DEPS pytest-cov;
   - if [[ $MINIMAL_ENV == 'False' ]] ; then
-      pip install .[all];
+      pip install .[tests] mrcz;
     else pip install .[tests];
     fi
 
@@ -64,8 +64,7 @@ before_script: # configure a headless display to test plot generation
 
 script:
   - python -c 'import matplotlib.pyplot as plt; print(plt.get_backend())';
-  - pip install coverage coveralls pytest-cov pytest-mpl;
-    pytest --mpl --cov=hyperspy --pyargs hyperspy;
+  - pytest --mpl --cov=hyperspy --pyargs hyperspy;
 
 #after_failure: # run only on failure in case there is a need to check matplotlib image comparison
 # This needs a service to upload the artifacts (and corresponding configuration)

--- a/.travis.yml
+++ b/.travis.yml
@@ -43,15 +43,16 @@ before_install:
 install:
 
   - if [[ $MINIMAL_ENV == 'False' ]] ; then
-      DEPS="pip numpy scipy matplotlib>2.2.3 ipython h5py sympy scikit-learn dill natsort setuptools scikit-image cython ipyparallel dask traits traitsui numexpr numba";
+      DEPS="pip numpy scipy matplotlib>2.2.3 ipython h5py sympy scikit-learn dill natsort setuptools scikit-image cython ipyparallel dask traits traitsui numexpr numba python-blosc";
     else DEPS="pip ipython numpy scipy matplotlib>2.2.3 h5py sympy scikit-image numexpr";
     fi
-  - conda create -n testenv --yes python=$PYTHON;
+  - conda update -y conda;
+    conda create -n testenv --yes python=$PYTHON;
     source activate testenv;
     conda install -y -c conda-forge $DEPS;
   - if [[ $MINIMAL_ENV == 'False' ]] ; then
-      pip install .[mrcz] && pip install 'matplotlib>=3.0.0';
-    else pip install "matplotlib>=3.0.0" && pip install .[tests];
+      pip install .[all];
+    else pip install .[tests];
     fi
 
 before_script: # configure a headless display to test plot generation

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -64,7 +64,7 @@ install:
   - "conda install -y -c conda-forge %DEPS% %TEST_DEPS%"
 
   - ps: Add-AppveyorMessage "Installing hyperspy..."
-  - "pip install .[all]"
+  - "pip install .[tests] mrcz"
 
 build: false  # Not a C# project, build stuff at the test step instead.
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,20 +5,25 @@ environment:
 
   global:
     TEST_DEPS: "pytest pytest-cov pytest-mpl wheel"
-    DEPS: "numpy scipy matplotlib ipython h5py sympy scikit-learn dill setuptools natsort scikit-image cython ipyparallel dask numexpr sparse numba"
+    DEPS: "numpy scipy matplotlib ipython h5py sympy scikit-learn dill setuptools natsort scikit-image cython ipyparallel dask numexpr sparse numba python-blosc tqdm pint requests imageio"
     MPLBACKEND: "agg"
 
-
   matrix:
-     - PYTHON: "C:\\Miniconda35"
+     - PY_VERSION: 3.7
+       PLATFORM: x64
+     - PY_VERSION: 3.7
+       PLATFORM: x86
+     - PY_VERSION: 3.6
+       PLATFORM: x64
+     - PY_VERSION: 3.6
+       PLATFORM: x86
        TAG_SCENARIO: true
-     - PYTHON: "C:\\Miniconda35-x64"
+     - PY_VERSION: 3.5
+       PLATFORM: x64
        TAG_SCENARIO: true
-     - PYTHON: "C:\\Miniconda36"
+     - PY_VERSION: 3.5
+       PLATFORM: x86
        TAG_SCENARIO: true
-     - PYTHON: "C:\\Miniconda36-x64"
-     - PYTHON: "C:\\Miniconda37"
-     - PYTHON: "C:\\Miniconda37-x64"
 
 for:
 -
@@ -37,19 +42,26 @@ init:
 
 install:
   - ps: Add-AppveyorMessage "Starting install..."
-  # Prepend miniconda Python to the PATH
-  - "SET PATH=%PYTHON%;%PYTHON%\\Scripts;%PATH%"
+
+  # Activate miniconda root environment
+  - if "%PLATFORM%"=="x86" set MINICONDA="C:\\Miniconda37"
+  - if "%PLATFORM%"=="x64" set MINICONDA="C:\\Miniconda37-x64"
+  - "%MINICONDA%\\Scripts\\activate.bat"
+
+  # Setup miniconda environment.
+  - ps: Add-AppveyorMessage "Setup miniconda environment..."
+  - "conda update -y conda"
+  - "conda create -y -n testenv python=%PY_VERSION%"
+  - "activate testenv"
 
   # Check that we have the expected version and architecture for Python
   - "python --version"
   - "python -c \"import sys; print(sys.version)\""  # this gives more info
   - "python -c \"import struct; print(struct.calcsize('P') * 8)\""
 
-  # Install the dependencies of the project.
+  # Install the dependencies of hyperspy.
   - ps: Add-AppveyorMessage "Installing conda packages..."
-  - 'conda update -y conda'
-  - "conda install -y -c conda-forge hyperspy-base --only-deps"
-  - "conda install -y -c conda-forge cython %TEST_DEPS%"
+  - "conda install -y -c conda-forge %DEPS% %TEST_DEPS%"
 
   - ps: Add-AppveyorMessage "Installing hyperspy..."
   - "pip install .[all]"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -51,7 +51,7 @@ install:
   # Setup miniconda environment.
   - ps: Add-AppveyorMessage "Setup miniconda environment..."
   - "conda update -y conda"
-  - "conda config --append channels conda-forge;"
+  - "conda config --append channels conda-forge"
   - "conda create -y -n testenv python=%PY_VERSION%"
   - "activate testenv"
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -47,10 +47,12 @@ install:
 
   # Install the dependencies of the project.
   - ps: Add-AppveyorMessage "Installing conda packages..."
-  - "conda install -yq -c conda-forge %DEPS% %TEST_DEPS%"
+  - 'conda update -y conda'
+  - "conda install -y -c conda-forge hyperspy-base --only-deps"
+  - "conda install -y -c conda-forge cython %TEST_DEPS%"
 
   - ps: Add-AppveyorMessage "Installing hyperspy..."
-  - "pip install \"matplotlib>=3.0.0\" & pip install .[mrcz]"
+  - "pip install .[all]"
 
 build: false  # Not a C# project, build stuff at the test step instead.
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -51,6 +51,7 @@ install:
   # Setup miniconda environment.
   - ps: Add-AppveyorMessage "Setup miniconda environment..."
   - "conda update -y conda"
+  - "conda config --append channels conda-forge;"
   - "conda create -y -n testenv python=%PY_VERSION%"
   - "activate testenv"
 
@@ -61,7 +62,7 @@ install:
 
   # Install the dependencies of hyperspy.
   - ps: Add-AppveyorMessage "Installing conda packages..."
-  - "conda install -y -c conda-forge %DEPS% %TEST_DEPS%"
+  - "conda install -y %DEPS% %TEST_DEPS%"
 
   - ps: Add-AppveyorMessage "Installing hyperspy..."
   - "pip install .[tests] mrcz"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,7 +5,7 @@ environment:
 
   global:
     TEST_DEPS: "pytest pytest-cov pytest-mpl wheel"
-    DEPS: "numpy scipy matplotlib ipython h5py sympy scikit-learn dill setuptools natsort scikit-image cython ipyparallel dask numexpr sparse numba python-blosc tqdm pint requests imageio"
+    DEPS: "numpy scipy matplotlib ipython h5py sympy scikit-learn dill setuptools natsort scikit-image cython ipyparallel dask numexpr sparse numba python-blosc tqdm pint requests imageio traits"
     MPLBACKEND: "agg"
 
   matrix:
@@ -66,6 +66,8 @@ install:
 
   - ps: Add-AppveyorMessage "Installing hyperspy..."
   - "pip install .[tests] mrcz"
+  # install pillow with pip as workaround for the DLL issue on win64 from defaults
+  - "pip install -I pillow"
 
 build: false  # Not a C# project, build stuff at the test step instead.
 

--- a/setup.py
+++ b/setup.py
@@ -75,7 +75,7 @@ extras_require = {
     "speed": ["numba"],
     # bug in pip: matplotib is ignored here because it is already present in
     # install_requires.
-    "tests": ["pytest>=3", "pytest-mpl", "matplotlib>=3.0.0"], # for testing
+    "tests": ["pytest>=3.6", "pytest-mpl", "matplotlib>=3.0.0"], # for testing
     "docs": ["sphinx>=1.7", "sphinx_rtd_theme"], # required to build the docs
 }
 


### PR DESCRIPTION
A further iteration to tweak the appveyor and travis configurations. Most of the changes follow the practice use by anaconda/conda-forge to build package.

### Progress of the PR
- [x] Update conda to latest release,
- [x] configure and activate the miniconda environment properly instead of setting the path (solve the current appveyor issue with numpy installation broken),
- [x] install as most as possible dependencies with conda to speed up installation time,
- [x] append `conda-forge` channel to conda configuration to prioritise `defaults` channel in favour of `conda-forge` one to support win32 and python35, which is not supported anymore by conda-forge since 6 months or so,
- [x] ready for review.

This is still a workaround required to install pillow (see https://ci.appveyor.com/project/ericpre/hyperspy/builds/21859827) but I can't reproduce locally so I will it for now. 

