### PR TITLE
Fix real time bcf for large spectrum image on windows

### DIFF
--- a/hyperspy/io_plugins/bruker.py
+++ b/hyperspy/io_plugins/bruker.py
@@ -821,7 +821,7 @@ class HyperHeader(object):
         """calculate and return real time for whole hypermap
         in seconds
         """
-        line_cnt_sum = np.sum(self.line_counter).astype(np.float64)
+        line_cnt_sum = np.sum(self.line_counter, dtype=np.float64)
         line_avg = self.dsp_metadata['LineAverage']
         pix_avg = self.dsp_metadata['PixelAverage']
         pix_time = self.dsp_metadata['PixelTime']

--- a/hyperspy/io_plugins/bruker.py
+++ b/hyperspy/io_plugins/bruker.py
@@ -821,12 +821,12 @@ class HyperHeader(object):
         """calculate and return real time for whole hypermap
         in seconds
         """
-        line_cnt_sum = np.sum(self.line_counter)
+        line_cnt_sum = np.sum(self.line_counter).astype(np.float64)
         line_avg = self.dsp_metadata['LineAverage']
         pix_avg = self.dsp_metadata['PixelAverage']
         pix_time = self.dsp_metadata['PixelTime']
         width = self.image.width
-        real_time = line_cnt_sum * line_avg * pix_avg * pix_time * width / 1000000.0
+        real_time = line_cnt_sum * line_avg * pix_avg * pix_time * width * 1E-6
         return float(real_time)
 
     def gen_hspy_item_dict_basic(self):


### PR DESCRIPTION
Fix the second part of #2244: with the numpy overflow warning. I could reproduce the issue on windows using the file provided by @jeinsle (https://www.dropbox.com/s/bqi8l4idppg45cl/E17_017.bcf?dl=0). The issue occurs on windows but not linux system.

### Progress of the PR
- [x] change dtype to float64,
- [x] ready for review.

