### PR TITLE
Fix for last numpy release 

### DIFF
--- a/hyperspy/learn/mva.py
+++ b/hyperspy/learn/mva.py
@@ -1277,7 +1277,7 @@ class LearningResults(object):
         ----------
         filename : string
         """
-        decomposition = np.load(filename)
+        decomposition = np.load(filename, allow_pickle=True)
         for key, value in decomposition.items():
             if value.dtype == np.dtype('object'):
                 value = None


### PR DESCRIPTION
A default value of `np.load` changed in the last numpy release (1.16.3).
See https://github.com/numpy/numpy/releases/tag/v1.16.3
