### PR TITLE
Drop python 3.5 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,16 +14,11 @@ matrix:
   - env: export PYTHON=3.7; FAIL_ON_EXTERNAL_DEPRECATION='False'; MINIMAL_ENV='True'
     # Only standard test for older supported versions of Python in Linux
   - env: export PYTHON=3.6; FAIL_ON_EXTERNAL_DEPRECATION='False'; MINIMAL_ENV='False'
-  - env: export PYTHON=3.5; FAIL_ON_EXTERNAL_DEPRECATION='False'; MINIMAL_ENV='False'
     # All tests, but the min requirements test run for the latest supported Python version in OSx
   - env: export PYTHON=3.7; FAIL_ON_EXTERNAL_DEPRECATION='False'; MINIMAL_ENV='False'
     os: osx
     language: generic
   - env: export PYTHON=3.6; FAIL_ON_EXTERNAL_DEPRECATION='False'; MINIMAL_ENV='False'
-    os: osx
-    language: generic
-    if: tag IS present
-  - env: export PYTHON=3.5; FAIL_ON_EXTERNAL_DEPRECATION='False'; MINIMAL_ENV='False'
     os: osx
     language: generic
     if: tag IS present

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,27 @@ What's new
 Current Version
 ===============
 
-.. _changes_1.4.1:
+.. _changes_1.5:
+
+v1.5
+++++
+
+* Drop support for python 3.5
+
+
+Changelog
+*********
+
+Previous Versions
+=================
+
+
+We only cover here the main highlights, for a detailed list of all the changes
+see `the commits in the GITHUB milestones
+<https://github.com/hyperspy/hyperspy/milestones?state=closed>`_.
+
+
+.. _changes_1.4.2:
 
 v1.4.2
 ++++++
@@ -17,6 +37,7 @@ and `enhancements
 <https://github.com/hyperspy/hyperspy/issues?q=is%3Aclosed+milestone%3Av1.4.1+label%3A"type%3A+enhancement">`_.
 
 
+.. _changes_1.4.1:
 
 v1.4.1
 ++++++
@@ -84,17 +105,6 @@ Enhancements
 
 
 
-
-Changelog
-*********
-
-Previous Versions
-=================
-
-
-We only cover here the main highlights, for a detailed list of all the changes
-see `the commits in the GITHUB milestones
-<https://github.com/hyperspy/hyperspy/milestones?state=closed>`_.
 
 .. _changes_1.3.2:
 v1.3.2

--- a/README.rst
+++ b/README.rst
@@ -44,8 +44,8 @@ HyperSpy is released under the GPL v3 license.
 
 .. warning::
 
-    **Since version 0.8.4 HyperSpy supports Python 3 (version 3.5 and newer). If you need to install
-    HyperSpy in Python 2.7 install HyperSpy 0.8.3.**
+    Since version 0.8.4 HyperSpy only supports Python 3. If you need to install
+    HyperSpy in Python 2.7 install HyperSpy 0.8.3.
 
 
 Contributing

--- a/README.rst
+++ b/README.rst
@@ -42,10 +42,8 @@ of signals.
 
 HyperSpy is released under the GPL v3 license.
 
-.. warning::
-
-    Since version 0.8.4 HyperSpy only supports Python 3. If you need to install
-    HyperSpy in Python 2.7 install HyperSpy 0.8.3.
+**Since version 0.8.4 HyperSpy only supports Python 3. If you need to install
+HyperSpy in Python 2.7 install HyperSpy 0.8.3.**
 
 
 Contributing

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -18,12 +18,6 @@ environment:
      - PY_VERSION: 3.6
        PLATFORM: x86
        TAG_SCENARIO: true
-     - PY_VERSION: 3.5
-       PLATFORM: x64
-       TAG_SCENARIO: true
-     - PY_VERSION: 3.5
-       PLATFORM: x86
-       TAG_SCENARIO: true
 
 for:
 -

--- a/setup.py
+++ b/setup.py
@@ -363,7 +363,6 @@ with update_version_when_dev() as version:
         },
         classifiers=[
             "Programming Language :: Python :: 3",
-            "Programming Language :: Python :: 3.5",
             "Programming Language :: Python :: 3.6",
             "Programming Language :: Python :: 3.7",
             "Development Status :: 4 - Beta",


### PR DESCRIPTION
Since a couple of weeks, hyperspy installation fails on appveyor and travis.
https://ci.appveyor.com/project/hyperspy/hyperspy/builds/25878228
https://travis-ci.org/hyperspy/hyperspy/builds/557181438

We could possibly find a workaround but I don't think it is worth it because it is going to be every time more complicated. Conda-forge is not building python 3.5 packaging since about 9 months.

It has been mentioned a couple of times that dropping python 3.5 will have the advantage to allow using f-string, which make the code mode readable, see for example https://github.com/hyperspy/start_jupyter_cm/pull/1#discussion_r301549351.

### Progress of the PR
- [x] Update setup.py and CI,
- [x] ready for review.


