### PR TITLE
Component Exponential, GaussianHF, Gaussian and PowerLaw documentation

### DIFF
--- a/hyperspy/_components/exponential.py
+++ b/hyperspy/_components/exponential.py
@@ -27,7 +27,7 @@ class Exponential(Expression):
         f(x) = A\\cdot\\exp\\left(-\\frac{x}{\\tau}\\right)
 
     ================= ===========
-      Parameter        Attribute 
+     Variable          Parameter 
     ================= ===========
      :math:`A`         A     
      :math:`\\tau`     tau    

--- a/hyperspy/_components/exponential.py
+++ b/hyperspy/_components/exponential.py
@@ -33,14 +33,15 @@ class Exponential(Expression):
     :math:`\tau`   tau    
     ============= =============
 
+    
     Parameters
     -----------
-        A: float
-            Maximum intensity
-        tau: float
-            Scale parameter (time constant)
-        **kwargs
-            Extra keyword arguments are passed to the ``Expression`` component.
+    A: float
+        Maximum intensity
+    tau: float
+        Scale parameter (time constant)
+    **kwargs
+        Extra keyword arguments are passed to the ``Expression`` component.
 
     """
 

--- a/hyperspy/_components/exponential.py
+++ b/hyperspy/_components/exponential.py
@@ -18,12 +18,13 @@
 
 from hyperspy._components.expression import Expression
 
+
 class Exponential(Expression):
 
     r"""Exponential function component.
 
     .. math::
-    
+
         f(x) = A\cdot\exp\left(-\frac{x}{\tau}\right)
 
     ============= =============
@@ -33,7 +34,7 @@ class Exponential(Expression):
     :math:`\tau`   tau    
     ============= =============
 
-    
+
     Parameters
     -----------
     A: float
@@ -42,7 +43,6 @@ class Exponential(Expression):
         Scale parameter (time constant)
     **kwargs
         Extra keyword arguments are passed to the ``Expression`` component.
-
     """
 
     def __init__(self, A=1., tau=1., module="numexpr", **kwargs):

--- a/hyperspy/_components/exponential.py
+++ b/hyperspy/_components/exponential.py
@@ -24,16 +24,27 @@ class Exponential(Expression):
 
     .. math::
     
-        f(x) = A*e^{-x/k}
+        f(x) = A\\cdot\\mathrm{exp}\\left(-\\frac{x}{\\tau}\\right)
 
-    +------------+-----------+
-    | Parameter  | Attribute |
-    +------------+-----------+
-    +------------+-----------+
-    |     A      |     A     |
-    +------------+-----------+
-    |     k      |    tau    |
-    +------------+-----------+
+    +-----------------+-----------+
+    |  Parameter      | Attribute |
+    +=================+===========+
+    | :math:`A`       |     A     |
+    +-----------------+-----------+
+    | :math:`\\tau`   |    tau    |
+    +-----------------+-----------+
+
+    Parameters
+    -----------
+        A: float
+            Maximum intensity
+        tau: float
+            Scale parameter (time constant)
+        **kwargs
+            Extra keyword arguments are passed to the ``Expression`` component.
+            An useful keyword argument that can be used to speed up the
+            component is `module`. See the ``Expression`` component
+            documentation for details.
 
     """
 

--- a/hyperspy/_components/exponential.py
+++ b/hyperspy/_components/exponential.py
@@ -20,18 +20,18 @@ from hyperspy._components.expression import Expression
 
 class Exponential(Expression):
 
-    """Exponential function component
+    r"""Exponential function component.
 
     .. math::
     
-        f(x) = A\\cdot\\exp\\left(-\\frac{x}{\\tau}\\right)
+        f(x) = A\cdot\exp\left(-\frac{x}{\tau}\right)
 
-    ================= ===========
-     Variable          Parameter 
-    ================= ===========
-     :math:`A`         A     
-     :math:`\\tau`     tau    
-    ================= ===========
+    ============= =============
+    Variable       Parameter 
+    ============= =============
+    :math:`A`      A     
+    :math:`\tau`   tau    
+    ============= =============
 
     Parameters
     -----------

--- a/hyperspy/_components/exponential.py
+++ b/hyperspy/_components/exponential.py
@@ -41,9 +41,6 @@ class Exponential(Expression):
             Scale parameter (time constant)
         **kwargs
             Extra keyword arguments are passed to the ``Expression`` component.
-            An useful keyword argument that can be used to speed up the
-            component is `module`. See the ``Expression`` component
-            documentation for details.
 
     """
 

--- a/hyperspy/_components/exponential.py
+++ b/hyperspy/_components/exponential.py
@@ -24,15 +24,14 @@ class Exponential(Expression):
 
     .. math::
     
-        f(x) = A\\cdot\\mathrm{exp}\\left(-\\frac{x}{\\tau}\\right)
+        f(x) = A\\cdot\\exp\\left(-\\frac{x}{\\tau}\\right)
 
-    +-----------------+-----------+
-    |  Parameter      | Attribute |
-    +=================+===========+
-    | :math:`A`       |     A     |
-    +-----------------+-----------+
-    | :math:`\\tau`   |    tau    |
-    +-----------------+-----------+
+    ================= ===========
+      Parameter        Attribute 
+    ================= ===========
+     :math:`A`         A     
+     :math:`\\tau`     tau    
+    ================= ===========
 
     Parameters
     -----------

--- a/hyperspy/_components/gaussian.py
+++ b/hyperspy/_components/gaussian.py
@@ -72,7 +72,8 @@ class Gaussian(Expression):
 
     .. math::
 
-        f(x) = \frac{A}{\sigma \sqrt{2\pi}}\exp\left[-\frac{\left(x-x_0\right)^{2}}{2\sigma^{2}}\right]
+        f(x) = \frac{A}{\sigma \sqrt{2\pi}}\exp\left[
+            -\frac{\left(x-x_0\right)^{2}}{2\sigma^{2}}\right]
 
     ============== ===========
     Variable         Parameter
@@ -82,19 +83,24 @@ class Gaussian(Expression):
     :math:`x_0`      centre
     ============== ===========
 
+
     Parameters
     -----------
-        A : float
-            Height scaled by :math:`\sigma\sqrt{(2\pi)}`. ``GaussianHF`` implements the Gaussian function with a height parameter corresponding to the peak height.
-        sigma : float
-            Scale parameter of the Gaussian distribution. 
-        centre : float
-            Location of the Gaussian maximum (peak position).
-        **kwargs
-            Extra keyword arguments are passed to the ``Expression`` component.
+    A : float
+        Height scaled by :math:`\sigma\sqrt{(2\pi)}`. ``GaussianHF`` 
+        implements the Gaussian function with a height parameter 
+        corresponding to the peak height.
+    sigma : float
+        Scale parameter of the Gaussian distribution. 
+    centre : float
+        Location of the Gaussian maximum (peak position).
+    **kwargs
+        Extra keyword arguments are passed to the ``Expression`` component.
+
 
     For convenience the `fwhm` attribute can be used to get and set
     the full-with-half-maximum.
+
 
     See also
     --------
@@ -104,7 +110,8 @@ class Gaussian(Expression):
 
     def __init__(self, A=1., sigma=1., centre=0., module="numexpr", **kwargs):
         super(Gaussian, self).__init__(
-            expression="A * (1 / (sigma * sqrt(2*pi))) * exp(-(x - centre)**2 / (2 * sigma**2))",
+            expression="A * (1 / (sigma * sqrt(2*pi))) * exp(-(x - centre)**2 \
+                        / (2 * sigma**2))",
             name="Gaussian",
             A=A,
             sigma=sigma,

--- a/hyperspy/_components/gaussian.py
+++ b/hyperspy/_components/gaussian.py
@@ -68,12 +68,30 @@ def _estimate_gaussian_parameters(signal, x1, x2, only_current):
 
 class Gaussian(Expression):
 
-    """Normalized gaussian function component
+    """Normalized Gaussian function component.
 
     .. math::
 
-        f(x) = \\frac{A}{\\sqrt{2\\pi sigma^{2}}}exp\\left[-\\frac{\\left(x-centre\\right)^{2}}{2sigma^{2}}\\right]
+        f(x) = \\frac{A}{\\sigma \\sqrt{2\\pi}}\\exp\\left[-\\frac{\\left(x-x_0\\right)^{2}}{2\\sigma^{2}}\\right]
 
+    ================= ===========
+     Variable          Parameter
+    ================= ===========
+     :math:`A`         A
+     :math:`\\sigma`   sigma
+     :math:`x_0`       centre
+    ================= ===========
+
+    Parameters
+    -----------
+        A : float
+            Height scaled by :math:`\\sigma\\sqrt{(2\\pi)}`. ``GaussianHF`` implements the Gaussian function with a height parameter corresponding to the peak height.
+        sigma : float
+            Scale parameter of the Gaussian distribution. 
+        centre : float
+            Location of the Gaussian maximum (peak position).
+        **kwargs
+            Extra keyword arguments are passed to the ``Expression`` component.
 
     For convenience the `fwhm` attribute can be used to get and set
     the full-with-half-maximum.
@@ -107,7 +125,7 @@ class Gaussian(Expression):
         self.convolved = True
 
     def estimate_parameters(self, signal, x1, x2, only_current=False):
-        """Estimate the gaussian by calculating the momenta.
+        """Estimate the Gaussian by calculating the momenta.
 
         Parameters
         ----------

--- a/hyperspy/_components/gaussian.py
+++ b/hyperspy/_components/gaussian.py
@@ -73,7 +73,7 @@ class Gaussian(Expression):
     .. math::
 
         f(x) = \frac{A}{\sigma \sqrt{2\pi}}\exp\left[
-            -\frac{\left(x-x_0\right)^{2}}{2\sigma^{2}}\right]
+               -\frac{\left(x-x_0\right)^{2}}{2\sigma^{2}}\right]
 
     ============== ===========
     Variable         Parameter
@@ -105,7 +105,6 @@ class Gaussian(Expression):
     See also
     --------
     hyperspy._components.gaussianhf.GaussianHF
-
     """
 
     def __init__(self, A=1., sigma=1., centre=0., module="numexpr", **kwargs):
@@ -166,8 +165,8 @@ class Gaussian(Expression):
         >>> s.axes_manager._axes[-1].offset = -10
         >>> s.axes_manager._axes[-1].scale = 0.01
         >>> g.estimate_parameters(s, -10, 10, False)
-
         """
+        
         super(Gaussian, self)._estimate_parameters(signal)
         axis = signal.axes_manager.signal_axes[0]
         centre, height, sigma = _estimate_gaussian_parameters(signal, x1, x2,

--- a/hyperspy/_components/gaussian.py
+++ b/hyperspy/_components/gaussian.py
@@ -68,24 +68,24 @@ def _estimate_gaussian_parameters(signal, x1, x2, only_current):
 
 class Gaussian(Expression):
 
-    """Normalized Gaussian function component.
+    r"""Normalized Gaussian function component.
 
     .. math::
 
-        f(x) = \\frac{A}{\\sigma \\sqrt{2\\pi}}\\exp\\left[-\\frac{\\left(x-x_0\\right)^{2}}{2\\sigma^{2}}\\right]
+        f(x) = \frac{A}{\sigma \sqrt{2\pi}}\exp\left[-\frac{\left(x-x_0\right)^{2}}{2\sigma^{2}}\right]
 
-    ================= ===========
-     Variable          Parameter
-    ================= ===========
-     :math:`A`         A
-     :math:`\\sigma`   sigma
-     :math:`x_0`       centre
-    ================= ===========
+    ============== ===========
+    Variable         Parameter
+    ============== ===========
+    :math:`A`        A
+    :math:`\sigma`  sigma
+    :math:`x_0`      centre
+    ============== ===========
 
     Parameters
     -----------
         A : float
-            Height scaled by :math:`\\sigma\\sqrt{(2\\pi)}`. ``GaussianHF`` implements the Gaussian function with a height parameter corresponding to the peak height.
+            Height scaled by :math:`\sigma\sqrt{(2\pi)}`. ``GaussianHF`` implements the Gaussian function with a height parameter corresponding to the peak height.
         sigma : float
             Scale parameter of the Gaussian distribution. 
         centre : float

--- a/hyperspy/_components/gaussianhf.py
+++ b/hyperspy/_components/gaussianhf.py
@@ -37,8 +37,15 @@ class GaussianHF(Expression):
 
     .. math::
 
-        f(x) = h \\sqrt{2\\pi}\\mathrm{exp}{\\left[-\\frac{4 \\log{2}\\left(x-c\\right)^{2}}{W^{2}}\\right]}
-
+        f(x) = h \\sqrt{2\\pi}\\cdot\\exp{\\left[-\\frac{4 \\log{2}\\left(x-c\\right)^{2}}{W^{2}}\\right]}
+    
+    ================= ===========
+      Parameter        Attribute 
+    ================= ===========
+     :math:`h`         height     
+     :math:`c`         centre
+     :math:`W`         fwhm    
+    ================= ===========
 
     Parameters
     -----------

--- a/hyperspy/_components/gaussianhf.py
+++ b/hyperspy/_components/gaussianhf.py
@@ -29,8 +29,8 @@ class GaussianHF(Expression):
 
     """Normalized gaussian function component, with a fwhm parameter instead
     of the sigma parameter, and a height parameter instead of the A parameter
-    (scaling difference of sigma * sqrt(2*Pi)). This makes the parameter vs.
-    peak maximum independent of sigma, and thereby makes locking of the
+    (scaling difference of :math:`\\sigma \\sqrt{\\left(2\\pi\\right)}`). This makes the parameter vs.
+    peak maximum independent of :math:`\\sigma`, and thereby makes locking of the
     parameter more viable. As long as there is no binning, the height parameter
     corresponds directly to the peak maximum, if not, the value is scaled by a
     linear constant (signal_axis.scale).
@@ -52,7 +52,7 @@ class GaussianHF(Expression):
             The full width half maximum value, i.e. the width of the gaussian
             at half the value of gaussian peak (at centre).
         **kwargs
-            Extra keyword arguments are passes to the ``Expression`` component.
+            Extra keyword arguments are passed to the ``Expression`` component.
             An useful keyword argument that can be used to speed up the
             component is `module`. See the ``Expression`` component
             documentation for details.

--- a/hyperspy/_components/gaussianhf.py
+++ b/hyperspy/_components/gaussianhf.py
@@ -37,7 +37,7 @@ class GaussianHF(Expression):
 
     .. math::
 
-        f(x) = h \\sqrt{2\\pi}\\cdot\\exp{\\left[-\\frac{4 \\log{2}\\left(x-c\\right)^{2}}{W^{2}}\\right]}
+        f(x) = h\\cdot\\exp{\\left[-\\frac{4 \\log{2}\\left(x-c\\right)^{2}}{W^{2}}\\right]}
     
     ================= ===========
       Parameter        Attribute 
@@ -69,7 +69,7 @@ class GaussianHF(Expression):
 
     See also
     --------
-    hyperspy.components.Gaussian
+    hyperspy._components.gaussian.Gaussian
 
     """
 

--- a/hyperspy/_components/gaussianhf.py
+++ b/hyperspy/_components/gaussianhf.py
@@ -39,13 +39,13 @@ class GaussianHF(Expression):
 
         f(x) = h\cdot\exp{\left[-\frac{4 \log{2}\left(x-c\right)^{2}}{W^{2}}\right]}
     
-    ================= ============
-     Variable          Parameter 
-    ================= ============
-     :math:`h`         height    
-     :math:`c`         centre    
-     :math:`W`         fwhm      
-    ================= ============
+    ============= =============
+     Variable      Parameter 
+    ============= =============
+     :math:`h`     height    
+     :math:`c`     centre    
+     :math:`W`     fwhm      
+    ============= =============
 
     Parameters
     -----------

--- a/hyperspy/_components/gaussianhf.py
+++ b/hyperspy/_components/gaussianhf.py
@@ -27,25 +27,25 @@ sigma2fwhm = 2 * math.sqrt(2 * math.log(2))
 
 class GaussianHF(Expression):
 
-    """Normalized gaussian function component, with a fwhm parameter instead
-    of the sigma parameter, and a height parameter instead of the A parameter
-    (scaling difference of :math:`\\sigma \\sqrt{\\left(2\\pi\\right)}`). This makes the parameter vs.
-    peak maximum independent of :math:`\\sigma`, and thereby makes locking of the
-    parameter more viable. As long as there is no binning, the height parameter
+    r"""Normalized gaussian function component, with a `fwhm` parameter instead
+    of the sigma parameter, and a `height` parameter instead of the `A` parameter
+    (scaling difference of :math:`\sigma \sqrt{\left(2\pi\right)}`). This makes the parameter vs.
+    peak maximum independent of :math:`\sigma`, and thereby makes locking of the
+    parameter more viable. As long as there is no binning, the `height` parameter
     corresponds directly to the peak maximum, if not, the value is scaled by a
-    linear constant (signal_axis.scale).
+    linear constant (`signal_axis.scale`).
 
     .. math::
 
-        f(x) = h\\cdot\\exp{\\left[-\\frac{4 \\log{2}\\left(x-c\\right)^{2}}{W^{2}}\\right]}
+        f(x) = h\cdot\exp{\left[-\frac{4 \log{2}\left(x-c\right)^{2}}{W^{2}}\right]}
     
-    ================= ===========
-     Variable          Parameter
-    ================= ===========
-     :math:`h`         height     
-     :math:`c`         centre
-     :math:`W`         fwhm    
-    ================= ===========
+    ================= ============
+     Variable          Parameter 
+    ================= ============
+     :math:`h`         height    
+     :math:`c`         centre    
+     :math:`W`         fwhm      
+    ================= ============
 
     Parameters
     -----------

--- a/hyperspy/_components/gaussianhf.py
+++ b/hyperspy/_components/gaussianhf.py
@@ -40,7 +40,7 @@ class GaussianHF(Expression):
 
         f(x) = h\cdot\exp{\left[-\frac{4 \log{2}
             \left(x-c\right)^{2}}{W^{2}}\right]}
-    
+
     ============= =============
      Variable      Parameter 
     ============= =============
@@ -51,7 +51,7 @@ class GaussianHF(Expression):
 
 
     Parameters
-    -----------
+    ----------
     height: float
         The height of the peak. If there is no binning, this corresponds
         directly to the maximum, otherwise the maximum divided by
@@ -132,7 +132,6 @@ class GaussianHF(Expression):
         >>> s.axes_manager._axes[-1].offset = -10
         >>> s.axes_manager._axes[-1].scale = 0.01
         >>> g.estimate_parameters(s, -10, 10, False)
-
         """
 
         super(GaussianHF, self)._estimate_parameters(signal)

--- a/hyperspy/_components/gaussianhf.py
+++ b/hyperspy/_components/gaussianhf.py
@@ -43,8 +43,8 @@ class GaussianHF(Expression):
      Variable      Parameter 
     ============= =============
      :math:`h`     height    
+     :math:`W`     fwhm 
      :math:`c`     centre    
-     :math:`W`     fwhm      
     ============= =============
 
     Parameters
@@ -53,11 +53,11 @@ class GaussianHF(Expression):
             The height of the peak. If there is no binning, this corresponds
             directly to the maximum, otherwise the maximum divided by
             signal_axis.scale
-        centre: float
-            Location of the gaussian maximum, also the mean position.
         fwhm: float
             The full width half maximum value, i.e. the width of the gaussian
             at half the value of gaussian peak (at centre).
+        centre: float
+            Location of the gaussian maximum, also the mean position.
         **kwargs
             Extra keyword arguments are passed to the ``Expression`` component.
 

--- a/hyperspy/_components/gaussianhf.py
+++ b/hyperspy/_components/gaussianhf.py
@@ -28,16 +28,18 @@ sigma2fwhm = 2 * math.sqrt(2 * math.log(2))
 class GaussianHF(Expression):
 
     r"""Normalized gaussian function component, with a `fwhm` parameter instead
-    of the sigma parameter, and a `height` parameter instead of the `A` parameter
-    (scaling difference of :math:`\sigma \sqrt{\left(2\pi\right)}`). This makes the parameter vs.
-    peak maximum independent of :math:`\sigma`, and thereby makes locking of the
-    parameter more viable. As long as there is no binning, the `height` parameter
-    corresponds directly to the peak maximum, if not, the value is scaled by a
-    linear constant (`signal_axis.scale`).
+    of the sigma parameter, and a `height` parameter instead of the `A` 
+    parameter (scaling difference of :math:`\sigma \sqrt{\left(2\pi\right)}`). 
+    This makes the parameter vs. peak maximum independent of :math:`\sigma`, 
+    and thereby makes locking of the parameter more viable. As long as there 
+    is no binning, the `height` parameter corresponds directly to the peak 
+    maximum, if not, the value is scaled by a linear constant 
+    (`signal_axis.scale`).
 
     .. math::
 
-        f(x) = h\cdot\exp{\left[-\frac{4 \log{2}\left(x-c\right)^{2}}{W^{2}}\right]}
+        f(x) = h\cdot\exp{\left[-\frac{4 \log{2}
+            \left(x-c\right)^{2}}{W^{2}}\right]}
     
     ============= =============
      Variable      Parameter 
@@ -47,19 +49,21 @@ class GaussianHF(Expression):
      :math:`c`     centre    
     ============= =============
 
+
     Parameters
     -----------
-        height: float
-            The height of the peak. If there is no binning, this corresponds
-            directly to the maximum, otherwise the maximum divided by
-            signal_axis.scale
-        fwhm: float
-            The full width half maximum value, i.e. the width of the gaussian
-            at half the value of gaussian peak (at centre).
-        centre: float
-            Location of the gaussian maximum, also the mean position.
-        **kwargs
-            Extra keyword arguments are passed to the ``Expression`` component.
+    height: float
+        The height of the peak. If there is no binning, this corresponds
+        directly to the maximum, otherwise the maximum divided by
+        signal_axis.scale
+    fwhm: float
+        The full width half maximum value, i.e. the width of the gaussian
+        at half the value of gaussian peak (at centre).
+    centre: float
+        Location of the gaussian maximum, also the mean position.
+    **kwargs
+        Extra keyword arguments are passed to the ``Expression`` component.
+
 
     The helper properties `sigma` and `A` are also defined for compatibility
     with `Gaussian` component.

--- a/hyperspy/_components/gaussianhf.py
+++ b/hyperspy/_components/gaussianhf.py
@@ -40,7 +40,7 @@ class GaussianHF(Expression):
         f(x) = h\\cdot\\exp{\\left[-\\frac{4 \\log{2}\\left(x-c\\right)^{2}}{W^{2}}\\right]}
     
     ================= ===========
-      Parameter        Attribute 
+     Variable          Parameter
     ================= ===========
      :math:`h`         height     
      :math:`c`         centre

--- a/hyperspy/_components/gaussianhf.py
+++ b/hyperspy/_components/gaussianhf.py
@@ -60,9 +60,6 @@ class GaussianHF(Expression):
             at half the value of gaussian peak (at centre).
         **kwargs
             Extra keyword arguments are passed to the ``Expression`` component.
-            An useful keyword argument that can be used to speed up the
-            component is `module`. See the ``Expression`` component
-            documentation for details.
 
     The helper properties `sigma` and `A` are also defined for compatibility
     with `Gaussian` component.

--- a/hyperspy/_components/power_law.py
+++ b/hyperspy/_components/power_law.py
@@ -38,18 +38,18 @@ class PowerLaw(Expression):
      Variable      Parameter
     ============= =============
      :math:`A`     A
-     :math:`x_0`   origin
      :math:`r`     r
+     :math:`x_0`   origin
     ============= =============
 
     Parameters
     -----------
         A : float
             Height parameter.
-        origin : float
-            Location parameter.
         r : float
             Power law coefficient.
+        origin : float
+            Location parameter.
         **kwargs
             Extra keyword arguments are passed to the ``Expression`` component.
 

--- a/hyperspy/_components/power_law.py
+++ b/hyperspy/_components/power_law.py
@@ -29,11 +29,11 @@ _logger = logging.getLogger(__name__)
 class PowerLaw(Expression):
 
     r"""Power law component.
-    
+
     .. math::
-    
-      f(x) = A\cdot(x-x_0)^{-r}
-      
+
+        f(x) = A\cdot(x-x_0)^{-r}
+
     ============= =============
      Variable      Parameter
     ============= =============
@@ -44,7 +44,7 @@ class PowerLaw(Expression):
 
 
     Parameters
-    -----------
+    ----------
     A : float
         Height parameter.
     r : float
@@ -57,8 +57,6 @@ class PowerLaw(Expression):
 
     The `left_cutoff` parameter can be used to set a lower threshold from which
     the component will return 0.
-
-
     """
 
     def __init__(self, A=10e5, r=3., origin=0., module="numexpr", **kwargs):

--- a/hyperspy/_components/power_law.py
+++ b/hyperspy/_components/power_law.py
@@ -28,19 +28,19 @@ _logger = logging.getLogger(__name__)
 
 class PowerLaw(Expression):
 
-    """Power law component.
+    r"""Power law component.
     
     .. math::
     
-      f(x) = A\\cdot(x-x_0)^{-r}
+      f(x) = A\cdot(x-x_0)^{-r}
       
-    ================= ===========
-     Variable          Parameter
-    ================= ===========
-     :math:`A`         A
-     :math:`x_0`       origin
-     :math:`r`         r
-    ================= ===========
+    ============= =============
+     Variable      Parameter
+    ============= =============
+     :math:`A`     A
+     :math:`x_0`   origin
+     :math:`r`     r
+    ============= =============
 
     Parameters
     -----------
@@ -108,7 +108,6 @@ class PowerLaw(Expression):
         x2 : float
             Defines the right limit of the spectral range to use for the
             estimation.
-
         only_current : bool
             If False, estimates the parameters for the full dataset.
         out : bool

--- a/hyperspy/_components/power_law.py
+++ b/hyperspy/_components/power_law.py
@@ -42,16 +42,18 @@ class PowerLaw(Expression):
      :math:`x_0`   origin
     ============= =============
 
+
     Parameters
     -----------
-        A : float
-            Height parameter.
-        r : float
-            Power law coefficient.
-        origin : float
-            Location parameter.
-        **kwargs
-            Extra keyword arguments are passed to the ``Expression`` component.
+    A : float
+        Height parameter.
+    r : float
+        Power law coefficient.
+    origin : float
+        Location parameter.
+    **kwargs
+        Extra keyword arguments are passed to the ``Expression`` component.
+
 
     The `left_cutoff` parameter can be used to set a lower threshold from which
     the component will return 0.
@@ -97,7 +99,8 @@ class PowerLaw(Expression):
 
     def estimate_parameters(self, signal, x1, x2, only_current=False,
                             out=False):
-        """Estimate the parameters for the power law component by the two area method.
+        """Estimate the parameters for the power law component by the two area 
+        method.
 
         Parameters
         ----------

--- a/hyperspy/_components/power_law.py
+++ b/hyperspy/_components/power_law.py
@@ -28,11 +28,32 @@ _logger = logging.getLogger(__name__)
 
 class PowerLaw(Expression):
 
-    """Power law component
+    """Power law component.
+    
+    .. math::
+    
+      f(x) = A\\cdot(x-x_0)^{-r}
+      
+    ================= ===========
+     Variable          Parameter
+    ================= ===========
+     :math:`A`         A
+     :math:`x_0`       origin
+     :math:`r`         r
+    ================= ===========
 
-    f(x) = A*(x-origin)^-r
+    Parameters
+    -----------
+        A : float
+            Height parameter.
+        origin : float
+            Location parameter.
+        r : float
+            Power law coefficient.
+        **kwargs
+            Extra keyword arguments are passed to the ``Expression`` component.
 
-    The left_cutoff parameter can be used to set a lower threshold from which
+    The `left_cutoff` parameter can be used to set a lower threshold from which
     the component will return 0.
 
 
@@ -76,7 +97,7 @@ class PowerLaw(Expression):
 
     def estimate_parameters(self, signal, x1, x2, only_current=False,
                             out=False):
-        """Estimate the parameters by the two area method
+        """Estimate the parameters for the power law component by the two area method.
 
         Parameters
         ----------

--- a/hyperspy/docstrings/parameters.py
+++ b/hyperspy/docstrings/parameters.py
@@ -5,6 +5,6 @@
 
 FUNCTION_ND_DOCSTRING = \
     """Returns a numpy array containing the value of the component for all
-        indices. If enought memory is available, this is useful to quickly to
+        indices. If enough memory is available, this is useful to quickly to
         obtain the fitted component without iterating over the navigation axes.
         """

--- a/hyperspy/tests/component/test_exponential.py
+++ b/hyperspy/tests/component/test_exponential.py
@@ -1,0 +1,33 @@
+# -*- coding: utf-8 -*-
+# Copyright 2007-2016 The HyperSpy developers
+#
+# This file is part of  HyperSpy.
+#
+#  HyperSpy is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+#  HyperSpy is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with  HyperSpy.  If not, see <http://www.gnu.org/licenses/>.
+
+
+import numpy as np
+from numpy.testing import assert_allclose
+
+from hyperspy.components1d import Exponential
+
+
+def test_function():
+    g = Exponential()
+    g.A.value = 2
+    g.tau.value = 3
+    assert g.function(0) == 2
+    assert_allclose(g.function(0.3),2*np.exp(-.1))
+    assert_allclose(g.function(-3),2*np.e)
+

--- a/hyperspy/tests/component/test_exponential.py
+++ b/hyperspy/tests/component/test_exponential.py
@@ -16,7 +16,6 @@
 # You should have received a copy of the GNU General Public License
 # along with  HyperSpy.  If not, see <http://www.gnu.org/licenses/>.
 
-
 import numpy as np
 from numpy.testing import assert_allclose
 
@@ -28,6 +27,5 @@ def test_function():
     g.A.value = 2
     g.tau.value = 3
     assert g.function(0) == 2
-    assert_allclose(g.function(0.3),2*np.exp(-.1))
-    assert_allclose(g.function(-3),2*np.e)
-
+    assert_allclose(g.function(0.3), 2*np.exp(-.1))
+    assert_allclose(g.function(-3), 2*np.e)

--- a/hyperspy/tests/component/test_gaussian.py
+++ b/hyperspy/tests/component/test_gaussian.py
@@ -16,7 +16,6 @@
 # You should have received a copy of the GNU General Public License
 # along with  HyperSpy.  If not, see <http://www.gnu.org/licenses/>.
 
-
 import itertools
 import numpy as np
 from numpy.testing import assert_allclose
@@ -37,9 +36,8 @@ def test_function():
     g.centre.value = 1
     g.sigma.value = 2 / sigma2fwhm
     g.A.value = 3 * sqrt2pi * g.sigma.value
-    assert_allclose(g.function(2),1.5)
-    assert_allclose(g.function(1),3)
-
+    assert_allclose(g.function(2), 1.5)
+    assert_allclose(g.function(1), 3)
 
 @pytest.mark.parametrize(("only_current", "binned"), TRUE_FALSE_2_TUPLE)
 def test_estimate_parameters_binned(only_current, binned):
@@ -59,7 +57,6 @@ def test_estimate_parameters_binned(only_current, binned):
     assert abs(g2.centre.value - g1.centre.value) <= 1e-3
     assert abs(g2.sigma.value - g1.sigma.value) <= 0.1
 
-
 @pytest.mark.parametrize(("binned"), (True, False))
 def test_function_nd(binned):
     s = Signal1D(np.empty((100,)))
@@ -76,18 +73,15 @@ def test_function_nd(binned):
     assert g2.binned == binned
     assert_allclose(g2.function_nd(axis.axis) * factor, s2.data)
 
-
 def test_util_fwhm_set():
     g1 = Gaussian()
     g1.fwhm = 1.0
     assert_allclose(g1.sigma.value, 1.0 / sigma2fwhm)
 
-
 def test_util_fwhm_get():
     g1 = Gaussian()
     g1.sigma.value = 1.0
     assert_allclose(g1.fwhm, 1.0 * sigma2fwhm)
-
 
 def test_util_fwhm_getset():
     g1 = Gaussian()

--- a/hyperspy/tests/component/test_gaussian.py
+++ b/hyperspy/tests/component/test_gaussian.py
@@ -1,0 +1,95 @@
+# -*- coding: utf-8 -*-
+# Copyright 2007-2016 The HyperSpy developers
+#
+# This file is part of  HyperSpy.
+#
+#  HyperSpy is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+#  HyperSpy is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with  HyperSpy.  If not, see <http://www.gnu.org/licenses/>.
+
+
+import itertools
+import numpy as np
+from numpy.testing import assert_allclose
+import pytest
+
+from hyperspy.components1d import Gaussian
+from hyperspy.signals import Signal1D
+from hyperspy.utils import stack
+
+sqrt2pi = np.sqrt(2 * np.pi)
+sigma2fwhm = 2 * np.sqrt(2 * np.log(2))
+
+TRUE_FALSE_2_TUPLE = [p for p in itertools.product((True, False), repeat=2)]
+
+
+def test_function():
+    g = Gaussian()
+    g.centre.value = 1
+    g.sigma.value = 2 / sigma2fwhm
+    g.A.value = 3 * sqrt2pi * g.sigma.value
+    assert_allclose(g.function(2),1.5)
+    assert_allclose(g.function(1),3)
+
+
+@pytest.mark.parametrize(("only_current", "binned"), TRUE_FALSE_2_TUPLE)
+def test_estimate_parameters_binned(only_current, binned):
+    s = Signal1D(np.empty((100,)))
+    s.metadata.Signal.binned = binned
+    axis = s.axes_manager.signal_axes[0]
+    axis.scale = 1
+    axis.offset = -20
+    g1 = Gaussian(50015.156, 10/sigma2fwhm, 10)
+    s.data = g1.function(axis.axis)
+    g2 = Gaussian()
+    factor = axis.scale if binned else 1
+    assert g2.estimate_parameters(s, axis.low_value, axis.high_value,
+                                  only_current=only_current)
+    assert g2.binned == binned
+    assert_allclose(g1.A.value, g2.A.value * factor)
+    assert abs(g2.centre.value - g1.centre.value) <= 1e-3
+    assert abs(g2.sigma.value - g1.sigma.value) <= 0.1
+
+
+@pytest.mark.parametrize(("binned"), (True, False))
+def test_function_nd(binned):
+    s = Signal1D(np.empty((100,)))
+    axis = s.axes_manager.signal_axes[0]
+    axis.scale = 1
+    axis.offset = -20
+    g1 = Gaussian(50015.156, 10/sigma2fwhm, 10)
+    s.data = g1.function(axis.axis)
+    s.metadata.Signal.binned = binned
+    s2 = stack([s] * 2)
+    g2 = Gaussian()
+    factor = axis.scale if binned else 1
+    g2.estimate_parameters(s2, axis.low_value, axis.high_value, False)
+    assert g2.binned == binned
+    assert_allclose(g2.function_nd(axis.axis) * factor, s2.data)
+
+
+def test_util_fwhm_set():
+    g1 = Gaussian()
+    g1.fwhm = 1.0
+    assert_allclose(g1.sigma.value, 1.0 / sigma2fwhm)
+
+
+def test_util_fwhm_get():
+    g1 = Gaussian()
+    g1.sigma.value = 1.0
+    assert_allclose(g1.fwhm, 1.0 * sigma2fwhm)
+
+
+def test_util_fwhm_getset():
+    g1 = Gaussian()
+    g1.fwhm = 1.0
+    assert_allclose(g1.fwhm, 1.0)

--- a/hyperspy/tests/component/test_gaussianhf.py
+++ b/hyperspy/tests/component/test_gaussianhf.py
@@ -16,7 +16,6 @@
 # You should have received a copy of the GNU General Public License
 # along with  HyperSpy.  If not, see <http://www.gnu.org/licenses/>.
 
-
 import itertools
 import numpy as np
 from numpy.testing import assert_allclose
@@ -29,7 +28,6 @@ from hyperspy.utils import stack
 sqrt2pi = np.sqrt(2 * np.pi)
 sigma2fwhm = 2 * np.sqrt(2 * np.log(2))
 
-
 TRUE_FALSE_2_TUPLE = [p for p in itertools.product((True, False), repeat=2)]
 
 
@@ -40,7 +38,6 @@ def test_function():
     g.height.value = 3
     assert g.function(2) == 1.5
     assert g.function(1) == 3
-
 
 def test_integral_as_signal():
     s = Signal1D(np.zeros((2, 3, 100)))
@@ -57,7 +54,6 @@ def test_integral_as_signal():
     s_out = g2.integral_as_signal()
     ref = (h_ref * 3.33 * sqrt2pi / sigma2fwhm).reshape(s_out.data.shape)
     assert_allclose(s_out.data, ref)
-
 
 @pytest.mark.parametrize(("only_current", "binned"), TRUE_FALSE_2_TUPLE)
 def test_estimate_parameters_binned(only_current, binned):
@@ -77,7 +73,6 @@ def test_estimate_parameters_binned(only_current, binned):
     assert abs(g2.centre.value - g1.centre.value) <= 1e-3
     assert abs(g2.fwhm.value - g1.fwhm.value) <= 0.1
 
-
 @pytest.mark.parametrize(("binned"), (True, False))
 def test_function_nd(binned):
     s = Signal1D(np.empty((100,)))
@@ -96,37 +91,31 @@ def test_function_nd(binned):
     # TODO: sort out while the rtol to be so high...
     assert_allclose(g2.function_nd(axis.axis) * factor, s2.data, rtol=0.05)
 
-
 def test_util_sigma_set():
     g1 = GaussianHF()
     g1.sigma = 1.0
     assert_allclose(g1.fwhm.value, 1.0 * sigma2fwhm)
-
 
 def test_util_sigma_get():
     g1 = GaussianHF()
     g1.fwhm.value = 1.0
     assert_allclose(g1.sigma, 1.0 / sigma2fwhm)
 
-
 def test_util_sigma_getset():
     g1 = GaussianHF()
     g1.sigma = 1.0
     assert_allclose(g1.sigma, 1.0)
 
-
 def test_util_fwhm_set():
     g1 = GaussianHF(fwhm=0.33)
     g1.A = 1.0
     assert_allclose(g1.height.value, 1.0 * sigma2fwhm / (
-        0.33 * sqrt2pi))
-
+                    0.33 * sqrt2pi))
 
 def test_util_fwhm_get():
     g1 = GaussianHF(fwhm=0.33)
     g1.height.value = 1.0
     assert_allclose(g1.A, 1.0 * sqrt2pi * 0.33 / sigma2fwhm)
-
 
 def test_util_fwhm_getset():
     g1 = GaussianHF(fwhm=0.33)

--- a/hyperspy/tests/component/test_powerlaw.py
+++ b/hyperspy/tests/component/test_powerlaw.py
@@ -52,7 +52,7 @@ def test_estimate_parameters_binned(only_current, binned):
     assert g2.estimate_parameters(s, axis.low_value, axis.high_value,
                                   only_current=only_current)
     assert g2.binned == binned
-    # error of the estimate function is rather large, especially when binned=FALSE
+    # error of the estimate function is rather large, esp. when binned=FALSE
     assert_allclose(g1.A.value, g2.A.value * factor,rtol=0.05)
     assert abs(g2.r.value - g1.r.value) <= 2e-2
 

--- a/hyperspy/tests/component/test_powerlaw.py
+++ b/hyperspy/tests/component/test_powerlaw.py
@@ -1,0 +1,75 @@
+# -*- coding: utf-8 -*-
+# Copyright 2007-2016 The HyperSpy developers
+#
+# This file is part of  HyperSpy.
+#
+#  HyperSpy is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+#  HyperSpy is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with  HyperSpy.  If not, see <http://www.gnu.org/licenses/>.
+
+
+import itertools
+import numpy as np
+from numpy.testing import assert_allclose
+import pytest
+
+from hyperspy.components1d import PowerLaw
+from hyperspy.signals import Signal1D
+from hyperspy.utils import stack
+
+TRUE_FALSE_2_TUPLE = [p for p in itertools.product((True, False), repeat=2)]
+
+
+def test_function():
+    g = PowerLaw()
+    g.A.value = 1
+    g.r.value = 2
+    g.origin.value = 3
+    assert g.function(2) == 1
+    assert g.function(1) == 0.25
+
+
+@pytest.mark.parametrize(("only_current", "binned"), TRUE_FALSE_2_TUPLE)
+def test_estimate_parameters_binned(only_current, binned):
+    s = Signal1D(np.empty((100,)))
+    s.metadata.Signal.binned = binned
+    axis = s.axes_manager.signal_axes[0]
+    axis.scale = 0.02
+    axis.offset = 1
+    g1 = PowerLaw(50015.156, 1.2)
+    s.data = g1.function(axis.axis)
+    g2 = PowerLaw()
+    factor = axis.scale if binned else 1
+    assert g2.estimate_parameters(s, axis.low_value, axis.high_value,
+                                  only_current=only_current)
+    assert g2.binned == binned
+    # error of the estimate function is rather large, especially when binned=FALSE
+    assert_allclose(g1.A.value, g2.A.value * factor,rtol=0.05)
+    assert abs(g2.r.value - g1.r.value) <= 2e-2
+
+
+@pytest.mark.parametrize(("binned"), (True, False))
+def test_function_nd(binned):
+    s = Signal1D(np.empty((100,)))
+    axis = s.axes_manager.signal_axes[0]
+    axis.scale = 0.02
+    axis.offset = 1
+    g1 = PowerLaw(50015.156, 1.2)
+    s.data = g1.function(axis.axis)
+    s.metadata.Signal.binned = binned
+    s2 = stack([s] * 2)
+    g2 = PowerLaw()
+    factor = axis.scale if binned else 1
+    g2.estimate_parameters(s2, axis.low_value, axis.high_value, False)
+    assert g2.binned == binned
+    assert_allclose(g2.function_nd(axis.axis) * factor, s2.data,rtol=0.05)
+

--- a/hyperspy/tests/component/test_powerlaw.py
+++ b/hyperspy/tests/component/test_powerlaw.py
@@ -16,7 +16,6 @@
 # You should have received a copy of the GNU General Public License
 # along with  HyperSpy.  If not, see <http://www.gnu.org/licenses/>.
 
-
 import itertools
 import numpy as np
 from numpy.testing import assert_allclose
@@ -37,7 +36,6 @@ def test_function():
     assert g.function(2) == 1
     assert g.function(1) == 0.25
 
-
 @pytest.mark.parametrize(("only_current", "binned"), TRUE_FALSE_2_TUPLE)
 def test_estimate_parameters_binned(only_current, binned):
     s = Signal1D(np.empty((100,)))
@@ -53,9 +51,8 @@ def test_estimate_parameters_binned(only_current, binned):
                                   only_current=only_current)
     assert g2.binned == binned
     # error of the estimate function is rather large, esp. when binned=FALSE
-    assert_allclose(g1.A.value, g2.A.value * factor,rtol=0.05)
+    assert_allclose(g1.A.value, g2.A.value * factor, rtol=0.05)
     assert abs(g2.r.value - g1.r.value) <= 2e-2
-
 
 @pytest.mark.parametrize(("binned"), (True, False))
 def test_function_nd(binned):
@@ -71,5 +68,4 @@ def test_function_nd(binned):
     factor = axis.scale if binned else 1
     g2.estimate_parameters(s2, axis.low_value, axis.high_value, False)
     assert g2.binned == binned
-    assert_allclose(g2.function_nd(axis.axis) * factor, s2.data,rtol=0.05)
-
+    assert_allclose(g2.function_nd(axis.axis) * factor, s2.data, rtol=0.05)


### PR DESCRIPTION
### Description of the change
Docstring for exponential component formatted using latex for math and a parameter table 
(using simple table layout, which works best in conjunction with latex) to create consistency among components.

Also some corrections in the docstring for GaussianHF (typo, parameter table, extra latex).

Added test functions where missing.

### Progress of the PR
- [X] update docstring (if appropriate),
- [X] Add test function for exponential, gaussian and power_law,
- [X] ready for review.
