### PR TITLE
Fix deprecation warning

### DIFF
--- a/hyperspy/_components/voigt.py
+++ b/hyperspy/_components/voigt.py
@@ -84,7 +84,7 @@ class Voigt(Expression):
     """
 
     def __init__(self, centre=10., area=1., gamma=0.2, sigma=0.1,
-                 module="scipy", **kwargs):
+                 module=["numpy", "scipy"], **kwargs):
         # Not to break scripts once we remove the legacy Voigt
         if "legacy" in kwargs:
             del kwargs["legacy"]

--- a/hyperspy/_signals/signal1d.py
+++ b/hyperspy/_signals/signal1d.py
@@ -1051,7 +1051,7 @@ class Signal1D(BaseSignal, CommonSignal1D):
                     show_progressbar=show_progressbar)
         else:
             model.set_signal_range(signal_range[0], signal_range[1])
-            model.multifit(show_progressbar=show_progressbar)
+            model.multifit(show_progressbar=show_progressbar, iterpath='serpentine')
             model.reset_signal_range()
             result = self - model.as_signal(show_progressbar=show_progressbar)
 

--- a/hyperspy/_signals/signal1d.py
+++ b/hyperspy/_signals/signal1d.py
@@ -1051,7 +1051,9 @@ class Signal1D(BaseSignal, CommonSignal1D):
                     show_progressbar=show_progressbar)
         else:
             model.set_signal_range(signal_range[0], signal_range[1])
-            model.multifit(show_progressbar=show_progressbar, iterpath='serpentine')
+            # HyperSpy 2.0: remove setting iterpath='serpentine'
+            model.multifit(show_progressbar=show_progressbar,
+                           iterpath='serpentine')
             model.reset_signal_range()
             result = self - model.as_signal(show_progressbar=show_progressbar)
 

--- a/hyperspy/misc/eds/utils.py
+++ b/hyperspy/misc/eds/utils.py
@@ -552,7 +552,7 @@ def get_abs_corr_zeta(weight_percent, mass_thickness, take_off_angle): # take_of
     take_off_angle: float
         X-ray take-off angle in degrees.
     """
-    from hyperspy.misc.utils import material
+    from hyperspy.misc import material
 
     toa_rad = np.radians(take_off_angle)
     csc_toa = 1.0/np.sin(toa_rad)
@@ -621,7 +621,7 @@ def get_abs_corr_cross_section(composition, number_of_atoms, take_off_angle, pro
     take_off_angle: float
         X-ray take-off angle in degrees.
     """
-    from hyperspy.misc.utils import material
+    from hyperspy.misc import material
 
     toa_rad = np.radians(take_off_angle)
     Av = constants.Avogadro

--- a/hyperspy/misc/eds/utils.py
+++ b/hyperspy/misc/eds/utils.py
@@ -1,7 +1,7 @@
 import numpy as np
 import math
 from scipy import constants
-from hyperspy import utils
+from hyperspy.misc.utils import stack
 from hyperspy.misc.elements import elements as elements_db
 from functools import reduce
 
@@ -534,11 +534,12 @@ def get_abs_corr_zeta(weight_percent, mass_thickness, take_off_angle): # take_of
     take_off_angle: float
         X-ray take-off angle in degrees.
     """
+    from hyperspy.misc.utils import material
 
     toa_rad = np.radians(take_off_angle)
     csc_toa = 1.0/np.sin(toa_rad)
-     # convert from cm^2/g to m^2/kg
-    mac = utils.stack(utils.material.mass_absorption_mixture(weight_percent=weight_percent)) * 0.1
+    # convert from cm^2/g to m^2/kg
+    mac = stack(material.mass_absorption_mixture(weight_percent=weight_percent)) * 0.1
     acf = mac.data * mass_thickness.data * csc_toa
     acf = acf/(1.0 - np.exp(-(acf)))
 
@@ -602,16 +603,16 @@ def get_abs_corr_cross_section(composition, number_of_atoms, take_off_angle, pro
     take_off_angle: float
         X-ray take-off angle in degrees.
     """
+    from hyperspy.misc.utils import material
 
     toa_rad = np.radians(take_off_angle)
     Av = constants.Avogadro
     elements = [intensity.metadata.Sample.elements[0] for intensity in number_of_atoms]
-    lines = [intensity.metadata.Sample.xray_lines[0] for intensity in number_of_atoms]
     atomic_weights = np.array(
         [elements_db[element]['General_properties']['atomic_weight']
             for element in elements])
 
-    number_of_atoms = utils.stack(number_of_atoms).data
+    number_of_atoms = stack(number_of_atoms).data
 
     #calculate the total_mass per pixel, or mass thicknessself.
     total_mass = np.zeros_like(number_of_atoms[0], dtype = 'float')
@@ -619,7 +620,7 @@ def get_abs_corr_cross_section(composition, number_of_atoms, take_off_angle, pro
         total_mass += (number_of_atoms[i] * weight / Av / probe_area / 1E-15)
 
      # determine mass absorption coefficients and convert from cm^2/g to m^2/atom.
-    mac = utils.stack(utils.material.mass_absorption_mixture(weight_percent=utils.material.atomic_to_weight(composition))) * 0.1
+    mac = stack(material.mass_absorption_mixture(weight_percent=material.atomic_to_weight(composition))) * 0.1
 
     acf = np.zeros_like(number_of_atoms)
     constant = 1/(Av * math.sin(toa_rad) * probe_area * 1E-16)

--- a/hyperspy/misc/material.py
+++ b/hyperspy/misc/material.py
@@ -1,3 +1,4 @@
+from collections.abc import Iterable
 import numpy as np
 import numbers
 import copy
@@ -285,7 +286,7 @@ def mass_absorption_coefficient(element, energies):
 
     See also
     --------
-    hs.material.mass_absorption_mixture
+    :py:func:`~hs.material.mass_absorption_mixture`
 
     Note
     ----
@@ -299,7 +300,7 @@ def mass_absorption_coefficient(element, energies):
     energies = copy.copy(energies)
     if isinstance(energies, str):
         energies = utils_eds._get_energy_xray_line(energies)
-    elif hasattr(energies, '__iter__'):
+    elif isinstance(energies, Iterable):
         for i, energy in enumerate(energies):
             if isinstance(energy, str):
                 energies[i] = utils_eds._get_energy_xray_line(energy)
@@ -344,7 +345,7 @@ def _mass_absorption_mixture(weight_percent,
 
     See also
     --------
-    hs.material.mass_absorption
+    :py:func:`~hs.material.mass_absorption`
 
     Note
     ----
@@ -356,7 +357,7 @@ def _mass_absorption_mixture(weight_percent,
     if len(elements) != len(weight_percent):
         raise ValueError(
             "Elements and weight_fraction should have the same length")
-    if hasattr(weight_percent[0], '__iter__'):
+    if isinstance(weight_percent[0], Iterable):
         weight_fraction = np.array(weight_percent)
         weight_fraction /= np.sum(weight_fraction, 0)
         mac_res = np.zeros([len(energies)] + list(weight_fraction.shape[1:]))
@@ -407,7 +408,7 @@ def mass_absorption_mixture(weight_percent,
 
     See also
     --------
-    hs.material.mass_absorption_coefficient
+    :py:func:`~hs.material.mass_absorption_coefficient`
 
     Note
     ----

--- a/hyperspy/models/model1d.py
+++ b/hyperspy/models/model1d.py
@@ -897,7 +897,6 @@ class Model1D(BaseModel):
              be manually specified by passing a tuple of floats. If None
              the current signal range is used. Note that ROIs can be used
              in place of a tuple.
-
         estimate_parameters : bool, default True
             If True will check if the component has an
             estimate_parameters function, and use it to estimate the
@@ -907,6 +906,11 @@ class Model1D(BaseModel):
             component paramemeters are fixed.
         %s
         %s
+        **kwargs : dict
+            All extra keyword arguments are passed to the
+            py:meth:`~hyperspy.model.BaseModel.fit` or 
+            py:meth:`~hyperspy.model.BaseModel.multifit`
+            method, depending if ``only_current`` is True or False.
 
         Examples
         --------

--- a/hyperspy/tests/component/test_components2D.py
+++ b/hyperspy/tests/component/test_components2D.py
@@ -211,7 +211,8 @@ class TestExpression2D:
         s2 = hs.stack([s]*2)
         m = s2.create_model()
         m.append(g)
-        m.multifit()
+        # HyperSpy 2.0: remove setting iterpath='serpentine'
+        m.multifit(iterpath='serpentine')
         res = g.function_nd(x, y)
         assert res.shape == (2, 3, 3)
         assert_allclose(res, s2.data)

--- a/hyperspy/tests/component/test_gaussianhf.py
+++ b/hyperspy/tests/component/test_gaussianhf.py
@@ -50,7 +50,8 @@ def test_integral_as_signal():
     g2 = GaussianHF()
     m.append(g2)
     g2.estimate_parameters(s, 0, 100, True)
-    m.multifit()
+    # HyperSpy 2.0: remove setting iterpath='serpentine'
+    m.multifit(iterpath='serpentine')
     s_out = g2.integral_as_signal()
     ref = (h_ref * 3.33 * sqrt2pi / sigma2fwhm).reshape(s_out.data.shape)
     assert_allclose(s_out.data, ref)

--- a/hyperspy/tests/model/test_edsmodel.py
+++ b/hyperspy/tests/model/test_edsmodel.py
@@ -1,6 +1,5 @@
 
 import numpy as np
-import pytest
 
 from hyperspy.misc.test_utils import assert_warns
 from hyperspy.misc import utils

--- a/hyperspy/tests/model/test_edsmodel.py
+++ b/hyperspy/tests/model/test_edsmodel.py
@@ -248,9 +248,10 @@ class TestMaps:
 
     def test_lines_intensity(self):
         s = self.s
+
         m = s.create_model()
         # HyperSpy 2.0: remove setting iterpath='serpentine'
-        m.multifit(iterpath='serpentine')    # m.fit() is just too inaccurate
+        m.multifit(iterpath='serpentine')
         ws = np.array([0.5, 0.7, 0.3, 0.5])
         w = np.zeros((4,) + self.mix.shape)
         for x in range(self.mix.shape[0]):
@@ -264,3 +265,13 @@ class TestMaps:
             s.compute()
         for fitted, expected in zip(m.get_lines_intensity(xray_lines), w):
             np.testing.assert_allclose(fitted, expected, atol=1e-7)
+
+        m_single_fit = s.create_model()
+        # make sure we fit the navigation indices (0, 0) and don't rely on
+        # the current index of the axes_manager.
+        m_single_fit.inav[0, 0].fit()
+
+        for fitted, expected in zip(
+                m.inav[0, 0].get_lines_intensity(xray_lines),
+                m_single_fit.inav[0, 0].get_lines_intensity(xray_lines)):
+            np.testing.assert_allclose(fitted, expected, atol=1e-7)  

--- a/hyperspy/tests/model/test_edsmodel.py
+++ b/hyperspy/tests/model/test_edsmodel.py
@@ -250,7 +250,8 @@ class TestMaps:
     def test_lines_intensity(self):
         s = self.s
         m = s.create_model()
-        m.multifit()    # m.fit() is just too inaccurate
+        # HyperSpy 2.0: remove setting iterpath='serpentine'
+        m.multifit(iterpath='serpentine')    # m.fit() is just too inaccurate
         ws = np.array([0.5, 0.7, 0.3, 0.5])
         w = np.zeros((4,) + self.mix.shape)
         for x in range(self.mix.shape[0]):

--- a/hyperspy/tests/model/test_fit_component.py
+++ b/hyperspy/tests/model/test_fit_component.py
@@ -169,7 +169,9 @@ class TestFitSI:
     def test_fit_spectrum_image(self):
         m = self.model
         G = self.G
-        m.fit_component(G, signal_range=(2, 7), only_current=False)
+        # HyperSpy 2.0: remove setting iterpath='serpentine'
+        m.fit_component(G, signal_range=(2, 7), only_current=False,
+                        iterpath='serpentine')
         m.axes_manager.indices = (0, 0)
         A = G.A.value
         m.axes_manager.indices = (1, 1)

--- a/hyperspy/tests/model/test_model.py
+++ b/hyperspy/tests/model/test_model.py
@@ -918,7 +918,9 @@ class TestModelSignalVariance:
         self.m = m
 
     def test_std1_red_chisq(self):
-        self.m.multifit(fitter="leastsq", method="ls", show_progressbar=None)
+        # HyperSpy 2.0: remove setting iterpath='serpentine'
+        self.m.multifit(fitter="leastsq", method="ls", show_progressbar=None,
+                        iterpath='serpentine')
         np.testing.assert_allclose(self.m.red_chisq.data[0], 0.813109,
                                    atol=1e-5)
         np.testing.assert_allclose(self.m.red_chisq.data[1], 0.697727,
@@ -947,14 +949,18 @@ class TestMultifit:
         m[0].A.value = 100
 
     def test_fetch_only_fixed_false(self):
-        self.m.multifit(fetch_only_fixed=False, show_progressbar=None)
+        # HyperSpy 2.0: remove setting iterpath='serpentine'
+        self.m.multifit(fetch_only_fixed=False, show_progressbar=None,
+                        iterpath='serpentine')
         np.testing.assert_array_almost_equal(self.m[0].r.map['values'],
                                              [3., 100.])
         np.testing.assert_array_almost_equal(self.m[0].A.map['values'],
                                              [2., 2.])
 
     def test_fetch_only_fixed_true(self):
-        self.m.multifit(fetch_only_fixed=True, show_progressbar=None)
+        # HyperSpy 2.0: remove setting iterpath='serpentine'
+        self.m.multifit(fetch_only_fixed=True, show_progressbar=None,
+                        iterpath='serpentine')
         np.testing.assert_array_almost_equal(self.m[0].r.map['values'],
                                              [3., 3.])
         np.testing.assert_array_almost_equal(self.m[0].A.map['values'],
@@ -965,7 +971,9 @@ class TestMultifit:
         rs = self.m[0].r.as_signal(field="values")
         np.testing.assert_allclose(rs.data, np.array([2., 100.]))
         assert not "Signal.Noise_properties.variance" in rs.metadata
-        self.m.multifit(fetch_only_fixed=True, show_progressbar=None)
+        # HyperSpy 2.0: remove setting iterpath='serpentine'
+        self.m.multifit(fetch_only_fixed=True, show_progressbar=None,
+                        iterpath='serpentine')
         rs = self.m[0].r.as_signal(field="values")
         assert "Signal.Noise_properties.variance" in rs.metadata
         assert isinstance(rs.metadata.Signal.Noise_properties.variance,
@@ -977,7 +985,9 @@ class TestMultifit:
         m.signal.data *= 2.
         m[0].A.value = 2.
         m[0].A.bmin = 3.
-        m.multifit(fitter='mpfit', bounded=True, show_progressbar=None)
+        # HyperSpy 2.0: remove setting iterpath='serpentine'
+        m.multifit(fitter='mpfit', bounded=True, show_progressbar=None,
+                   iterpath='serpentine')
         np.testing.assert_array_almost_equal(self.m[0].r.map['values'],
                                              [3., 3.])
         np.testing.assert_array_almost_equal(self.m[0].A.map['values'],
@@ -989,7 +999,9 @@ class TestMultifit:
         m.signal.data *= 2.
         m[0].A.value = 2.
         m[0].A.bmin = 3.
-        m.multifit(fitter='leastsq', bounded=True, show_progressbar=None)
+        # HyperSpy 2.0: remove setting iterpath='serpentine'
+        m.multifit(fitter='leastsq', bounded=True, show_progressbar=None,
+                   iterpath='serpentine')
         np.testing.assert_array_almost_equal(self.m[0].r.map['values'],
                                              [3., 3.])
         np.testing.assert_array_almost_equal(self.m[0].A.map['values'],
@@ -1261,7 +1273,8 @@ def test_as_signal_parallel():
     m = s.create_model()
     m.append(hs.model.components1D.PowerLaw())
     m.set_signal_range(2, 5)
-    m.multifit(show_progressbar=False)
+    # HyperSpy 2.0: remove setting iterpath='serpentine'
+    m.multifit(show_progressbar=False, iterpath='serpentine')
 
     s1 = m.as_signal(out_of_range_to_nan=True, parallel=True,
                      show_progressbar=False)

--- a/hyperspy/tests/samfire/test_goodness_of_fit_tests.py
+++ b/hyperspy/tests/samfire/test_goodness_of_fit_tests.py
@@ -70,7 +70,8 @@ class TestInformationCriteria:
     def setup_method(self, method):
         m = Signal1D(np.arange(30).reshape((3, 10))).create_model()
         m.append(Lorentzian())
-        m.multifit(show_progressbar=False)
+        # HyperSpy 2.0: remove setting iterpath='serpentine'
+        m.multifit(show_progressbar=False, iterpath='serpentine')
         self.m = m
         # have to be imported here, as otherwise crashes nosetools
         from hyperspy.samfire_utils.goodness_of_fit_tests.information_theory \


### PR DESCRIPTION
### Progress of the PR
- [x] Specify `iterpath='serpentine'` in the test suite to avoid deprecation warning,
- [x] add numpy module to the Voigt components to avoid deprecation warning about `scipy.real`
- [x] ready for review.

