### PR TITLE
Interactive crop_image

### DIFF
--- a/hyperspy/_signals/signal2d.py
+++ b/hyperspy/_signals/signal2d.py
@@ -28,6 +28,8 @@ from skimage.feature.register_translation import _upsampled_dft
 from hyperspy.defaults_parser import preferences
 from hyperspy.external.progressbar import progressbar
 from hyperspy.misc.math_tools import symmetrize, antisymmetrize
+from hyperspy.misc.signal_tools import _get_crop_range
+from hyperspy.roi import RectangularROI
 from hyperspy.signal import BaseSignal
 from hyperspy._signals.lazy import LazySignal
 from hyperspy._signals.common_signal2d import CommonSignal2D
@@ -703,7 +705,7 @@ class Signal2D(BaseSignal, CommonSignal2D):
         See also:
         ---------
         crop
-
+        crop_image_interactive
         """
         self._check_signal_dimension_equals_two()
         self.crop(self.axes_manager.signal_axes[1].index_in_axes_manager,
@@ -714,6 +716,36 @@ class Signal2D(BaseSignal, CommonSignal2D):
                   right)
         if convert_units:
             self.axes_manager.convert_units('signal')
+
+    def crop_image_interactive(self, color='green', coords=None):
+        '''Crops image interactively, returning a new signal.
+        If a plot does not already exist, one is created.
+
+        Parameters
+        ----------
+        color : str
+            Color of the 
+        coords : None or tuple of (bottom, top, left, right)
+            Default is None
+            If supplied, sets the starting placement of the rectangle in
+            calibrated signal units
+
+        See also:
+        ---------
+        crop
+        crop_image
+        '''
+        if not self._plot:
+            self.plot()
+        if coords:
+            crop_x_low, crop_x_high, crop_y_low, crop_y_high = coords
+        else:
+            crop_x_low, crop_x_high = _get_crop_range(self, 0)
+            crop_y_low, crop_y_high = _get_crop_range(self, 1)
+
+        rect = RectangularROI(crop_x_low, crop_y_low, crop_x_high, crop_y_high)    
+        crop = rect.interactive(self, color=color)
+        return crop
 
     def add_ramp(self, ramp_x, ramp_y, offset=0):
         """Add a linear ramp to the signal.

--- a/hyperspy/misc/signal_tools.py
+++ b/hyperspy/misc/signal_tools.py
@@ -28,20 +28,29 @@ def _get_shapes(am, ignore_axis):
             ignore_axis = am[ignore_axis]
         except ValueError:
             pass
-    sigsh = tuple(axis.size if (ignore_axis is None or axis is not
-                                ignore_axis)
-                  else 1 for axis in am.signal_axes) if am.signal_dimension != 0 else ()
+    sigsh = (
+        tuple(
+            axis.size if (ignore_axis is None or axis is not ignore_axis) else 1
+            for axis in am.signal_axes
+        )
+        if am.signal_dimension != 0
+        else ()
+    )
 
-    navsh = tuple(axis.size if (ignore_axis is None or axis is not
-                                ignore_axis)
-                  else 1 for axis in am.navigation_axes) if am.navigation_dimension != 0 else ()
+    navsh = (
+        tuple(
+            axis.size if (ignore_axis is None or axis is not ignore_axis) else 1
+            for axis in am.navigation_axes
+        )
+        if am.navigation_dimension != 0
+        else ()
+    )
     return sigsh, navsh
 
 
 def are_signals_aligned(*args, ignore_axis=None):
     if len(args) < 2:
-        raise ValueError(
-            "This function requires at least two signal instances")
+        raise ValueError("This function requires at least two signal instances")
     args = list(args)
     am = args.pop().axes_manager
 
@@ -50,8 +59,10 @@ def are_signals_aligned(*args, ignore_axis=None):
         amo = args.pop().axes_manager
         sigsho, navsho = _get_shapes(amo, ignore_axis)
 
-        if not (are_aligned(sigsh[::-1], sigsho[::-1]) and
-                are_aligned(navsh[::-1], navsho[::-1])):
+        if not (
+            are_aligned(sigsh[::-1], sigsho[::-1])
+            and are_aligned(navsh[::-1], navsho[::-1])
+        ):
             return False
     return True
 
@@ -74,8 +85,7 @@ def broadcast_signals(*args, ignore_axis=None):
     list of signals
     """
     if len(args) < 2:
-        raise ValueError(
-            "This function requires at least two signal instances")
+        raise ValueError("This function requires at least two signal instances")
     args = list(args)
     if not are_signals_aligned(*args, ignore_axis=ignore_axis):
         raise ValueError("The signals cannot be broadcasted")
@@ -89,26 +99,30 @@ def broadcast_signals(*args, ignore_axis=None):
                     pass
         new_nav_axes = []
         new_nav_shapes = []
-        for axes in zip_longest(*[s.axes_manager.navigation_axes
-                                  for s in args], fillvalue=None):
+        for axes in zip_longest(
+            *[s.axes_manager.navigation_axes for s in args], fillvalue=None
+        ):
             only_left = filter(lambda x: x is not None, axes)
             longest = sorted(only_left, key=lambda x: x.size, reverse=True)[0]
             new_nav_axes.append(longest)
-            new_nav_shapes.append(longest.size if (ignore_axis is None or
-                                                   ignore_axis not in
-                                                   axes)
-                                  else None)
+            new_nav_shapes.append(
+                longest.size
+                if (ignore_axis is None or ignore_axis not in axes)
+                else None
+            )
         new_sig_axes = []
         new_sig_shapes = []
-        for axes in zip_longest(*[s.axes_manager.signal_axes
-                                  for s in args], fillvalue=None):
+        for axes in zip_longest(
+            *[s.axes_manager.signal_axes for s in args], fillvalue=None
+        ):
             only_left = filter(lambda x: x is not None, axes)
             longest = sorted(only_left, key=lambda x: x.size, reverse=True)[0]
             new_sig_axes.append(longest)
-            new_sig_shapes.append(longest.size if (ignore_axis is None or
-                                                   ignore_axis not in
-                                                   axes)
-                                  else None)
+            new_sig_shapes.append(
+                longest.size
+                if (ignore_axis is None or ignore_axis not in axes)
+                else None
+            )
 
         results = []
         new_axes = new_nav_axes[::-1] + new_sig_axes[::-1]
@@ -139,3 +153,19 @@ def broadcast_signals(*args, ignore_axis=None):
             ns.get_dimensions_from_data()
             results.append(ns.transpose(signal_axes=len(new_sig_axes)))
         return results
+
+
+def _get_crop_range(s, axis=0, n=4):
+    """Returns (low, high) axes coordinates 1/n distance from the 
+    minimum and maximum of axis range. n=4 gives points a quarter
+    distance from the minimum and maximum values
+    """
+    sigax = s.axes_manager.signal_axes
+
+    high, low = sigax[axis].high_value, sigax[axis].low_value
+    dist = high - low
+
+    crop_high = high - dist / n
+    crop_low = low + dist / n
+    return crop_low, crop_high
+


### PR DESCRIPTION
### Description of the change
I've written a method for interactive cropping that plots a signal (unless it already is plotted), and then displays a rectangle centered a quarter of the way into the image. I find it rather cumbersome if I just want to get a slightly smaller image to have to plot it, and then read off the coordinates number by number and then crop using `s.isig` or `s.crop_image`.
![image](https://user-images.githubusercontent.com/2721423/65246920-bfb72300-daef-11e9-9822-a0046452d76e.png)

We already have two methods that are related:
`s.crop()` and `s.crop_image`. I don't really see why we have these, since .isig and.inav do the same thing in a general manner, unless their intention is to save memory in some manner.

### Progress of the PR
- [x] Change implemented
- [x] update docstring
- [ ] update user guide
- [ ] add tests,
- [ ] ready for review.

### Minimal example of the bug fix or the new feature
```python
#%matplotlib notebook | widget | qt # your favourite backend here
import hyperspy.api as hs
s = hs.datasets.example_signals.object_hologram()
s.crop_image_interactive()
```

