### PR TITLE
Printing important decomposition information

### DIFF
--- a/hyperspy/learn/mva.py
+++ b/hyperspy/learn/mva.py
@@ -118,11 +118,12 @@ class MVA():
         Parameters
         ----------
         normalize_poissonian_noise : bool, default False
-            If True, scale the SI to normalize Poissonian noise
+            If True, scale the signal to normalize Poissonian noise using
+            the algorithm described in [1]_.
         algorithm : 'svd' | 'fast_svd' | 'mlpca' | 'fast_mlpca' | 'nmf' |
             'sparse_pca' | 'mini_batch_sparse_pca' | 'RPCA_GoDec' | 'ORPCA'
         output_dimension : None or int
-            number of components to keep/calculate
+            Number of components to keep/calculate
         centre : None | 'variables' | 'trials'
             If None (default), no centering is applied.
             If 'variable', the centring will be performed in the variable axis.
@@ -151,8 +152,9 @@ class MVA():
         return_info: bool, default False
             The result of the decomposition is stored internally. However,
             some algorithms generate some extra information that is not
-            stored. If True (the default is False) return any extra
-            information if available
+            stored. If True, return any extra information if available.
+            In the case of sklearn.decomposition objects, this includes the
+            sklearn Estimator object.
         print_info : bool, default True
             If True, print information about the decomposition being performed.
             In the case of sklearn.decomposition objects, this includes the
@@ -171,6 +173,11 @@ class MVA():
         :py:meth:`~.signal.MVATools.plot_decomposition_results`,
         :py:meth:`~.learn.mva.MVA.plot_explained_variance_ratio`,
 
+        References
+        ----------
+        .. [1] M. Keenan and P. Kotula, "Accounting for Poisson noise in the
+               multivariate analysis of ToF-SIMS spectrum images",
+               Surf. Interface Anal 36(3) (2004): 203-212.
         """
         to_return = None
         to_print = [
@@ -1276,17 +1283,21 @@ class MVA():
     def normalize_poissonian_noise(self, navigation_mask=None,
                                    signal_mask=None):
         """
-        Scales the SI following Surf. Interface Anal. 2004; 36: 203–212
-        to "normalize" the poissonian data for decomposition analysis
+        Scales the signal using the algorithm in Surf. Interface Anal. 2004; 36: 203–212
+        to "normalize" the Poissonian data for subsequent decomposition analysis.
 
         Parameters
         ----------
-        navigation_mask : boolen numpy array
-        signal_mask  : boolen numpy array
+        navigation_mask : boolean numpy array
+        signal_mask  : boolean numpy array
+
+        References
+        ----------
+        .. [1] M. Keenan and P. Kotula, "Accounting for Poisson noise in the
+               multivariate analysis of ToF-SIMS spectrum images",
+               Surf. Interface Anal 36(3) (2004): 203-212.
         """
-        _logger.info(
-            "Scaling the data to normalize the (presumably)"
-            " Poissonian noise")
+        _logger.info("Scaling the data to normalize Poissonian noise")
         with self.unfolded():
             # The rest of the code assumes that the first data axis
             # is the navigation axis. We transpose the data if that is not the

--- a/hyperspy/learn/mva.py
+++ b/hyperspy/learn/mva.py
@@ -130,7 +130,7 @@ class MVA():
             It only has effect when using the svd or fast_svd algorithms
         auto_transpose : bool, default True
             If True, automatically transposes the data to boost performance.
-            Only has effect when using the svd of fast_svd algorithms.
+            Only used by the 'svd' and 'fast_svd' algorithms.
         navigation_mask : boolean numpy array
             The navigation locations marked as True are not used in the
             decompostion.
@@ -179,7 +179,6 @@ class MVA():
             "  algorithm={}".format(algorithm),
             "  output_dimension={}".format(output_dimension),
             "  centre={}".format(centre),
-            "  auto_transpose={}".format(auto_transpose),
         ]
 
         # Check if it is the wrong data type

--- a/hyperspy/learn/mva.py
+++ b/hyperspy/learn/mva.py
@@ -180,8 +180,6 @@ class MVA():
             "  output_dimension={}".format(output_dimension),
             "  centre={}".format(centre),
             "  auto_transpose={}".format(auto_transpose),
-            "  polyfit={}".format(polyfit),
-            "  reproject={}".format(reproject)
         ]
 
         # Check if it is the wrong data type
@@ -298,10 +296,10 @@ class MVA():
                 explained_variance = sk.explained_variance_
                 mean = sk.mean_
                 centre = 'trials'
+
+                to_print.extend(["scikit-learn estimator:", sk])
                 if return_info:
                     to_return = sk
-                if print_info:
-                    to_print.extend(["scikit-learn estimator:", sk])
 
             elif algorithm == 'nmf':
                 if import_sklearn.sklearn_installed is False:
@@ -312,10 +310,10 @@ class MVA():
                 loadings = sk.fit_transform((
                     dc[:, signal_mask][navigation_mask, :]))
                 factors = sk.components_.T
+
+                to_print.extend(["scikit-learn estimator:", sk])
                 if return_info:
                     to_return = sk
-                if print_info:
-                    to_print.extend(["scikit-learn estimator:", sk])
 
             elif algorithm == 'sparse_pca':
                 if import_sklearn.sklearn_installed is False:
@@ -326,10 +324,10 @@ class MVA():
                 loadings = sk.fit_transform(
                     dc[:, signal_mask][navigation_mask, :])
                 factors = sk.components_.T
+
+                to_print.extend(["scikit-learn estimator:", sk])
                 if return_info:
                     to_return = sk
-                if print_info:
-                    to_print.extend(["scikit-learn estimator:", sk])
 
             elif algorithm == 'mini_batch_sparse_pca':
                 if import_sklearn.sklearn_installed is False:
@@ -340,10 +338,10 @@ class MVA():
                 loadings = sk.fit_transform(
                     dc[:, signal_mask][navigation_mask, :])
                 factors = sk.components_.T
+
+                to_print.extend(["scikit-learn estimator:", sk])
                 if return_info:
                     to_return = sk
-                if print_info:
-                    to_print.extend(["scikit-learn estimator:", sk])
 
             elif algorithm == 'mlpca' or algorithm == 'fast_mlpca':
                 _logger.info("Performing the MLPCA training")

--- a/hyperspy/tests/mva/test_decomposition.py
+++ b/hyperspy/tests/mva/test_decomposition.py
@@ -265,6 +265,42 @@ class TestNormalizeComponents():
                                       self.loadings / 2.)
 
 
+class TestPrintInfo:
+
+    def setup_method(self, method):
+        self.s = signals.Signal1D(np.random.random((20, 100)))
+
+    def test_decomposition(self, capfd):
+        # Not testing MLPCA, takes too long
+        for algorithm in ["svd", "fast_svd"]:
+            print(algorithm)
+            self.s.decomposition(algorithm=algorithm, output_dimension=2)
+            captured = capfd.readouterr()
+            assert "Decomposition info:" in captured.out
+
+    # Warning filter can be removed after scikit-learn >= 0.22
+    # See sklearn.decomposition.sparse_pca.SparsePCA docstring
+    @pytest.mark.filterwarnings("ignore:normalize_components=False:DeprecationWarning")
+    @pytest.mark.skipif(not sklearn_installed, reason="sklearn not installed")
+    def test_decomposition_sklearn(self, capfd):
+        for algorithm in ["sklearn_pca", "nmf",
+                          "sparse_pca", "mini_batch_sparse_pca"]:
+            print(algorithm)
+            self.s.decomposition(algorithm=algorithm, output_dimension=2)
+            captured = capfd.readouterr()
+            assert "Decomposition info:" in captured.out
+            assert "scikit-learn estimator:" in captured.out
+
+    def test_decomposition_no_print(self, capfd):
+        # Not testing MLPCA, takes too long
+        for algorithm in ["svd", "fast_svd"]:
+            print(algorithm)
+            self.s.decomposition(algorithm=algorithm, output_dimension=2,
+                                 print_info=False)
+            captured = capfd.readouterr()
+            assert "Decomposition info:" not in captured.out
+
+
 class TestReturnInfo:
 
     def setup_method(self, method):


### PR DESCRIPTION
### Description of the change
@thomasaarholt and I were discussing the idea of printing out information about `s.decomposition()`, after I discovered that the issue described in #1361 was likely caused by a hidden default argument passed to sklearn.

This PR introduces a `print_info=True/False` argument to `s.decomposition`, which prints out the values of the main arguments of the function such as `normalize_poissonian_noise`, and, if the chosen algorithm is an sklearn estimator, such as NMF, prints out `repr(estimator)` as well to highlight the (default) arguments sklearn is be using.

There are couple of bits open for review here

1. `polyfit=` is not documented in the docstring (see #1159)
2. Should the default value of `print_info` be True or False?
3. Should we log **ALL** the arguments? I've ignored the mask arguments, which can be ndarrays, for example.

### Progress of the PR
- [x] Change implemented
- [x] update docstring (if appropriate)
- [x] update user guide (if appropriate)
- [x] add tests
- [x] ready for review.

### Example
Default arguments/algorithm (no sklearn)
```python
>>> import numpy as np
>>> import hyperspy.api as hs
>>> s0 = hs.signals.Signal2D(np.abs(np.random.randn(16, 16, 512)))
>>> s0.decomposition(output_dimension=3)

Decomposition info:
  normalize_poissonian_noise=False
  algorithm=svd
  output_dimension=3
  centre=None
```
With an sklearn object
```python
>>> import numpy as np
>>> import hyperspy.api as hs
>>> s0 = hs.signals.Signal2D(np.abs(np.random.randn(16, 16, 512)))
>>> s0.decomposition(output_dimension=3, algorithm='nmf')

Decomposition info:
  normalize_poissonian_noise=False
  algorithm=nmf
  output_dimension=3
  centre=None
scikit-learn estimator:
NMF(alpha=0.0, beta_loss='frobenius', init=None, l1_ratio=0.0, max_iter=200,
    n_components=3, random_state=None, shuffle=False, solver='cd', tol=0.0001,
    verbose=0)
```




