### PR TITLE
Improve error message when start and end value are equal in the crop method.

### DIFF
--- a/hyperspy/signal.py
+++ b/hyperspy/signal.py
@@ -2190,6 +2190,10 @@ class BaseSignal(FancySlicing,
         """
         axis = self.axes_manager[axis]
         i1, i2 = axis._get_index(start), axis._get_index(end)
+        # To prevent an axis error, which may confuse users
+        if i1 is not None and i2 is not None and not i1 != i2:
+            raise ValueError("The `start` and `end` values need to be "
+                             "different.")
         if i1 is not None:
             new_offset = axis.axis[i1]
         # We take a copy to guarantee the continuity of the data

--- a/hyperspy/tests/signal/test_tools.py
+++ b/hyperspy/tests/signal/test_tools.py
@@ -90,6 +90,13 @@ class Test2D:
         s.crop(0, 2, 2.)
         nt.assert_array_almost_equal(s.data, d[2:4, :])
 
+    def test_crop_start_end_equal(self):
+        s = self.signal
+        with pytest.raises(ValueError):
+            s.crop(0, 2, 2)
+        with pytest.raises(ValueError):
+            s.crop(0, 2., 2.)
+
     def test_crop_float_no_unit_convertion_signal1D(self):
         # Should convert the unit to eV
         d = np.arange(5 * 10 * 2000).reshape(5, 10, 2000)


### PR DESCRIPTION
### Progress of the PR
- [x] Check if start and end value are different when cropping and raise ValueError if equal to avoid misleading axis error message in specific situations,
- [x] add tests,
- [x] ready for review.

