### PR TITLE
Problem to run the latest release

### DIFF
--- a/hyperspy/drawing/image.py
+++ b/hyperspy/drawing/image.py
@@ -375,8 +375,8 @@ class ImagePlot(BlittedFigure):
                 if col >= 0 and row >= 0:
                     z = data[row, col]
                     if np.isfinite(z):
-                        return f'x={x:1.4g}, y={y:1.4g}, intensity={z:1.4g}'
-                return f'x={x:1.4g}, y={y:1.4g}'
+                        return 'x={x:1.4g}, y={y:1.4g}, intensity={z:1.4g}'
+                return 'x={x:1.4g}, y={y:1.4g}'
             self.ax.format_coord = format_coord
 
             old_vmin, old_vmax = self.vmin, self.vmax

--- a/hyperspy/io.py
+++ b/hyperspy/io.py
@@ -434,12 +434,12 @@ def dict2signal(signal_dict, lazy=False):
             importlib.import_module(signal_dict["package"])
         except ImportError:
             _logger.warning(
-                f"This file contains a signal provided by the " +
-                f'{signal_dict["package"]} Python package that is not ' +
-                f'currently installed. The signal will be loaded into a '
-                f'generic HyperSpy signal. Consider installing ' +
-                f'{signal_dict["package"]} to load this dataset into its '
-                f'original signal class.')
+                "This file contains a signal provided by the " + 
+                '{signal_dict["package"]} Python package that is not ' + 
+                'currently installed. The signal will be loaded into a ' 
+                'generic HyperSpy signal. Consider installing ' + 
+                '{signal_dict["package"]} to load this dataset into its ' 
+                'original signal class.')
     signal_dimension = -1  # undefined
     signal_type = ""
     if "metadata" in signal_dict:

--- a/hyperspy/misc/io/fei_stream_readers.py
+++ b/hyperspy/misc/io/fei_stream_readers.py
@@ -1,11 +1,11 @@
 import numpy as np
 import dask.array as da
-import sparse
+from scipy import sparse
 
 from hyperspy.decorators import jit_ifnumba
 
 
-class DenseSliceCOO(sparse.COO):
+class DenseSliceCOO(sparse.coo_matrix):
     """Just like sparse.COO, but returning a dense array on indexing/slicing"""
 
     def __getitem__(self, *args, **kwargs):

--- a/hyperspy/model.py
+++ b/hyperspy/model.py
@@ -73,10 +73,10 @@ def reconstruct_component(comp_dictionary, **init_args):
         _class = dill.loads(comp_dictionary['_class_dump'])
     else:
         raise ImportError(
-            f'Loading the {comp_dictionary["class"]} component ' +
+            'Loading the {comp_dictionary["class"]} component ' +
             'failed because the component is provided by the ' +
-            f'{comp_dictionary["package"]} Python package, but ' +
-            f'{comp_dictionary["package"]} is not installed.')
+            '{comp_dictionary["package"]} Python package, but ' +
+            '{comp_dictionary["package"]} is not installed.')
     return _class(**init_args)
 
 

--- a/hyperspy/signal_tools.py
+++ b/hyperspy/signal_tools.py
@@ -554,10 +554,10 @@ class ImageContrastEditor(t.HasTraits):
         'Symlog',
         default='Linear')
     linthresh = t.Range(0.0, 1.0, 0.01, exclude_low=True, exclude_high=False,
-                        desc=f"Range of value closed to zero, which are "
+                        desc="Range of value closed to zero, which are "
                         "linearly extrapolated. {mpl_help}")
     linscale = t.Range(0.0, 10.0, 0.1, exclude_low=False, exclude_high=False,
-                       desc=f"Number of decades to use for each half of "
+                       desc="Number of decades to use for each half of "
                        "the linear range. {mpl_help}")
     auto = t.Bool(True,
                   desc="Adjust automatically the display when changing "


### PR DESCRIPTION
Hi all,

### Description of the change
- Remove the 'f' in front of text comments on these files to be able to run hyperspy package.
- 'from scipy import sparse' instead of 'import sparse'
- 'sparse.coo_matrix' instead of 'sparse.COO' 

