### PR TITLE
Update tests following pint 0.10 release

### DIFF
--- a/hyperspy/tests/axes/test_conversion_units.py
+++ b/hyperspy/tests/axes/test_conversion_units.py
@@ -56,12 +56,12 @@ class TestUnitConversion:
         assert not self.uc._ignore_conversion('m')
 
     def test_converted_compact_scale_units(self):
-        self.uc.units = 'micron'
+        self.uc.units = 'toto'
         with assert_warns(
                 message="not supported for conversion.",
                 category=UserWarning):
             self.uc._convert_compact_units()
-        assert self.uc.units == 'micron'
+        assert self.uc.units == 'toto'
         nt.assert_almost_equal(self.uc.scale, 1.0E-3)
 
     def test_convert_to_units(self):
@@ -74,7 +74,7 @@ class TestUnitConversion:
         self._set_units_scale_size('m', 1.0E-3)
         out = self.uc._convert_units('µm')
         assert out is None
-        assert self.uc.units == 'um'
+        assert self.uc.units == 'µm'
         nt.assert_almost_equal(self.uc.scale, 1E3)
 
         self._set_units_scale_size('µm', 0.5)
@@ -110,7 +110,7 @@ class TestUnitConversion:
 
         self._set_units_scale_size('m', 1.0E-3)
         out = self.uc.convert_to_units('µm', inplace=False)
-        assert out == (1E3, 0.0, 'um')
+        assert out == (1E3, 0.0, 'µm')
         assert self.uc.units == 'm'
         nt.assert_almost_equal(self.uc.scale, 1.0E-3)
         nt.assert_almost_equal(self.uc.offset, 0.0)
@@ -148,7 +148,7 @@ class TestUnitConversion:
         # typical TEM diffraction
         self._set_units_scale_size('1/m', 0.01E9, 256)
         self.uc._convert_compact_units()
-        assert self.uc.units == '1 / um'
+        assert self.uc.units == '1 / µm'
         nt.assert_almost_equal(self.uc.scale, 10.0)
 
         # high camera length diffraction
@@ -246,18 +246,18 @@ class TestDataAxis:
     def test_convert_to_units(self):
         self.axis.convert_to_units(units='µm')
         nt.assert_almost_equal(self.axis.scale, 12E-6)
-        assert self.axis.units == 'um'
+        assert self.axis.units == 'µm'
         nt.assert_almost_equal(self.axis.offset, 0.005)
 
     def test_units_not_supported_by_pint_warning_raised(self):
         # raising a warning, not converting scale
-        self.axis.units = 'micron'
+        self.axis.units = 'toto'
         with assert_warns(
                 message="not supported for conversion.",
                 category=UserWarning):
             self.axis.convert_to_units('m')
         nt.assert_almost_equal(self.axis.scale, 12E-12)
-        assert self.axis.units == 'micron'
+        assert self.axis.units == 'toto'
 
     def test_units_not_supported_by_pint_warning_raised2(self):
         # raising a warning, not converting scale
@@ -416,14 +416,14 @@ class TestAxesManager:
         nt.assert_almost_equal(self.am['x'].scale, 1.5)
         assert self.am['x'].units == 'nm'
         nt.assert_almost_equal(self.am['y'].scale, 0.5E-3)
-        assert self.am['y'].units == 'um'
+        assert self.am['y'].units == 'µm'
         nt.assert_almost_equal(self.am['energy'].scale, 5E3)
         assert self.am['energy'].units == 'meV'
 
     def test_convert_to_units_list_same_units(self):
         self.am2.convert_units(units=['µm', 'eV', 'meV'], same_units=True)
         nt.assert_almost_equal(self.am2['x'].scale, 0.0015)
-        assert self.am2['x'].units == 'um'
+        assert self.am2['x'].units == 'µm'
         nt.assert_almost_equal(self.am2['energy'].scale,
                                self.axes_list2[1]['scale'])
         assert self.am2['energy'].units == self.axes_list2[1]['units']
@@ -434,7 +434,7 @@ class TestAxesManager:
     def test_convert_to_units_list_signal2D(self):
         self.am2.convert_units(units=['µm', 'eV', 'meV'], same_units=False)
         nt.assert_almost_equal(self.am2['x'].scale, 0.0015)
-        assert self.am2['x'].units == 'um'
+        assert self.am2['x'].units == 'µm'
         nt.assert_almost_equal(self.am2['energy'].scale, 2500)
         assert self.am2['energy'].units == 'meV'
         nt.assert_almost_equal(self.am2['energy2'].scale, 5.0)

--- a/hyperspy/tests/io/test_blockfile.py
+++ b/hyperspy/tests/io/test_blockfile.py
@@ -128,10 +128,10 @@ axes2_converted = {
         'scale': 64.0, 'size': 3, 'units': 'nm'},
     'axis-2': {
         'name': 'dy', 'navigate': False, 'offset': 0.0,
-        'scale': 160.61676839061997, 'size': 5, 'units': 'um'},
+        'scale': 160.61676839061997, 'size': 5, 'units': 'µm'},
     'axis-3': {
         'name': 'dx', 'navigate': False, 'offset': 0.0,
-        'scale': 160.61676839061997, 'size': 5, 'units': 'um'}}
+        'scale': 160.61676839061997, 'size': 5, 'units': 'µm'}}
 
 
 def test_load1():

--- a/hyperspy/tests/io/test_emd.py
+++ b/hyperspy/tests/io/test_emd.py
@@ -336,10 +336,10 @@ class TestFeiEMD():
         fei_image = np.load(os.path.join(self.fei_files_path,
                                          'fei_emd_image.npy'))
         assert signal.axes_manager[0].name == 'x'
-        assert signal.axes_manager[0].units == 'um'
+        assert signal.axes_manager[0].units == 'µm'
         assert_allclose(signal.axes_manager[0].scale, 0.00530241, rtol=1E-5)
         assert signal.axes_manager[1].name == 'y'
-        assert signal.axes_manager[1].units == 'um'
+        assert signal.axes_manager[1].units == 'µm'
         assert_allclose(signal.axes_manager[1].scale, 0.00530241, rtol=1E-5)
         assert_allclose(signal.data, fei_image)
         assert_deep_almost_equal(signal.metadata.as_dictionary(), md)

--- a/hyperspy/tests/io/test_tiff.py
+++ b/hyperspy/tests/io/test_tiff.py
@@ -185,8 +185,8 @@ def test_write_read_unit_imagej_with_description():
         fname3 = os.path.join(tmpdir, 'description2.tif')
         s.save(fname3, export_scale=True, overwrite=True, description='test')
         s3 = hs.load(fname3, convert_units=True)
-        assert s3.axes_manager[0].units == 'um'
-        assert s3.axes_manager[1].units == 'um'
+        assert s3.axes_manager[0].units == 'µm'
+        assert s3.axes_manager[1].units == 'µm'
         assert_allclose(s3.axes_manager[0].scale, 0.16867, atol=1E-5)
         assert_allclose(s3.axes_manager[1].scale, 0.16867, atol=1E-5)
 
@@ -346,8 +346,8 @@ def test_write_scale_unit_image_stack():
     s.axes_manager[1].scale = 0.5
     s.axes_manager[2].scale = 1.5
     s.axes_manager[0].units = 'nm'
-    s.axes_manager[1].units = 'um'
-    s.axes_manager[2].units = 'um'
+    s.axes_manager[1].units = 'µm'
+    s.axes_manager[2].units = 'µm'
     with tempfile.TemporaryDirectory() as tmpdir:
         fname = os.path.join(tmpdir, 'test_export_scale_unit_stack2.tif')
         s.save(fname, overwrite=True, export_scale=True)
@@ -355,8 +355,8 @@ def test_write_scale_unit_image_stack():
         _compare_signal_shape_data(s, s1)
         assert s1.axes_manager[0].units == 'pm'
         # only one unit can be read
-        assert s1.axes_manager[1].units == 'um'
-        assert s1.axes_manager[2].units == 'um'
+        assert s1.axes_manager[1].units == 'µm'
+        assert s1.axes_manager[2].units == 'µm'
         assert_allclose(s1.axes_manager[0].scale, 250.0)
         assert_allclose(s1.axes_manager[1].scale, s.axes_manager[1].scale)
         assert_allclose(s1.axes_manager[2].scale, s.axes_manager[2].scale)
@@ -397,8 +397,8 @@ FEI_Helios_metadata = {'Acquisition_instrument': {'SEM': {'Stage': {'rotation': 
 def test_read_FEI_SEM_scale_metadata_8bits():
     fname = os.path.join(MY_PATH2, 'FEI-Helios-Ebeam-8bits.tif')
     s = hs.load(fname, convert_units=True)
-    assert s.axes_manager[0].units == 'um'
-    assert s.axes_manager[1].units == 'um'
+    assert s.axes_manager[0].units == 'µm'
+    assert s.axes_manager[1].units == 'µm'
     assert_allclose(s.axes_manager[0].scale, 3.3724, rtol=1E-5)
     assert_allclose(s.axes_manager[1].scale, 3.3724, rtol=1E-5)
     assert s.data.dtype == 'uint8'
@@ -410,8 +410,8 @@ def test_read_FEI_SEM_scale_metadata_8bits():
 def test_read_FEI_SEM_scale_metadata_16bits():
     fname = os.path.join(MY_PATH2, 'FEI-Helios-Ebeam-16bits.tif')
     s = hs.load(fname, convert_units=True)
-    assert s.axes_manager[0].units == 'um'
-    assert s.axes_manager[1].units == 'um'
+    assert s.axes_manager[0].units == 'µm'
+    assert s.axes_manager[1].units == 'µm'
     assert_allclose(s.axes_manager[0].scale, 3.3724, rtol=1E-5)
     assert_allclose(s.axes_manager[1].scale, 3.3724, rtol=1E-5)
     assert s.data.dtype == 'uint16'
@@ -447,8 +447,8 @@ def test_read_Zeiss_SEM_scale_metadata_1k_image():
 
     fname = os.path.join(MY_PATH2, 'test_tiff_Zeiss_SEM_1k.tif')
     s = hs.load(fname, convert_units=True)
-    assert s.axes_manager[0].units == 'um'
-    assert s.axes_manager[1].units == 'um'
+    assert s.axes_manager[0].units == 'µm'
+    assert s.axes_manager[1].units == 'µm'
     assert_allclose(s.axes_manager[0].scale, 2.614514, rtol=1E-6)
     assert_allclose(s.axes_manager[1].scale, 2.614514, rtol=1E-6)
     assert s.data.dtype == 'uint8'
@@ -478,8 +478,8 @@ def test_read_Zeiss_SEM_scale_metadata_512_image():
 
     fname = os.path.join(MY_PATH2, 'test_tiff_Zeiss_SEM_512pix.tif')
     s = hs.load(fname, convert_units=True)
-    assert s.axes_manager[0].units == 'um'
-    assert s.axes_manager[1].units == 'um'
+    assert s.axes_manager[0].units == 'µm'
+    assert s.axes_manager[1].units == 'µm'
     assert_allclose(s.axes_manager[0].scale, 0.011649976, rtol=1E-6)
     assert_allclose(s.axes_manager[1].scale, 0.011649976, rtol=1E-6)
     assert s.data.dtype == 'uint8'
@@ -505,8 +505,8 @@ def test_read_BW_Zeiss_optical_scale_metadata():
     s = hs.load(fname, force_read_resolution=True, convert_units=True)
     assert s.data.dtype == np.uint8
     assert s.data.shape == (10, 13)
-    assert s.axes_manager[0].units == 'um'
-    assert s.axes_manager[1].units == 'um'
+    assert s.axes_manager[0].units == 'µm'
+    assert s.axes_manager[1].units == 'µm'
     assert_allclose(s.axes_manager[0].scale, 169.333, rtol=1E-5)
     assert_allclose(s.axes_manager[1].scale, 169.333, rtol=1E-5)
     assert s.metadata.General.date == '2016-06-13'
@@ -529,8 +529,8 @@ def test_read_BW_Zeiss_optical_scale_metadata2():
     s = hs.load(fname, force_read_resolution=True, convert_units=True)
     assert s.data.dtype == np.uint8
     assert s.data.shape == (10, 13)
-    assert s.axes_manager[0].units == 'um'
-    assert s.axes_manager[1].units == 'um'
+    assert s.axes_manager[0].units == 'µm'
+    assert s.axes_manager[1].units == 'µm'
     assert_allclose(s.axes_manager[0].scale, 169.333, rtol=1E-5)
     assert_allclose(s.axes_manager[1].scale, 169.333, rtol=1E-5)
     assert s.metadata.General.date == '2016-06-13'

--- a/hyperspy/tests/signal/test_tools.py
+++ b/hyperspy/tests/signal/test_tools.py
@@ -203,8 +203,8 @@ class Test2D:
         s.crop(1, 0.0, 5.0, convert_units=True)
         nt.assert_almost_equal(s.axes_manager[0].scale, 0.01)
         nt.assert_almost_equal(s.axes_manager[1].scale, 0.01)
-        assert s.axes_manager[0].units == "um"
-        assert s.axes_manager[1].units == "um"
+        assert s.axes_manager[0].units == "µm"
+        assert s.axes_manager[1].units == "µm"
         nt.assert_allclose(s.data, d[:500, :500])
 
     def test_crop_image_unit_convertion_signal2D(self):
@@ -252,8 +252,8 @@ class Test2D:
         s.crop_image(0, 5.0, 0.0, 5.0, convert_units=True)
         nt.assert_almost_equal(s.axes_manager[0].scale, 0.01)
         nt.assert_almost_equal(s.axes_manager[1].scale, 0.01)
-        assert s.axes_manager[0].units == "um"
-        assert s.axes_manager[1].units == "um"
+        assert s.axes_manager[0].units == "µm"
+        assert s.axes_manager[1].units == "µm"
         nt.assert_allclose(s.data, d[:500, :500])
 
     def test_split_axis0(self):


### PR DESCRIPTION
In pint 0.10, `"µ"` is used as default instead of `"u"`. Update tests accordingly.