### PR TITLE
Fix value error when plotting not finite value

### DIFF
--- a/hyperspy/drawing/image.py
+++ b/hyperspy/drawing/image.py
@@ -34,6 +34,7 @@ from hyperspy.misc import rgb_tools
 from hyperspy.drawing.figure import BlittedFigure
 from hyperspy.ui_registry import DISPLAY_DT, TOOLKIT_DT
 from hyperspy.docstrings.plot import PLOT2D_DOCSTRING
+from hyperspy.misc.test_utils import ignore_warning
 
 
 _logger = logging.getLogger(__name__)
@@ -196,8 +197,14 @@ class ImagePlot(BlittedFigure):
     def optimize_contrast(self, data):
         if (self._vmin_user is not None and self._vmax_user is not None):
             return
-        self._vmin_auto, self._vmax_auto = utils.contrast_stretching(
-            data, self.saturated_pixels)
+        with ignore_warning(category=RuntimeWarning):
+            # In case of "All-NaN slices"
+            vmin, vmax = utils.contrast_stretching(data, self.saturated_pixels)
+        if vmin == np.nan:
+            vmin = None
+        if vmax == np.nan:
+            vmax = None
+        self._vmin_auto, self._vmax_auto = vmin, vmax
 
     def create_figure(self, max_size=None, min_size=2, **kwargs):
         """Create matplotlib figure

--- a/hyperspy/drawing/image.py
+++ b/hyperspy/drawing/image.py
@@ -353,9 +353,9 @@ class ImagePlot(BlittedFigure):
                     row = -1
                 if col >= 0 and row >= 0:
                     z = data[row, col]
-                    return 'x=%1.4g, y=%1.4g, intensity=%1.4g' % (x, y, z)
-                else:
-                    return 'x=%1.4g, y=%1.4g' % (x, y)
+                    if np.isfinite(z):
+                        return 'x=%1.4g, y=%1.4g, intensity=%1.4g' % (x, y, z)
+                return 'x=%1.4g, y=%1.4g' % (x, y)
             self.ax.format_coord = format_coord
             old_vmax, old_vmin = self.vmax, self.vmin
             self.optimize_contrast(data)

--- a/hyperspy/drawing/signal1d.py
+++ b/hyperspy/drawing/signal1d.py
@@ -28,6 +28,7 @@ from hyperspy.drawing.figure import BlittedFigure
 from hyperspy.drawing import utils
 from hyperspy.events import Event, Events
 from hyperspy.exceptions import VisibleDeprecationWarning
+from hyperspy.misc.test_utils import ignore_warning
 
 
 _logger = logging.getLogger(__name__)
@@ -385,15 +386,19 @@ class Signal1DLine(object):
             y2 += 2
             y1, y2 = np.clip((y1, y2), 0, len(ydata - 1))
             clipped_ydata = ydata[y1:y2]
-            y_max, y_min = (np.nanmax(clipped_ydata),
-                            np.nanmin(clipped_ydata))
+            with ignore_warning(category=RuntimeWarning):
+                # In case of "All-NaN slices"
+                y_max, y_min = (np.nanmax(clipped_ydata),
+                                np.nanmin(clipped_ydata))
 
             if self._plot_imag:
                 # Add real plot
                 yreal = self._get_data(real_part=True)
                 clipped_yreal = yreal[y1:y2]
-                y_min = min(y_min, clipped_yreal.min())
-                y_max = max(y_max, clipped_yreal.max())
+                with ignore_warning(category=RuntimeWarning):
+                    # In case of "All-NaN slices"
+                    y_min = min(y_min, np.nanmin(clipped_yreal))
+                    y_max = max(y_max, np.nanmin(clipped_yreal))
             if y_min == y_max:
                 # To avoid matplotlib UserWarning when calling `set_ylim`
                 y_min, y_max = y_min - 0.1, y_max + 0.1

--- a/hyperspy/drawing/signal1d.py
+++ b/hyperspy/drawing/signal1d.py
@@ -397,7 +397,10 @@ class Signal1DLine(object):
             if y_min == y_max:
                 # To avoid matplotlib UserWarning when calling `set_ylim`
                 y_min, y_max = y_min - 0.1, y_max + 0.1
-            self.ax.set_ylim(y_min, y_max)
+            if np.isfinite(y_min):
+                self.ax.set_ylim(y_min, None) # data are -inf or all NaN
+            if np.isfinite(y_max):
+                self.ax.set_ylim(None, y_max) # data are inf or all NaN
         if self.plot_indices is True:
             self.text.set_text(self.axes_manager.indices)
         if render_figure:

--- a/hyperspy/drawing/signal1d.py
+++ b/hyperspy/drawing/signal1d.py
@@ -402,10 +402,11 @@ class Signal1DLine(object):
             if y_min == y_max:
                 # To avoid matplotlib UserWarning when calling `set_ylim`
                 y_min, y_max = y_min - 0.1, y_max + 0.1
-            if np.isfinite(y_min):
-                self.ax.set_ylim(y_min, None) # data are -inf or all NaN
-            if np.isfinite(y_max):
-                self.ax.set_ylim(None, y_max) # data are inf or all NaN
+            if not np.isfinite(y_min):
+                y_min = None # data are -inf or all NaN
+            if not np.isfinite(y_max):
+                y_max = None # data are inf or all NaN
+            self.ax.set_ylim(y_min, y_max)
         if self.plot_indices is True:
             self.text.set_text(self.axes_manager.indices)
         if render_figure:

--- a/hyperspy/drawing/utils.py
+++ b/hyperspy/drawing/utils.py
@@ -26,9 +26,10 @@ from mpl_toolkits.axes_grid1 import make_axes_locatable
 from matplotlib.backend_bases import key_press_handler
 import warnings
 import numpy as np
-import hyperspy as hs
 from distutils.version import LooseVersion
 import logging
+
+import hyperspy as hs
 
 
 _logger = logging.getLogger(__name__)
@@ -62,11 +63,8 @@ def contrast_stretching(data, saturated_pixels):
     if not 0 <= saturated_pixels <= 100:
         raise ValueError(
             "saturated_pixels must be a scalar in the range[0, 100]")
-    nans = np.isnan(data)
-    if nans.any():
-        data = data[~nans]
-    vmin = np.percentile(data, saturated_pixels / 2.)
-    vmax = np.percentile(data, 100 - saturated_pixels / 2.)
+    vmin = np.nanpercentile(data, saturated_pixels / 2.)
+    vmax = np.nanpercentile(data, 100 - saturated_pixels / 2.)
     return vmin, vmax
 
 

--- a/hyperspy/tests/drawing/test_plot_signal1d.py
+++ b/hyperspy/tests/drawing/test_plot_signal1d.py
@@ -237,3 +237,21 @@ def test_plot_two_cursors(ndim, plot_type):
 @update_close_figure
 def test_plot_nav2_sig1_two_cursors_close():
     return _test_plot_two_cursors(ndim=2)
+
+
+def test_plot_with_non_finite_value():
+    s = hs.signals.Signal1D(np.array([np.nan, 2.0]))
+    s.plot()
+    s.axes_manager.events.indices_changed.trigger(s.axes_manager)
+
+    s = hs.signals.Signal1D(np.array([np.nan, np.nan]))
+    s.plot()
+    s.axes_manager.events.indices_changed.trigger(s.axes_manager)
+
+    s = hs.signals.Signal1D(np.array([-np.inf, 2.0]))
+    s.plot()
+    s.axes_manager.events.indices_changed.trigger(s.axes_manager)
+
+    s = hs.signals.Signal1D(np.array([np.inf, 2.0]))
+    s.plot()
+    s.axes_manager.events.indices_changed.trigger(s.axes_manager)

--- a/hyperspy/tests/drawing/test_plot_signal2d.py
+++ b/hyperspy/tests/drawing/test_plot_signal2d.py
@@ -443,3 +443,21 @@ def test_plot_images_not_signal():
 
     with pytest.raises(ValueError):
         hs.plot.plot_images('not a list of signal')
+
+
+def test_plot_with_non_finite_value():
+    s = hs.signals.Signal2D(np.array([[np.nan, 2.0] for v in range(2)]))
+    s.plot()
+    s.axes_manager.events.indices_changed.trigger(s.axes_manager)
+
+    s = hs.signals.Signal2D(np.array([[np.nan, np.nan] for v in range(2)]))
+    s.plot()
+    s.axes_manager.events.indices_changed.trigger(s.axes_manager)
+
+    s = hs.signals.Signal2D(np.array([[-np.inf, np.nan] for v in range(2)]))
+    s.plot()
+    s.axes_manager.events.indices_changed.trigger(s.axes_manager)
+
+    s = hs.signals.Signal2D(np.array([[np.inf, np.nan] for v in range(2)]))
+    s.plot()
+    s.axes_manager.events.indices_changed.trigger(s.axes_manager)


### PR DESCRIPTION
Fix setting limits when plotting data with infinite. 

### Progress of the PR
- [x] Check the plotting limits are finite before setting them,
- [x] Catch "All-NaN slices" numpy runtime warning,
- [x] add tests,
- [x] ready for review.

```python
import hyperspy.api as hs

s = hs.signals.Signal1D(np.array([np.nan, np.nan]))
s.plot()
s.axes_manager.events.indices_changed.trigger(s.axes_manager)

s = hs.signals.Signal1D(np.array([-np.inf, 2.0]))
s.plot()
s.axes_manager.events.indices_changed.trigger(s.axes_manager)
```
