### PR TITLE
Remove pillow workaround in appveyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -70,8 +70,6 @@ install:
 
   - ps: Add-AppveyorMessage "Installing hyperspy..."
   - "pip install .[tests]"
-  # install pillow with pip as workaround for the DLL issue on win64 from defaults
-  - "pip install -I pillow"
 
 build: false  # Not a C# project, build stuff at the test step instead.
 


### PR DESCRIPTION
Revert https://github.com/hyperspy/hyperspy/pull/2123/commits/b18ea220af642b777a3efff34d6ece6987cda0d6 since last version of pillow seems to work fine in appveyor.

Original error was:
https://ci.appveyor.com/project/ericpre/hyperspy/builds/21859827
```
============================= test session starts =============================
platform win32 -- Python 3.7.2, pytest-4.1.1, py-1.7.0, pluggy-0.8.1
Matplotlib: 3.0.2
Freetype: 2.9.1
rootdir: C:\projects\hyperspy, inifile: pytest.ini
plugins: mpl-0.10, cov-2.6.1
collected 0 items / 1 errors
=================================== ERRORS ====================================
______________________________ ERROR collecting  ______________________________
C:\Miniconda37-x64\envs\testenv\lib\site-packages\_pytest\config\__init__.py:427: in _importconftest
    return self._conftestpath2mod[conftestpath]
E   KeyError: local('C:\\projects\\hyperspy\\hyperspy\\conftest.py')
During handling of the above exception, another exception occurred:
C:\Miniconda37-x64\envs\testenv\lib\site-packages\_pytest\config\__init__.py:433: in _importconftest
    mod = conftestpath.pyimport()
C:\Miniconda37-x64\envs\testenv\lib\site-packages\py\_path\local.py:668: in pyimport
    __import__(modname)
C:\Miniconda37-x64\envs\testenv\lib\site-packages\_pytest\assertion\rewrite.py:308: in load_module
    six.exec_(co, mod.__dict__)
hyperspy\conftest.py:12: in <module>
    import hyperspy.api as hs
hyperspy\api.py:1: in <module>
    from hyperspy.api_nogui import *
hyperspy\api_nogui.py:75: in <module>
    from hyperspy import signals
hyperspy\signals.py:44: in <module>
    from hyperspy._signals.signal2d import Signal2D
hyperspy\_signals\signal2d.py:26: in <module>
    from skimage.feature.register_translation import _upsampled_dft
C:\Miniconda37-x64\envs\testenv\lib\site-packages\skimage\__init__.py:177: in <module>
    from .data import data_dir
C:\Miniconda37-x64\envs\testenv\lib\site-packages\skimage\data\__init__.py:15: in <module>
    from ..io import imread, use_plugin
C:\Miniconda37-x64\envs\testenv\lib\site-packages\skimage\io\__init__.py:7: in <module>
    from .manage_plugins import *
C:\Miniconda37-x64\envs\testenv\lib\site-packages\skimage\io\manage_plugins.py:28: in <module>
    from .collection import imread_collection_wrapper
C:\Miniconda37-x64\envs\testenv\lib\site-packages\skimage\io\collection.py:12: in <module>
    from PIL import Image
C:\Miniconda37-x64\envs\testenv\lib\site-packages\PIL\Image.py:94: in <module>
    from . import _imaging as core
E   ImportError: DLL load failed: The specified module could not be found.
During handling of the above exception, another exception occurred:
C:\Miniconda37-x64\envs\testenv\lib\site-packages\py\_path\common.py:377: in visit
    for x in Visitor(fil, rec, ignore, bf, sort).gen(self):
C:\Miniconda37-x64\envs\testenv\lib\site-packages\py\_path\common.py:418: in gen
    dirs = self.optsort([p for p in entries
C:\Miniconda37-x64\envs\testenv\lib\site-packages\py\_path\common.py:419: in <listcomp>
    if p.check(dir=1) and (rec is None or rec(p))])
C:\Miniconda37-x64\envs\testenv\lib\site-packages\_pytest\main.py:635: in _recurse
    ihook = self.gethookproxy(dirpath)
C:\Miniconda37-x64\envs\testenv\lib\site-packages\_pytest\main.py:452: in gethookproxy
    my_conftestmodules = pm._getconftestmodules(fspath)
C:\Miniconda37-x64\envs\testenv\lib\site-packages\_pytest\config\__init__.py:411: in _getconftestmodules
    mod = self._importconftest(conftestpath)
C:\Miniconda37-x64\envs\testenv\lib\site-packages\_pytest\config\__init__.py:450: in _importconftest
    raise ConftestImportFailure(conftestpath, sys.exc_info())
E   _pytest.config.ConftestImportFailure: (local('C:\\projects\\hyperspy\\hyperspy\\conftest.py'), (<class 'ImportError'>, ImportError('DLL load failed: The specified module could not be found.'), <traceback object at 0x0000007BF3463808>))
```

