### PR TITLE
Fix "0" not being printed with print_current_values

### DIFF
--- a/hyperspy/misc/model_tools.py
+++ b/hyperspy/misc/model_tools.py
@@ -136,7 +136,7 @@ class current_model_values():
         self.model = model
         self.only_free = only_free
         self.only_active = only_active
-        self.component_list = model if component_list == None else component_list
+        self.component_list = model if component_list is None else component_list
         self.model_type = str(self.model.__class__).split("'")[
             1].split('.')[-1]
 

--- a/hyperspy/misc/model_tools.py
+++ b/hyperspy/misc/model_tools.py
@@ -34,8 +34,17 @@ def _non_iter(val):
 
 
 class current_component_values():
-    """Convenience class that makes use of __repr__ methods for nice printing in
-     the notebook"""
+    """Convenience class that makes use of __repr__ methods for nice printing in the notebook
+    of the properties of parameters of a component
+     
+    Parameters
+    ----------
+    component : hyperspy component instance
+    only_free : True or False, default False
+        If True: Only include the free parameters in the view
+    only_active : True or False, default False
+        If True: Only include active parameters in the view
+     """
 
     def __init__(self, component, only_free=False, only_active=False):
         self.name = component.name
@@ -129,16 +138,24 @@ class current_component_values():
 
 
 class current_model_values():
-    """Convenience class that makes use of __repr__ methods for nice printing in
-     the notebook"""
+    """Convenience class that makes use of __repr__ methods for nice printing in the notebook
+    of the properties of parameters in components in a model 
+     
+    Parameters
+    ----------
+    component : hyperspy component instance
+    only_free : True or False, default False
+        If True: Only include the free parameters in the view
+    only_active : True or False, default False
+        If True: Only include active parameters in the view
+    """
 
-    def __init__(self, model, only_free, only_active, component_list=None):
+    def __init__(self, model, only_free=False, only_active=False, component_list=None):
         self.model = model
         self.only_free = only_free
         self.only_active = only_active
         self.component_list = model if component_list == None else component_list
-        self.model_type = str(self.model.__class__).split("'")[
-            1].split('.')[-1]
+        self.model_type = str(self.model.__class__).split("'")[1].split('.')[-1]
 
     def __repr__(self):
         text = "{}: {}\n".format(
@@ -147,7 +164,10 @@ class current_model_values():
             if not self.only_active or self.only_active and comp.active:
                 if not self.only_free or comp.free_parameters and self.only_free:
                     text += current_component_values(
-                        component=comp, only_free=self.only_free, only_active=self.only_active).__repr__() + "\n"
+                        component=comp, 
+                        only_free=self.only_free, 
+                        only_active=self.only_active
+                        ).__repr__() + "\n"
         return text
 
     def _repr_html_(self):
@@ -158,5 +178,8 @@ class current_model_values():
             if not self.only_active or self.only_active and comp.active:
                 if not self.only_free or comp.free_parameters and self.only_free:
                     html += current_component_values(
-                        component=comp, only_free=self.only_free, only_active=self.only_active)._repr_html_()
+                        component=comp, 
+                        only_free=self.only_free, 
+                        only_active=self.only_active
+                        )._repr_html_()
         return html

--- a/hyperspy/misc/model_tools.py
+++ b/hyperspy/misc/model_tools.py
@@ -43,7 +43,8 @@ class current_component_values():
     only_free : True or False, default False
         If True: Only include the free parameters in the view
     only_active : True or False, default False
-        If True: Only include active parameters in the view
+        If True: Helper for current_model_values. Only include active components in the view.
+        Always shows values if used on an individual component.
      """
 
     def __init__(self, component, only_free=False, only_active=False):

--- a/hyperspy/misc/model_tools.py
+++ b/hyperspy/misc/model_tools.py
@@ -24,13 +24,12 @@ def _is_iter(val):
 
 def _iter_join(val):
     "Joins values of iterable parameters for the fancy view, unless it equals None, then blank"
-    return "(" + ", ".join(["{:6g}".format(v)
-                            for v in val]) + ")" if val != None else ""
+    return "(" + ", ".join(["{:6g}".format(v) for v in val]) + ")" if val is not None else ""
 
 
 def _non_iter(val):
     "Returns formatted string for a value unless it equals None, then blank"
-    return "{:6g}".format(val) if val != None else ""
+    return "{:6g}".format(val) if val is not None else ""
 
 
 class current_component_values():
@@ -40,9 +39,9 @@ class current_component_values():
     Parameters
     ----------
     component : hyperspy component instance
-    only_free : True or False, default False
+    only_free : bool, default False
         If True: Only include the free parameters in the view
-    only_active : True or False, default False
+    only_active : bool, default False
         If True: Helper for current_model_values. Only include active components in the view.
         Always shows values if used on an individual component.
      """
@@ -145,9 +144,9 @@ class current_model_values():
     Parameters
     ----------
     component : hyperspy component instance
-    only_free : True or False, default False
+    only_free : bool, default False
         If True: Only include the free parameters in the view
-    only_active : True or False, default False
+    only_active : bool, default False
         If True: Only include active parameters in the view
     """
 

--- a/hyperspy/misc/model_tools.py
+++ b/hyperspy/misc/model_tools.py
@@ -23,14 +23,14 @@ def _is_iter(val):
 
 
 def _iter_join(val):
-    "Joins values of iterable parameters for the fancy view, unless it is None, then blank"
+    "Joins values of iterable parameters for the fancy view, unless it equals None, then blank"
     return "(" + ", ".join(["{:6g}".format(v)
-                            for v in val]) + ")" if val else ""
+                            for v in val]) + ")" if val != None else ""
 
 
 def _non_iter(val):
-    "Returns formatted string for a value unless it is None, then blank"
-    return "{:6g}".format(val) if val else ""
+    "Returns formatted string for a value unless it equals None, then blank"
+    return "{:6g}".format(val) if val != None else ""
 
 
 class current_component_values():
@@ -109,6 +109,8 @@ class current_component_values():
             if not self.only_free or self.only_free and para.free:
                 if _is_iter(para.value):
                     # iterables (polynomial.value) must be handled separately
+                    # This should be removed with hyperspy 2.0 as Polynomial 
+                    # has been replaced.
                     value = _iter_join(para.value)
                     std = _iter_join(para.std)
                     bmin = _iter_join(para.bmin)
@@ -134,7 +136,7 @@ class current_model_values():
         self.model = model
         self.only_free = only_free
         self.only_active = only_active
-        self.component_list = model if component_list is None else component_list
+        self.component_list = model if component_list == None else component_list
         self.model_type = str(self.model.__class__).split("'")[
             1].split('.')[-1]
 

--- a/hyperspy/tests/component/test_component_print_current.py
+++ b/hyperspy/tests/component/test_component_print_current.py
@@ -18,7 +18,7 @@
 import pytest
 
 from hyperspy.datasets.example_signals import EDS_SEM_Spectrum
-from hyperspy.misc.model_tools import current_component_values, current_model_values
+from hyperspy.misc.model_tools import current_component_values, current_model_values, _is_iter, _iter_join, _non_iter
 
 class TestSetParameters:
 
@@ -106,3 +106,16 @@ class TestSetParameters:
     def test_zero_in_normal_print(self):
         "Ensure parameters with value=0 are printed too"
         assert "            a0 |  True |          0 |" in str(current_component_values(self.model[0]).__repr__)
+
+    def test_related_tools(self):
+        assert _is_iter([1,2,3])
+        assert _is_iter((1,2,3))
+        assert not _is_iter(1)
+
+        assert _iter_join([1.2345678, 5.67890]) == '(1.23457, 5.6789)'
+        assert _iter_join([1.2345678, 5.67890]) == '(1.23457, 5.6789)'
+        assert _iter_join([1, 5]) == '(     1,      5)'
+
+        assert _non_iter(None) == ""
+        assert _non_iter(5) == '     5'
+        assert _non_iter(5.123456789) == '5.12346'

--- a/hyperspy/tests/component/test_component_print_current.py
+++ b/hyperspy/tests/component/test_component_print_current.py
@@ -99,3 +99,10 @@ class TestSetParameters:
     def test_model_print_current_values(self, fancy):
         self.model.print_current_values(fancy=fancy)
 
+    def test_zero_in_fancy_print(self):
+        "Ensure parameters with value=0 are printed too"
+        assert "<td>a1</td><td>True</td><td>     0</td>" in current_component_values(self.model[0])._repr_html_()
+
+    def test_zero_in_normal_print(self):
+        "Ensure parameters with value=0 are printed too"
+        assert "            a0 |  True |          0 |" in str(current_component_values(self.model[0]).__repr__)

--- a/hyperspy/tests/component/test_component_print_current.py
+++ b/hyperspy/tests/component/test_component_print_current.py
@@ -18,13 +18,79 @@
 import pytest
 
 from hyperspy.datasets.example_signals import EDS_SEM_Spectrum
-
+from hyperspy.misc.model_tools import current_component_values, current_model_values
 
 class TestSetParameters:
 
     def setup_method(self):
         self.model = EDS_SEM_Spectrum().create_model()
+        self.component = self.model[1]
+        # We use bmin instead of A because it's a bit more exotic
+        self.component.A.bmin = 1.23456789012
+        self.component_not_free = self.model[3]
+        self.component_not_free.set_parameters_not_free()
+        self.component_not_free.A.bmin = 9.87654321098
+        self.component_inactive = self.model[4]
+        self.component_inactive.active = False
+        self.component_inactive.A.bmin = 5.67890123456
 
+    @pytest.mark.parametrize("only_free, only_active", [(True, False), (True, False)])
+    def test_component_current_component_values(self, only_free, only_active):
+        "Many decimals aren't printed, few decimals are"
+        string_representation = str(current_component_values(self.component, only_free, only_active).__repr__())
+        html_representation = str(current_component_values(self.component, only_free, only_active)._repr_html_())
+        assert "1.234" in string_representation
+        assert "1.23456789012" not in string_representation
+        assert "1.234" in html_representation
+        assert "1.23456789012" not in html_representation
+
+    def test_component_current_component_values_only_free(self, only_free=True, only_active=False):
+        "Parameters with free=False values should not be present in repr"
+        string_representation = str(current_component_values(self.component_not_free, only_free, only_active).__repr__())
+        html_representation = str(current_component_values(self.component_not_free, only_free, only_active)._repr_html_())
+        assert "9.87" not in string_representation
+        assert "9.87" not in html_representation
+
+    @pytest.mark.parametrize("only_free, only_active", [(True, False), (True, False)])
+    def test_component_current_model_values(self, only_free, only_active):
+        "Many decimals aren't printed, few decimals are"
+        string_representation = str(current_model_values(self.model, only_free, only_active).__repr__())
+        html_representation = str(current_model_values(self.model, only_free, only_active)._repr_html_())
+        assert "1.234" in string_representation
+        assert "1.23456789012" not in string_representation
+        assert "1.234" in html_representation
+        assert "1.23456789012" not in html_representation
+
+        if only_free:
+            # Parameters with free=False values should not be present in repr
+            assert "9.87" not in string_representation
+            assert "9.87" not in html_representation
+        if only_active:
+            # components with active=False values should not be present in repr"
+            assert "5.67" not in string_representation
+            assert "5.67" not in html_representation
+
+    @pytest.mark.parametrize("only_free, only_active", [(True, False), (True, False)])
+    def test_component_current_model_values_comp_list(self, only_free, only_active):
+        comp_list = [self.component, self.component_not_free, self.component_inactive]
+        string_representation = str(current_model_values(self.model, only_free, only_active, comp_list).__repr__())
+        html_representation = str(current_model_values(self.model, only_free, only_active, comp_list)._repr_html_())
+        assert "1.234" in string_representation
+        assert "1.23456789012" not in string_representation
+        assert "1.234" in html_representation
+        assert "1.23456789012" not in html_representation
+
+        if only_free:
+            assert "9.87" not in string_representation
+            assert "9.87" not in html_representation
+        if only_active:
+            assert "5.67" not in string_representation
+            assert "5.67" not in html_representation
+
+    @pytest.mark.parametrize("fancy", (True, False))
+    def test_model_current_model_values(self, fancy):
+        self.model.print_current_values(fancy=fancy)
+        
     @pytest.mark.parametrize("fancy", (True, False))
     def test_component_print_current_values(self, fancy):
         self.model[0].print_current_values(fancy=fancy)
@@ -32,3 +98,4 @@ class TestSetParameters:
     @pytest.mark.parametrize("fancy", (True, False))
     def test_model_print_current_values(self, fancy):
         self.model.print_current_values(fancy=fancy)
+


### PR DESCRIPTION
### Description of the change
When a value of a component's parameter is 0, it was not being printed by `m.print_current_values()`. Thanks to @erh3cq for bringing it to my attention.

### Progress of the PR
- [x] Change implemented (can be split into several points),
- [x] add tests,
- [x] ready for review.
