### PR TITLE
Housekeeping on EDS quantification [ignore]

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,18 @@ What's new
 Current Version
 ===============
 
+.. _changes_1.5.2:
+
+v1.5.2
+++++++
+
+This is a maintenance release that adds compatibility with Numpy 1.17 and Dask
+2.3.0 and fixes a bug in the Brucker reader. See
+ `the issue tracker
+<https://github.com/hyperspy/hyperspy/issues?q=label%3A"type%3A+bug"+is%3Aclosed+milestone%3Av1.5.2>`_
+for details.
+
+
 .. _changes_1.5.1:
 
 v1.5.1

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,7 +10,7 @@ v1.5.2
 ++++++
 
 This is a maintenance release that adds compatibility with Numpy 1.17 and Dask
-2.3.0 and fixes a bug in the Brucker reader. See `the issue tracker
+2.3.0 and fixes a bug in the Bruker reader. See `the issue tracker
 <https://github.com/hyperspy/hyperspy/issues?q=label%3A"type%3A+bug"+is%3Aclosed+milestone%3Av1.5.2>`_
 for details.
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,8 +10,7 @@ v1.5.2
 ++++++
 
 This is a maintenance release that adds compatibility with Numpy 1.17 and Dask
-2.3.0 and fixes a bug in the Brucker reader. See
- `the issue tracker
+2.3.0 and fixes a bug in the Brucker reader. See `the issue tracker
 <https://github.com/hyperspy/hyperspy/issues?q=label%3A"type%3A+bug"+is%3Aclosed+milestone%3Av1.5.2>`_
 for details.
 

--- a/README.rst
+++ b/README.rst
@@ -57,5 +57,5 @@ Cite
 
 |DOI|_
 
-.. |DOI| image:: https://zenodo.org/badge/doi/10.5281/zenodo.3353463.svg
-.. _DOI: https://doi.org/10.5281/zenodo.3353463
+.. |DOI| image:: https://zenodo.org/badge/doi/10.5281/zenodo.3396791.svg
+.. _DOI: https://doi.org/10.5281/zenodo.3396791

--- a/doc/citing.rst
+++ b/doc/citing.rst
@@ -6,5 +6,5 @@ If HyperSpy has been significant to a project that leads to an academic
 publication, please acknowledge that fact by citing the software. Click on
 the DOI badge below for formatted citation formats.
 
-.. image:: https://zenodo.org/badge/doi/10.5281/zenodo.3353463.svg
-   :target: https://doi.org/10.5281/zenodo.3353463
+.. image:: https://zenodo.org/badge/doi/10.5281/zenodo.3396791.svg
+   :target: https://doi.org/10.5281/zenodo.3396791

--- a/hyperspy/Release.py
+++ b/hyperspy/Release.py
@@ -25,7 +25,7 @@ name = 'hyperspy'
 # When running setup.py the ".dev" string will be replaced (if possible)
 # by the output of "git describe" if git is available or the git
 # hash if .git is present.
-version = "1.5.2.dev"
+version = "1.5.2"
 description = "Multidimensional data analysis toolbox"
 license = 'GPL v3'
 

--- a/hyperspy/Release.py
+++ b/hyperspy/Release.py
@@ -25,7 +25,7 @@ name = 'hyperspy'
 # When running setup.py the ".dev" string will be replaced (if possible)
 # by the output of "git describe" if git is available or the git
 # hash if .git is present.
-version = "1.5.2"
+version = "1.5.3.dev"
 description = "Multidimensional data analysis toolbox"
 license = 'GPL v3'
 

--- a/hyperspy/misc/eds/utils.py
+++ b/hyperspy/misc/eds/utils.py
@@ -443,8 +443,8 @@ def _quantification_cliff_lorimer(intensities,
     if len(intensities) != len(kfactors):
         raise ValueError('The number of kfactors must match the size of the '
                          'first axis of intensities.')
-    ab = np.zeros_like(intensities, dtype='float')
-    composition = np.ones_like(intensities, dtype='float')
+    ab = np.zeros(intensities.shape, dtype='float')
+    composition = np.ones(intensities.shape, dtype='float')
     # ab = Ia/Ib / kab
 
     other_index = list(range(len(kfactors)))


### PR DESCRIPTION
In response to this [gitter chat question](https://gitter.im/hyperspy/hyperspy?at=5dc5311b50010612b27ee4e1) I took a look at the EDS quantification function. I thought that I could improve things a bit, so I did. Not sure about a good answer to the gitter chat question though.

### Description of the change
- Moved `min_intensity` to be keyword argument in function so it can be modified if necessary
- `reduce(lambda x, y: x * y, dim[1:])` -> `np.prod(dim[1:])` (also changed name, so now `np.prod(original_shape[1:])`)
- `np.zeros_like(A)` is 10 slower than `np.zeros(A.shape)` for small arrays, also slower in general. Saves time on large navigation shapes.
- Changed object names to be more readable.

### Progress of the PR
- [x] Change implemented (can be split into several points),
- [x] update docstring (if appropriate),
- [x] ready for review.

### Minimal example of the bug fix or the new feature
Reduced example taken from the EDS TEM demo
```python
#Download the data (1MB)
from urllib.request import urlretrieve, urlopen
from zipfile import ZipFile
files = urlretrieve("https://www.dropbox.com/s/ecdlgwxjq04m5mx/HyperSpy_demos_EDS_TEM_files.zip?raw=1", "./HyperSpy_demos_EDX_TEM_files.zip")
with ZipFile("HyperSpy_demos_EDX_TEM_files.zip") as z:
    z.extractall()
import hyperspy.api as hs

cs = hs.load("core_shell.hdf5")
cs.set_elements(['Fe', 'Pt'])
cs.set_lines(['Fe_Ka', 'Pt_La'])
bw = cs.estimate_background_windows(line_width=[5.0, 2.0])
iw =  cs.estimate_integration_windows(windows_width=3)
factors = [1.450226, 5.75602]

cs_intensities = cs.get_lines_intensity(background_windows=bw, integration_windows=iw)
cs.set_microscope_parameters(live_time = 6.15) #in seconds
cs.set_microscope_parameters(beam_current = 0.5) #in nA

quant = cs.quantification(cs_intensities, 'CL', factors=factors)
```
Note that this example can be useful to update the user guide.

