### PR TITLE
Fix beam current zeiss

### DIFF
--- a/doc/user_guide/metadata_structure.rst
+++ b/doc/user_guide/metadata_structure.rst
@@ -21,6 +21,7 @@ in the following sections of this chapter.
     ├── Acquisition_instrument
     │   ├── SEM
     │   │   ├── Detector
+    │   │   │   ├── detector_type
     │   │   │   └── EDS
     │   │   │       ├── azimuth_angle (º)
     │   │   │       ├── elevation_angle (º)
@@ -290,6 +291,11 @@ Detector
 All instruments can contain a "Detector" node with information about the
 detector used to acquire the signal. EDX and EELS detectors should follow the
 following structure:
+
+detector_type
+    type: Str
+
+    The type of the detector, e.g. SE for SEM
 
 EELS
 ^^^^

--- a/hyperspy/io_plugins/tiff.py
+++ b/hyperspy/io_plugins/tiff.py
@@ -565,6 +565,9 @@ mapping_cz_sem = {
     'CZ_SEM.ap_iprobe':
     ("Acquisition_instrument.SEM.beam_current",
      lambda tup: _parse_tuple_Zeiss_with_units(tup, to_units='nA')),
+    'CZ_SEM.dp_detector_type':
+    ("Acquisition_instrument.SEM.Detector.detector_type",
+      lambda tup: _parse_tuple_Zeiss(tup)),
     'CZ_SEM.sv_serial_number':
     ("Acquisition_instrument.SEM.microscope", _parse_tuple_Zeiss),
     'CZ_SEM.ap_date':

--- a/hyperspy/io_plugins/tiff.py
+++ b/hyperspy/io_plugins/tiff.py
@@ -487,7 +487,7 @@ def _parse_tuple_Zeiss_with_units(tup, to_units=None):
     (value, parse_units) = tup[1:]
     if to_units is not None:
         v = value * ureg(parse_units)
-        value = float("%.3e" % v.to(to_units).magnitude)
+        value = float("%.6e" % v.to(to_units).magnitude)
     return value
 
 
@@ -544,11 +544,14 @@ mapping_cz_sem = {
     'CZ_SEM.ap_mag':
     ("Acquisition_instrument.SEM.magnification", _parse_tuple_Zeiss),
     'CZ_SEM.ap_stage_at_x':
-    ("Acquisition_instrument.SEM.Stage.x", _parse_tuple_Zeiss),
+    ("Acquisition_instrument.SEM.Stage.x",
+     lambda tup: _parse_tuple_Zeiss_with_units(tup, to_units='mm')),
     'CZ_SEM.ap_stage_at_y':
-    ("Acquisition_instrument.SEM.Stage.y", _parse_tuple_Zeiss),
+    ("Acquisition_instrument.SEM.Stage.y",
+     lambda tup: _parse_tuple_Zeiss_with_units(tup, to_units='mm')),
     'CZ_SEM.ap_stage_at_z':
-    ("Acquisition_instrument.SEM.Stage.z", _parse_tuple_Zeiss),
+    ("Acquisition_instrument.SEM.Stage.z",
+     lambda tup: _parse_tuple_Zeiss_with_units(tup, to_units='mm')),
     'CZ_SEM.ap_stage_at_r':
     ("Acquisition_instrument.SEM.Stage.rotation", _parse_tuple_Zeiss),
     'CZ_SEM.ap_stage_at_t':

--- a/hyperspy/io_plugins/tiff.py
+++ b/hyperspy/io_plugins/tiff.py
@@ -559,7 +559,7 @@ mapping_cz_sem = {
     'CZ_SEM.dp_dwell_time':
     ("Acquisition_instrument.SEM.dwell_time",
      lambda tup: _parse_tuple_Zeiss_with_units(tup, to_units='s')),
-    'CZ_SEM.ap_beam_current':
+    'CZ_SEM.ap_iprobe':
     ("Acquisition_instrument.SEM.beam_current",
      lambda tup: _parse_tuple_Zeiss_with_units(tup, to_units='nA')),
     'CZ_SEM.sv_serial_number':

--- a/hyperspy/tests/io/test_tiff.py
+++ b/hyperspy/tests/io/test_tiff.py
@@ -426,6 +426,8 @@ def test_read_Zeiss_SEM_scale_metadata_1k_image():
                                                        'x': 75.6442,
                                                        'y': 60.4901,
                                                        'z': 25.193},
+                                             'Detector':{'detector_type':
+                                                 'HE-SE2'},
                                              'beam_current': 1.0,
                                              'beam_energy': 25.0,
                                              'dwell_time': 5e-08,

--- a/hyperspy/tests/io/test_tiff.py
+++ b/hyperspy/tests/io/test_tiff.py
@@ -426,7 +426,7 @@ def test_read_Zeiss_SEM_scale_metadata_1k_image():
                                                        'x': 75.6442,
                                                        'y': 60.4901,
                                                        'z': 25.193},
-                                             'beam_current': 80000.0,
+                                             'beam_current': 1.0,
                                              'beam_energy': 25.0,
                                              'dwell_time': 5e-08,
                                              'magnification': 105.0,

--- a/hyperspy/tests/io/test_tiff.py
+++ b/hyperspy/tests/io/test_tiff.py
@@ -431,7 +431,7 @@ def test_read_Zeiss_SEM_scale_metadata_1k_image():
                                              'dwell_time': 5e-08,
                                              'magnification': 105.0,
                                              'microscope': 'Merlin-61-08',
-                                             'working_distance': 14.81}},
+                                             'working_distance': 14.808}},
           'General': {'authors': 'LIM',
                       'date': '2015-12-23',
                       'original_filename': 'test_tiff_Zeiss_SEM_1k.tif',


### PR DESCRIPTION
This PR fixes a bug when reading the beam current from tiff ("ap_beam_current" was imported instead of "ap_iprobe") for data acquired on Zeiss SEM.
It also add support for importing the type of detector to the metadata. 

### Progress of the PR
- [x] Fix reading beam current for Zeiss tiff file,
- [x] use units when reading metadata,
- [x] Add `detector_type` to metadata,
- [x] update user guide,
- [x] add tests,
- [x] ready for review.

