### PR TITLE
Fix fast background

### DIFF
--- a/hyperspy/_signals/signal1d.py
+++ b/hyperspy/_signals/signal1d.py
@@ -1044,8 +1044,10 @@ class Signal1D(BaseSignal, CommonSignal1D):
             only_current=False)
         if fast and not self._lazy:
             try:
-                axis = self.axes_manager.signal_axes[0].axis
-                result = self - background_estimator.function_nd(axis)
+                axis = self.axes_manager.signal_axes[0]
+                scale_factor = axis.scale if self.metadata.Signal.binned else 1
+                bkg = background_estimator.function_nd(axis.axis) * scale_factor
+                result = self - bkg
             except MemoryError:
                 result = self - model.as_signal(
                     show_progressbar=show_progressbar)

--- a/hyperspy/tests/signal/test_remove_background.py
+++ b/hyperspy/tests/signal/test_remove_background.py
@@ -25,6 +25,7 @@ from hyperspy.decorators import lazifyTestClass
 
 
 @lazifyTestClass
+@pytest.mark.parametrize('binning', (True, False))
 class TestRemoveBackground1DGaussian:
 
     def setup_method(self, method):
@@ -35,16 +36,17 @@ class TestRemoveBackground1DGaussian:
         self.signal = signals.Signal1D(
             gaussian.function(np.arange(0, 20, 0.01)))
         self.signal.axes_manager[0].scale = 0.01
-        self.signal.metadata.Signal.binned = False
 
-    def test_background_remove_gaussian(self):
+    def test_background_remove_gaussian(self, binning):
+        self.signal.metadata.Signal.binned = binning
         s1 = self.signal.remove_background(
             signal_range=(None, None),
             background_type='Gaussian',
             show_progressbar=None)
         assert np.allclose(s1.data, np.zeros(len(s1.data)))
 
-    def test_background_remove_gaussian_full_fit(self):
+    def test_background_remove_gaussian_full_fit(self, binning):
+        self.signal.metadata.Signal.binned = binning
         s1 = self.signal.remove_background(
             signal_range=(None, None),
             background_type='Gaussian',


### PR DESCRIPTION
### Description of the change
Fixed incorrect background subtraction using "fast" option due to the missing scaling for binned signals. Updated version of #2264 with a correct target branch and added tests.

### Progress of the PR
- [x] Change implemented,
- [x] Ready for review.

### Minimal example of the bug fix or the new feature
```python
>>> from hyperspy.components1d import PowerLaw
>>> from hyperspy.signals import Signal1D
>>> import numpy as np

# Generate a power law spectrum
>>> s = Signal1D(np.empty((100,)))
>>> axis = s.axes_manager.signal_axes[0]
>>> axis.scale = 0.02
>>> axis.offset = 1
>>> g1 = PowerLaw(50015.156, 1.2)
>>> s.data = g1.function(axis.axis)
>>> s.metadata.Signal.binned = True

# Subtract background using "fast" option
>>> s2 = s.remove_background(signal_range=[1.0, 2.0], background_type='PowerLaw', fast=True)

# Assert that the result is relatively close to zero
>>> assert(np.linalg.norm(s2.data) / np.linalg.norm(s.data) < 0.05)
```

