### PR TITLE
Fix #2206: "Centre='variables(/trials)' causes error"

### DIFF
--- a/doc/user_guide/mva.rst
+++ b/doc/user_guide/mva.rst
@@ -217,7 +217,9 @@ To perform Poissonian noise normalization:
      >>> s.decomposition(True)
 
 More details about the scaling procedure can be found in
-:ref:`[Keenan2004] <Keenan2004>`.
+:ref:`[Keenan2004] <Keenan2004>`. Note that  Poisson noise normalization
+cannot be used in combination with data centering using the 'centre' argument.
+Attempting to do so will raise an error.
 
 .. _rpca-label:
 

--- a/hyperspy/learn/mva.py
+++ b/hyperspy/learn/mva.py
@@ -214,11 +214,19 @@ class MVA():
             # Normalize the poissonian noise
             # TODO this function can change the masks and this can cause
             # problems when reprojecting
-            if normalize_poissonian_noise is True:
+            if normalize_poissonian_noise:
+                if centre is not None:
+                    raise ValueError(
+                        ("normalize_poissonian_noise=True is only compatible "
+                         "with centre=None, not centre={}.").format(centre)
+                    )
+
                 self.normalize_poissonian_noise(
                     navigation_mask=navigation_mask,
                     signal_mask=signal_mask,)
+
             _logger.info('Performing decomposition analysis')
+
             # The rest of the code assumes that the first data axis
             # is the navigation axis. We transpose the data if that is not the
             # case.


### PR DESCRIPTION
### Description of the change
Fixes #2206.

> @francisco-dlp commented on 12 Jun 2019
> Yes, `centre` and `normalize_poisson_noise` are not compatible. That should raise an error.

### Progress of the PR
- [x] Change implemented
- [x] update user guide

### Example

`s.decomposition(normalize_poissonian_noise=True, centre='variables')` now raises a ValueError:

```
normalize_poissonian_noise=True is only compatible with centre=None,
not centre='variables'.
```
