### PR TITLE
Fix warning test suite

### DIFF
--- a/hyperspy/_signals/lazy.py
+++ b/hyperspy/_signals/lazy.py
@@ -124,10 +124,12 @@ class LazySignal(BaseSignal):
                 _logger.exception("Failed to close lazy Signal file")
 
     def _get_dask_chunks(self, axis=None, dtype=None):
-        """Returns dask chunks
+        """Returns dask chunks.
+
         Aims:
             - Have at least one signal (or specified axis) in a single chunk,
-            or as many as fit in memory
+              or as many as fit in memory
+
         Parameters
         ----------
         axis : {int, string, None, axis, tuple}
@@ -136,6 +138,7 @@ class LazySignal(BaseSignal):
             only that particular axis is guaranteed to be "not sliced".
         dtype : {string, np.dtype}
             The dtype of target chunks.
+
         Returns
         -------
         Tuple of tuples, dask chunks

--- a/hyperspy/learn/mva.py
+++ b/hyperspy/learn/mva.py
@@ -537,6 +537,9 @@ class MVA():
 
         """
         from hyperspy.signal import BaseSignal
+        if self._lazy:
+            raise NotImplementedError("Blind source separation is not "
+                                      "implemented for lazy signal.")
 
         lr = self.learning_results
 

--- a/hyperspy/learn/mva.py
+++ b/hyperspy/learn/mva.py
@@ -21,6 +21,7 @@ import types
 import logging
 
 import numpy as np
+import dask.array as da
 import matplotlib.pyplot as plt
 from matplotlib.ticker import MaxNLocator, FuncFormatter
 try:
@@ -158,7 +159,10 @@ class MVA():
 
         See also
         --------
-        plot_decomposition_factors, plot_decomposition_loadings, plot_lev
+        :py:meth:`~.signal.MVATools.plot_decomposition_factors`,
+        :py:meth:`~.signal.MVATools.plot_decomposition_loadings`,
+        :py:meth:`~.signal.MVATools.plot_decomposition_results`,
+        :py:meth:`~.learn.mva.MVA.plot_explained_variance_ratio`,
 
         """
         to_return = None
@@ -492,6 +496,9 @@ class MVA():
 
         Available algorithms: FastICA, JADE, CuBICA, and TDSEP
 
+        For lazy signal, the factors or loadings are computed to perfom the
+        BSS.
+
         Parameters
         ----------
         number_of_components : int
@@ -524,10 +531,6 @@ class MVA():
         reverse_component_criterion : str {'factors', 'loadings'}
             Use either the `factor` or the `loading` to determine if the 
             component needs to be reversed.
-        compute: bool
-           If the decomposition results are lazy, compute the BSS components
-           so that they are not lazy.
-           Default is False.
 
         **kwargs : extra key word arguments
             Any keyword arguments are passed to the BSS algorithm.
@@ -535,11 +538,14 @@ class MVA():
         FastICA documentation is here, with more arguments that can be passed as **kwargs:
         http://scikit-learn.org/stable/modules/generated/sklearn.decomposition.FastICA.html
 
+        See also
+        --------
+        :py:meth:`~.signal.MVATools.plot_bss_factors`,
+        :py:meth:`~.signal.MVATools.plot_bss_loadings`,
+        :py:meth:`~.signal.MVATools.plot_bss_results`,
+
         """
         from hyperspy.signal import BaseSignal
-        if self._lazy:
-            raise NotImplementedError("Blind source separation is not "
-                                      "implemented for lazy signal.")
 
         lr = self.learning_results
 
@@ -548,12 +554,16 @@ class MVA():
                 raise AttributeError(
                     'A decomposition must be performed before blind '
                     'source seperation or factors must be provided.')
-
             else:
                 if on_loadings:
                     factors = self.get_decomposition_loadings()
                 else:
                     factors = self.get_decomposition_factors()
+
+        if hasattr(factors, 'compute'):
+            # if the factors are lazy, we compute them, which should be fine
+            # since we already reduce the dimensionality of the data.
+            factors.compute()
 
         # Check factors
         if not isinstance(factors, BaseSignal):
@@ -588,6 +598,13 @@ class MVA():
                          str(mask.axes_manager.signal_shape),
                          space,
                          str(ref_shape)))
+            if hasattr(mask, 'compute'):
+                # if the mask is lazy, we compute them, which should be fine
+                # since we already reduce the dimensionality of the data.
+                if isinstance(mask, da.Array):
+                    mask = mask.compute()
+                else:
+                    mask.compute()
 
         # Note that we don't check the factor's signal dimension. This is on
         # purpose as an user may like to apply pretreaments that change their
@@ -680,7 +697,9 @@ class MVA():
             lr.bss_node.train(factors)
             unmixing_matrix = lr.bss_node.get_recmatrix()
         w = unmixing_matrix @ invsqcovmat
-        if lr.explained_variance is not None:
+        if lr.explained_variance is not None: 
+            if hasattr(lr.explained_variance, "compute"):
+                lr.explained_variance = lr.explained_variance.compute()
             # The output of ICA is not sorted in any way what makes it
             # difficult to compare results from different unmixings. The
             # following code is an experimental attempt to sort them in a
@@ -913,7 +932,7 @@ class MVA():
                                         mva_type='decomposition')
         return rec
 
-    def get_bss_model(self, components=None):
+    def get_bss_model(self, components=None, chunks="auto"):
         """Return the spectrum generated with the selected number of
         independent components
 
@@ -928,6 +947,12 @@ class MVA():
         -------
         Signal instance
         """
+        lr = self.learning_results
+        if self._lazy:
+            if isinstance(lr.bss_factors, np.ndarray):
+                lr.factors = da.from_array(lr.bss_factors, chunks=chunks)
+            if isinstance(lr.bss_factors, np.ndarray):
+                lr.loadings = da.from_array(lr.bss_loadings, chunks=chunks)
         rec = self._calculate_recmatrix(components=components, mva_type='bss',)
         return rec
 
@@ -943,9 +968,10 @@ class MVA():
         See Also:
         ---------
 
-        `plot_explained_variance_ration`, `decomposition`,
-        `get_decomposition_loadings`,
-        `get_decomposition_factors`.
+        :py:meth:`~.learn.mva.MVA.plot_explained_variance_ratio`,
+        :py:meth:`~.learn.mva.MVA.decomposition`,
+        :py:meth:`~.learn.mva.MVA.get_decomposition_loadings`,
+        :py:meth:`~.learn.mva.MVA.get_decomposition_factors`.
 
         """
         from hyperspy._signals.signal1d import Signal1D

--- a/hyperspy/learn/mva.py
+++ b/hyperspy/learn/mva.py
@@ -521,7 +521,7 @@ class MVA():
         comp_list : boolen numpy array
             choose the components to use by the boolean list. It permits
             to choose non contiguous components.
-        mask : bool numpy array or Signal instance.
+        mask : :py:class:`~hyperspy.signal.BaseSignal` (or subclass)
             If not None, the signal locations marked as True are masked. The
             mask shape must be equal to the signal shape
             (navigation shape) when `on_loadings` is False (True).
@@ -601,10 +601,7 @@ class MVA():
             if hasattr(mask, 'compute'):
                 # if the mask is lazy, we compute them, which should be fine
                 # since we already reduce the dimensionality of the data.
-                if isinstance(mask, da.Array):
-                    mask = mask.compute()
-                else:
-                    mask.compute()
+                mask.compute()
 
         # Note that we don't check the factor's signal dimension. This is on
         # purpose as an user may like to apply pretreaments that change their

--- a/hyperspy/signal.py
+++ b/hyperspy/signal.py
@@ -808,6 +808,9 @@ class MVATools(object):
                                       "signals of dimension higher than 2."
                                       "You can use "
                                       "`plot_decomposition_results` instead.")
+        if self.learning_results.factors is None:
+            raise RuntimeError("No learning results found. A 'decomposition' "
+                               "needs to be performed first.")
         if same_window is None:
             same_window = True
         factors = self.learning_results.factors
@@ -876,6 +879,10 @@ class MVATools(object):
                                       "signals of dimension higher than 2."
                                       "You can use "
                                       "`plot_decomposition_results` instead.")
+        if self.learning_results.bss_factors is None:
+            raise RuntimeError("No learning results found. A "
+                               "'blind_source_separation' needs to be "
+                               "performed first.")
 
         if same_window is None:
             same_window = True
@@ -966,6 +973,9 @@ class MVATools(object):
                                       "dimension higher than 2."
                                       "You can use "
                                       "`plot_decomposition_results` instead.")
+        if self.learning_results.loadings is None:
+            raise RuntimeError("No learning results found. A 'decomposition' "
+                               "needs to be performed first.")
         if same_window is None:
             same_window = True
         loadings = self.learning_results.loadings.T
@@ -1066,6 +1076,10 @@ class MVATools(object):
                                       "dimension higher than 2."
                                       "You can use "
                                       "`plot_bss_results` instead.")
+        if self.learning_results.bss_loadings is None:
+            raise RuntimeError("No learning results found. A "
+                               "'blind_source_separation' needs to be "
+                               "performed first.")
         if same_window is None:
             same_window = True
         title = _change_API_comp_label(title, comp_label)
@@ -1335,6 +1349,8 @@ class MVATools(object):
                               save_figures_format=save_figures_format)
 
     def _get_loadings(self, loadings):
+        if loadings is None:
+            raise RuntimeError("No learning results found.")
         from hyperspy.api import signals
         data = loadings.T.reshape(
             (-1,) + self.axes_manager.navigation_shape[::-1])
@@ -1348,6 +1364,8 @@ class MVATools(object):
         return signal
 
     def _get_factors(self, factors):
+        if factors is None:
+            raise RuntimeError("No learning results found.")
         signal = self.__class__(
             factors.T.reshape((-1,) + self.axes_manager.signal_shape[::-1]),
             axes=[{"size": factors.shape[-1], "navigate": True}] +
@@ -1508,6 +1526,7 @@ class MVATools(object):
         plot_bss_results
 
         """
+
         factors = self.get_decomposition_factors()
         loadings = self.get_decomposition_loadings()
         _plot_x_results(factors=factors, loadings=loadings,

--- a/hyperspy/signal.py
+++ b/hyperspy/signal.py
@@ -1376,8 +1376,11 @@ class MVATools(object):
         return signal
 
     def get_decomposition_loadings(self):
-        """Return the decomposition loadings as a
-        :py:class:`~hyperspy.signal.BaseSignal` (or subclass).
+        """Return the decomposition loadings.
+        
+        Returns
+        -------
+        signal : :py:class:`~hyperspy.signal.BaseSignal` (or subclass)
 
         See also
         --------
@@ -1391,8 +1394,11 @@ class MVATools(object):
         return signal
 
     def get_decomposition_factors(self):
-        """Return the decomposition factors as a
-        :py:class:`~hyperspy.signal.BaseSignal` (or subclass).
+        """Return the decomposition factors.
+        
+        Returns
+        -------
+        signal : :py:class:`~hyperspy.signal.BaseSignal` (or subclass)
 
         See also
         --------
@@ -1406,8 +1412,11 @@ class MVATools(object):
         return signal
 
     def get_bss_loadings(self):
-        """Return the blind source separation loadings as a
-        :py:class:`~hyperspy.signal.BaseSignal` (or subclass).
+        """Return the blind source separation loadings.
+        
+        Returns
+        -------
+        signal : :py:class:`~hyperspy.signal.BaseSignal` (or subclass)
 
         See also
         --------
@@ -1422,8 +1431,11 @@ class MVATools(object):
         return signal
 
     def get_bss_factors(self):
-        """Return the blind source separation factors as a
-        :py:class:`~hyperspy.signal.BaseSignal` (or subclass).
+        """Return the blind source separation factors.
+        
+        Returns
+        -------
+        signal : :py:class:`~hyperspy.signal.BaseSignal` (or subclass)
 
         See also
         --------

--- a/hyperspy/tests/drawing/test_plot_mva.py
+++ b/hyperspy/tests/drawing/test_plot_mva.py
@@ -82,3 +82,19 @@ class TestPlotExplainedVarianceRatio:
         return self.s2.plot_decomposition_loadings(n, per_row=per_row,
                                                    title='Loading',
                                                    axes_decor=axes_decor)
+
+def test_plot_without_decomposition():
+    sources = np.random.random(size=(5, 100))
+    mixmat = np.random.random((100, 5))
+    s = signals.Signal1D(np.dot(mixmat, sources))
+    with pytest.raises(RuntimeError):
+        s.plot_decomposition_factors()
+    with pytest.raises(RuntimeError):
+        s.plot_decomposition_loadings()
+    with pytest.raises(RuntimeError):
+        s.plot_decomposition_results()
+    s.decomposition()
+    with pytest.raises(RuntimeError):
+        s.plot_bss_factors()
+    with pytest.raises(RuntimeError):
+        s.plot_bss_loadings()

--- a/hyperspy/tests/drawing/test_plot_signal2d.py
+++ b/hyperspy/tests/drawing/test_plot_signal2d.py
@@ -469,6 +469,8 @@ def test_plot_images_tranpose():
     hs.plot.plot_images([a, b])
 
 
+# Ignore numpy warning about clipping np.nan values
+@pytest.mark.filterwarnings("ignore:Passing `np.nan` to mean no clipping in np.clip")
 def test_plot_with_non_finite_value():
     s = hs.signals.Signal2D(np.array([[np.nan, 2.0] for v in range(2)]))
     s.plot()

--- a/hyperspy/tests/mva/test_bss.py
+++ b/hyperspy/tests/mva/test_bss.py
@@ -122,12 +122,12 @@ class TestBSS1D:
     def test_mask_diff_order_1_on_loadings(self):
         # This test, unlike most other tests, either passes or raises an error.
         # It is designed to test if the mask is correctly dilated inside the
-        # `blind_source_separation_method`. If the mask is not correctely
+        # `blind_source_separation_method`. If the mask is not correctly
         # dilated the nan in the loadings should raise an error.
         mask = self.s._get_navigation_signal(dtype="bool")
         mask.isig[5] = True
         self.s.learning_results.loadings[5, :] = np.nan
-        self.s.blind_source_separation(3, diff_order=1, mask=mask,
+        self.s.blind_source_separation(2, diff_order=1, mask=mask,
                                        on_loadings=True)
 
 

--- a/hyperspy/tests/mva/test_bss.py
+++ b/hyperspy/tests/mva/test_bss.py
@@ -6,6 +6,7 @@ from hyperspy._signals.signal1d import Signal1D
 from hyperspy._signals.signal2d import Signal2D
 from hyperspy.misc.machine_learning.import_sklearn import sklearn_installed
 from hyperspy.datasets import artificial_data
+from hyperspy.decorators import lazifyTestClass
 
 
 def are_bss_components_equivalent(c1_list, c2_list, atol=1e-4):
@@ -35,6 +36,7 @@ def are_bss_components_equivalent(c1_list, c2_list, atol=1e-4):
     return matches == len(c1_list)
 
 
+@lazifyTestClass
 class TestReverseBSS:
 
     def setup_method(self, method):
@@ -64,14 +66,26 @@ class TestReverseBSS:
                                            reverse_component_criterion='toto')
 
 
+@lazifyTestClass
 class TestBSS1D:
 
     def setup_method(self, method):
         ics = np.random.laplace(size=(3, 1000))
         np.random.seed(1)
         mixing_matrix = np.random.random((100, 3))
-        self.s = Signal1D(np.dot(mixing_matrix, ics))
-        self.s.decomposition()
+        s = Signal1D(np.dot(mixing_matrix, ics))
+        s.decomposition()
+        
+        mask_sig = s._get_signal_signal(dtype="bool")
+        mask_sig.isig[5] = True
+
+        mask_nav = s._get_navigation_signal(dtype="bool")
+        mask_nav.isig[5] = True
+
+        self.s = s
+        self.mask_nav = mask_nav
+        self.mask_sig = mask_sig
+
 
     @pytest.mark.skipif(not sklearn_installed, reason="sklearn not installed")
     def test_on_loadings(self):
@@ -90,10 +104,8 @@ class TestBSS1D:
         # It is designed to test if the mask is correctly dilated inside the
         # `blind_source_separation_method`. If the mask is not correctely
         # dilated the nan in the loadings should raise an error.
-        mask = self.s._get_signal_signal(dtype="bool")
-        mask.isig[5] = True
         self.s.learning_results.factors[5, :] = np.nan
-        self.s.blind_source_separation(3, diff_order=0, mask=mask)
+        self.s.blind_source_separation(3, diff_order=0, mask=self.mask_sig)
 
     @pytest.mark.skipif(not sklearn_installed, reason="sklearn not installed")
     def test_mask_diff_order_1(self):
@@ -101,10 +113,8 @@ class TestBSS1D:
         # It is designed to test if the mask is correctly dilated inside the
         # `blind_source_separation_method`. If the mask is not correctely
         # dilated the nan in the loadings should raise an error.
-        mask = self.s._get_signal_signal(dtype="bool")
-        mask.isig[5] = True
         self.s.learning_results.factors[5, :] = np.nan
-        self.s.blind_source_separation(3, diff_order=1, mask=mask)
+        self.s.blind_source_separation(3, diff_order=1, mask=self.mask_sig)
 
     @pytest.mark.skipif(not sklearn_installed, reason="sklearn not installed")
     def test_mask_diff_order_0_on_loadings(self):
@@ -112,10 +122,8 @@ class TestBSS1D:
         # It is designed to test if the mask is correctly dilated inside the
         # `blind_source_separation_method`. If the mask is not correctely
         # dilated the nan in the loadings should raise an error.
-        mask = self.s._get_navigation_signal(dtype="bool")
-        mask.isig[5] = True
         self.s.learning_results.loadings[5, :] = np.nan
-        self.s.blind_source_separation(3, diff_order=0, mask=mask,
+        self.s.blind_source_separation(3, diff_order=0, mask=self.mask_nav,
                                        on_loadings=True)
 
     @pytest.mark.skipif(not sklearn_installed, reason="sklearn not installed")
@@ -124,13 +132,12 @@ class TestBSS1D:
         # It is designed to test if the mask is correctly dilated inside the
         # `blind_source_separation_method`. If the mask is not correctly
         # dilated the nan in the loadings should raise an error.
-        mask = self.s._get_navigation_signal(dtype="bool")
-        mask.isig[5] = True
         self.s.learning_results.loadings[5, :] = np.nan
-        self.s.blind_source_separation(2, diff_order=1, mask=mask,
+        self.s.blind_source_separation(2, diff_order=1, mask=self.mask_nav,
                                        on_loadings=True)
 
 
+@lazifyTestClass
 class TestBSS2D:
 
     def setup_method(self, method):
@@ -141,27 +148,38 @@ class TestBSS2D:
         for (axis, name) in zip(s.axes_manager._axes, ("z", "y", "x")):
             axis.name = name
         s.decomposition()
+
+        mask_sig = s._get_signal_signal(dtype="bool")
+        mask_sig.unfold()
+        mask_sig.isig[5] = True
+        mask_sig.fold()
+
+        mask_nav = s._get_navigation_signal(dtype="bool")
+        mask_nav.unfold()
+        mask_nav.isig[5] = True
+        mask_nav.fold()
+
         self.s = s
+        self.mask_nav = mask_nav
+        self.mask_sig = mask_sig
 
     @pytest.mark.skipif(not sklearn_installed, reason="sklearn not installed")
     def test_diff_axes_string_with_mask(self):
-        mask = self.s._get_signal_signal(dtype="bool")
-        mask.unfold()
-        mask.isig[5] = True
-        mask.fold()
         self.s.learning_results.factors[5, :] = np.nan
         factors = self.s.get_decomposition_factors().inav[:3]
+        if self.mask_sig._lazy:
+            self.mask_sig.compute()
         self.s.blind_source_separation(
             3, diff_order=0, fun="exp", on_loadings=False,
             factors=factors.diff(axis="x", order=1),
-            mask=mask.diff(axis="x", order=1))
+            mask=self.mask_sig.diff(axis="x", order=1))
         matrix = self.s.learning_results.unmixing_matrix.copy()
         self.s.blind_source_separation(
             3, diff_order=1, fun="exp", on_loadings=False,
-            diff_axes=["x"], mask=mask
+            diff_axes=["x"], mask=self.mask_sig
         )
         assert np.allclose(matrix, self.s.learning_results.unmixing_matrix,
-                           atol=1e-6)
+                            atol=1e-6)
 
     @pytest.mark.skipif(not sklearn_installed, reason="sklearn not installed")
     def test_diff_axes_string_without_mask(self):
@@ -175,7 +193,7 @@ class TestBSS2D:
             diff_axes=["x"],
         )
         assert np.allclose(matrix, self.s.learning_results.unmixing_matrix,
-                           atol=1e-3)
+                            atol=1e-3)
 
     @pytest.mark.skipif(not sklearn_installed, reason="sklearn not installed")
     def test_diff_axes_without_mask(self):
@@ -187,7 +205,7 @@ class TestBSS2D:
         self.s.blind_source_separation(
             3, diff_order=1, fun="exp", on_loadings=False, diff_axes=[2],)
         assert np.allclose(matrix, self.s.learning_results.unmixing_matrix,
-                           atol=1e-3)
+                            atol=1e-3)
 
     @pytest.mark.skipif(not sklearn_installed, reason="sklearn not installed")
     def test_on_loadings(self):
@@ -206,12 +224,8 @@ class TestBSS2D:
         # It is designed to test if the mask is correctly dilated inside the
         # `blind_source_separation_method`. If the mask is not correctely
         # dilated the nan in the loadings should raise an error.
-        mask = self.s._get_signal_signal(dtype="bool")
-        mask.unfold()
-        mask.isig[5] = True
-        mask.fold()
         self.s.learning_results.factors[5, :] = np.nan
-        self.s.blind_source_separation(3, diff_order=0, mask=mask)
+        self.s.blind_source_separation(3, diff_order=0, mask=self.mask_sig)
 
     @pytest.mark.skipif(not sklearn_installed, reason="sklearn not installed")
     def test_mask_diff_order_1(self):
@@ -219,12 +233,8 @@ class TestBSS2D:
         # It is designed to test if the mask is correctly dilated inside the
         # `blind_source_separation_method`. If the mask is not correctely
         # dilated the nan in the loadings should raise an error.
-        mask = self.s._get_signal_signal(dtype="bool")
-        mask.unfold()
-        mask.isig[5] = True
-        mask.fold()
         self.s.learning_results.factors[5, :] = np.nan
-        self.s.blind_source_separation(3, diff_order=1, mask=mask)
+        self.s.blind_source_separation(3, diff_order=1, mask=self.mask_sig)
 
     @pytest.mark.skipif(not sklearn_installed, reason="sklearn not installed")
     def test_mask_diff_order_1_diff_axes(self):
@@ -232,13 +242,9 @@ class TestBSS2D:
         # It is designed to test if the mask is correctly dilated inside the
         # `blind_source_separation_method`. If the mask is not correctely
         # dilated the nan in the loadings should raise an error.
-        mask = self.s._get_signal_signal(dtype="bool")
-        mask.unfold()
-        mask.isig[5] = True
-        mask.fold()
         self.s.learning_results.factors[5, :] = np.nan
-        self.s.blind_source_separation(3, diff_order=1, mask=mask,
-                                       diff_axes=["x", ])
+        self.s.blind_source_separation(3, diff_order=1, mask=self.mask_sig,
+                                        diff_axes=["x", ])
 
     @pytest.mark.skipif(not sklearn_installed, reason="sklearn not installed")
     def test_mask_diff_order_0_on_loadings(self):
@@ -246,13 +252,9 @@ class TestBSS2D:
         # It is designed to test if the mask is correctly dilated inside the
         # `blind_source_separation_method`. If the mask is not correctely
         # dilated the nan in the loadings should raise an error.
-        mask = self.s._get_navigation_signal(dtype="bool")
-        mask.unfold()
-        mask.isig[5] = True
-        mask.fold()
         self.s.learning_results.loadings[5, :] = np.nan
-        self.s.blind_source_separation(3, diff_order=0, mask=mask,
-                                       on_loadings=True)
+        self.s.blind_source_separation(3, diff_order=0, mask=self.mask_nav,
+                                        on_loadings=True)
 
     @pytest.mark.skipif(not sklearn_installed, reason="sklearn not installed")
     def test_mask_diff_order_1_on_loadings(self):
@@ -262,12 +264,10 @@ class TestBSS2D:
         # dilated the nan in the loadings should raise an error.
         s = self.s.to_signal1D()
         s.decomposition()
-        mask = s._get_navigation_signal(dtype="bool")
-        mask.unfold()
-        mask.isig[5] = True
-        mask.fold()
+        if hasattr(s.learning_results.loadings, 'compute'):
+            s.learning_results.loadings = s.learning_results.loadings.compute()
         s.learning_results.loadings[5, :] = np.nan
-        s.blind_source_separation(3, diff_order=1, mask=mask,
+        s.blind_source_separation(3, diff_order=1, mask=self.mask_sig,
                                   on_loadings=True)
 
     @pytest.mark.skipif(not sklearn_installed, reason="sklearn not installed")
@@ -278,10 +278,8 @@ class TestBSS2D:
         # dilated the nan in the loadings should raise an error.
         s = self.s.to_signal1D()
         s.decomposition()
-        mask = s._get_navigation_signal(dtype="bool")
-        mask.unfold()
-        mask.isig[5] = True
-        mask.fold()
+        if hasattr(s.learning_results.loadings, 'compute'):
+            s.learning_results.loadings = s.learning_results.loadings.compute()
         s.learning_results.loadings[5, :] = np.nan
-        s.blind_source_separation(3, diff_order=1, mask=mask,
+        s.blind_source_separation(3, diff_order=1, mask=self.mask_sig,
                                   on_loadings=True, diff_axes=["x"])

--- a/hyperspy/tests/mva/test_decomposition.py
+++ b/hyperspy/tests/mva/test_decomposition.py
@@ -116,10 +116,14 @@ class TestGetModel:
     def test_get_bss_model(self):
         s = self.s
         s.decomposition(algorithm='svd')
-        s.blind_source_separation(3)
-        sc = self.s.get_bss_model()
-        rms = np.sqrt(((sc.data - s.data)**2).sum())
-        assert rms < 5e-7
+        if self.s._lazy:
+            with pytest.raises(NotImplementedError):
+                s.blind_source_separation(3)
+        else:
+            s.blind_source_separation(3)
+            sc = self.s.get_bss_model()
+            rms = np.sqrt(((sc.data - s.data)**2).sum())
+            assert rms < 5e-7
 
 
 class TestGetExplainedVarinaceRatio:

--- a/hyperspy/tests/mva/test_decomposition.py
+++ b/hyperspy/tests/mva/test_decomposition.py
@@ -116,16 +116,13 @@ class TestGetModel:
     def test_get_bss_model(self):
         s = self.s
         s.decomposition(algorithm='svd')
-        if self.s._lazy:
-            with pytest.raises(NotImplementedError):
-                s.blind_source_separation(3)
-        else:
-            s.blind_source_separation(3)
-            sc = self.s.get_bss_model()
-            rms = np.sqrt(((sc.data - s.data)**2).sum())
-            assert rms < 5e-7
+        s.blind_source_separation(3)
+        sc = self.s.get_bss_model()
+        rms = np.sqrt(((sc.data - s.data)**2).sum())
+        assert rms < 5e-7
 
 
+@lazifyTestClass
 class TestGetExplainedVarinaceRatio:
 
     def setup_method(self, method):

--- a/hyperspy/tests/signal/test_apodization.py
+++ b/hyperspy/tests/signal/test_apodization.py
@@ -101,26 +101,26 @@ def test_apodization(lazy, window_type, inplace):
             signal3d_a = signal3d.apply_apodization(window=window_type, inplace=inplace)
         data3_a = data3 * window3d[np.newaxis, :, :, :]
 
-        assert np.alltrue(signal1d_a.data == data_a)
-        assert np.alltrue(signal2d_a.data == data2_a)
+        assert np.allclose(signal1d_a.data, data_a)
+        assert np.allclose(signal2d_a.data, data2_a)
         assert np.allclose(signal3d_a.data, data3_a)
 
         for hann_order in 9 * (np.random.rand(5)) + 1:
             window = hann_window_nth_order(SIZE_SIG0, order=int(hann_order))
             signal1d_a = signal1d.apply_apodization(window=window_type, hann_order=int(hann_order))
             data_a = data * window[np.newaxis, np.newaxis, np.newaxis, :]
-            assert np.alltrue(signal1d_a.data == data_a)
+            assert np.allclose(signal1d_a.data, data_a)
     elif window_type == 'hamming':
         window = np.hamming(SIZE_SIG0)
         signal1d_a = signal1d.apply_apodization(window=window_type)
         data_a = data * window[np.newaxis, np.newaxis, np.newaxis, :]
-        assert np.alltrue(signal1d_a.data == data_a)
+        assert np.allclose(signal1d_a.data, data_a)
     elif window_type == 'tukey':
         for tukey_alpha in np.random.rand(5):
             window = tukey(SIZE_SIG0, alpha=tukey_alpha)
             signal1d_a = signal1d.apply_apodization(window=window_type, tukey_alpha=tukey_alpha)
             data_a = data * window[np.newaxis, np.newaxis, np.newaxis, :]
-            assert np.alltrue(signal1d_a.data == data_a)
+            assert np.allclose(signal1d_a.data, data_a)
 
     # 2. Test raises:
     with pytest.raises(ValueError):


### PR DESCRIPTION
There is an issue with the warnings of the test suite on travis (see https://travis-ci.org/hyperspy/hyperspy/builds/634148599). Fixing the warning seems to be fix this error.

### Progress of the PR
- [x] raise `NotImplementedError` for bss of lazy signal,
- [x] replace the use of `np.alltrue` by `np.allclose`,
- [x] catch irrelevant warning,
- [x] ready for review.

