### PR TITLE
Update Link to dev-guide and discussion section

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,8 +1,8 @@
 ## Discussions
 
-For discussions on the use of hyperspy, please use the [mailing list](http://groups.google.com/group/hyperspy-users): useful to discuss use cases of HyperSpy and ask about specific applications.
+For discussions on the use of HyperSpy, please use the [gitter chat](https://gitter.im/hyperspy/hyperspy): useful to ask quick questions, discuss use cases of HyperSpy and ask about specific applications.
 
-Discussion on the [gitter chat](https://gitter.im/hyperspy/hyperspy): useful to ask quick questions.
+Alternatively, there is the HyperSpy [mailing list](http://groups.google.com/group/hyperspy-users). It predates the gitter chat and is now less frequently used. But please do not double post on gitter and the mailing list!
 
 ## Issues
 
@@ -12,5 +12,5 @@ The [issue tracker](https://github.com/hyperspy/hyperspy/issues) can be used to 
 
 ## Contribute
 
-If you want to contribute to the HyperSpy source code, you can send us a [pull requests](https://github.com/hyperspy/hyperspy/pulls). For more information, please read the [developer guide](http://hyperspy.org/hyperspy-doc/current/dev_guide.html).
+If you want to contribute to the HyperSpy source code, you can send us a [pull requests](https://github.com/hyperspy/hyperspy/pulls). For more information, please read the [developer guide](http://hyperspy.org/hyperspy-doc/current/dev_guide/index.html).
 


### PR DESCRIPTION
- Link to developer guide was broken.
- Changed the priority of gitter and mailing lists under discussions, as brought up in issue #2252.