### PR TITLE
Improve compute and as_lazy to make extending HyperSpy easier

### DIFF
--- a/hyperspy/_signals/lazy.py
+++ b/hyperspy/_signals/lazy.py
@@ -82,6 +82,7 @@ class LazySignal(BaseSignal):
     (assuming storing the full result of computation in memory is not feasible)
     """
     _lazy = True
+    _non_lazy_signal_class = None
 
     def compute(self, progressbar=True, close_file=False):
         """Attempt to store the full signal in memory.
@@ -103,7 +104,8 @@ class LazySignal(BaseSignal):
                 self.close_file()
             self.data = data
         self._lazy = False
-        self._assign_subclass()
+        self._assign_subclass(
+                signal_class=self._non_lazy_signal_class)
 
     def close_file(self):
         """Closes the associated data file if any.


### PR DESCRIPTION
pixStem implements much of its functionality by creating two new classes, `PixelatedStem` and `LazyPixelatedStem`, which inherit either `Signal2D` or `LazySignal2D`. Most the inherited functions return the same signal type, which makes this approach of extending HyperSpy very practical.

However, s.compute() returns only HyperSpy signals, not any of the extended ones in pixStem. This pull request adds new attributes to `BaseSignal` and `LazySignal`, adds a new parameter to `s._assign_subclass`, so that both `s.compute` and `s.as_lazy` can specify which signal class the output signal from these functions should be.

So currently this happens:
```python
import dask.array as da
import hyperspy.api as hs
from hyperspy._signals.signal2d import LazySignal2D, Signal2D

class LazyTestSignal(LazySignal2D):

    pass

s = LazyTestSignal(da.random.random((100, 100)))
print(s) # <LazyTestSignal, title: , dimensions: (|100, 100)>
s.compute()
print(s) # <Signal2D, title: , dimensions: (|100, 100)>
```

With the new implementation
```python
import dask.array as da
import hyperspy.api as hs
from hyperspy._signals.signal2d import LazySignal2D, Signal2D

class LazyTestSignal(LazySignal2D):

    def __init__(self, *args, **kwargs):
        self._non_lazy_signal_class = TestSignal
        super().__init__(*args, **kwargs)


class TestSignal(Signal2D):

    def __init__(self, *args, **kwargs):
        self._lazy_signal_class = LazyTestSignal
        super().__init__(*args, **kwargs)

s = LazyTestSignal(da.random.random((100, 100)))
print(s) # <LazyTestSignal, title: , dimensions: (|100, 100)>
s.compute()
print(s) # <TestSignal, title: , dimensions: (|100, 100)>
s1 = s.as_lazy()
print(s1) # <LazyTestSignal, title: , dimensions: (|100, 100)>
```

## Todos

- [ ] Finish implementation
- [ ] Write tests
- [ ] Add info to developer guide about this

https://github.com/hyperspy/hyperspy/issues/2142