### PR TITLE
Skew normal estimate parameters

### DIFF
--- a/doc/user_guide/signal1d.rst
+++ b/doc/user_guide/signal1d.rst
@@ -44,7 +44,6 @@ It is possible to crop interactively using :ref:`roi-label`. For example:
 
    Interactive spectrum cropping using a ROI.
 
-
 .. _signal1D.remove_background:
 
 Background removal
@@ -56,11 +55,12 @@ Background removal
 
 The :py:meth:`~._signals.signal1d.Signal1D.remove_background` method provides
 background removal capabilities through both a CLI and a GUI. The GUI displays
-an interactive preview of the remainder after background subtraction. Current
-background type supported are power law, offset, polynomial and gaussian.
-By default the background parameters are estimated using analytical approximations
-(keyword argument ``fast=True``). For better accuracy, but higher processing
-time, the parameters can be estimated by curve fitting by setting ``fast=False``.
+an interactive preview of the remainder after background subtraction. Currently,
+the following background types are supported: power law, offset, polynomial, 
+Gaussian, Lorentzian and skew normal. By default, the background parameters are
+estimated using analytical approximations (keyword argument ``fast=True``). For 
+better accuracy, but higher processing time, the parameters can be estimated 
+using curve fitting by setting ``fast=False``.
 
 Example of usage:
 
@@ -105,7 +105,6 @@ Integration
     is required.
 
 
-
 Data smoothing
 --------------
 
@@ -121,15 +120,14 @@ Spike removal
 --------------
 
 :py:meth:`~._signals.signal1d.Signal1D.spikes_removal_tool` provides an user
-interface to remove spikes from spectra.
-
+interface to remove spikes from spectra. The ``derivative histogram`` allows to
+identify the appropriate threshold.
 
 .. figure::  images/spikes_removal_tool.png
    :align:   center
    :width:   500
 
    Spikes removal tool.
-
 
 Peak finding
 ------------

--- a/hyperspy/_components/skew_normal.py
+++ b/hyperspy/_components/skew_normal.py
@@ -50,14 +50,12 @@ def _estimate_skewnormal_parameters(signal, x1, x2, only_current):
         _sqrt = da.sqrt
         _abs = abs
         _argmin = da.argmin
-        _take = da.take
 
     else:
         _sum = np.sum
         _sqrt = np.sqrt
         _abs = np.abs
         _argmin = np.argmin
-        _take = np.take
 
     a1 = np.sqrt(2 / np.pi)
     b1 = (4 / np.pi - 1) * a1
@@ -76,7 +74,12 @@ def _estimate_skewnormal_parameters(signal, x1, x2, only_current):
     if isinstance(data, da.Array):
         x0, iheight, scale, shape = da.compute(x0, iheight, scale, shape)
     # Take does not do the job. Get the right indexing mechanism
-    height = _take(data,iheight,i)
+    if only_current is True or signal.axes_manager.navigation_dimension == 0:
+        height = data[iheight]
+    elif signal.axes_manager.navigation_dimension == 1:
+        height = data.__getitem__((np.arange(signal.axes_manager.navigation_size), iheight))
+    else:
+        height = data.__getitem__((*np.indices(signal.axes_manager.navigation_shape), iheight))
 
     return x0, height, scale, shape
 

--- a/hyperspy/_components/skew_normal.py
+++ b/hyperspy/_components/skew_normal.py
@@ -61,9 +61,9 @@ def _estimate_skewnormal_parameters(signal, x1, x2, only_current):
     b1 = (4 / np.pi - 1) * a1
     m1 = _sum(X.reshape(X_shape) * data, i) / _sum(data, i)
     m2 = _abs(_sum((X.reshape(X_shape) - m1.reshape(x0_shape)) ** 2 * data, i)
-         / _sum(data, i))
+              / _sum(data, i))
     m3 = _abs(_sum((X.reshape(X_shape) - m1.reshape(x0_shape)) ** 3 * data, i)
-         / _sum(data, i))
+              / _sum(data, i))
 
     x0 = m1 - a1 * (m3 / b1) ** (1 / 3)
     scale = _sqrt(m2 + a1 ** 2 * (m3 / b1) ** (2 / 3))
@@ -71,27 +71,27 @@ def _estimate_skewnormal_parameters(signal, x1, x2, only_current):
     shape = delta / _sqrt(1 - delta**2)
 
     iheight = _argmin(_abs(X.reshape(X_shape) - x0.reshape(x0_shape)), i)
-    # height is the value of the function at x0, shich has to be computed 
+    # height is the value of the function at x0, shich has to be computed
     # differently for dask array (lazy) and depending on the dimension
     if isinstance(data, da.Array):
         x0, iheight, scale, shape = da.compute(x0, iheight, scale, shape)
         if only_current is True or signal.axes_manager.navigation_dimension == 0:
             height = data.vindex[iheight].compute()
         elif signal.axes_manager.navigation_dimension == 1:
-            height = data.vindex[np.arange(signal.axes_manager.navigation_size), 
-                          iheight].compute()
+            height = data.vindex[np.arange(signal.axes_manager.navigation_size),
+                                 iheight].compute()
         else:
-            height = data.vindex[(*np.indices(signal.axes_manager.navigation_shape), 
-                          iheight)].compute()
-    else: 
+            height = data.vindex[(*np.indices(signal.axes_manager.navigation_shape),
+                                  iheight)].compute()
+    else:
         if only_current is True or signal.axes_manager.navigation_dimension == 0:
             height = data[iheight]
         elif signal.axes_manager.navigation_dimension == 1:
-            height = data[np.arange(signal.axes_manager.navigation_size), 
+            height = data[np.arange(signal.axes_manager.navigation_size),
                           iheight]
         else:
-            height = data[(*np.indices(signal.axes_manager.navigation_shape), 
-                          iheight)]
+            height = data[(*np.indices(signal.axes_manager.navigation_shape),
+                           iheight)]
 
     return x0, height, scale, shape
 
@@ -173,7 +173,6 @@ class SkewNormal(Expression):
         self.isbackground = False
         self.convolved = True
 
-
     def estimate_parameters(self, signal, x1, x2, only_current=False):
         """Estimate the skew normal distribution by calculating the momenta.
 
@@ -214,8 +213,8 @@ class SkewNormal(Expression):
 
         super(SkewNormal, self)._estimate_parameters(signal)
         axis = signal.axes_manager.signal_axes[0]
-        x0, height, scale, shape = _estimate_skewnormal_parameters(signal, x1, 
-                                                             x2, only_current)
+        x0, height, scale, shape = _estimate_skewnormal_parameters(signal, x1,
+                                                                   x2, only_current)
         if only_current is True:
             self.x0.value = x0
             self.A.value = height * sqrt2pi
@@ -254,8 +253,8 @@ class SkewNormal(Expression):
     @property
     def skewness(self):
         delta = self.shape.value / np.sqrt(1 + self.shape.value**2)
-        return (4 - np.pi)/2 * (delta * np.sqrt(2/np.pi))**3 / (1 - \
-            2 * delta**2 / np.pi)**(3/2)
+        return (4 - np.pi)/2 * (delta * np.sqrt(2/np.pi))**3 / (1 -
+                                                                2 * delta**2 / np.pi)**(3/2)
 
     @property
     def mode(self):

--- a/hyperspy/_components/skew_normal.py
+++ b/hyperspy/_components/skew_normal.py
@@ -73,13 +73,13 @@ def _estimate_skewnormal_parameters(signal, x1, x2, only_current):
     iheight = _argmin(_abs(X.reshape(X_shape) - x0.reshape(x0_shape)), i)
     if isinstance(data, da.Array):
         x0, iheight, scale, shape = da.compute(x0, iheight, scale, shape)
-    # Take does not do the job. Get the right indexing mechanism
+    # Dask array still as a problem with this fancy indexing!
     if only_current is True or signal.axes_manager.navigation_dimension == 0:
         height = data[iheight]
     elif signal.axes_manager.navigation_dimension == 1:
-        height = data.__getitem__((np.arange(signal.axes_manager.navigation_size), iheight))
+        height = data[np.arange(signal.axes_manager.navigation_size), iheight]
     else:
-        height = data.__getitem__((*np.indices(signal.axes_manager.navigation_shape), iheight))
+        height = data[(*np.indices(signal.axes_manager.navigation_shape), iheight)]
 
     return x0, height, scale, shape
 

--- a/hyperspy/_signals/signal1d.py
+++ b/hyperspy/_signals/signal1d.py
@@ -1087,7 +1087,7 @@ class Signal1D(BaseSignal, CommonSignal1D):
         background_type : str
             The type of component which should be used to fit the background.
             Possible components: PowerLaw, Gaussian, Offset, Polynomial, 
-            Lorentzian.
+            Lorentzian, SkewNormal.
             If Polynomial is used, the polynomial order can be specified
         polynomial_order : int, default 2
             Specify the polynomial order if a Polynomial background is used.
@@ -1154,6 +1154,8 @@ class Signal1D(BaseSignal, CommonSignal1D):
                         polynomial_order, legacy=False)
             elif background_type == 'Lorentzian':
                 background_estimator = components1d.Lorentzian()
+            elif background_type in ('SkewNormal', 'Skew Normal'):
+                background_estimator = components1d.SkewNormal()
             else:
                 raise ValueError(
                     "Background type: " +

--- a/hyperspy/signal_tools.py
+++ b/hyperspy/signal_tools.py
@@ -943,6 +943,7 @@ class BackgroundRemoval(SpanSelectorInSignal1D):
         'Offset',
         'Polynomial',
         'Lorentzian',
+        'SkewNormal',
         default='Power Law')
     polynomial_order = t.Range(1, 10)
     fast = t.Bool(True,
@@ -1004,6 +1005,9 @@ class BackgroundRemoval(SpanSelectorInSignal1D):
             self.bg_line_range = 'full'
         elif self.background_type == 'Lorentzian':
             self.background_estimator = components1d.Lorentzian()
+            self.bg_line_range = 'full'
+        elif self.background_type == 'SkewNormal':
+            self.background_estimator = components1d.SkewNormal()
             self.bg_line_range = 'full'
 
     def _polynomial_order_changed(self, old, new):

--- a/hyperspy/tests/component/test_skewnormal.py
+++ b/hyperspy/tests/component/test_skewnormal.py
@@ -17,6 +17,7 @@
 # along with  HyperSpy.  If not, see <http://www.gnu.org/licenses/>.
 
 
+import itertools
 import numpy as np
 from numpy.testing import assert_allclose
 import pytest
@@ -25,7 +26,9 @@ import sympy
 
 from hyperspy.components1d import SkewNormal
 from hyperspy.signals import Signal1D
+from hyperspy.utils import stack
 
+TRUE_FALSE_2_TUPLE = [p for p in itertools.product((True, False), repeat=2)]
 
 pytestmark = pytest.mark.skipif(LooseVersion(sympy.__version__) <
                                 LooseVersion("1.3"),
@@ -47,29 +50,47 @@ def test_function():
     assert_allclose(g.function(0), 6.28e-3, rtol=1e-3)
     assert_allclose(g.function(g.mean), 2.855, rtol=1e-3)
 
-
-def test_fit(A=1, x0=0, shape=1, scale=1, noise=0.01):
-    """
-    Creates a simulated noisy skew normal distribution based on the input
-    parameters and fits a skew normal component to this data.
-    """
-    # create skew normal signal and add noise
-    g = SkewNormal(A=A, x0=x0, scale=scale, shape=shape)
-    x = np.arange(x0 - scale * 3, x0 + scale * 3, step=0.01 * scale)
-    s = Signal1D(g.function(x))
-    s.axes_manager.signal_axes[0].axis = x
-    s.add_gaussian_noise(std=noise * A)
-    # fit skew normal component to signal
+@pytest.mark.parametrize(("lazy"), (True, False))
+@pytest.mark.parametrize(("only_current", "binned"), TRUE_FALSE_2_TUPLE)
+def test_estimate_parameters_binned(only_current, binned, lazy):
+    s = Signal1D(np.empty((300,)))
+    s.metadata.Signal.binned = binned
+    axis = s.axes_manager.signal_axes[0]
+    axis.scale = 0.2
+    axis.offset = -10
+    g1 = SkewNormal(A=2, x0=2, scale=10, shape=5)
+    s.data = g1.function(axis.axis)
+    if lazy:
+        s = s.as_lazy()
     g2 = SkewNormal()
-    m = s.create_model()
-    m.append(g2)
-    g2.x0.bmin = x0 - scale * 3  # prevent parameters to run away
-    g2.x0.bmax = x0 + scale * 3
-    g2.x0.bounded = True
-    m.fit(bounded=True)
-    m.print_current_values()  # print out parameter values
-    m.plot()  # plot fit
-    return m
+    factor = axis.scale if binned else 1
+    assert g2.estimate_parameters(s, axis.low_value, axis.high_value,
+                                  only_current=only_current)
+    assert g2.binned == binned
+    assert_allclose(g1.A.value, g2.A.value * factor)
+    assert abs(g2.x0.value - g1.x0.value) <= 0.002
+    assert abs(g2.shape.value - g1.shape.value) <= 0.01
+    assert abs(g2.scale.value - g1.scale.value) <= 0.01
+
+
+@pytest.mark.parametrize(("lazy"), (True, False))
+@pytest.mark.parametrize(("binned"), (True, False))
+def test_function_nd(binned, lazy):
+    s = Signal1D(np.empty((300,)))
+    axis = s.axes_manager.signal_axes[0]
+    axis.scale = 0.2
+    axis.offset = -10
+    g1 = SkewNormal(A=2, x0=2, scale=10, shape=5)
+    s.data = g1.function(axis.axis)
+    s.metadata.Signal.binned = binned
+    s2 = stack([s] * 2)
+    if lazy:
+        s2 = s2.as_lazy()
+    g2 = SkewNormal()
+    factor = axis.scale if binned else 1
+    assert g2.estimate_parameters(s2, axis.low_value, axis.high_value, False)
+    assert g2.binned == binned
+    assert_allclose(g2.function_nd(axis.axis) * factor, s2.data,0.06)
 
 
 def test_util_mean_get():

--- a/hyperspy/tests/component/test_skewnormal.py
+++ b/hyperspy/tests/component/test_skewnormal.py
@@ -50,6 +50,7 @@ def test_function():
     assert_allclose(g.function(0), 6.28e-3, rtol=1e-3)
     assert_allclose(g.function(g.mean), 2.855, rtol=1e-3)
 
+
 @pytest.mark.parametrize(("lazy"), (True, False))
 @pytest.mark.parametrize(("only_current", "binned"), TRUE_FALSE_2_TUPLE)
 def test_estimate_parameters_binned(only_current, binned, lazy):
@@ -90,7 +91,7 @@ def test_function_nd(binned, lazy):
     factor = axis.scale if binned else 1
     assert g2.estimate_parameters(s2, axis.low_value, axis.high_value, False)
     assert g2.binned == binned
-    assert_allclose(g2.function_nd(axis.axis) * factor, s2.data,0.06)
+    assert_allclose(g2.function_nd(axis.axis) * factor, s2.data, 0.06)
 
 
 def test_util_mean_get():

--- a/hyperspy/tests/signal/test_remove_background.py
+++ b/hyperspy/tests/signal/test_remove_background.py
@@ -188,7 +188,8 @@ def compare_axes_manager_metadata(s0, s1):
 @pytest.mark.parametrize('show_progressbar', [True, False])
 @pytest.mark.parametrize('plot_remainder', [True, False])
 @pytest.mark.parametrize('background_type',
-                         ['Power Law', 'Polynomial', 'Offset'])
+                         ['Power Law', 'Polynomial', 'Offset',
+                         'Gaussian', 'Lorentzian', 'SkewNormal'])
 def test_remove_background_metadata_axes_manager_copy(nav_dim,
                                                       fast,
                                                       zero_fill,

--- a/hyperspy/tests/signal/test_remove_background.py
+++ b/hyperspy/tests/signal/test_remove_background.py
@@ -140,6 +140,35 @@ class TestRemoveBackground1DLorentzian:
             fast=False)
         assert np.allclose(s1.data, np.zeros(len(s1.data)))
 
+@lazifyTestClass
+class TestRemoveBackground1DSkewNormal:
+
+    def setup_method(self, method):
+        lorentzian = components1d.SkewNormal()
+        lorentzian.A.value = 3
+        lorentzian.x0.value = 1
+        lorentzian.scale.value = 2
+        lorentzian.shape.value = 10
+        self.signal = signals.Signal1D(
+            lorentzian.function(np.arange(0, 10, 0.01)))
+        self.signal.axes_manager[0].scale = 0.01
+        self.signal.metadata.Signal.binned = False
+
+    def test_background_remove_skewnormal(self):
+        # Fast is not accurate
+        s1 = self.signal.remove_background(
+            signal_range=(None, None),
+            background_type='SkewNormal',
+            show_progressbar=None)
+        assert np.allclose(np.zeros(len(s1.data)), s1.data, atol=0.2)
+
+    def test_background_remove_lorentzian_full_fit(self):
+        s1 = self.signal.remove_background(
+            signal_range=(None, None),
+            background_type='SkewNormal',
+            fast=False)
+        assert np.allclose(s1.data, np.zeros(len(s1.data)))
+
 
 def compare_axes_manager_metadata(s0, s1):
     assert s0.data.shape == s1.data.shape


### PR DESCRIPTION
### Description of the change
Implemented parameter estimation for skew normal component based on the methods of moments. Added tests.

### Progress of the PR
- [X] Added parameter estimation,
- [X] Added tests,
- [x] Fix issue in determining `A` (height),
- [x] Make it work for lazy signal (dask array),
- [x] Add to background removal,
- [x] update user guide,
- [x] add further tests,
- [x] ready for review.

### Minimal example of the bug fix or the new feature
```python
>>> g = hs.model.components1D.SkewNormal()
>>> x = np.arange(-10, 10, 0.01)
>>> data = np.zeros((32, 32, 2000))
>>> data[:] = g.function(x).reshape((1, 1, 2000))
>>> s = hs.signals.Signal1D(data)
>>> s.axes_manager._axes[-1].offset = -10
>>> s.axes_manager._axes[-1].scale = 0.01
>>> g.estimate_parameters(s, -10, 10, False)
```
Note that this example can be useful to update the user guide.

