### PR TITLE
Open plots will now be updated when using s.align_zero_loss_peak

### DIFF
--- a/hyperspy/_signals/eels.py
+++ b/hyperspy/_signals/eels.py
@@ -277,6 +277,7 @@ class EELSSpectrum_mixin:
                 value = value.compute()
             for signal in signals:
                 signal.axes_manager[-1].offset -= value
+                signal.events.data_changed.trigger(signal)
 
         def estimate_zero_loss_peak_centre(s, mask, signal_range):
             if signal_range:


### PR DESCRIPTION
Previously, when using align_zero_loss_peak with the plot of the
signal open, it would not update. This could lead to the user
thinking that the function wasn't working correctly.

This change also updates other signals specified with the
also_align parameter in align_zero_loss_peak.

To test this:

```python
import numpy as np
import hyperspy.api as hs
g = hs.model.components1D.Gaussian(A=1, sigma=2, centre=20)
s = hs.signals.EELSSpectrum(g.function(np.arange(100)))
s.axes_manager.signal_axes[0].offset = -10
s1 = hs.signals.EELSSpectrum(np.arange(100))

s.plot()
s1.plot()
s.align_zero_loss_peak(also_align=[s1]) # Without this fix: it does not update the plots. With this fix: both plots update.
```

https://github.com/hyperspy/hyperspy/issues/2141