### PR TITLE
Fix dead mrc format specification link in docs

### DIFF
--- a/doc/user_guide/io.rst
+++ b/doc/user_guide/io.rst
@@ -336,7 +336,7 @@ MRC
 
 This is a format widely used for tomographic data. Our implementation is based
 on `this specification
-<http://ami.scripps.edu/software/mrctools/mrc_specification.php>`_. We also
+<https://www2.mrc-lmb.cam.ac.uk/research/locally-developed-software/image-processing-software/>`_. We also
 partly support FEI's custom header. We do not provide writing features for this
 format, but, as it is an open format, we may implement this feature in the
 future on demand.


### PR DESCRIPTION
The mrc format specification page we refer to in the docs is dead. I've checked with the wayback machine and the format specification in the updated link appears to be identical. 

I've copied the format below, in case that site dies too.


1 | NX | number of columns (fastest changing in map)
-- | -- | --
2 | NY | number of rows
3 | NZ | number of sections (slowest changing in map)
4 | MODE | data type :0image : signed 8-bit bytes range -128 to 1271image : 16-bit halfwords2image : 32-bit reals3transform : complex 16-bit integers4transform : complex 32-bit reals | data type : | 0 | image : signed 8-bit bytes range -128 to 127 |   | 1 | image : 16-bit halfwords |   | 2 | image : 32-bit reals |   | 3 | transform : complex 16-bit integers |   | 4 | transform : complex 32-bit reals
data type : | 0 | image : signed 8-bit bytes range -128 to 127
  | 1 | image : 16-bit halfwords
  | 2 | image : 32-bit reals
  | 3 | transform : complex 16-bit integers
  | 4 | transform : complex 32-bit reals
5 | NXSTART | number of first column in map (Default = 0)
6 | NYSTART | number of first row in map
7 | NZSTART | number of first section in map
8 | MX | number of intervals along X
9 | MY | number of intervals along Y
10 | MZ | number of intervals along Z
11-13 | CELLA | cell dimensions in angstroms
14-16 | CELLB | cell angles in degrees
17 | MAPC | axis corresp to cols (1,2,3 for X,Y,Z)
18 | MAPR | axis corresp to rows (1,2,3 for X,Y,Z)
19 | MAPS | axis corresp to sections (1,2,3 for X,Y,Z)
20 | DMIN | minimum density value
21 | DMAX | maximum density value
22 | DMEAN | mean density value
23 | ISPG | space group number 0 or 1 (default=0)
24 | NSYMBT | number of bytes used for symmetry data (0 or 80)
25-49 | EXTRA | extra space used for anything – 0 by default
50-52 | ORIGIN | origin in X,Y,Z used for transforms
53 | MAP | character string ‘MAP ‘ to identify file type
54 | MACHST | machine stamp
55 | RMS | rms deviation of map from mean density
56 | NLABL | number of labels being used
57-256 | LABEL(20,10) | 10 80-character text labels

