### PR TITLE
Fix issue with lambdify and FiniteSet

### DIFF
--- a/hyperspy/component.py
+++ b/hyperspy/component.py
@@ -246,7 +246,7 @@ class Parameter(t.HasTraits):
         if not self.twin_inverse_function:
             y = sympy.Symbol(x.name + "2")
             try:
-                inv = sympy.solveset(sympy.Eq(y, expr), x)
+                inv = list(sympy.solveset(sympy.Eq(y, expr), x))
                 self._twin_inverse_sympy = lambdify(y, inv)
                 self._twin_inverse_function = None
             except BaseException:

--- a/hyperspy/tests/model/test_model_as_dictionary.py
+++ b/hyperspy/tests/model/test_model_as_dictionary.py
@@ -19,7 +19,6 @@
 import numpy as np
 
 import pytest
-from numpy.testing import assert_allclose
 
 from hyperspy._signals.signal1d import Signal1D
 from hyperspy.component import Parameter, Component
@@ -58,7 +57,7 @@ class TestParameterDictionary:
         self.par.name = 'asd'
         self.par._id_name = 'newone'
         self.par.twin_function_expr = "x * x"
-        self.par.twin_inverse_function_expr = "x * x + 1"
+        self.par.twin_inverse_function_expr = "sqrt(x)"
         self.par._axes_manager = DummyAxesManager()
         self.par._create_array()
         self.par.value = 1


### PR DESCRIPTION
The string representation of `FiniteSet` have changed in sympy 1.5, which breaks setting twin functions: `sympy.solveset` returns a `sympy.FiniteSet` which is then used by `sympy.lambdify`. The later step breaks with sympy 1.5 because the string representation of `FiniteSet(1, 2)` changed from `'FiniteSet(1, 2)'` to `{1, 2}` (https://github.com/sympy/sympy/pull/17845).

The following example does not work with sympy 1.5:
```python
from sympy import *

x = symbols('x')
expr = FiniteSet(-x, x)

f = lambdify(x, expr)
f(1)
```

Changing `FiniteSet(-x, x)` to `list(FiniteSet(-x, x))` makes it work.

Example of failure in the test suite:
https://travis-ci.org/hyperspy/hyperspy/jobs/627201279
```python
        np.testing.assert_equal(
>           p.twin_inverse_function(rn),
            self.par.twin_inverse_function(rn))
hyperspy/tests/model/test_model_as_dictionary.py:109: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
hyperspy/component.py:289: in <lambda>
    return lambda x: self._twin_inverse_sympy(x).pop()
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
x2 = 0.08748220955359087
    def _lambdifygenerated(x2):
        return (  # Not supported in Python with SciPy:
      # FiniteSet
>   FiniteSet(sqrt(x2), -sqrt(x2)))
E       NameError: name 'FiniteSet' is not defined
```