### PR TITLE
Add lorentzian remove background

### DIFF
--- a/hyperspy/_signals/signal1d.py
+++ b/hyperspy/_signals/signal1d.py
@@ -1086,7 +1086,8 @@ class Signal1D(BaseSignal, CommonSignal1D):
             If tuple is given, the a spectrum will be returned.
         background_type : str
             The type of component which should be used to fit the background.
-            Possible components: PowerLaw, Gaussian, Offset, Polynomial
+            Possible components: PowerLaw, Gaussian, Offset, Polynomial, 
+            Lorentzian.
             If Polynomial is used, the polynomial order can be specified
         polynomial_order : int, default 2
             Specify the polynomial order if a Polynomial background is used.
@@ -1151,6 +1152,8 @@ class Signal1D(BaseSignal, CommonSignal1D):
                 with ignore_warning(message="The API of the `Polynomial` component"):
                     background_estimator = components1d.Polynomial(
                         polynomial_order, legacy=False)
+            elif background_type == 'Lorentzian':
+                background_estimator = components1d.Lorentzian()
             else:
                 raise ValueError(
                     "Background type: " +

--- a/hyperspy/signal_tools.py
+++ b/hyperspy/signal_tools.py
@@ -942,6 +942,7 @@ class BackgroundRemoval(SpanSelectorInSignal1D):
         'Gaussian',
         'Offset',
         'Polynomial',
+        'Lorentzian',
         default='Power Law')
     polynomial_order = t.Range(1, 10)
     fast = t.Bool(True,
@@ -1000,6 +1001,9 @@ class BackgroundRemoval(SpanSelectorInSignal1D):
             with ignore_warning(message="The API of the `Polynomial` component"):
                 self.background_estimator = components1d.Polynomial(
                     self.polynomial_order)
+            self.bg_line_range = 'full'
+        elif self.background_type == 'Lorentzian':
+            self.background_estimator = components1d.Lorentzian()
             self.bg_line_range = 'full'
 
     def _polynomial_order_changed(self, old, new):

--- a/hyperspy/tests/signal/test_remove_background.py
+++ b/hyperspy/tests/signal/test_remove_background.py
@@ -112,6 +112,35 @@ class TestRemoveBackground1DPowerLaw:
         assert np.allclose(s1.data[:10], np.zeros(10))
 
 
+@lazifyTestClass
+class TestRemoveBackground1DLorentzian:
+
+    def setup_method(self, method):
+        lorentzian = components1d.Lorentzian()
+        lorentzian.A.value = 10
+        lorentzian.centre.value = 10
+        lorentzian.gamma.value = 1
+        self.signal = signals.Signal1D(
+            lorentzian.function(np.arange(0, 20, 0.01)))
+        self.signal.axes_manager[0].scale = 0.01
+        self.signal.metadata.Signal.binned = False
+
+    def test_background_remove_lorentzian(self):
+        # Fast is not accurate
+        s1 = self.signal.remove_background(
+            signal_range=(None, None),
+            background_type='Lorentzian',
+            show_progressbar=None)
+        assert np.allclose(np.zeros(len(s1.data)), s1.data, atol=0.2)
+
+    def test_background_remove_lorentzian_full_fit(self):
+        s1 = self.signal.remove_background(
+            signal_range=(None, None),
+            background_type='Lorentzian',
+            fast=False)
+        assert np.allclose(s1.data, np.zeros(len(s1.data)))
+
+
 def compare_axes_manager_metadata(s0, s1):
     assert s0.data.shape == s1.data.shape
     assert s0.axes_manager.shape == s1.axes_manager.shape


### PR DESCRIPTION
Continuation of #2185.

### Progress of the PR
- [x] Fix lazy `estimate_parameters` of the `Lorentzian` component,
- [x] add `Lorentzian` component to `remove_background`,
- [x] update docstring (if appropriate),
- [x] add tests,
- [x] ready for review.

### Minimal example of the bug fix or the new feature
```python
import hyperspy.api as hs
import numpy as np

lorentzian = hs.model.components1D.Lorentzian()
lorentzian.A.value = 10
lorentzian.centre.value = 10
lorentzian.gamma.value = 1
s = hs.signals.Signal1D(lorentzian.function(np.arange(0, 20, 0.01)))
s.axes_manager[0].scale = 0.01
s1 = s.remove_background(signal_range=(None, None),
                         background_type='Lorentzian',
                         show_progressbar=None,
                         fast=False)

```

