### PR TITLE
Remove "added in version X" from docs up to 1.1 + minor docs changes

### DIFF
--- a/doc/user_guide/dielectric_function.rst
+++ b/doc/user_guide/dielectric_function.rst
@@ -1,8 +1,6 @@
 Dielectric function tools
 -------------------------
 
-.. versionadded:: 0.7
-
 The :py:class:`~._signals.dielectric_function.DielectricFunction` class
 inherits from :py:class:`~._signals.complex_signal.ComplexSignal` and can
 thus access complex properties. To convert a
@@ -21,8 +19,6 @@ complex and therefore is a subclass of
 
 Number of effective electrons
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-.. versionadded:: 0.7
 
 The Bethe f-sum rule gives rise to two definitions of the effective number (see
 :ref:`[Egerton2011] <Egerton2011>`):
@@ -43,8 +39,6 @@ method computes both.
 
 Compute the electron energy-loss signal
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-.. versionadded:: 0.7
 
 The
 :py:meth:`~._signals.dielectric_function.DielectricFunction.get_electron_energy_loss_spectrum`

--- a/doc/user_guide/eds.rst
+++ b/doc/user_guide/eds.rst
@@ -411,8 +411,6 @@ An example of multi-dimensional EDS data (e.g. 3D SEM-EDS) is given in
 Plotting X-ray lines
 ^^^^^^^^^^^^^^^^^^^^
 
-.. versionadded:: 0.8
-
 X-ray lines can be added as plot labels with
 :py:meth:`~._signals.eds.EDSSpectrum.plot`. The lines are either retrieved
 from "metadata.Sample.Xray_lines", or selected with the same method as
@@ -450,8 +448,6 @@ You can also select a subset of lines to label:
 
 Geting the intensity of an X-ray line
 -------------------
-
-.. versionadded:: 0.8
 
 The sample and data used in this section are described in
 :ref:`[Rossouw2015] <Rossouw2015>`, and can be downloaded using:
@@ -512,8 +508,6 @@ Finally, the windows of integration can be visualised using
 Background subtraction
 ^^^^^^^^^^^^^^^^^^^^^^
 
-.. versionadded:: 0.8
-
 The background can be subtracted from the X-ray intensities with
 :py:meth:`~._signals.eds.EDS_mixin.get_lines_intensity`.
 The background value is obtained by averaging the intensity in two
@@ -540,10 +534,6 @@ can be plotted using :py:meth:`~._signals.eds.EDS_mixin.plot`:
 
 EDS Quantification
 ------------------
-
-.. versionadded:: 0.8 EDS Quantification
-
-.. versionadded:: 1.0 zeta-factors and ionization cross sections
 
 HyperSpy now includes three methods for EDS quantification:
 

--- a/doc/user_guide/eels.rst
+++ b/doc/user_guide/eels.rst
@@ -94,8 +94,6 @@ the npoints keyword.
 Kramers-Kronig Analysis
 ^^^^^^^^^^^^^^^^^^^^^^^
 
-.. versionadded:: 0.7
-
 The single-scattering EEL spectrum is approximately related to the complex
 permittivity of the sample and can be estimated by Kramers-Kronig analysis.
 The :py:meth:`~._signals.eels.EELSSpectrum_mixin.kramers_kronig_analysis`
@@ -271,10 +269,8 @@ overlapping. This method is executed automatically when e.g. components are
 added or removed from the model, but sometimes is necessary to call it
 manually.
 
-.. versionadded:: 0.7.1
-
-   Sometimes it is desirable to disable the automatic adjustment of the fine
-   structure width. It is possible to suspend this feature by calling
-   :py:meth:`~.models.eelsmodel.EELSModel.suspend_auto_fine_structure_width`.
-   To resume it use
-   :py:meth:`~.models.eelsmodel.EELSModel.suspend_auto_fine_structure_width`
+Sometimes it is desirable to disable the automatic adjustment of the fine
+structure width. It is possible to suspend this feature by calling
+:py:meth:`~.models.eelsmodel.EELSModel.suspend_auto_fine_structure_width`.
+To resume it use
+:py:meth:`~.models.eelsmodel.EELSModel.suspend_auto_fine_structure_width`

--- a/doc/user_guide/events.rst
+++ b/doc/user_guide/events.rst
@@ -4,9 +4,6 @@
 Events
 ******
 
-
-.. versionadded:: 9.0
-
 Events are a mechanism to send notifications. HyperSpy events are
 decentralised, meaning that there is not a central events dispatcher.
 Instead, each object that can emit events has an :py:attr:`events`

--- a/doc/user_guide/getting_started.rst
+++ b/doc/user_guide/getting_started.rst
@@ -222,10 +222,6 @@ experimental data.
 
 .. _eelsdb-label:
 
-.. versionadded:: 1.0
-    :py:func:`~.misc.eels.eelsdb.eelsdb` function.
-
-
 The :py:func:`~.misc.eels.eelsdb.eelsdb` function in `hs.datasets` can
 directly load spectra from `The EELS Database <http://eelsdb.eu>`_. For
 example, the following loads all the boron trioxide spectra currently
@@ -609,8 +605,6 @@ to disable the traitsui GUI elements and save the changes to disk:
 
 Messages log
 ------------
-
-.. versionadded:: 1.0
 
 HyperSpy writes messages to the `Python logger
 <https://docs.python.org/3/howto/logging.html#logging-basic-tutorial>`_. The

--- a/doc/user_guide/install.rst
+++ b/doc/user_guide/install.rst
@@ -24,8 +24,6 @@ Those experienced with Python may like to
 HyperSpy Bundle for Microsoft Windows
 -------------------------------------
 
-.. versionadded:: 0.6
-
 The easiest way to install HyperSpy in Windows is installing the HyperSpy
 Bundle. This is a customised `WinPython <http://winpython.github.io/>`_
 distribution that includes HyperSpy, all its dependencies and many other

--- a/doc/user_guide/io.rst
+++ b/doc/user_guide/io.rst
@@ -773,7 +773,7 @@ asdf
 .. _emd_fei-format:
 
 EMD (Velox)
-^^^^^^^^^
+^^^^^^^^^^^
 
 This is a non-compliant variant of the standard EMD format developed by 
 Thermo-Fisher (former FEI). HyperSpy supports importing images, EDS spectrum and EDS

--- a/doc/user_guide/io.rst
+++ b/doc/user_guide/io.rst
@@ -86,7 +86,7 @@ and if set to `False`, the units will not be converted. The default is `False`.
 
 More details on lazy evaluation support in :ref:`big-data-label`.
 
-.. load-multiple-label::
+.. load-multiple-label:
 
 Loading multiple files
 ----------------------
@@ -294,6 +294,7 @@ possible to customise the chunk shape using the ``chunks`` keyword. For example,
 ``(20, 20, 256)`` chunks instead of the default ``(7, 7, 2048)`` chunks for this signal:
 
 .. code-block:: python
+
     >>> s = hs.signals.Signal1D(np.random.random((100, 100, 2048)))
     >>> s.save("test_chunks", chunks=(20, 20, 256), overwrite=True)
 
@@ -370,22 +371,29 @@ install the `mrcz` and optionally the `blosc` Python packages.
 Extra saving arguments
 ^^^^^^^^^^^^^^^^^^^^^^
 
-`do_async`:   currently supported within Hyperspy for writing only, this will save
-              the file in a background thread and return immediately. Defaults
-              to `False`.
+`do_async`: 
+  currently supported within Hyperspy for writing only, this will save 
+  the file in a background thread and return immediately. Defaults
+  to `False`.
+
 .. Warning::
 
     There is no method currently implemented within Hyperspy to tell if an
     asychronous write has finished.
 
-`compressor`: The compression codec, one of [`None`,`'zlib`',`'zstd'`, `'lz4'`].
-              Defaults to `None`.
-`clevel`:     The compression level, an `int` from 1 to 9. Defaults to 1.
-`n_threads`:  The number of threads to use for `blosc` compression. Defaults to
-              the maximum number of virtual cores (including Intel Hyperthreading)
-              on your system, which is recommended for best performance. If \
-              `do_asyc = True` you may wish to leave one thread free for the
-              Python GIL.
+
+`compressor`: 
+  The compression codec, one of [`None`,`'zlib`',`'zstd'`, `'lz4'`]. Defaults to `None`.
+
+`clevel`: 
+  The compression level, an `int` from 1 to 9. Defaults to 1.
+
+`n_threads`: 
+  The number of threads to use for `blosc` compression. Defaults to
+  the maximum number of virtual cores (including Intel Hyperthreading)
+  on your system, which is recommended for best performance. If \
+  `do_asyc = True` you may wish to leave one thread free for the
+  Python GIL.
 
 The recommended compression codec is 'zstd' (zStandard) with `clevel=1` for
 general use. If speed is critical, use 'lz4' (LZ4) with `clevel=9`. Integer data

--- a/doc/user_guide/io.rst
+++ b/doc/user_guide/io.rst
@@ -250,9 +250,6 @@ filename e.g.:
     >>> s.save('test.hdf5')
 
 
-.. versionadded:: 0.8
-    Saving list, tuples and signals present in :py:attr:`~.metadata`.
-
 When saving to ``hspy``, all supported objects in the signal's
 :py:attr:`~.metadata` is stored. This includes  lists, tuples and signals.
 Please note that in order to increase saving efficiency and speed, if possible,

--- a/doc/user_guide/model.rst
+++ b/doc/user_guide/model.rst
@@ -11,7 +11,6 @@ the :py:class:`~.model.BaseModel` class is available for both kinds.
 
 .. _2D_model-label:
 
-.. versionadded:: 1.0
    2D models. Note that this first implementation lacks many of the
    features of 1D models e.g. plotting. Those will be added in future releases.
 
@@ -23,8 +22,8 @@ dimensional model is created for a :py:class:`~._signals.signal2d.Signal2D`.
 At present plotting and gradient fitting methods tools for are not yet
 provided for the :py:class:`~.models.model2d.Model2D` class.
 
-.. versionadded:: 0.7
-   Binned/unbinned signals
+Binned/unbinned signals
+-----------------------
 
 Before creating a model verify that the ``Signal.binned`` metadata
 attribute of the signal is set to the correct value because the resulting
@@ -70,13 +69,8 @@ voltage, convergence and collection semi-angles etc.
 
 .. _model_components-label:
 
-Adding components to the model
-------------------------------
-
-.. versionchanged:: 1.0 `hyperspy.api.model.components` renamed to
-   `hyperspy.api.model.components1D`
-
-.. versionadded:: 1.0 `hyperspy.api.model.components2D`.
+Creating components for the model
+---------------------------------
 
 In HyperSpy a model consists of a linear combination of components
 and various components are available in one (:py:mod:`~.components1d`)and
@@ -90,6 +84,7 @@ The following components are currently available for one-dimensional models:
 * :py:class:`~._components.power_law.PowerLaw`
 * :py:class:`~._components.offset.Offset`
 * :py:class:`~._components.exponential.Exponential`
+* :py:class:`~._components.expression.Expression`
 * :py:class:`~._components.scalable_fixed_pattern.ScalableFixedPattern`
 * :py:class:`~._components.gaussian.Gaussian`
 * :py:class:`~._components.gaussianhf.GaussianHF`
@@ -103,22 +98,18 @@ The following components are currently available for one-dimensional models:
 * :py:class:`~._components.arctan.Arctan`
 * :py:class:`~._components.heaviside.HeavisideStep`
 
-.. versionadded:: 1.0 The following components are currently available for
-                  two-dimensional models:
+The following components are currently available for two-dimensional models:
 
 * :py:class:`~._components.gaussian2d.Gaussian2D`
+* :py:class:`~._components.expression.Expression`
 
 However, this doesn't mean that you have to limit yourself to this meagre list
-of functions. A new function can easily be written or a custom function may
-be specified as below.
+of functions. A new function can easily be written as specified as below.
 
 Specifying custom components
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 .. _expression_component-label:
-
-.. versionadded:: 0.8.1 :py:class:`~._components.expression.Expression`
-                  component
 
 .. versionadded:: 1.2 :py:class:`~._components.expression.Expression` component
                   can create 2D components.
@@ -237,9 +228,10 @@ If you need help with the task please submit your question to the :ref:`users
 mailing list <http://groups.google.com/group/hyperspy-users>`.
 
 
-.. _model_components-label:
+Adding components to the model
+------------------------------
 
-.. versionchanged:: 0.8.1 printing current model components
+.. _model_components-label:
 
 To print the current components in a model use
 :py:attr:`~.model.BaseModel.components`. A table with component number,
@@ -336,7 +328,6 @@ index in the model.
     >>> m["Long Hydrogen name"]
     <Long Hydrogen name (Gaussian component)>
 
-.. versionadded:: 0.8.1 :py:attr:`~.model.BaseModel.components` attribute
 
 In addition, the components can be accessed in the
 :py:attr:`~.model.BaseModel.components` `Model` attribute. This is specially
@@ -359,8 +350,6 @@ It is possible to "switch off" a component by setting its
 ``active`` attribute to ``False``. When a component is
 switched off, to all effects it is as if it was not part of the model. To
 switch it on simply set the ``active`` attribute back to ``True``.
-
-.. versionadded:: 0.7.1 :py:attr:`~.component.Component.active_is_multidimensional`
 
 In multidimensional signals it is possible to store the value of the
 ``active`` attribute at each navigation index.
@@ -394,9 +383,6 @@ To enable this feature for a given component set the
 
 Indexing the model
 --------------
-
-.. versionadded:: 1.0 model indexing
-
 
 Often it is useful to consider only part of the model - for example at
 a particular location (i.e. a slice in the navigation space) or energy range
@@ -890,8 +876,6 @@ component using mpfit and bounds on the ``centre`` parameter.
 Goodness of fit
 ^^^^^^^^^^^^^^^
 
-.. versionadded:: 0.7 chi-squared and reduced chi-squared
-
 The chi-squared, reduced chi-squared and the degrees of freedom are
 computed automatically when fitting. They are stored as signals, in the
 :attr:`~.model.BaseModel.chisq`, :attr:`~.model.BaseModel.red_chisq`  and
@@ -915,8 +899,6 @@ To visualise the result use the :py:meth:`~.model.BaseModel.plot` method:
 
 
 
-.. versionadded:: 0.7 plot componets features
-
 By default only the full model line is displayed in the plot. In addition, it
 is possible to display the individual components by calling
 :py:meth:`~.model.BaseModel.enable_plot_components` or directly using
@@ -928,9 +910,6 @@ is possible to display the individual components by calling
 
 To disable this feature call
 :py:meth:`~.model.BaseModel.disable_plot_components`.
-
-.. versionadded:: 0.7.1 :py:meth:`~.model.BaseModel.suspend_update`
-..                and :py:meth:`~.model.Model.resume_update`
 
 .. versionadded:: 1.4 ``Signal1D.plot`` keyword arguments
 
@@ -959,15 +938,6 @@ Non-linear regression often requires setting sensible starting
 parameters. This can be done by plotting the model and adjusting the parameters
 by hand.
 
-.. versionadded:: 0.7
-
-    In addition, it is possible to fit a given component  independently using
-    the :py:meth:`~.model.BaseModel.fit_component` method.
-
-
-.. versionadded:: 0.8.5
-    :py:meth:`~.model.BaseModel.gui`,
-
 .. versionchanged:: 1.3
     All :meth:`notebook_interaction` methods renamed to :meth:`gui`. The
     :meth:`notebook_interaction` methods will be removed in 2.0
@@ -989,10 +959,6 @@ conveniently adjust the parameter values by running
     sliders to adjust current parameter values. Typing different minimum and
     maximum values changes the boundaries of the slider.
 
-
-.. versionadded:: 0.6
-    :py:meth:`~.models.model1d.Model1D.enable_adjust_position` and
-    :py:meth:`~.models.model1d.Model1D.disable_adjust_position`
 
 Also, :py:meth:`~.models.model1d.Model1D.enable_adjust_position` provides an
 interactive way of setting the position of the components with a
@@ -1067,7 +1033,6 @@ datasets**.
 
 Storing models
 --------------
-.. versionadded:: 1.0 :py:class:`~.signal.ModelManager`
 
 Multiple models can be stored in the same signal. In particular, when
 :py:meth:`~.model.BaseModel.store` is called, a full "frozen" copy of the model
@@ -1131,7 +1096,6 @@ Current stored models can be listed by calling ``s.models``:
 
 Saving and loading the result of the fit
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. versionadded:: 1.0
 
 To save a model, a convenience function :py:meth:`~.model.BaseModel.save` is
 provided, which stores the current model into its signal and saves the
@@ -1186,7 +1150,6 @@ formats.
 
 Batch setting of parameter attributes
 -------------------------------------
-.. versionadded:: 0.6
 
 The following model methods can be used to ease the task of setting some important
 parameter attributes. These can also be used on a per-component basis, by calling them
@@ -1200,9 +1163,6 @@ on individual components.
 
 Smart Adaptive Multi-dimensional Fitting (SAMFire)
 --------------------------------------------------
-
-.. versionadded:: 1.0
-    SAMFire
 
 SAMFire (Smart Adaptive Multi-dimensional Fitting) is an algorithm created to
 reduce the starting value (or local / false minima) problem, which often arises

--- a/doc/user_guide/model.rst
+++ b/doc/user_guide/model.rst
@@ -257,10 +257,11 @@ attribute name, component name and component type will be printed:
 In fact, components may be created automatically in some cases. For example, if
 the :py:class:`~._signals.signal1d.Signal1D` is recognised as EELS data, a
 power-law background component will automatically be placed in the model. To
-add a component first we have to create an instance of the component. Once
+add a component, first we have to create an instance of the component. Once
 the instance has been created we can add the component to the model using
-the :py:meth:`~.model.BaseModel.append` method, e.g. for a type of data that
-can be modelled using Gaussians we might proceed as follows:
+the :py:meth:`~.model.BaseModel.append` and :py:meth:`~.model.BaseModel.extend` 
+methods for one or more components respectively. As an example for a type of data 
+that can be modelled using Gaussians we might proceed as follows:
 
 
 .. code-block:: python
@@ -855,8 +856,13 @@ passed, using the following signature:
 Bounded optimisation
 ^^^^^^^^^^^^^^^^^^^^
 
-Problems of ill-conditioning and divergence can be ameliorated by using bounded
-optimization. Currently, not all optimizers support bounds - see the
+Problems of ill-conditioning and divergence can be improved by using bounded
+optimization. All components' parameters have the attributes `parameter.bmin` and 
+`parameter.bmax` ("bounded min" and "bounded max"). When fitting using the 
+`bounded=True` argument by `m.fit(bounded=True)` or `m.multifit(bounded=True)`, 
+these attributes set the minimum and maximum values allowed for `parameter.value`.
+
+Currently, not all optimizers support bounds - see the
 :ref:`table above <optimizers-table>`. In the following example a gaussian
 histogram is fitted using a :class:`~._components.gaussian.Gaussian`
 component using mpfit and bounds on the ``centre`` parameter.
@@ -1182,8 +1188,9 @@ Batch setting of parameter attributes
 -------------------------------------
 .. versionadded:: 0.6
 
-The following methods can be used to ease the task of setting some important
-parameter attributes:
+The following model methods can be used to ease the task of setting some important
+parameter attributes. These can also be used on a per-component basis, by calling them
+on individual components.
 
 * :py:meth:`~.model.BaseModel.set_parameters_not_free`
 * :py:meth:`~.model.BaseModel.set_parameters_free`

--- a/doc/user_guide/model.rst
+++ b/doc/user_guide/model.rst
@@ -67,10 +67,11 @@ voltage, convergence and collection semi-angles etc.
 
 
 
-.. _model_components-label:
 
 Creating components for the model
 ---------------------------------
+
+.. _model_components-label:
 
 In HyperSpy a model consists of a linear combination of components
 and various components are available in one (:py:mod:`~.components1d`)and
@@ -231,8 +232,6 @@ mailing list <http://groups.google.com/group/hyperspy-users>`.
 Adding components to the model
 ------------------------------
 
-.. _model_components-label:
-
 To print the current components in a model use
 :py:attr:`~.model.BaseModel.components`. A table with component number,
 attribute name, component name and component type will be printed:
@@ -382,7 +381,7 @@ To enable this feature for a given component set the
 .. _model_indexing-label:
 
 Indexing the model
---------------
+------------------
 
 Often it is useful to consider only part of the model - for example at
 a particular location (i.e. a slice in the navigation space) or energy range

--- a/doc/user_guide/mva.rst
+++ b/doc/user_guide/mva.rst
@@ -126,8 +126,6 @@ notation, specify the ``xaxis_type`` parameter:
    PCA scree plot with number-based axis labeling and a threshold value
    specified
 
-.. versionadded:: 0.7
-
 Sometimes it can be useful to get the explained variance ratio as a spectrum,
 for example to plot several scree plots obtained using
 different data pre-treatmentd in the same figure using
@@ -352,7 +350,6 @@ clicking on their corresponding line in the legend.
 
 Obtaining the results as BaseSignal instances
 =============================================
-.. versionadded:: 0.7
 
 The decomposition and BSS results are internally stored as numpy arrays in the
 :py:class:`~.signal.BaseSignal` class. Frequently it is useful to obtain the

--- a/doc/user_guide/mva.rst
+++ b/doc/user_guide/mva.rst
@@ -276,7 +276,7 @@ properties of stochastic gradient descent. This takes the further parameter
    ...                 momentum=0.5)
 
 Non-negative matrix factorization
-----------------------------
+---------------------------------
 
 Another popular decomposition method is non-negative matrix factorization
 (NMF), which can be accessed in HyperSpy with:

--- a/doc/user_guide/signal1d.rst
+++ b/doc/user_guide/signal1d.rst
@@ -119,7 +119,6 @@ passed) can perform data smoothing with different algorithms:
 
 Spike removal
 --------------
-.. versionadded:: 0.5
 
 :py:meth:`~._signals.signal1d.Signal1D.spikes_removal_tool` provides an user
 interface to remove spikes from spectra.

--- a/doc/user_guide/signal2d.rst
+++ b/doc/user_guide/signal2d.rst
@@ -11,16 +11,11 @@ signals in the Signal2D class.
 Two dimensional signal registration (alignment)
 -----------------------------------------------
 
-.. versionadded:: 0.5
-   :py:meth:`~._signals.signal2d.Signal2D.align2D` and
-   :py:meth:`~._signals.signal2d.Signal2D.estimate_shift2D` methods.
-
-
 .. versionadded:: 1.4
    ``sub_pixel_factor`` keyword.
 
-
-The :py:meth:`~._signals.signal2d.Signal2D.align2D` method provides
+The :py:meth:`~._signals.signal2d.Signal2D.align2D` and 
+:py:meth:`~._signals.signal2d.Signal2D.estimate_shift2D` methods provide
 advanced image alignment functionality. Sub-pixel accuracy can be achieved
 by using skimage's upsampled matrix-multiplication DFT method
 :ref:`[Guizar2008] <Guizar2008>`—by setting the `sub_pixel_factor` keyword argument—

--- a/doc/user_guide/tools.rst
+++ b/doc/user_guide/tools.rst
@@ -26,21 +26,6 @@ spectroscopy data analysis.
 The :ref:`table below <signal_subclasses_table-label>` summarises all the
 currently available specialised :py:class:`~.signal.BaseSignal` subclasses.
 
-.. versionchanged:: 1.0
-
-    The :py:class:`~._signals.signal1d.Signal1D`,
-    :py:class:`~._signals.signal2d.Signal2D` and :py:class:`~.signal.BaseSignal`
-    classes deprecated the old `Spectrum` `Image` and `Signal` classes.
-
-.. versionadded:: 1.0
-
-    New :py:class:`~._signals.complex_signal.ComplexSignal`,
-    :py:class:`~._signals.complex_signal1d.ComplexSignal1D` and
-    :py:class:`~._signals.complex_signal2d.Complex2D`
-    :py:class:`~.signal.BaseSignal` subclasses specialised in complex data.
-
-
-
 The :py:mod:`~.signals` module, which contains all available signal subclasses,
 is imported in the user namespace when loading HyperSpy. In the following
 example we create a Signal2D instance from a 2D numpy array:
@@ -258,8 +243,6 @@ The following example shows how to transform between different subclasses.
 Binned and unbinned signals
 ---------------------------
 
-.. versionadded:: 0.7
-
 Signals that are a histogram of a probability density function (pdf) should
 have the ``signal.metadata.Signal.binned`` attribute set to
 ``True``. This is because some methods operate differently in signals that are
@@ -320,8 +303,6 @@ subclasses.
 Mathematical operations
 ^^^^^^^^^^^^^^^^^^^^^^^
 
-.. versionchanged:: 1.0
-
 A number of mathematical operations are available
 in :py:class:`~.signal.BaseSignal`. Most of them are just wrapped numpy
 functions.
@@ -368,21 +349,14 @@ Example:
 
 The following methods operate only on one axis at a time:
 
-.. versionadded:: 1.2
-   :py:meth:`~.signal.BaseSignal.valuemin`, :py:meth:`~.signal.BaseSignal.indexmin`
-
 * :py:meth:`~.signal.BaseSignal.diff`
 * :py:meth:`~.signal.BaseSignal.derivative`
 * :py:meth:`~.signal.BaseSignal.integrate_simpson`
 * :py:meth:`~.signal.BaseSignal.integrate1D`
-* :py:meth:`~.signal.BaseSignal.valuemax`
+* :py:meth:`~.signal.BaseSignal.indexmin`
 * :py:meth:`~.signal.BaseSignal.indexmax`
 * :py:meth:`~.signal.BaseSignal.valuemin`
-* :py:meth:`~.signal.BaseSignal.indexmin`
-
-.. versionadded:: 1.0
-   numpy ufunc operate on HyperSpy signals
-
+* :py:meth:`~.signal.BaseSignal.valuemax`
 
 .. _ufunc-label:
 
@@ -429,8 +403,6 @@ array instead of a :py:class:`~.signal.BaseSignal` instance e.g.:
 
 Indexing
 ^^^^^^^^
-.. versionadded:: 0.6
-.. versionchanged:: 0.8.1
 
 Indexing a :py:class:`~.signal.BaseSignal`  provides a powerful, convenient and
 Pythonic way to access and modify its data. In HyperSpy indexing is achieved
@@ -665,9 +637,6 @@ dimensions respectively:
 
 Signal operations
 ^^^^^^^^^^^^^^^^^
-.. versionadded:: 0.6
-
-.. versionadded:: 0.8.3
 
 :py:class:`~.signal.BaseSignal` supports all the Python binary arithmetic
 operations (+, -, \*, //, %, divmod(), pow(), \*\*, <<, >>, &, ^, \|),
@@ -809,8 +778,6 @@ to make a horizontal "collage" of the image stack:
 
 Iterating external functions with the map method
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-.. versionadded:: 0.7
 
 Performing an operation on the data at each coordinate, as in the previous example,
 using an external function can be more easily accomplished using the
@@ -1126,9 +1093,6 @@ type in place, e.g.:
         Data type: float64
 
 
-.. versionadded:: 0.7
-   Support for RGB signals.
-
 In addition to all standard numpy dtypes, HyperSpy supports four extra dtypes
 for RGB images **for visualization purposes only**: ``rgb8``, ``rgba8``,
 ``rgb16`` and ``rgba16``. This includes of course multi-dimensional RGB images.
@@ -1271,7 +1235,6 @@ methods e.g.:
 
 Basic statistical analysis
 --------------------------
-.. versionadded:: 0.7
 
 :py:meth:`~.signal.BaseSignal.get_histogram` computes the histogram and
 conveniently returns it as signal instance. It provides methods to
@@ -1393,8 +1356,6 @@ model, for example:
 Speeding up operations
 ----------------------
 
-.. versionadded:: 1.0
-
 Reusing a Signal for output
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
@@ -1433,8 +1394,6 @@ operation.
 
 Interactive operations
 ----------------------
-
-.. versionadded:: 1.0
 
 
 The function :py:func:`~.interactive.interactive` ease the task of defining
@@ -1479,8 +1438,6 @@ The interactive operations can be chained.
 
 Region Of Interest (ROI)
 ------------------------
-
-.. versionadded:: 1.0
 
 A number of different ROIs are available:
 

--- a/doc/user_guide/visualisation.rst
+++ b/doc/user_guide/visualisation.rst
@@ -171,8 +171,6 @@ The following keyboard shortcuts are availalbe when the 2D signal figure is in f
 Customising image plot
 ======================
 
-.. versionadded:: 0.8
-
 The image plot can be customised by passing additional arguments when plotting.
 Colorbar, scalebar and contrast controls are HyperSpy-specific, however
 `matplotlib.imshow
@@ -232,8 +230,6 @@ them as a dictionary in ``navigator_kwds`` argument when plotting:
 
 .. _plot.divergent_colormaps-label:
 
-
-.. versionadded:: 0.8.1
 
 When plotting using divergent colormaps, if ``centre_colormap`` is ``True``
 (default) the contrast is automatically adjusted so that zero corresponds to
@@ -453,8 +449,6 @@ other signals): :py:func:`~.drawing.utils.plot_images`,
 
 Plotting several images
 -----------------------
-
-.. versionadded:: 0.8
 
 :py:func:`~.drawing.utils.plot_images` is used to plot several images in the
 same figure. It supports many configurations and has many options available
@@ -1017,8 +1011,6 @@ each plot:
 
 Markers
 =======
-
-.. versionadded:: 0.8
 
 HyperSpy provides an easy access to the main marker of matplotlib. The markers
 can be used in a static way


### PR DESCRIPTION
### Description of the change
- Removed "Added in version 0.7, 0.8, etc up to and including 1.0"
- Replaced aforementioned with a title where necessary
- Reworked some text, most importantly included text-references to `parameter.bmin` and `.bmax`.
- Fixed a bunch of minor warnings

This fixes #1276.
### Progress of the PR
- [x] Change implemented
- [x] update user guide (if appropriate),
- [x] ready for review.