### PR TITLE
Fix warning when plotting Signal1D with only zero values

### DIFF
--- a/hyperspy/drawing/signal1d.py
+++ b/hyperspy/drawing/signal1d.py
@@ -393,6 +393,8 @@ class Signal1DLine(object):
                 clipped_yreal = yreal[y1:y2]
                 y_min = min(y_min, clipped_yreal.min())
                 y_max = max(y_max, clipped_yreal.max())
+            if y_min == y_max:
+                y_min, y_max = y_min - 0.1, y_max + 0.1
             self.ax.set_ylim(y_min, y_max)
         if self.plot_indices is True:
             self.text.set_text(self.axes_manager.indices)

--- a/hyperspy/drawing/signal1d.py
+++ b/hyperspy/drawing/signal1d.py
@@ -394,6 +394,7 @@ class Signal1DLine(object):
                 y_min = min(y_min, clipped_yreal.min())
                 y_max = max(y_max, clipped_yreal.max())
             if y_min == y_max:
+                # To avoid matplotlib UserWarning when calling `set_ylim`
                 y_min, y_max = y_min - 0.1, y_max + 0.1
             self.ax.set_ylim(y_min, y_max)
         if self.plot_indices is True:


### PR DESCRIPTION
When navigating over a multidimensional Signal1D where
some (or all) of the spectra had only zero values, a
warning was raised in the console (or notebook) leading to
the console becoming filled up with warnings.

This was due to the matplotlib subplot ylims being set
to the same values (set_ylim(0, 0)). This solves this
by adding -+ 0.1 to the y_min and y_max, if they're the
same value.

This bug would also occurs if all the values in the spectra
was some other non-zero value.

Minimal working example of the bug:

```python
import numpy as np
import hyperspy.api as hs
s = hs.signals.Signal1D(np.zeros((2, 10)))
s.plot() # Move the navigation slider
```

https://github.com/hyperspy/hyperspy/issues/2140