### PR TITLE
Fix travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ env:
     - MINIMAL_ENV=false
     - DEPS="numpy ipython scipy matplotlib traits natsort requests tqdm sympy dill h5py python-dateutil ipyparallel dask scikit-image pint numexpr statsmodels sparse imageio pyyaml PTable tifffile"
     - DEPS_OPTIONAL="scikit-learn mrcz numba cython"
-    - DEPS_DOC="sphinx"
+    - DEPS_DOC="sphinx sphinx_rtd_theme"
     - TEST_DEPS="pytest pytest-cov pytest-mpl wheel"
     - MPLBACKEND="agg"
     - TEST_ARG_OPT="--mpl"
@@ -57,8 +57,9 @@ script:
   - python -c 'import matplotlib.pyplot as plt; print("Matplotlib backend:", plt.get_backend())';
   - if [ $ENV == pip ]; then TEST_ARG_OPT=""; fi
   - pytest --pyargs hyperspy --cov=hyperspy $TEST_ARG_OPT;
+  - ls
   # build doc here to check warnings easily
-  - if [ $BUILD_DOC == true ]; then doc/make html; fi
+  - if [ $BUILD_DOC == true ]; then (cd doc && make html) ; fi
 
 #after_failure: # run only on failure in case there is a need to check matplotlib image comparison
 # This needs a service to upload the artifacts (and corresponding configuration)

--- a/hyperspy/_components/error_function.py
+++ b/hyperspy/_components/error_function.py
@@ -49,7 +49,7 @@ class Erf(Expression):
             Position of the zero crossing.
     """
     
-    def __init__(self, A=1., sigma=1., origin=0., module="scipy",
+    def __init__(self, A=1., sigma=1., origin=0., module=["numpy", "scipy"],
                  **kwargs):
         if LooseVersion(sympy.__version__) < LooseVersion("1.3"):
             raise ImportError("The `ErrorFunction` component requires "

--- a/hyperspy/_components/expression.py
+++ b/hyperspy/_components/expression.py
@@ -19,7 +19,6 @@
 from functools import wraps
 import numpy as np
 import sympy
-from sympy import lambdify
 import warnings
 
 from hyperspy.component import Component
@@ -93,7 +92,7 @@ class Expression(Component):
             applicable. It enables interative adjustment of the position of the
             component in the model. For 2D components, a tuple must be passed
             with the name of the two parameters e.g. `("x0", "y0")`.
-        module : {"numpy", "numexpr"}, default "numpy"
+        module : {"numpy", "numexpr", "scipy"}, default "numpy"
             Module used to evaluate the function. numexpr is often faster but
             it supports fewer functions and requires installing numexpr.
         add_rotation : bool, default False
@@ -215,7 +214,7 @@ class Expression(Component):
             # lambdify doesn't support constant
             # https://github.com/sympy/sympy/issues/5642
             # x = [sympy.Symbol('x')]
-            raise ValueError('Expression must contain the "x" symbol.')            
+            raise ValueError('Expression must contain the "x" symbol.')
         x = x[0]
         # Extract y
         y = [symbol for symbol in expr.free_symbols if symbol.name == "y"]

--- a/hyperspy/_components/skew_normal.py
+++ b/hyperspy/_components/skew_normal.py
@@ -146,8 +146,8 @@ class SkewNormal(Expression):
     (=position of maximum) are defined for convenience.
     """
 
-    def __init__(self, x0=0., A=1., scale=1., shape=0., module="scipy",
-                 **kwargs):
+    def __init__(self, x0=0., A=1., scale=1., shape=0.,
+                 module=['numpy', 'scipy'], **kwargs):
         if LooseVersion(sympy.__version__) < LooseVersion("1.3"):
             raise ImportError("The `SkewNormal` component requires "
                               "SymPy >= 1.3")

--- a/hyperspy/tests/signal/test_remove_background.py
+++ b/hyperspy/tests/signal/test_remove_background.py
@@ -146,13 +146,13 @@ class TestRemoveBackground1DLorentzian:
 class TestRemoveBackground1DSkewNormal:
 
     def setup_method(self, method):
-        lorentzian = components1d.SkewNormal()
-        lorentzian.A.value = 3
-        lorentzian.x0.value = 1
-        lorentzian.scale.value = 2
-        lorentzian.shape.value = 10
+        skewnormal = components1d.SkewNormal()
+        skewnormal.A.value = 3
+        skewnormal.x0.value = 1
+        skewnormal.scale.value = 2
+        skewnormal.shape.value = 10
         self.signal = signals.Signal1D(
-            lorentzian.function(np.arange(0, 10, 0.01)))
+            skewnormal.function(np.arange(0, 10, 0.01)))
         self.signal.axes_manager[0].scale = 0.01
         self.signal.metadata.Signal.binned = False
 
@@ -164,7 +164,7 @@ class TestRemoveBackground1DSkewNormal:
             show_progressbar=None)
         assert np.allclose(np.zeros(len(s1.data)), s1.data, atol=0.2)
 
-    def test_background_remove_lorentzian_full_fit(self):
+    def test_background_remove_skewnormal_full_fit(self):
         s1 = self.signal.remove_background(
             signal_range=(None, None),
             background_type='SkewNormal',
@@ -184,34 +184,34 @@ def compare_axes_manager_metadata(s0, s1):
     assert s0.metadata.General.title == s1.metadata.General.title
 
 
-# @pytest.mark.parametrize('nav_dim', [0, 1])
-# @pytest.mark.parametrize('fast', [True, False])
-# @pytest.mark.parametrize('zero_fill', [True, False])
-# @pytest.mark.parametrize('show_progressbar', [True, False])
-# @pytest.mark.parametrize('plot_remainder', [True, False])
-# @pytest.mark.parametrize('background_type',
-#                          ['Power Law', 'Polynomial', 'Offset',
-#                          'Gaussian', 'Lorentzian', 'SkewNormal'])
-# def test_remove_background_metadata_axes_manager_copy(nav_dim,
-#                                                       fast,
-#                                                       zero_fill,
-#                                                       show_progressbar,
-#                                                       plot_remainder,
-#                                                       background_type):
-#     if nav_dim == 0:
-#         s = signals.Signal1D(np.arange(10, 100)[::-1])
-#     else:
-#         s = signals.Signal1D(np.arange(10, 210)[::-1].reshape(2, 100))
-#     s.axes_manager[0].name = 'axis0'
-#     s.axes_manager[0].units = 'units0'
-#     s.axes_manager[0].scale = 0.9
-#     s.axes_manager[0].offset = 1.
-#     s.metadata.General.title = "atitle"
+@pytest.mark.parametrize('nav_dim', [0, 1])
+@pytest.mark.parametrize('fast', [True, False])
+@pytest.mark.parametrize('zero_fill', [True, False])
+@pytest.mark.parametrize('show_progressbar', [True, False])
+@pytest.mark.parametrize('plot_remainder', [True, False])
+@pytest.mark.parametrize('background_type',
+                          ['Power Law', 'Polynomial', 'Offset',
+                          'Gaussian', 'Lorentzian', 'SkewNormal'])
+def test_remove_background_metadata_axes_manager_copy(nav_dim,
+                                                      fast,
+                                                      zero_fill,
+                                                      show_progressbar,
+                                                      plot_remainder,
+                                                      background_type):
+    if nav_dim == 0:
+        s = signals.Signal1D(np.arange(10, 100)[::-1])
+    else:
+        s = signals.Signal1D(np.arange(10, 210)[::-1].reshape(2, 100))
+    s.axes_manager[0].name = 'axis0'
+    s.axes_manager[0].units = 'units0'
+    s.axes_manager[0].scale = 0.9
+    s.axes_manager[0].offset = 1.
+    s.metadata.General.title = "atitle"
 
-#     s_r = s.remove_background(signal_range=(2, 50),
-#                               fast=fast,
-#                               zero_fill=zero_fill,
-#                               show_progressbar=show_progressbar,
-#                               plot_remainder=plot_remainder,
-#                               background_type=background_type)
-#     compare_axes_manager_metadata(s, s_r)
+    s_r = s.remove_background(signal_range=(2, 50),
+                              fast=fast,
+                              zero_fill=zero_fill,
+                              show_progressbar=show_progressbar,
+                              plot_remainder=plot_remainder,
+                              background_type=background_type)
+    compare_axes_manager_metadata(s, s_r)

--- a/hyperspy/tests/signal/test_remove_background.py
+++ b/hyperspy/tests/signal/test_remove_background.py
@@ -184,34 +184,34 @@ def compare_axes_manager_metadata(s0, s1):
     assert s0.metadata.General.title == s1.metadata.General.title
 
 
-@pytest.mark.parametrize('nav_dim', [0, 1])
-@pytest.mark.parametrize('fast', [True, False])
-@pytest.mark.parametrize('zero_fill', [True, False])
-@pytest.mark.parametrize('show_progressbar', [True, False])
-@pytest.mark.parametrize('plot_remainder', [True, False])
-@pytest.mark.parametrize('background_type',
-                         ['Power Law', 'Polynomial', 'Offset',
-                         'Gaussian', 'Lorentzian', 'SkewNormal'])
-def test_remove_background_metadata_axes_manager_copy(nav_dim,
-                                                      fast,
-                                                      zero_fill,
-                                                      show_progressbar,
-                                                      plot_remainder,
-                                                      background_type):
-    if nav_dim == 0:
-        s = signals.Signal1D(np.arange(10, 100)[::-1])
-    else:
-        s = signals.Signal1D(np.arange(10, 210)[::-1].reshape(2, 100))
-    s.axes_manager[0].name = 'axis0'
-    s.axes_manager[0].units = 'units0'
-    s.axes_manager[0].scale = 0.9
-    s.axes_manager[0].offset = 1.
-    s.metadata.General.title = "atitle"
+# @pytest.mark.parametrize('nav_dim', [0, 1])
+# @pytest.mark.parametrize('fast', [True, False])
+# @pytest.mark.parametrize('zero_fill', [True, False])
+# @pytest.mark.parametrize('show_progressbar', [True, False])
+# @pytest.mark.parametrize('plot_remainder', [True, False])
+# @pytest.mark.parametrize('background_type',
+#                          ['Power Law', 'Polynomial', 'Offset',
+#                          'Gaussian', 'Lorentzian', 'SkewNormal'])
+# def test_remove_background_metadata_axes_manager_copy(nav_dim,
+#                                                       fast,
+#                                                       zero_fill,
+#                                                       show_progressbar,
+#                                                       plot_remainder,
+#                                                       background_type):
+#     if nav_dim == 0:
+#         s = signals.Signal1D(np.arange(10, 100)[::-1])
+#     else:
+#         s = signals.Signal1D(np.arange(10, 210)[::-1].reshape(2, 100))
+#     s.axes_manager[0].name = 'axis0'
+#     s.axes_manager[0].units = 'units0'
+#     s.axes_manager[0].scale = 0.9
+#     s.axes_manager[0].offset = 1.
+#     s.metadata.General.title = "atitle"
 
-    s_r = s.remove_background(signal_range=(2, 50),
-                              fast=fast,
-                              zero_fill=zero_fill,
-                              show_progressbar=show_progressbar,
-                              plot_remainder=plot_remainder,
-                              background_type=background_type)
-    compare_axes_manager_metadata(s, s_r)
+#     s_r = s.remove_background(signal_range=(2, 50),
+#                               fast=fast,
+#                               zero_fill=zero_fill,
+#                               show_progressbar=show_progressbar,
+#                               plot_remainder=plot_remainder,
+#                               background_type=background_type)
+#     compare_axes_manager_metadata(s, s_r)


### PR DESCRIPTION
Continuation of #2300 and #2301.

### Progress of the PR
- [x] Fix scipy deprecation warning which was crashing travis:
`DeprecationWarning: scipy.exp is deprecated and will be removed in SciPy 2.0.0, use numpy.exp instead`, see for example: https://travis-ci.org/ericpre/hyperspy/jobs/638103136
- [x] fix doc build,
- [x] ready for review.

