### PR TITLE
bug-fix_bcf_v2_1

### DIFF
--- a/hyperspy/io_plugins/bruker.py
+++ b/hyperspy/io_plugins/bruker.py
@@ -727,8 +727,7 @@ class HyperHeader(object):
                     "./ClassInstance[@Type='TRTSpectrumRegion']"):
                 tmp_d = dictionarize(j)
                 self.elements[tmp_d['XmlClassName']] = {'line': tmp_d['Line'],
-                                                        'energy': tmp_d['Energy'],
-                                                        'width': tmp_d['Width']}
+                                                        'energy': tmp_d['Energy']}
         except AttributeError:
             _logger.info('no element selection present in the spectra..')
 


### PR DESCRIPTION
### Description of the change
bcf files sometimes have automatic or fixed energy width mode.
Prior code implementation was assuming that bcf XML part always have
width window of xray line energy in the XML. That is causing error when bcf is
set to use automatic width function, and energy Width is absent from xml.
Moreover, energy width was not exposed to hyperspy metadata (only to original_metadata).
So there is no loss with getting rid of that one line, and it is most simple solution to the problem.

### Progress of the PR
- [x] Change implemented,
- [x] check tests,
- [x] ready for review.

