### PR TITLE
Fix '"is" with a literal' warnings in Python 3.8

### DIFF
--- a/hyperspy/_signals/complex_signal.py
+++ b/hyperspy/_signals/complex_signal.py
@@ -198,7 +198,7 @@ class ComplexSignal_mixin:
         %s
 
         """
-        if norm is "auto":
+        if norm == "auto":
             norm = 'log' if power_spectrum else 'linear'
 
         kwargs.update({'norm': norm,

--- a/hyperspy/misc/export_dictionary.py
+++ b/hyperspy/misc/export_dictionary.py
@@ -100,7 +100,7 @@ def export_to_dictionary(target, whitelist, dic, fullcopy=True):
         flags_str, value = value
         flags = parse_flag_string(flags_str)
         check_that_flags_make_sense(flags)
-        if key is 'self':
+        if key == 'self':
             if 'id' not in flags:
                 raise ValueError(
                     'Key "self" is only available with flag "id" given')

--- a/hyperspy/tests/io/test_dm3.py
+++ b/hyperspy/tests/io/test_dm3.py
@@ -51,7 +51,7 @@ class TestImageObject():
         images = self._load_file(fname)
         image = images[0]
         # Should return None because the tags are missing
-        assert image._get_microscope_name(image.imdict.ImageTags) is None
+        assert image._get_microscope_name(image.imdict.ImageTags) == None
 
         fname = os.path.join(MY_PATH, "dm3_2D_data",
                              "test_diffraction_pattern.dm3")
@@ -67,8 +67,8 @@ class TestImageObject():
         assert self.imageobject._get_time("6:56:37 pm") == "18:56:37"
 
     def test_parse_string(self):
-        assert self.imageobject._parse_string("") is None
-        assert self.imageobject._parse_string("string") is "string"
+        assert self.imageobject._parse_string("") == None
+        assert self.imageobject._parse_string("string") == "string"
 
 
 def test_missing_tag():

--- a/hyperspy/tests/io/test_dm3.py
+++ b/hyperspy/tests/io/test_dm3.py
@@ -51,7 +51,7 @@ class TestImageObject():
         images = self._load_file(fname)
         image = images[0]
         # Should return None because the tags are missing
-        assert image._get_microscope_name(image.imdict.ImageTags) == None
+        assert image._get_microscope_name(image.imdict.ImageTags) is None
 
         fname = os.path.join(MY_PATH, "dm3_2D_data",
                              "test_diffraction_pattern.dm3")
@@ -67,7 +67,7 @@ class TestImageObject():
         assert self.imageobject._get_time("6:56:37 pm") == "18:56:37"
 
     def test_parse_string(self):
-        assert self.imageobject._parse_string("") == None
+        assert self.imageobject._parse_string("") is None
         assert self.imageobject._parse_string("string") == "string"
 
 

--- a/hyperspy/tests/signal/test_lazy.py
+++ b/hyperspy/tests/signal/test_lazy.py
@@ -77,7 +77,7 @@ def test_blockiter_bothmasks(signal, flat, dtype, nm, sm):
         real_first = real_first.reshape((2 * 4, -1))[slices1]
         real_second = real_second.reshape((2 * 5, -1))[:, sigslice]
     else:
-        value = np.nan if dtype is 'float' else 0
+        value = np.nan if dtype == 'float' else 0
         if nm is not None:
             real_first[nm, ...] = value
         if sm is not None:

--- a/hyperspy/utils/parallel_pool.py
+++ b/hyperspy/utils/parallel_pool.py
@@ -117,7 +117,7 @@ class ParallelPool:
     def has_pool(self):
         """Returns bool if the pool is ready and set-up"""
         return self.is_ipyparallel or self.is_multiprocessing and \
-            self.pool._state is 0
+            self.pool._state == 0
 
     def _setup_ipyparallel(self):
         import ipyparallel as ipp


### PR DESCRIPTION
### Description of the change
Python 3.8 is now warning when one is comparing an object to a literal with `is`. That is, `array.dtype is "float"` should really be `array.dtype == "float"`. This PR changes the code to reflect those warnings. 
`hyperspy.api` now imports without warning, and I've checked the warnings from running the tests for any further warnings of the same kind.

For what is meant by the term _literal_, see [this stackoverflow post](https://stackoverflow.com/questions/34189086/what-are-literals-in-python).

**Clarification with an example:**
The following will raise a warning:
```python
1 is None
<stdin>:1: SyntaxWarning: "is" with a literal. Did you mean "=="?
```
But the following will not:
```python
a = 1
a is None
```

This will also raise a warning:
```python
a = "mystring"
a is "abc"
<stdin>:1: SyntaxWarning: "is" with a literal. Did you mean "=="?
```

### Progress of the PR
- [x] Change implemented (can be split into several points),
- [x] ready for review.
