### PR TITLE
Fix issues with numpy 1.17 and dask 2.3.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,8 @@ env:
   global:
     - MPLBACKEND="agg"
     - TEST_DEPS="pytest pytest-cov pytest-mpl wheel"
+    - FAIL_ON_EXTERNAL_DEPRECATION=false
+    - USE_CONDA=true
 
 services:
   - xvfb
@@ -12,46 +14,52 @@ services:
 matrix:
   include:
     # All tests run for the latest supported Python version in Linux
-  - env: export PYTHON=3.7; FAIL_ON_EXTERNAL_DEPRECATION='False'; MINIMAL_ENV='False'
-  - env: export PYTHON=3.7; FAIL_ON_EXTERNAL_DEPRECATION='False'; MINIMAL_ENV='True'
+  - env: export PYTHON=3.7; MINIMAL_ENV=false
+  - env: export PYTHON=3.7; MINIMAL_ENV=false; USE_CONDA=false
+  - env: export PYTHON=3.7; MINIMAL_ENV=true
+  - env: export PYTHON=3.7; MINIMAL_ENV=false; USE_CONDA=false
     # Only standard test for older supported versions of Python in Linux
-  - env: export PYTHON=3.6; FAIL_ON_EXTERNAL_DEPRECATION='False'; MINIMAL_ENV='False'
+  - env: export PYTHON=3.6; MINIMAL_ENV=false
     # All tests, but the min requirements test run for the latest supported Python version in OSx
-  - env: export PYTHON=3.7; FAIL_ON_EXTERNAL_DEPRECATION='False'; MINIMAL_ENV='False'
+  - env: export PYTHON=3.7; MINIMAL_ENV=false
     os: osx
     language: generic
-  - env: export PYTHON=3.6; FAIL_ON_EXTERNAL_DEPRECATION='False'; MINIMAL_ENV='False'
+  - env: export PYTHON=3.6; MINIMAL_ENV=false
     os: osx
     language: generic
     if: tag IS present
   allow_failures:
     # Only test for the latest supported version as chances are that it'll
     # contain the most up-to-date external libraries.
-  - env: export PYTHON=3.7; FAIL_ON_EXTERNAL_DEPRECATION='True'; MINIMAL_ENV='False'
+  - env: export PYTHON=3.7; MINIMAL_ENV=false; FAIL_ON_EXTERNAL_DEPRECATION=true
 
 before_install:
   - if [[ $TRAVIS_OS_NAME == 'osx' ]] ; then
       curl "https://repo.continuum.io/miniconda/Miniconda3-latest-MacOSX-x86_64.sh" -o miniconda.sh;
     else wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh;
     fi
-  - chmod +x miniconda.sh;
-    ./miniconda.sh -b -p $HOME/miniconda;
-    export "PATH=$HOME/miniconda/bin:$PATH";
-    hash -r;
-install:
+  - |
+    if [ $USE_CONDA == true ]; then
+      chmod +x miniconda.sh;
+      ./miniconda.sh -b -p $HOME/miniconda;
+    fi
 
-  - if [[ $MINIMAL_ENV == 'False' ]] ; then
+install:
+  - if [[ $MINIMAL_ENV == false ]] ; then
       DEPS="pip numpy scipy matplotlib>2.2.3 ipython h5py sympy scikit-learn dill natsort setuptools scikit-image cython ipyparallel dask traits traitsui numexpr numba mrcz";
     else DEPS="pip ipython numpy scipy matplotlib>2.2.3 h5py sympy scikit-image numexpr";
     fi
-  - conda update -y conda;
-    conda config --append channels conda-forge;
-    conda create -n testenv --yes python=$PYTHON;
-    source activate testenv;
-    conda install -y $DEPS $TEST_DEPS;
-  - if [[ $MINIMAL_ENV == 'False' ]] ; then
+  - |
+    if [ $USE_CONDA == true ]; then
+      source $HOME/miniconda/bin/activate root
+      conda config --append channels conda-forge
+      conda create -n testenv --yes python=$PYTHON
+      source activate testenv
+      conda install -y $DEPS $TEST_DEPS
+    fi
+  - if [[ $MINIMAL_ENV == false ]] ; then
       pip install .;
-    else pip install .;
+    else pip install . --no-deps;
     fi
 
 before_script: # configure a headless display to test plot generation
@@ -76,7 +84,7 @@ script:
 
 after_success:
 - coveralls
-- if [[ $MINIMAL_ENV == 'False' ]]; then
+- if [[ $MINIMAL_ENV == false ]]; then
     python setup.py bdist_wheel;
   else python setup.py sdist;
   fi
@@ -93,4 +101,4 @@ deploy:
   skip_cleanup: true
   on:
     tags: true
-    condition: $MINIMAL_ENV = 'False'
+    condition: $MINIMAL_ENV = false

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,7 @@
-language: python
-python:
-  - "3.7"
+language: generic
 
 env:
+  # We set the default value in global and changed it in the matrix when necessary
   global:
     - ENV=conda
     - MINIMAL_ENV=false
@@ -19,19 +18,21 @@ services:
 matrix:
   include:
     # All tests run for the latest supported Python version in Linux
-  - env: export PYTHON=3.7;
-  - env: export PYTHON=3.7; MINIMAL_ENV=true
+  - env: export CONDA_PYTHON=3.7
+  - env: export CONDA_PYTHON=3.7; MINIMAL_ENV=true
   - env: export ENV=pip
+    language: python
+    python: 3.7
   - env: export ENV=pip; MINIMAL_ENV=true
+    language: python
+    python: 3.7
     # Only standard test for older supported versions of Python in Linux
-  - env: export PYTHON=3.6;
+  - env: export CONDA_PYTHON=3.6
     # All tests, but the min requirements test run for the latest supported Python version in OSx
-  - env: export PYTHON=3.7;
+  - env: export CONDA_PYTHON=3.7
     os: osx
-    language: generic
-  - env: export PYTHON=3.6;
+  - env: export CONDA_PYTHON=3.6
     os: osx
-    language: generic
     if: tag IS present
   allow_failures:
     # Only test for the latest supported version as chances are that it'll
@@ -48,10 +49,7 @@ install:
       DEPS="${DEPS} ${DEPS_OPTIONAL}";
     fi
   - source ./ci/travis_install_with_$ENV.sh
-  - if [[ $MINIMAL_ENV == false ]] ; then
-      pip install .[all];
-    else pip install .;
-    fi
+  - pip install .
 
 script:
   - which python

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,11 +4,14 @@ python:
 
 env:
   global:
-    - MPLBACKEND="agg"
-    - TEST_DEPS="pytest pytest-cov pytest-mpl wheel"
-    - FAIL_ON_EXTERNAL_DEPRECATION=false
     - ENV=conda
     - MINIMAL_ENV=false
+    - DEPS="numpy ipython scipy matplotlib traits natsort requests tqdm sympy dill h5py python-dateutil ipyparallel dask scikit-image pint numexpr statsmodels sparse imageio pyyaml PTable"
+    - DEPS_OPTIONAL="scikit-learn mrcz numba cython"
+    - TEST_DEPS="pytest pytest-cov pytest-mpl wheel"
+    - MPLBACKEND="agg"
+    - FAIL_ON_EXTERNAL_DEPRECATION=false
+
 
 services:
   - xvfb
@@ -36,43 +39,19 @@ matrix:
   - env: export PYTHON=3.7; MINIMAL_ENV=false; FAIL_ON_EXTERNAL_DEPRECATION=true
 
 before_install:
-  - if [[ $TRAVIS_OS_NAME == 'osx' ]] ; then
-      curl "https://repo.continuum.io/miniconda/Miniconda3-latest-MacOSX-x86_64.sh" -o miniconda.sh;
-    else wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh;
-    fi
-  - |
-    if [ $ENV == conda ]; then
-      chmod +x miniconda.sh;
-      ./miniconda.sh -b -p $HOME/miniconda;
+  - if [ $ENV == conda ]; then
+      source ./ci/travis_setup_conda_$TRAVIS_OS_NAME.sh;
     fi
 
 install:
   - if [[ $MINIMAL_ENV == false ]] ; then
-      DEPS="pip numpy scipy matplotlib>2.2.3 ipython h5py sympy scikit-learn dill natsort setuptools scikit-image cython ipyparallel dask traits numexpr numba mrcz";
-    else DEPS="pip ipython numpy scipy matplotlib>2.2.3 h5py sympy scikit-image numexpr traits";
+      DEPS="${DEPS} ${DEPS_OPTIONAL}";
     fi
-  - |
-    if [ $ENV == conda ]; then
-      source $HOME/miniconda/bin/activate root
-      conda config --append channels conda-forge
-      conda info
-      conda create -n testenv --yes python=$PYTHON
-      conda activate testenv
-      conda install -y $DEPS $TEST_DEPS
-    else
-      pip install -U $DEPS $TEST_DEPS
-      pip list installed
-    fi
+  - source ./ci/travis_install_with_$ENV.sh
   - if [[ $MINIMAL_ENV == false ]] ; then
       pip install .[all];
     else pip install .;
     fi
-
-before_script: # configure a headless display to test plot generation
-  # from http://afitnerd.com/2011/09/06/headless-browser-testing-on-mac/
-  # and https://github.com/travis-ci/travis-ci/issues/7313#issuecomment-279914149
-  - if [ "${TRAVIS_OS_NAME}" = "osx" ]; then ( sudo Xvfb :99 -ac -screen 0 1024x768x8; echo ok ) & fi
-  - sleep 1 # give xvfb some time to start
 
 script:
   - which python

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ env:
     - DEPS_OPTIONAL="scikit-learn mrcz numba cython"
     - TEST_DEPS="pytest pytest-cov pytest-mpl wheel"
     - MPLBACKEND="agg"
+    - TEST_ARG_OPT="--mpl"
     - FAIL_ON_EXTERNAL_DEPRECATION=false
 
 
@@ -54,7 +55,8 @@ install:
 script:
   - which python
   - python -c 'import matplotlib.pyplot as plt; print("Matplotlib backend:", plt.get_backend())';
-  - pytest --mpl --cov=hyperspy --pyargs hyperspy;
+  - if [ $ENV == pip ]; then TEST_ARG_OPT=""; fi
+  - pytest --pyargs hyperspy --cov=hyperspy $TEST_ARG_OPT;
 
 #after_failure: # run only on failure in case there is a need to check matplotlib image comparison
 # This needs a service to upload the artifacts (and corresponding configuration)

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,11 @@ language: python
 
 env:
   global:
-    - DISPLAY=99.0
     - MPLBACKEND="agg"
     - TEST_DEPS="pytest pytest-cov pytest-mpl wheel"
+
+services:
+  - xvfb
 
 matrix:
   include:
@@ -53,11 +55,10 @@ install:
     fi
 
 before_script: # configure a headless display to test plot generation
-  - if [ "${TRAVIS_OS_NAME}" = "linux" ]; then sh -e /etc/init.d/xvfb start; fi
   # from http://afitnerd.com/2011/09/06/headless-browser-testing-on-mac/
   # and https://github.com/travis-ci/travis-ci/issues/7313#issuecomment-279914149
   - if [ "${TRAVIS_OS_NAME}" = "osx" ]; then ( sudo Xvfb :99 -ac -screen 0 1024x768x8; echo ok ) & fi
-  - sleep 3 # give xvfb some time to start
+  - sleep 1 # give xvfb some time to start
 
 script:
   - python -c 'import matplotlib.pyplot as plt; print(plt.get_backend())';

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,14 @@
 language: python
-
+python:
+  - "3.7"
 
 env:
   global:
     - MPLBACKEND="agg"
     - TEST_DEPS="pytest pytest-cov pytest-mpl wheel"
     - FAIL_ON_EXTERNAL_DEPRECATION=false
-    - USE_CONDA=true
+    - ENV=conda
+    - MINIMAL_ENV=false
 
 services:
   - xvfb
@@ -14,17 +16,17 @@ services:
 matrix:
   include:
     # All tests run for the latest supported Python version in Linux
-  - env: export PYTHON=3.7; MINIMAL_ENV=false
-  - env: export PYTHON=3.7; MINIMAL_ENV=false; USE_CONDA=false
+  - env: export PYTHON=3.7;
   - env: export PYTHON=3.7; MINIMAL_ENV=true
-  - env: export PYTHON=3.7; MINIMAL_ENV=false; USE_CONDA=false
+  - env: export ENV=pip
+  - env: export ENV=pip; MINIMAL_ENV=true
     # Only standard test for older supported versions of Python in Linux
-  - env: export PYTHON=3.6; MINIMAL_ENV=false
+  - env: export PYTHON=3.6;
     # All tests, but the min requirements test run for the latest supported Python version in OSx
-  - env: export PYTHON=3.7; MINIMAL_ENV=false
+  - env: export PYTHON=3.7;
     os: osx
     language: generic
-  - env: export PYTHON=3.6; MINIMAL_ENV=false
+  - env: export PYTHON=3.6;
     os: osx
     language: generic
     if: tag IS present
@@ -39,27 +41,31 @@ before_install:
     else wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh;
     fi
   - |
-    if [ $USE_CONDA == true ]; then
+    if [ $ENV == conda ]; then
       chmod +x miniconda.sh;
       ./miniconda.sh -b -p $HOME/miniconda;
     fi
 
 install:
   - if [[ $MINIMAL_ENV == false ]] ; then
-      DEPS="pip numpy scipy matplotlib>2.2.3 ipython h5py sympy scikit-learn dill natsort setuptools scikit-image cython ipyparallel dask traits traitsui numexpr numba mrcz";
-    else DEPS="pip ipython numpy scipy matplotlib>2.2.3 h5py sympy scikit-image numexpr";
+      DEPS="pip numpy scipy matplotlib>2.2.3 ipython h5py sympy scikit-learn dill natsort setuptools scikit-image cython ipyparallel dask traits numexpr numba mrcz";
+    else DEPS="pip ipython numpy scipy matplotlib>2.2.3 h5py sympy scikit-image numexpr traits";
     fi
   - |
-    if [ $USE_CONDA == true ]; then
+    if [ $ENV == conda ]; then
       source $HOME/miniconda/bin/activate root
       conda config --append channels conda-forge
+      conda info
       conda create -n testenv --yes python=$PYTHON
-      source activate testenv
+      conda activate testenv
       conda install -y $DEPS $TEST_DEPS
+    else
+      pip install -U $DEPS $TEST_DEPS
+      pip list installed
     fi
   - if [[ $MINIMAL_ENV == false ]] ; then
-      pip install .;
-    else pip install . --no-deps;
+      pip install .[all];
+    else pip install .;
     fi
 
 before_script: # configure a headless display to test plot generation
@@ -69,7 +75,8 @@ before_script: # configure a headless display to test plot generation
   - sleep 1 # give xvfb some time to start
 
 script:
-  - python -c 'import matplotlib.pyplot as plt; print(plt.get_backend())';
+  - which python
+  - python -c 'import matplotlib.pyplot as plt; print("Matplotlib backend:", plt.get_backend())';
   - pytest --mpl --cov=hyperspy --pyargs hyperspy;
 
 #after_failure: # run only on failure in case there is a need to check matplotlib image comparison
@@ -84,10 +91,7 @@ script:
 
 after_success:
 - coveralls
-- if [[ $MINIMAL_ENV == false ]]; then
-    python setup.py bdist_wheel;
-  else python setup.py sdist;
-  fi
+- python setup.py bdist_wheel;
 
 before_deploy:
 - export DISTRIB=$(ls ./dist/*);

--- a/ci/travis_install_with_conda.sh
+++ b/ci/travis_install_with_conda.sh
@@ -2,7 +2,7 @@
 source $HOME/miniconda/bin/activate root
 conda update -y conda
 conda config --append channels conda-forge
-conda create -n testenv --yes python=$PYTHON
+conda create -n testenv --yes python=$CONDA_PYTHON
 conda activate testenv
 # Install package with conda
 conda install -y $DEPS $TEST_DEPS

--- a/ci/travis_install_with_conda.sh
+++ b/ci/travis_install_with_conda.sh
@@ -1,0 +1,9 @@
+# Configure conda
+source $HOME/miniconda/bin/activate root
+conda update -y conda
+conda config --append channels conda-forge
+conda create -n testenv --yes python=$PYTHON
+conda activate testenv
+# Install package with conda
+conda install -y $DEPS $TEST_DEPS
+conda info

--- a/ci/travis_install_with_pip.sh
+++ b/ci/travis_install_with_pip.sh
@@ -1,0 +1,3 @@
+# install packages with pip, use -U to get last version
+pip install -U $DEPS $TEST_DEPS
+pip list installed

--- a/ci/travis_setup_conda_linux.sh
+++ b/ci/travis_setup_conda_linux.sh
@@ -1,0 +1,4 @@
+# Setup conda
+wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh
+chmod +x miniconda.sh
+./miniconda.sh -b -p $HOME/miniconda

--- a/ci/travis_setup_conda_osx.sh
+++ b/ci/travis_setup_conda_osx.sh
@@ -1,0 +1,9 @@
+# Setup headless display
+sudo Xvfb :99 -ac -screen 0 1024x768x8
+sleep 3
+
+# Setup conda
+curl "https://repo.continuum.io/miniconda/Miniconda3-latest-MacOSX-x86_64.sh" -o miniconda.sh
+chmod +x miniconda.sh
+./miniconda.sh -b -p $HOME/miniconda
+

--- a/ci/travis_setup_conda_osx.sh
+++ b/ci/travis_setup_conda_osx.sh
@@ -1,9 +1,10 @@
 # Setup headless display
-sudo Xvfb :99 -ac -screen 0 1024x768x8
-sleep 3
+# https://github.com/travis-ci/travis-ci/issues/7313
+sudo Xvfb :99 -ac -screen 0 1024x768x8 &
+sleep 1 # give xvfb some time to start
 
 # Setup conda
-curl "https://repo.continuum.io/miniconda/Miniconda3-latest-MacOSX-x86_64.sh" -o miniconda.sh
+curl https://repo.continuum.io/miniconda/Miniconda3-latest-MacOSX-x86_64.sh -o miniconda.sh
 chmod +x miniconda.sh
 ./miniconda.sh -b -p $HOME/miniconda
 

--- a/hyperspy/_signals/eds.py
+++ b/hyperspy/_signals/eds.py
@@ -20,9 +20,7 @@ import logging
 
 import numpy as np
 import warnings
-import matplotlib
 from matplotlib import pyplot as plt
-from distutils.version import LooseVersion
 
 from hyperspy import utils
 from hyperspy.signal import BaseSignal
@@ -970,12 +968,9 @@ class EDS_mixin:
             keywords argument for markers.vertical_line
         """
         per_xray = len(position[0])
-        if LooseVersion(matplotlib.__version__) >= "1.5.3":
-            colors = itertools.cycle(np.sort(
+        colors = itertools.cycle(np.sort(
                 plt.rcParams['axes.prop_cycle'].by_key()["color"] * per_xray))
-        else:
-            colors = itertools.cycle(np.sort(
-                plt.rcParams['axes.color_cycle'] * per_xray))
+
         for x, color in zip(np.ravel(position), colors):
             line = markers.vertical_line(x=x, color=color, **kwargs)
             self.add_marker(line, render_figure=False)

--- a/hyperspy/component.py
+++ b/hyperspy/component.py
@@ -556,10 +556,18 @@ class Parameter(t.HasTraits):
         shape = self._axes_manager._navigation_shape_in_array
         if not shape:
             shape = [1, ]
-        dtype_ = np.dtype([
-            ('values', 'float', self._number_of_elements),
-            ('std', 'float', self._number_of_elements),
-            ('is_set', 'bool', 1)])
+        # Shape-1 fields in dtypes won’t be collapsed to scalars in a future
+        # numpy version (see release notes numpy 1.17.0)
+        if self._number_of_elements > 1:
+            dtype_ = np.dtype([
+                ('values', 'float', self._number_of_elements),
+                ('std', 'float', self._number_of_elements),
+                ('is_set', 'bool')])
+        else:
+            dtype_ = np.dtype([
+                ('values', 'float'),
+                ('std', 'float'),
+                ('is_set', 'bool')])
         if (self.map is None or self.map.shape != shape or
                 self.map.dtype != dtype_):
             self.map = np.zeros(shape, dtype_)

--- a/hyperspy/drawing/utils.py
+++ b/hyperspy/drawing/utils.py
@@ -26,7 +26,6 @@ from mpl_toolkits.axes_grid1 import make_axes_locatable
 from matplotlib.backend_bases import key_press_handler
 import warnings
 import numpy as np
-from distutils.version import LooseVersion
 import logging
 
 import hyperspy as hs
@@ -1151,18 +1150,6 @@ def make_cmap(colors, name='my_colormap', position=None,
         switch to control whether or not to register the custom colormap
         with matplotlib in order to enable use by just the name string
     """
-    def _html_color_to_rgb(color_string):
-        """ convert #RRGGBB to an (R, G, B) tuple """
-        color_string = color_string.strip()
-        if color_string[0] == '#':
-            color_string = color_string[1:]
-        if len(color_string) != 6:
-            raise ValueError(
-                "input #{} is not in #RRGGBB format".format(color_string))
-        r, g, b = color_string[:2], color_string[2:4], color_string[4:]
-        r, g, b = [int(n, 16) / 255 for n in (r, g, b)]
-        return r, g, b
-
     bit_rgb = np.linspace(0, 1, 256)
 
     if position is None:
@@ -1177,8 +1164,7 @@ def make_cmap(colors, name='my_colormap', position=None,
 
     for pos, color in zip(position, colors):
         if isinstance(color, str):
-            color = _html_color_to_rgb(color)
-
+            color = mpl.colors.to_rgb(color)
         elif bit:
             color = (bit_rgb[color[0]],
                      bit_rgb[color[1]],
@@ -1306,11 +1292,8 @@ def plot_spectra(
             raise ValueError("Color must be None, a valid matplotlib color "
                              "string or a list of valid matplotlib colors.")
     else:
-        if LooseVersion(mpl.__version__) >= "1.5.3":
-            color = itertools.cycle(
+        color = itertools.cycle(
                 plt.rcParams['axes.prop_cycle'].by_key()["color"])
-        else:
-            color = itertools.cycle(plt.rcParams['axes.color_cycle'])
 
     if line_style is not None:
         if isinstance(line_style, str):

--- a/hyperspy/signal.py
+++ b/hyperspy/signal.py
@@ -31,7 +31,6 @@ import dask.array as da
 from matplotlib import pyplot as plt
 import traits.api as t
 import numbers
-from prettytable import PrettyTable
 
 from hyperspy.axes import AxesManager
 from hyperspy import io
@@ -51,7 +50,7 @@ from hyperspy.external.astroML.histtools import histogram
 from hyperspy.drawing.utils import animate_legend
 from hyperspy.drawing.marker import markers_metadata_dict_to_markers
 from hyperspy.misc.slicing import SpecialSlicers, FancySlicing
-from hyperspy.misc.utils import slugify, print_html
+from hyperspy.misc.utils import slugify
 from hyperspy.docstrings.signal import (
     ONE_AXIS_PARAMETER, MANY_AXIS_PARAMETER, OUT_ARG, NAN_FUNC, OPTIMIZE_ARG,
     RECHUNK_ARG, SHOW_PROGRESSBAR_ARG, PARALLEL_ARG)
@@ -62,9 +61,8 @@ from hyperspy.interactive import interactive
 from hyperspy.misc.signal_tools import (are_signals_aligned,
                                         broadcast_signals)
 from hyperspy.misc.math_tools import outer_nd, hann_window_nth_order
-
 from hyperspy.exceptions import VisibleDeprecationWarning
-from hyperspy.ui_registry import ALL_EXTENSIONS
+
 
 _logger = logging.getLogger(__name__)
 
@@ -1986,6 +1984,8 @@ class BaseSignal(FancySlicing,
             axes_manager = self.axes_manager
         value = np.atleast_1d(self.data.__getitem__(
             axes_manager._getitem_tuple))
+        if isinstance(value, da.Array):
+            value = np.asarray(value)
         if fft_shift:
             value = np.fft.fftshift(value)
         return value

--- a/hyperspy/signal.py
+++ b/hyperspy/signal.py
@@ -4075,7 +4075,7 @@ class BaseSignal(FancySlicing,
         sig_shape = None
         if not ragged:
             sig_shape = () if shapes[0] == (1,) else shapes[0]
-            res_data = np.stack(res_data.flat).reshape(
+            res_data = np.stack(res_data.ravel()).reshape(
                 self.axes_manager._navigation_shape_in_array + sig_shape)
         res = map_result_construction(self, inplace, res_data, ragged,
                                       sig_shape)

--- a/hyperspy/tests/misc/test_fei_stream_readers.py
+++ b/hyperspy/tests/misc/test_fei_stream_readers.py
@@ -19,9 +19,9 @@ def test_dense_stream(lazy):
     arr = np.random.randint(0, 65535, size=(2, 3, 4, 5)).astype("uint16")
     stream = array_to_stream(arr)
     if lazy:
-        arrs = da.from_array(stream_to_sparse_COO_array(
+        arrs = stream_to_sparse_COO_array(
             stream, spatial_shape=(3, 4), sum_frames=False, channels=5,
-            last_frame=2), chunks=(1, 1, 2, 5))
+            last_frame=2)
         arrs = arrs.compute()
         assert (arrs == arr).all()
     else:
@@ -36,9 +36,9 @@ def test_empty_stream(lazy):
     arr = np.zeros((2, 3, 4, 5), dtype="uint16")
     stream = array_to_stream(arr)
     if lazy:
-        arrs = da.from_array(stream_to_sparse_COO_array(
+        arrs = stream_to_sparse_COO_array(
             stream, spatial_shape=(3, 4), sum_frames=False, channels=5,
-            last_frame=2), chunks=(1, 1, 2, 5))
+            last_frame=2)
         arrs = arrs.compute()
         assert not arrs.any()
     else:
@@ -56,9 +56,9 @@ def test_sparse_stream(lazy):
     arr[1, 1, 3, 3] = 3
     stream = array_to_stream(arr)
     if lazy:
-        arrs = da.from_array(stream_to_sparse_COO_array(
+        arrs = stream_to_sparse_COO_array(
             stream, spatial_shape=(3, 4), sum_frames=False, channels=5,
-            last_frame=2), chunks=(1, 1, 2, 5))
+            last_frame=2)
         arrs = arrs.compute()
         assert (arrs == arr).all()
     else:

--- a/hyperspy/tests/signal/test_1D_tools.py
+++ b/hyperspy/tests/signal/test_1D_tools.py
@@ -20,6 +20,7 @@ from unittest import mock
 import numpy as np
 from scipy.signal import savgol_filter
 import pytest
+import dask.array as da
 
 from hyperspy.misc.tv_denoise import _tv_denoise_1d
 from hyperspy.decorators import lazifyTestClass
@@ -210,6 +211,8 @@ class TestInterpolateInBetween:
         s = self.s.inav[0]
         s.change_dtype('float')
         tmp = np.zeros_like(s.data)
+        if isinstance(tmp, da.Array):
+            tmp = np.asarray(np.zeros_like(s.data))
         tmp[12] = s.data[12]
         s.data += tmp * 9.
         s.interpolate_in_between(8, 12, delta=2, kind='cubic')
@@ -221,6 +224,8 @@ class TestInterpolateInBetween:
         s = self.s.inav[0]
         s.change_dtype('float')
         tmp = np.zeros_like(s.data)
+        if isinstance(tmp, da.Array):
+            tmp = np.asarray(np.zeros_like(s.data))
         tmp[12] = s.data[12]
         s.data += tmp * 9.
         s.interpolate_in_between(8, 12, delta=0.31, kind='cubic')

--- a/hyperspy/ui_registry.py
+++ b/hyperspy/ui_registry.py
@@ -11,8 +11,6 @@ widgets externally (usually for testing or customisation purposes).
 
 '''
 
-import functools
-import types
 import importlib
 
 from hyperspy.misc.utils import isiterable


### PR DESCRIPTION
### Description of the change
This mainly fixes issue with last numpy and dask release. Following the activation of the `__array_function__` protocol (NEP18) in numpy 1.17, numpy function can return any type of array, typically if a dask array is provided to a numpy function, a dask array will be returned. Previously, a numpy array was returned. This breaks the `map` function and the `__call__`, and therefore quite a lot of things!

A temporary workaround to the numpy issue can be:
- install numpy <1.17

or

- set the environment variable NUMPY_EXPERIMENTAL_ARRAY_FUNCTION=0 to disable the `__array_function__` protocol

https://numpy.org/neps/nep-0018-array-function-protocol.html#implementation
http://blog.christianperone.com/2019/07/numpy-dispatcher-when-numpy-becomes-a-protocol-for-an-ecosystem/
https://docs.scipy.org/doc/numpy/release.html#changes

### Progress of the PR
A few sentences and/or a bulleted list to describe and motivate the change:
- [x] Fix a velox stream test with dask 2.3.0,
- [x] Fix travis (update to ubuntu xenial),
- [x] add virtualenv environment on travis to test pip installation: this should help to notice releases of upstream libraries breaking hyperspy faster than relying on conda packages,
- [x] reorganise travis configuration file,
- [x] fix issues related to the activation of the `__array_function` protocol in numpy 1.17,
- [x] add support for the matplotlib "classic" style in `hs.plot.plot_images` (test was failing when pytest was run without the `--mpl` option),
- [x] fix future warning introduce in numpy 1.17,
- [x] add tests (numpy 1.17 is tested in the virtualenv environment),
- [x] ready for review.



