### PR TITLE
Add option to skip SSL certificate verification to ``eelsdb``

### DIFF
--- a/hyperspy/misc/eels/eelsdb.py
+++ b/hyperspy/misc/eels/eelsdb.py
@@ -12,7 +12,7 @@ def eelsdb(spectrum_type=None, title=None, author=None, element=None, formula=No
            edge=None, min_energy=None, max_energy=None, resolution=None,
            min_energy_compare="gt", max_energy_compare="lt",
            resolution_compare="lt", max_n=-1, monochromated=None, order=None,
-           order_direction="ASC"):
+           order_direction="ASC", verify_certificate=True):
     r"""Download spectra from the EELS Data Base.
 
     Parameters
@@ -93,6 +93,11 @@ def eelsdb(spectrum_type=None, title=None, author=None, element=None, formula=No
         * "otherURLs"
     order_direction : {"ASC", "DESC"}
         Sorting `order` direction.
+    verify_certificate: bool
+        If True, verify the eelsdb website certificate and raise an error
+        if it is invalid. If False, continue querying the database if the certificate
+        is invalid. (This is a potential security risk.)
+
 
 
     Returns
@@ -195,7 +200,7 @@ def eelsdb(spectrum_type=None, title=None, author=None, element=None, formula=No
     else:
         params["element[]"] = element
 
-    request = requests.get('http://api.eelsdb.eu/spectra', params=params, )
+    request = requests.get('http://api.eelsdb.eu/spectra', params=params, verify=verify_certificate)
     spectra = []
     jsons = request.json()
     if "message" in jsons:
@@ -205,7 +210,7 @@ def eelsdb(spectrum_type=None, title=None, author=None, element=None, formula=No
             "%s" % jsons["message"])
     for json_spectrum in jsons:
         download_link = json_spectrum['download_link']
-        msa_string = requests.get(download_link).text
+        msa_string = requests.get(download_link, verify=verify_certificate).text
         try:
             s = dict2signal(parse_msa_string(msa_string)[0])
             emsa = s.original_metadata


### PR DESCRIPTION
Currently the ``eelsdb`` function is not working because there is an issue with the SSL certificate of https://eelsldb.eu . To workaround the issue this PR adds as ``verify_certificate`` to ``eelsdb`` that, when ``False`` (default is ``True``) skips the verification.

Of course, the right thing to do is to fix the certificate issue. Still this may be useful in the meantime (now and in the future, since this has happened before).