### PR TITLE
Fix saving msa on linux

### DIFF
--- a/hyperspy/io_plugins/msa.py
+++ b/hyperspy/io_plugins/msa.py
@@ -325,7 +325,7 @@ def file_writer(filename, signal, format=None, separator=', ',
             # their name depends on library versions, platform etc.
             loc = locale.getlocale(locale.LC_TIME)
             if os_name == 'posix':
-                locale.setlocale(locale.LC_TIME, ('en_US', 'latin-1'))
+                locale.setlocale(locale.LC_TIME, ('en_US', 'utf8'))
             elif os_name == 'windows':
                 locale.setlocale(locale.LC_TIME, 'english')
             try:


### PR DESCRIPTION
The latin-1 locale did not exist on my version of Ubuntu (by default, at least). This raised an error when saving .msa files. If someone else running Linux or Mac could try the code snippet below to confirm that this is a common issue, that would be great.

```python
s = hs.datasets.example_signals.EDS_SEM_Spectrum()
s.original_metadata.FORMAT = None
s.metadata.General.date = "2019-02-11"
s.save('test.msa', overwrite=True)
```
