### PR TITLE
Add ``__getitem__`` method to ROIs

### DIFF
--- a/doc/user_guide/tools.rst
+++ b/doc/user_guide/tools.rst
@@ -1642,7 +1642,7 @@ order to increase responsiveness.
 
 
 ROIs can be used in place of slices when indexing and to define a
-signal range in functions taken a ``signal_range`` argument. For example:
+signal range in functions that take the ``signal_range`` argument. For example:
 
 .. code-block:: python
 
@@ -1656,6 +1656,23 @@ signal range in functions taken a ``signal_range`` argument. For example:
 
 .. versionadded:: 1.3
     :meth:`gui` method.
+
+.. versionadded:: 1.6
+    New :meth:`__getitem__` method for :py:class:`~.roi.Point1DROI`,
+    :py:class:`~.roi.Point2DROI`, :py:class:`~.roi.SpanROI` and
+    :py:class:`~.roi.RectangularROI`.
+
+In addition the following ROIs have a :meth:`__getitem__` method that enables
+using them as tuples:
+
+* :py:class:`~.roi.Point1DROI`
+* :py:class:`~.roi.Point2DROI`
+* :py:class:`~.roi.SpanROI`
+* :py:class:`~.roi.RectangularROI`
+
+For example, the method :py:meth:`~._signals.signal2d.align2D` takes a ``roi``
+argument with the left, right, top, bottom coordinates of the ROI. Handifly,
+we can pass a :py:class:`~.roi.RectangularROI` ROI instead.
 
 
 All ROIs have a :meth:`gui` method that displays an user interface if

--- a/doc/user_guide/tools.rst
+++ b/doc/user_guide/tools.rst
@@ -1641,15 +1641,13 @@ order to increase responsiveness.
     signal range in functions taken a ``signal_range`` argument.
 
 
-ROIs can be used in place of slices when indexing and to define a
-signal range in functions that take the ``signal_range`` argument. For example:
+ROIs can be used in place of slices when indexing. For example:
 
 .. code-block:: python
 
     >>> s = hs.datasets.example_signals.EDS_TEM_Spectrum()
     >>> roi = hs.roi.SpanROI(left=5, right=15)
     >>> sc = s.isig[roi]
-    >>> s.remove_background(signal_range=roi, background_type="Polynomial")
     >>> im = hs.datasets.example_signals.object_hologram()
     >>> roi = hs.roi.RectangularROI(left=120, right=460., top=300, bottom=560)
     >>> imc = im.isig[roi]
@@ -1663,7 +1661,7 @@ signal range in functions that take the ``signal_range`` argument. For example:
     :py:class:`~.roi.RectangularROI`.
 
 In addition the following ROIs have a :meth:`__getitem__` method that enables
-using them as tuples:
+using them in place of tuples:
 
 * :py:class:`~.roi.Point1DROI`
 * :py:class:`~.roi.Point2DROI`

--- a/doc/user_guide/tools.rst
+++ b/doc/user_guide/tools.rst
@@ -1656,21 +1656,12 @@ ROIs can be used in place of slices when indexing. For example:
     :meth:`gui` method.
 
 .. versionadded:: 1.6
-    New :meth:`__getitem__` method for :py:class:`~.roi.Point1DROI`,
-    :py:class:`~.roi.Point2DROI`, :py:class:`~.roi.SpanROI` and
-    :py:class:`~.roi.RectangularROI`.
+    New :meth:`__getitem__` method for all ROIs.
 
-In addition the following ROIs have a :meth:`__getitem__` method that enables
-using them in place of tuples:
-
-* :py:class:`~.roi.Point1DROI`
-* :py:class:`~.roi.Point2DROI`
-* :py:class:`~.roi.SpanROI`
-* :py:class:`~.roi.RectangularROI`
-
-For example, the method :py:meth:`~._signals.signal2d.align2D` takes a ``roi``
-argument with the left, right, top, bottom coordinates of the ROI. Handily,
-we can pass a :py:class:`~.roi.RectangularROI` ROI instead.
+In addition the following all ROIs have a :meth:`__getitem__` method that enables
+using them in place of tuples. For example, the method :py:meth:`~._signals.signal2d.align2D` takes a
+ ``roi`` argument with the left, right, top, bottom coordinates of the ROI.
+ Handily, we can pass a :py:class:`~.roi.RectangularROI` ROI instead.
 
 .. code-block:: python
 

--- a/doc/user_guide/tools.rst
+++ b/doc/user_guide/tools.rst
@@ -1671,8 +1671,19 @@ using them as tuples:
 * :py:class:`~.roi.RectangularROI`
 
 For example, the method :py:meth:`~._signals.signal2d.align2D` takes a ``roi``
-argument with the left, right, top, bottom coordinates of the ROI. Handifly,
+argument with the left, right, top, bottom coordinates of the ROI. Handily,
 we can pass a :py:class:`~.roi.RectangularROI` ROI instead.
+
+.. code-block:: python
+
+    >>> import hyperspy.api as hs
+    >>> import numpy as np
+    >>> im = hs.signals.Signal2D(np.random.random((10,30,30))
+    >>> roi = hs.roi.RectangularROI(left=2, right=10, top=0, bottom=5))
+    >>> tuple(roi)
+    (2.0, 10.0, 0.0, 5.0)
+    >>> im.align2D(roi=roi)
+
 
 
 All ROIs have a :meth:`gui` method that displays an user interface if

--- a/hyperspy/_signals/eels.py
+++ b/hyperspy/_signals/eels.py
@@ -31,7 +31,7 @@ import hyperspy.axes
 from hyperspy.defaults_parser import preferences
 from hyperspy.components1d import PowerLaw
 from hyperspy.misc.utils import (
-    isiterable, closest_power_of_two, underline, signal_range_from_roi)
+    isiterable, closest_power_of_two, underline)
 from hyperspy.ui_registry import add_gui_method, DISPLAY_DT, TOOLKIT_DT
 from hyperspy.docstrings.signal1d import CROP_PARAMETER_DOC
 from hyperspy.docstrings.signal import SHOW_PROGRESSBAR_ARG, PARALLEL_ARG
@@ -271,7 +271,6 @@ class EELSSpectrum_mixin:
         more information read its docstring.
 
         """
-        signal_range = signal_range_from_roi(signal_range)
 
         def substract_from_offset(value, signals):
             if isinstance(value, da.Array):

--- a/hyperspy/_signals/eels.py
+++ b/hyperspy/_signals/eels.py
@@ -241,7 +241,8 @@ class EELSSpectrum_mixin:
             in integers, the range will be in index values. If given floats,
             the range will be in spectrum values. Useful if there are features
             in the spectrum which are more intense than the ZLP.
-            Default is searching in the whole signal.
+            Default is searching in the whole signal. Note that ROIs can be used
+            in place of a tuple.
         %s
         %s
 

--- a/hyperspy/_signals/signal1d.py
+++ b/hyperspy/_signals/signal1d.py
@@ -38,7 +38,6 @@ from hyperspy.signal_tools import SpikesRemoval
 from hyperspy.models.model1d import Model1D
 
 
-from hyperspy.misc.utils import signal_range_from_roi
 from hyperspy.defaults_parser import preferences
 from hyperspy.signal_tools import (
     Signal1DCalibration,
@@ -813,7 +812,6 @@ class Signal1D(BaseSignal, CommonSignal1D):
             "be removed in v2.0. Use a `roi.SpanRoi` followed by `integrate1D` "
             "instead.")
         deprecation_warning(msg)
-        signal_range = signal_range_from_roi(signal_range)
 
         if signal_range == 'interactive':
             self_copy = self.deepcopy()
@@ -826,7 +824,6 @@ class Signal1D(BaseSignal, CommonSignal1D):
         return integrated_signal1D
 
     def _integrate_in_range_commandline(self, signal_range):
-        signal_range = signal_range_from_roi(signal_range)
         e1 = signal_range[0]
         e2 = signal_range[1]
         integrated_signal1D = self.isig[e1:e2].integrate1D(-1)
@@ -1033,7 +1030,6 @@ class Signal1D(BaseSignal, CommonSignal1D):
     def _remove_background_cli(
             self, signal_range, background_estimator, fast=True,
             zero_fill=False, show_progressbar=None):
-        signal_range = signal_range_from_roi(signal_range)
         from hyperspy.models.model1d import Model1D
         model = Model1D(self)
         model.append(background_estimator)
@@ -1192,7 +1188,7 @@ class Signal1D(BaseSignal, CommonSignal1D):
         """
         self._check_signal_dimension_equals_one()
         try:
-            left_value, right_value = signal_range_from_roi(left_value)
+            left_value, right_value = left_value
         except TypeError:
             # It was not a ROI, we carry on
             pass

--- a/hyperspy/_signals/signal1d.py
+++ b/hyperspy/_signals/signal1d.py
@@ -775,7 +775,8 @@ class Signal1D(BaseSignal, CommonSignal1D):
             If l and r are floats the `signal_range` will be in axis units (for
             example eV). If l and r are integers the `signal_range` will be in
             index units. When `signal_range` is "interactive" (default) the
-            range is selected using a GUI.
+            range is selected using a GUI. Note that ROIs can be used
+            in place of a tuple.
 
         Returns
         --------

--- a/hyperspy/_signals/signal2d.py
+++ b/hyperspy/_signals/signal2d.py
@@ -387,7 +387,8 @@ class Signal2D(BaseSignal, CommonSignal2D):
             as reference are limited to the given value.
         roi : tuple of ints or floats (left, right, top, bottom)
              Define the region of interest. If int(float) the position
-             is given axis index(value).
+             is given axis index(value). Note that ROIs can be used
+            in place of a tuple.
         sobel : bool
             apply a sobel filter for edge enhancement
         medfilter :  bool

--- a/hyperspy/misc/utils.py
+++ b/hyperspy/misc/utils.py
@@ -1074,14 +1074,6 @@ def iterable_not_string(thing):
         not isinstance(thing, str)
 
 
-def signal_range_from_roi(signal_range):
-    from hyperspy.roi import SpanROI
-    if isinstance(signal_range, SpanROI):
-        return (signal_range.left, signal_range.right)
-    else:
-        return signal_range
-
-
 def deprecation_warning(msg):
     warnings.warn(msg, VisibleDeprecationWarning)
 

--- a/hyperspy/models/model1d.py
+++ b/hyperspy/models/model1d.py
@@ -895,7 +895,9 @@ class Model1D(BaseModel):
             If 'interactive' the signal range is selected using the span
              selector on the spectrum plot. The signal range can also
              be manually specified by passing a tuple of floats. If None
-             the current signal range is used.
+             the current signal range is used. Note that ROIs can be used
+             in place of a tuple.
+
         estimate_parameters : bool, default True
             If True will check if the component has an
             estimate_parameters function, and use it to estimate the

--- a/hyperspy/models/model1d.py
+++ b/hyperspy/models/model1d.py
@@ -29,7 +29,6 @@ from hyperspy.drawing.widgets import VerticalLineWidget, LabelWidget
 from hyperspy.events import EventSuppressor
 from hyperspy.signal_tools import SpanSelectorInSignal1D
 from hyperspy.ui_registry import add_gui_method, DISPLAY_DT, TOOLKIT_DT
-from hyperspy.misc.utils import signal_range_from_roi
 
 
 @add_gui_method(toolkey="hyperspy.Model1D.fit_component")
@@ -463,7 +462,7 @@ class Model1D(BaseModel):
 
         """
         try:
-            x1, x2 = signal_range_from_roi(x1)
+            x1, x2 = x1
         except TypeError:
             # It was not a ROI, we carry on
             pass
@@ -494,7 +493,7 @@ class Model1D(BaseModel):
 
         """
         try:
-            x1, x2 = signal_range_from_roi(x1)
+            x1, x2 = x1
         except TypeError:
             # It was not a ROI, we carry on
             pass
@@ -529,7 +528,7 @@ class Model1D(BaseModel):
 
         """
         try:
-            x1, x2 = signal_range_from_roi(x1)
+            x1, x2 = x1
         except TypeError:
             # It was not a ROI, we carry on
             pass
@@ -872,7 +871,6 @@ class Model1D(BaseModel):
             display=True,
             toolkit=None,
             **kwargs):
-        signal_range = signal_range_from_roi(signal_range)
         component = self._get_component(component)
         cf = ComponentFit(self, component, signal_range,
                           estimate_parameters, fit_independent,

--- a/hyperspy/roi.py
+++ b/hyperspy/roi.py
@@ -238,6 +238,9 @@ class BaseROI(t.HasTraits):
 
         return axes_out
 
+    def __getitem__(self, *args, **kwargs):
+        return self._tuple.__getitem__(*args, **kwargs)
+
 
 def _get_mpl_ax(plot, axes):
     """
@@ -501,7 +504,7 @@ class BasePointROI(BaseInteractiveROI):
 
 
 def guess_vertical_or_horizontal(axes, signal):
-    # Figure out whether to use horizontal or veritcal line:
+    # Figure out whether to use horizontal or vertical line:
     if axes[0].navigate:
         plotdim = len(signal._plot.navigator_data_function().shape)
         axdim = signal.axes_manager.navigation_dimension
@@ -548,6 +551,7 @@ class Point1DROI(BasePointROI):
     def __init__(self, value):
         super(Point1DROI, self).__init__()
         self.value = value
+        self._tuple = (self.value,)
 
     def is_valid(self):
         return self.value != t.Undefined
@@ -559,8 +563,6 @@ class Point1DROI(BasePointROI):
         ranges = ((self.value,),)
         return ranges
 
-    def __getitem__(self, i):
-        return (self.value,)[i]
 
     def _set_from_widget(self, widget):
         self.value = widget.position[0]
@@ -608,6 +610,7 @@ class Point2DROI(BasePointROI):
     def __init__(self, x, y):
         super(Point2DROI, self).__init__()
         self.x, self.y = x, y
+        self._tuple = (self.x, self.y)
 
     def is_valid(self):
         return t.Undefined not in (self.x, self.y)
@@ -621,9 +624,6 @@ class Point2DROI(BasePointROI):
     def _get_ranges(self):
         ranges = ((self.x,), (self.y,),)
         return ranges
-
-    def __getitem__(self, i):
-        return (self.x, self.y)[i]
 
     def _set_from_widget(self, widget):
         self.x, self.y = widget.position
@@ -664,6 +664,8 @@ class SpanROI(BaseInteractiveROI):
         super(SpanROI, self).__init__()
         self._bounds_check = True   # Use reponsibly!
         self.left, self.right = left, right
+        self._tuple = (self.left, self.right)
+
 
     def is_valid(self):
         return (t.Undefined not in (self.left, self.right) and
@@ -686,9 +688,6 @@ class SpanROI(BaseInteractiveROI):
     def _get_ranges(self):
         ranges = ((self.left, self.right),)
         return ranges
-
-    def __getitem__(self, i):
-        return (self.left, self.right)[i]
 
     def _set_from_widget(self, widget):
         value = (widget.position[0], widget.position[0] + widget.size[0])
@@ -738,6 +737,7 @@ class RectangularROI(BaseInteractiveROI):
         super(RectangularROI, self).__init__()
         self._bounds_check = True   # Use reponsibly!
         self.top, self.bottom, self.left, self.right = top, bottom, left, right
+        self._tuple = (left, right, top, bottom)
 
     def is_valid(self):
         return (t.Undefined not in (self.top, self.bottom,
@@ -840,9 +840,6 @@ class RectangularROI(BaseInteractiveROI):
         ranges = ((self.left, self.right), (self.top, self.bottom),)
         return ranges
 
-    def __getitem__(self, i):
-        return (self.left, self.right, self.top, self.bottom)[i]
-
     def _set_from_widget(self, widget):
         p = np.array(widget.position)
         s = np.array(widget.size)
@@ -876,6 +873,9 @@ class CircleROI(BaseInteractiveROI):
         self.cx, self.cy, self.r = cx, cy, r
         if r_inner:
             self.r_inner = r_inner
+            self._tuple = (self.cx, self.cy, self.r, self.r_inner)
+        else:
+            self._tuple = (self.cx, self.cy, self.r)
 
     def is_valid(self):
         return (t.Undefined not in (self.cx, self.cy, self.r,) and
@@ -940,6 +940,7 @@ class CircleROI(BaseInteractiveROI):
                   space can fit the right number of axis, and use that if it
                   fits. If not, it will try the signal space.
         """
+
 
         if axes is None and signal in self.signal_map:
             axes = self.signal_map[signal][1]
@@ -1037,6 +1038,7 @@ class Line2DROI(BaseInteractiveROI):
         super(Line2DROI, self).__init__()
         self.x1, self.y1, self.x2, self.y2 = x1, y1, x2, y2
         self.linewidth = linewidth
+        self._tuple = (self.x1, self.y1, self.x2, self.y2)
 
     def is_valid(self):
         return t.Undefined not in (self.x1, self.y1, self.x2, self.y2)

--- a/hyperspy/roi.py
+++ b/hyperspy/roi.py
@@ -876,6 +876,13 @@ class RectangularROI(BaseInteractiveROI):
 
 @add_gui_method(toolkey="hyperspy.CircleROI")
 class CircleROI(BaseInteractiveROI):
+    """Selects a circular or annular region in a 2D space. The coordinates of
+    the center of the circle are stored in the 'cx' and 'cy' attributes. The
+    radious in the `r` attribute. If an internal radious is defined using the
+    `r_inner` attribute, then an annular region is selected instead.
+    `CircleROI` can be used in place of a tuple containing `(cx, cy, r)`, `(cx,
+    cy, r, r_inner)` when `r_inner` is not `None`.
+    """
 
     cx, cy, r, r_inner = (t.CFloat(t.Undefined),) * 4
     _ndim = 2
@@ -1048,6 +1055,11 @@ class CircleROI(BaseInteractiveROI):
 
 @add_gui_method(toolkey="hyperspy.Line2DROI")
 class Line2DROI(BaseInteractiveROI):
+    """Selects a line of a given width in 2D space. The coordinates of the end points of the line are stored in the `x1`, `y1`, `x2`, `y2` attributes.
+    The length is available in the `length` attribute and the method `angle` computes the angle of the line with the axes.
+
+    `Line2DROI` can be used in place of a tuple containing the coordinates of the two end-points of the line and the linewdith `(x1, y1, x2, y2, linewidth)`.
+    """
 
     x1, y1, x2, y2, linewidth = (t.CFloat(t.Undefined),) * 5
     _ndim = 2
@@ -1058,10 +1070,8 @@ class Line2DROI(BaseInteractiveROI):
         self.linewidth = linewidth
 
     def __getitem__(self, *args, **kwargs):
-        if self.linewidth:
-            _tuple = (self.x1, self.y1, self.x2, self.y2, self.linewidth)
-        else:
-            _tuple = (self.x1, self.y1, self.x2, self.y2)
+        _tuple = (self.x1, self.y1, self.x2, self.y2, self.linewidth)
+        _tuple = (self.x1, self.y1, self.x2, self.y2)
         return _tuple.__getitem__(*args, **kwargs)
 
 

--- a/hyperspy/roi.py
+++ b/hyperspy/roi.py
@@ -895,7 +895,7 @@ class CircleROI(BaseInteractiveROI):
             self.r_inner = r_inner
 
     def __getitem__(self, *args, **kwargs):
-        if self.r_inner:
+        if self.r_inner and self.r_inner is not t.Undefined:
             _tuple = (self.cx, self.cy, self.r, self.r_inner)
         else:
             _tuple = (self.cx, self.cy, self.r)
@@ -1071,7 +1071,6 @@ class Line2DROI(BaseInteractiveROI):
 
     def __getitem__(self, *args, **kwargs):
         _tuple = (self.x1, self.y1, self.x2, self.y2, self.linewidth)
-        _tuple = (self.x1, self.y1, self.x2, self.y2)
         return _tuple.__getitem__(*args, **kwargs)
 
 

--- a/hyperspy/roi.py
+++ b/hyperspy/roi.py
@@ -529,6 +529,18 @@ class Point1DROI(BasePointROI):
 
     """Selects a single point in a 1D space. The coordinate of the point in the
     1D space is stored in the 'value' trait.
+
+    `Point1DROI` behaves like a one-element tuple containing the value of `value`.
+
+
+    Example
+    -------
+
+    >>> roi = hs.roi.Point1DROI(0.5) 
+    >>> value, = roi
+    >>> print(value)
+    0.5
+
     """
     value = t.CFloat(t.Undefined)
     _ndim = 1
@@ -546,6 +558,9 @@ class Point1DROI(BasePointROI):
     def _get_ranges(self):
         ranges = ((self.value,),)
         return ranges
+
+    def __getitem__(self, i):
+        return (self.value,)[i]
 
     def _set_from_widget(self, widget):
         self.value = widget.position[0]
@@ -573,6 +588,19 @@ class Point2DROI(BasePointROI):
 
     """Selects a single point in a 2D space. The coordinates of the point in
     the 2D space are stored in the traits 'x' and 'y'.
+
+    `Point2DROI` behaves like a tuple containing the coordinates
+    of the point `(x, y)`.
+
+
+    Example
+    -------
+
+    >>> roi = hs.roi.Point2DROI(3, 5)
+    >>> x, y = roi
+    >>> print(x, y)
+    3 5
+
     """
     x, y = (t.CFloat(t.Undefined),) * 2
     _ndim = 2
@@ -594,6 +622,9 @@ class Point2DROI(BasePointROI):
         ranges = ((self.x,), (self.y,),)
         return ranges
 
+    def __getitem__(self, i):
+        return (self.x, self.y)[i]
+
     def _set_from_widget(self, widget):
         self.x, self.y = widget.position
 
@@ -614,6 +645,17 @@ class SpanROI(BaseInteractiveROI):
 
     """Selects a range in a 1D space. The coordinates of the range in
     the 1D space are stored in the traits 'left' and 'right'.
+
+    `SpanROI` behaves like a tuple containing the left and right values.
+
+    Example
+    -------
+
+    >>> roi = hs.roi.SpanROI(-3, 5)
+    >>> left, right = roi
+    >>> print(left, right)
+    3 5
+
     """
     left, right = (t.CFloat(t.Undefined),) * 2
     _ndim = 1
@@ -645,6 +687,9 @@ class SpanROI(BaseInteractiveROI):
         ranges = ((self.left, self.right),)
         return ranges
 
+    def __getitem__(self, i):
+        return (self.left, self.right)[i]
+
     def _set_from_widget(self, widget):
         value = (widget.position[0], widget.position[0] + widget.size[0])
         self.left, self.right = value
@@ -675,6 +720,16 @@ class RectangularROI(BaseInteractiveROI):
     the 2D space are stored in the traits 'left', 'right', 'top' and 'bottom'.
     Convenience properties 'x', 'y', 'width' and 'height' are also available,
     but cannot be used for initialization.
+
+    `RectangularROI` behaves like a tuple containing `(left, right, top, bottom)`.
+
+    Example
+    -------
+
+    >>> roi = hs.roi.RectangularROI(left=0, right=10, top=20, bottom=20.5)
+    >>> left, right, top, bottom = roi
+    >>> print(left, right, top, bottom)
+    0 10 20 20.5
     """
     top, bottom, left, right = (t.CFloat(t.Undefined),) * 4
     _ndim = 2
@@ -784,6 +839,9 @@ class RectangularROI(BaseInteractiveROI):
     def _get_ranges(self):
         ranges = ((self.left, self.right), (self.top, self.bottom),)
         return ranges
+
+    def __getitem__(self, i):
+        return (self.left, self.right, self.top, self.bottom)[i]
 
     def _set_from_widget(self, widget):
         p = np.array(widget.position)

--- a/hyperspy/roi.py
+++ b/hyperspy/roi.py
@@ -238,9 +238,6 @@ class BaseROI(t.HasTraits):
 
         return axes_out
 
-    def __getitem__(self, *args, **kwargs):
-        return self._tuple.__getitem__(*args, **kwargs)
-
 
 def _get_mpl_ax(plot, axes):
     """
@@ -551,7 +548,11 @@ class Point1DROI(BasePointROI):
     def __init__(self, value):
         super(Point1DROI, self).__init__()
         self.value = value
-        self._tuple = (self.value,)
+
+    def __getitem__(self, *args, **kwargs):
+        _tuple = (self.value,)
+        return _tuple.__getitem__(*args, **kwargs)
+
 
     def is_valid(self):
         return self.value != t.Undefined
@@ -610,7 +611,11 @@ class Point2DROI(BasePointROI):
     def __init__(self, x, y):
         super(Point2DROI, self).__init__()
         self.x, self.y = x, y
-        self._tuple = (self.x, self.y)
+
+    def __getitem__(self, *args, **kwargs):
+        _tuple = (self.x, self.y)
+        return _tuple.__getitem__(*args, **kwargs)
+
 
     def is_valid(self):
         return t.Undefined not in (self.x, self.y)
@@ -664,7 +669,11 @@ class SpanROI(BaseInteractiveROI):
         super(SpanROI, self).__init__()
         self._bounds_check = True   # Use reponsibly!
         self.left, self.right = left, right
-        self._tuple = (self.left, self.right)
+
+    def __getitem__(self, *args, **kwargs):
+        _tuple = (self.left, self.right)
+        return _tuple.__getitem__(*args, **kwargs)
+
 
 
     def is_valid(self):
@@ -737,7 +746,11 @@ class RectangularROI(BaseInteractiveROI):
         super(RectangularROI, self).__init__()
         self._bounds_check = True   # Use reponsibly!
         self.top, self.bottom, self.left, self.right = top, bottom, left, right
-        self._tuple = (left, right, top, bottom)
+
+    def __getitem__(self, *args, **kwargs):
+        _tuple = (self.left, self.right, self.top, self.bottom)
+        return _tuple.__getitem__(*args, **kwargs)
+
 
     def is_valid(self):
         return (t.Undefined not in (self.top, self.bottom,
@@ -873,9 +886,14 @@ class CircleROI(BaseInteractiveROI):
         self.cx, self.cy, self.r = cx, cy, r
         if r_inner:
             self.r_inner = r_inner
-            self._tuple = (self.cx, self.cy, self.r, self.r_inner)
+
+    def __getitem__(self, *args, **kwargs):
+        if self.r_inner:
+            _tuple = (self.cx, self.cy, self.r, self.r_inner)
         else:
-            self._tuple = (self.cx, self.cy, self.r)
+            _tuple = (self.cx, self.cy, self.r)
+        return _tuple.__getitem__(*args, **kwargs)
+
 
     def is_valid(self):
         return (t.Undefined not in (self.cx, self.cy, self.r,) and
@@ -1039,6 +1057,10 @@ class Line2DROI(BaseInteractiveROI):
         self.x1, self.y1, self.x2, self.y2 = x1, y1, x2, y2
         self.linewidth = linewidth
         self._tuple = (self.x1, self.y1, self.x2, self.y2)
+
+    def __getitem__(self, *args, **kwargs):
+        return self._tuple.__getitem__(*args, **kwargs)
+
 
     def is_valid(self):
         return t.Undefined not in (self.x1, self.y1, self.x2, self.y2)

--- a/hyperspy/roi.py
+++ b/hyperspy/roi.py
@@ -530,7 +530,7 @@ class Point1DROI(BasePointROI):
     """Selects a single point in a 1D space. The coordinate of the point in the
     1D space is stored in the 'value' trait.
 
-    `Point1DROI` behaves like a one-element tuple containing the value of `value`.
+    `Point1DROI` can be used in place of a tuple containing the value of `value`.
 
 
     Example
@@ -592,7 +592,7 @@ class Point2DROI(BasePointROI):
     """Selects a single point in a 2D space. The coordinates of the point in
     the 2D space are stored in the traits 'x' and 'y'.
 
-    `Point2DROI` behaves like a tuple containing the coordinates
+    `Point2DROI` can be used in place of a tuple containing the coordinates
     of the point `(x, y)`.
 
 
@@ -651,7 +651,7 @@ class SpanROI(BaseInteractiveROI):
     """Selects a range in a 1D space. The coordinates of the range in
     the 1D space are stored in the traits 'left' and 'right'.
 
-    `SpanROI` behaves like a tuple containing the left and right values.
+    `SpanROI` can be used in place of a tuple containing the left and right values.
 
     Example
     -------
@@ -729,7 +729,7 @@ class RectangularROI(BaseInteractiveROI):
     Convenience properties 'x', 'y', 'width' and 'height' are also available,
     but cannot be used for initialization.
 
-    `RectangularROI` behaves like a tuple containing `(left, right, top, bottom)`.
+    `RectangularROI` can be used in place of a tuple containing `(left, right, top, bottom)`.
 
     Example
     -------

--- a/hyperspy/roi.py
+++ b/hyperspy/roi.py
@@ -1056,10 +1056,13 @@ class Line2DROI(BaseInteractiveROI):
         super(Line2DROI, self).__init__()
         self.x1, self.y1, self.x2, self.y2 = x1, y1, x2, y2
         self.linewidth = linewidth
-        self._tuple = (self.x1, self.y1, self.x2, self.y2)
 
     def __getitem__(self, *args, **kwargs):
-        return self._tuple.__getitem__(*args, **kwargs)
+        if self.linewidth:
+            _tuple = (self.x1, self.y1, self.x2, self.y2, self.linewidth)
+        else:
+            _tuple = (self.x1, self.y1, self.x2, self.y2)
+        return _tuple.__getitem__(*args, **kwargs)
 
 
     def is_valid(self):

--- a/hyperspy/tests/misc/test_utils.py
+++ b/hyperspy/tests/misc/test_utils.py
@@ -1,15 +1,5 @@
-from hyperspy.misc.utils import signal_range_from_roi, slugify, parse_quantity
+from hyperspy.misc.utils import slugify, parse_quantity
 from hyperspy import roi
-
-
-def test_signal_range_from_roi():
-    sr = roi.SpanROI(20, 50)
-    left, right = signal_range_from_roi(sr)
-    assert left == 20
-    assert right == 50
-    left, right = signal_range_from_roi((20, 50))
-    assert left == 20
-    assert right == 50
 
 
 def test_slugify():

--- a/hyperspy/tests/utils/test_roi.py
+++ b/hyperspy/tests/utils/test_roi.py
@@ -76,6 +76,10 @@ class TestROIs():
         np.testing.assert_equal(
             sr.data, s.data[:, int(35 / scale), ...])
 
+    def test_point1d_getitem(self):
+        r = Point1DROI(35)
+        assert (35,) == tuple(r)
+
     def test_point2d_image(self):
         s = self.s_i
         r = Point2DROI(35, 40)
@@ -95,6 +99,10 @@ class TestROIs():
                 s.axes_manager.signal_shape[2:])
         np.testing.assert_equal(
             sr.data, s.data[..., int(2 / scale), int(1 / scale)])
+
+    def test_point2d_getitem(self):
+        r = Point2DROI(1, 2)
+        assert tuple(r) == (1, 2)
 
     def test_span_spectrum_nav(self):
         s = self.s_s
@@ -139,6 +147,10 @@ class TestROIs():
         assert w2._pos[0] == 0
         assert w2._size[0] == 12
 
+    def test_spanroi_getitem(self):
+        r = SpanROI(15, 30)
+        assert tuple(r) == (15, 30)
+
     def test_widget_initialisation(self):
         s = Signal1D(np.arange(2 * 4 * 6).reshape(2, 4, 6))
         s.axes_manager[0].scale = 0.5
@@ -172,6 +184,10 @@ class TestROIs():
                 (n[0][1] - n[0][0], n[1][1] - n[1][0]))
         np.testing.assert_equal(
             sr.data, s.data[n[1][0]:n[1][1], n[0][0]:n[0][1], ...])
+
+    def test_rectroi_getitem(self):
+        r = RectangularROI(left=2.3, top=5.6, right=3.5, bottom=12.2)
+        assert tuple(r) == (2.3, 3.5, 5.6, 12.2)
 
     def test_rect_image_boundary_roi(self):
         s = self.s_i

--- a/hyperspy/tests/utils/test_roi.py
+++ b/hyperspy/tests/utils/test_roi.py
@@ -296,6 +296,18 @@ class TestROIs():
         assert np.sum(r_signal.sum().data) == (n**2 - 3 * 4) * 4
         assert np.sum(r_ann_signal.sum().data) == 4 * 5 * 4
 
+    def test_circle_getitem(self):
+        r = CircleROI(20, 25, 20)
+        assert tuple(r) == (20, 25, 20)
+
+    def test_annulus_getitem(self):
+        r_ann = CircleROI(20, 25, 20, 15)
+        assert tuple(r_ann) == (20, 25, 20, 15)
+
+    def test_2d_line_getitem(self):
+        r = Line2DROI(10, 10, 150, 50, 5)
+        assert tuple(r) == (10, 10, 150, 50, 5)
+
     def test_2d_line_spec_plot(self):
         r = Line2DROI(10, 10, 150, 50, 5)
         s = self.s_s


### PR DESCRIPTION
### Description of the change

Add ``__getitem__`` method to the following ROIs:

* ``Point1DROI``
* ``Point2DROI``
* ``SpanROI``
* ``RectangularROI``

In this way, they can be used in place of tuples.

### Progress of the PR
- [x] Change implemented (can be split into several points),
- [x] update docstring (if appropriate),
- [x] update user guide (if appropriate),
- [x] add tests,
- [x] ready for review.

### Minimal example of the bug fix or the new feature
```python
>>> import hyperspy.api as hs
>>> import numpy as np
>>> im = hs.signals.Signal2D(np.random.random((10,30,30))
>>> roi = hs.roi.RectangularROI(left=2, right=10, top=0, bottom=5))
>>> tuple(roi)
(2.0, 10.0, 0.0, 5.0)
>>> im.align2D(roi=roi)
```


