### PR TITLE
Fix CI and deprecation warnings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -44,7 +44,7 @@ before_install:
 install:
 
   - if [[ $MINIMAL_ENV == 'False' ]] ; then
-      DEPS="pip numpy scipy matplotlib>2.2.3 ipython h5py sympy scikit-learn dill natsort setuptools scikit-image cython ipyparallel dask traits traitsui numexpr numba python-blosc";
+      DEPS="pip numpy scipy matplotlib>2.2.3 ipython h5py sympy scikit-learn dill natsort setuptools scikit-image cython ipyparallel dask traits traitsui numexpr numba mrcz";
     else DEPS="pip ipython numpy scipy matplotlib>2.2.3 h5py sympy scikit-image numexpr";
     fi
   - conda update -y conda;
@@ -53,7 +53,7 @@ install:
     source activate testenv;
     conda install -y $DEPS $TEST_DEPS;
   - if [[ $MINIMAL_ENV == 'False' ]] ; then
-      pip install .[mrcz];
+      pip install .;
     else pip install .;
     fi
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -50,11 +50,11 @@ install:
 
   # Setup miniconda environment.
   - ps: Add-AppveyorMessage "Setup miniconda environment..."
-  - "conda update -y conda"
+  # Disable update conda until the following issue is solved
+  # https://github.com/conda/conda/issues/7144
+  # https://github.com/appveyor/ci/issues/2270
+  # - "conda update -y conda"
   - "conda config --append channels conda-forge"
-  # Workaround for https://github.com/conda/conda/issues/7144
-  # see https://github.com/appveyor/ci/issues/2270
-  - set PATH=%MINICONDA%;%MINICONDA%\\Scripts;%PATH%
   - "conda create -y -n testenv python=%PY_VERSION%"
   - "activate testenv"
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,7 +5,7 @@ environment:
 
   global:
     TEST_DEPS: "pytest pytest-cov pytest-mpl wheel"
-    DEPS: "numpy scipy matplotlib ipython h5py sympy scikit-learn dill setuptools natsort scikit-image cython ipyparallel dask numexpr sparse numba python-blosc tqdm pint requests imageio traits"
+    DEPS: "numpy scipy matplotlib ipython h5py sympy scikit-learn dill setuptools natsort scikit-image cython ipyparallel dask numexpr sparse numba tqdm pint requests imageio traits mrcz"
     MPLBACKEND: "agg"
 
   matrix:
@@ -65,7 +65,7 @@ install:
   - "conda install -y %DEPS% %TEST_DEPS%"
 
   - ps: Add-AppveyorMessage "Installing hyperspy..."
-  - "pip install .[tests] mrcz"
+  - "pip install .[tests]"
   # install pillow with pip as workaround for the DLL issue on win64 from defaults
   - "pip install -I pillow"
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,7 +5,7 @@ environment:
 
   global:
     TEST_DEPS: "pytest pytest-cov pytest-mpl wheel"
-    DEPS: "numpy scipy matplotlib ipython h5py sympy scikit-learn dill setuptools natsort scikit-image cython ipyparallel dask numexpr sparse numba tqdm pint requests imageio traits mrcz"
+    DEPS: "numpy scipy matplotlib ipython h5py sympy scikit-learn dill setuptools natsort scikit-image cython ipyparallel dask numexpr sparse numba tqdm pint requests imageio traits"
     MPLBACKEND: "agg"
 
   matrix:
@@ -51,12 +51,12 @@ install:
   # Setup miniconda environment.
   - ps: Add-AppveyorMessage "Setup miniconda environment..."
   - "conda update -y conda"
+  - "conda config --append channels conda-forge"
   # Workaround for https://github.com/conda/conda/issues/7144
   # see https://github.com/appveyor/ci/issues/2270
   - set PATH=%MINICONDA%;%MINICONDA%\\Scripts;%PATH%
-  - "conda config --append channels conda-forge"
   - "conda create -y -n testenv python=%PY_VERSION%"
-  - "conda activate testenv"
+  - "activate testenv"
 
   # Check that we have the expected version and architecture for Python
   - "python --version"
@@ -65,6 +65,7 @@ install:
 
   # Install the dependencies of hyperspy.
   - ps: Add-AppveyorMessage "Installing conda packages..."
+  - if "%PLATFORM%"=="x64" set DEPS=%DEPS% mrcz
   - "conda install -y %DEPS% %TEST_DEPS%"
 
   - ps: Add-AppveyorMessage "Installing hyperspy..."
@@ -112,3 +113,4 @@ deploy:
   force_update: true
   on:
     appveyor_repo_tag: true        # deploy on tag push only
+

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -51,6 +51,9 @@ install:
   # Setup miniconda environment.
   - ps: Add-AppveyorMessage "Setup miniconda environment..."
   - "conda update -y conda"
+  # Workaround for https://github.com/conda/conda/issues/7144
+  # see https://github.com/appveyor/ci/issues/2270
+  - set PATH=%MINICONDA%;%MINICONDA%\\Scripts;%PATH%
   - "conda config --append channels conda-forge"
   - "conda create -y -n testenv python=%PY_VERSION%"
   - "conda activate testenv"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -53,7 +53,7 @@ install:
   - "conda update -y conda"
   - "conda config --append channels conda-forge"
   - "conda create -y -n testenv python=%PY_VERSION%"
-  - "activate testenv"
+  - "conda activate testenv"
 
   # Check that we have the expected version and architecture for Python
   - "python --version"

--- a/hyperspy/io_plugins/emd.py
+++ b/hyperspy/io_plugins/emd.py
@@ -500,7 +500,7 @@ def fei_check(filename):
     with h5py.File(filename, 'r') as f:
         if 'Version' in list(f.keys()):
             version = f.get('Version')
-            v_dict = json.loads(version.value[0].decode('utf-8'))
+            v_dict = json.loads(version[0].decode('utf-8'))
             if v_dict['format'] in ['Velox', 'DevelopersKit']:
                 return True
 
@@ -818,7 +818,7 @@ class FeiEMDReader(object):
             self.map_label_dict = {}
             for key in key_list:
                 v = json.loads(
-                    image_display_group[key].value[0].decode('utf-8'))
+                    image_display_group[key][0].decode('utf-8'))
                 data_key = v['dataPath'].split('/')[-1]  # key in data group
                 self.map_label_dict[data_key] = v['display']['label']
         except KeyError:
@@ -834,10 +834,10 @@ class FeiEMDReader(object):
                     sub_dict = {}
                     for subgroup_key in _get_keys_from_group(subgroup):
                         v = json.loads(
-                            subgroup[subgroup_key].value[0].decode('utf-8'))
+                            subgroup[subgroup_key][0].decode('utf-8'))
                         sub_dict[subgroup_key] = v
                 else:
-                    sub_dict = json.loads(subgroup.value[0].decode('utf-8'))
+                    sub_dict = json.loads(subgroup[0].decode('utf-8'))
                 d[group_key] = sub_dict
         except IndexError:
             _logger.warning("Some metadata can't be read.")
@@ -1132,7 +1132,7 @@ class FeiSpectrumStream(object):
         # Parse acquisition settings to get bin_count and dtype
         acquisition_settings_group = stream_group['AcquisitionSettings']
         acquisition_settings = json.loads(
-            acquisition_settings_group.value[0].decode('utf-8'))
+            acquisition_settings_group[0].decode('utf-8'))
         self.bin_count = int(acquisition_settings['bincount'])
         if self.bin_count % self.reader.rebin_energy != 0:
             raise ValueError('The `rebin_energy` needs to be a divisor of the',

--- a/hyperspy/tests/mva/test_decomposition.py
+++ b/hyperspy/tests/mva/test_decomposition.py
@@ -251,6 +251,9 @@ class TestReturnInfo:
             assert self.s.decomposition(
                 algorithm=algorithm, return_info=True, output_dimension=1) is None
 
+    # Warning filter can be removed after scikit-learn >= 0.22
+    # See sklearn.decomposition.sparse_pca.SparsePCA docstring
+    @pytest.mark.filterwarnings("ignore:normalize_components=False:DeprecationWarning")
     @pytest.mark.skipif(not sklearn_installed, reason="sklearn not installed")
     def test_decomposition_supported_return_true(self):
         for algorithm in ["RPCA_GoDec", "ORPCA"]:
@@ -259,12 +262,15 @@ class TestReturnInfo:
                 return_info=True,
                 output_dimension=1) is not None
         for algorithm in ["sklearn_pca", "nmf",
-                          "sparse_pca", "mini_batch_sparse_pca", ]:
+                          "sparse_pca", "mini_batch_sparse_pca"]:
             assert self.s.decomposition(
                 algorithm=algorithm,
                 return_info=True,
                 output_dimension=1) is not None
 
+    # Warning filter can be removed after scikit-learn >= 0.22
+    # See sklearn.decomposition.sparse_pca.SparsePCA docstring
+    @pytest.mark.filterwarnings("ignore:normalize_components=False:DeprecationWarning")
     @pytest.mark.skipif(not sklearn_installed, reason="sklearn not installed")
     def test_decomposition_supported_return_false(self):
         for algorithm in ["RPCA_GoDec", "ORPCA"]:

--- a/hyperspy/tests/signal/test_fancy_indexing.py
+++ b/hyperspy/tests/signal/test_fancy_indexing.py
@@ -133,8 +133,9 @@ class Test1D:
     def test_units_error(self):
         self.signal.axes_manager[0].scale = 0.5
         self.signal.axes_manager[0].units = 'µm'
-        with pytest.raises(ValueError, message='should contains an units'):
-            s = self.signal.isig[:'4000.0']
+        with pytest.raises(ValueError):
+            self.signal.isig[:'4000.0']
+            pytest.fail("should contains an units")
 
 
 class Test2D:

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,3 +1,5 @@
 [pytest]
 markers =
     parallel: a test that is itself parallel and should be run serially
+filterwarnings =
+    ignore:Matplotlib is currently using agg:UserWarning


### PR DESCRIPTION
### Progress of the PR
- [x] use mrcz from conda-forge,
- [x] disable conda update windows until https://github.com/conda/conda/issues/7144 is fixed,
- [x] fix h5py and pytest deprecation warning,
- [x] filter matplotlib warning when running test with the `agg` backend,
- [x] filter scikit-learn deprecation warning,
- [x] ready for review.


