### PR TITLE
Horizontal plotting with the ipympl backend

### DIFF
--- a/hyperspy/_signals/signal1d.py
+++ b/hyperspy/_signals/signal1d.py
@@ -1579,6 +1579,8 @@ class Signal1D(BaseSignal, CommonSignal1D):
              norm="auto",
              axes_manager=None,
              navigator_kwds={},
+             SEEHERE={},
+
              **kwargs):
         """%s
         %s
@@ -1594,6 +1596,7 @@ class Signal1D(BaseSignal, CommonSignal1D):
                      norm=norm,
                      axes_manager=axes_manager,
                      navigator_kwds=navigator_kwds,
+                     SEEHERE=SEEHERE,
                      **kwargs)
     plot.__doc__ %= (BASE_PLOT_DOCSTRING, BASE_PLOT_DOCSTRING_PARAMETERS,
                      PLOT1D_DOCSTRING)

--- a/hyperspy/defaults_parser.py
+++ b/hyperspy/defaults_parser.py
@@ -142,11 +142,10 @@ class GUIs(t.HasTraits):
 class PlotConfig(t.HasTraits):
     enable_ipympl_plotting = t.CBool(
         False,
-        desc='Use the widget-based ipympl plotting instead of the classic plot. Allows for horizontal plotting. Requires ipywidget_gui.')
-    ipympl_plot_style = t.Str(
-        'horizontal',
-        label='ipympl plot style (horizontal", "vertical" or "dontshow")',
-        desc = 'Set the orientation of ipympl plotting or dont show at all for custom plotting')
+        label='Enable ipympl plotting: Use the widget-based ipympl plotting for horizontal plotting. Requires ipywidget_gui_hyperspy.')
+    ipympl_plot_style = t.Enum(
+        ['horizontal', 'vertical', 'hidden'],
+        label='ipympl plot style: (Use "hidden" for custom plot layouts)')
     saturated_pixels = t.CFloat(0.,
                                 label='Saturated pixels (deprecated)',
                                 desc='Warning: this is deprecated and will be removed in HyperSpy v2.0'

--- a/hyperspy/defaults_parser.py
+++ b/hyperspy/defaults_parser.py
@@ -141,7 +141,7 @@ class GUIs(t.HasTraits):
 
 class PlotConfig(t.HasTraits):
     enable_ipympl_plotting = t.CBool(
-        True,
+        False,
         desc='Use the widget-based ipympl plotting instead of the classic plot. Allows for horizontal plotting. Requires ipywidget_gui.')
     ipympl_plot_style = t.Str(
         'horizontal',

--- a/hyperspy/defaults_parser.py
+++ b/hyperspy/defaults_parser.py
@@ -140,12 +140,12 @@ class GUIs(t.HasTraits):
 
 
 class PlotConfig(t.HasTraits):
-    enable_ipympl_plotting = t.CBool(
+    enable_widget_plotting = t.CBool(
         False,
-        label='Enable ipympl plotting: Use the widget-based ipympl plotting for horizontal plotting. Requires ipywidget_gui_hyperspy.')
-    ipympl_plot_style = t.Enum(
-        ['horizontal', 'vertical', 'hidden'],
-        label='ipympl plot style: (Use "hidden" for custom plot layouts)')
+        label='Enable widget plotting: Use the ipympl-based widget plotting for horizontal plotting. Requires ipywidgets_gui_hyperspy.')
+    widget_plot_style = t.Enum(
+        ['horizontal', 'vertical'],
+        label='ipympl plot style:')
     saturated_pixels = t.CFloat(0.,
                                 label='Saturated pixels (deprecated)',
                                 desc='Warning: this is deprecated and will be removed in HyperSpy v2.0'

--- a/hyperspy/defaults_parser.py
+++ b/hyperspy/defaults_parser.py
@@ -140,6 +140,13 @@ class GUIs(t.HasTraits):
 
 
 class PlotConfig(t.HasTraits):
+    enable_ipympl_plotting = t.CBool(
+        True,
+        desc='Use the widget-based ipympl plotting instead of the classic plot. Allows for horizontal plotting. Requires ipywidget_gui.')
+    ipympl_plot_style = t.Str(
+        'horizontal',
+        label='ipympl plot style (horizontal", "vertical" or "dontshow")',
+        desc = 'Set the orientation of ipympl plotting or dont show at all for custom plotting')
     saturated_pixels = t.CFloat(0.,
                                 label='Saturated pixels (deprecated)',
                                 desc='Warning: this is deprecated and will be removed in HyperSpy v2.0'

--- a/hyperspy/defaults_parser.py
+++ b/hyperspy/defaults_parser.py
@@ -140,12 +140,9 @@ class GUIs(t.HasTraits):
 
 
 class PlotConfig(t.HasTraits):
-    enable_widget_plotting = t.CBool(
-        False,
-        label='Enable widget plotting: Use the ipympl-based widget plotting for horizontal plotting. Requires ipywidgets_gui_hyperspy.')
     widget_plot_style = t.Enum(
         ['horizontal', 'vertical'],
-        label='ipympl plot style:')
+        label='Widget plot style: (requires jupyter-matplotlib)')
     saturated_pixels = t.CFloat(0.,
                                 label='Saturated pixels (deprecated)',
                                 desc='Warning: this is deprecated and will be removed in HyperSpy v2.0'

--- a/hyperspy/drawing/figure.py
+++ b/hyperspy/drawing/figure.py
@@ -29,7 +29,7 @@ _logger = logging.getLogger(__name__)
 
 class BlittedFigure(object):
 
-    def __init__(self, widget=None):
+    def __init__(self):
         self._draw_event_cid = None
         self._background = None
         self.events = Events()

--- a/hyperspy/drawing/figure.py
+++ b/hyperspy/drawing/figure.py
@@ -29,7 +29,7 @@ _logger = logging.getLogger(__name__)
 
 class BlittedFigure(object):
 
-    def __init__(self):
+    def __init__(self, widget=None):
         self._draw_event_cid = None
         self._background = None
         self.events = Events()
@@ -43,18 +43,20 @@ class BlittedFigure(object):
         self.title = ""
         self.ax_markers = list()
 
-    def create_figure(self, **kwargs):
+    def create_figure(self, widget=None, **kwargs):
         """Create matplotlib figure
 
         Parameters
         ----------
+        widget: ipywidgets output widget to place the figure in
         **kwargs
             All keyword arguments are passed to ``plt.figure``.
 
         """
         self.figure = utils.create_figure(
-            window_title="Figure " + self.title if self.title
-            else None, **kwargs)
+            window_title="Figure " + self.title if self.title else None, 
+            widget=widget,
+            **kwargs)
         utils.on_figure_window_close(self.figure, self._on_close)
         if self.figure.canvas.supports_blit:
             self._draw_event_cid = self.figure.canvas.mpl_connect(

--- a/hyperspy/drawing/figure.py
+++ b/hyperspy/drawing/figure.py
@@ -43,7 +43,7 @@ class BlittedFigure(object):
         self.title = ""
         self.ax_markers = list()
 
-    def create_figure(self, widget=None, **kwargs):
+    def create_figure(self, **kwargs):
         """Create matplotlib figure
 
         Parameters
@@ -53,6 +53,7 @@ class BlittedFigure(object):
             All keyword arguments are passed to ``plt.figure``.
 
         """
+        widget = kwargs.pop('widget', None)
         self.figure = utils.create_figure(
             window_title="Figure " + self.title if self.title else None, 
             widget=widget,

--- a/hyperspy/drawing/image.py
+++ b/hyperspy/drawing/image.py
@@ -63,13 +63,8 @@ class ImagePlot(BlittedFigure):
 
     """ % PLOT2D_DOCSTRING
 
-<<<<<<< HEAD
     def __init__(self, title=""):
         super(ImagePlot, self).__init__()
-=======
-    def __init__(self, widget=None):
-        super(ImagePlot, self).__init__(widget=widget)
->>>>>>> 270d5a349 (changed to be able to take signal_widget and navigation_widget as arguments to s.plot)
         self.data_function = None
         self.data_function_kwargs = {}
 

--- a/hyperspy/drawing/image.py
+++ b/hyperspy/drawing/image.py
@@ -276,7 +276,7 @@ class ImagePlot(BlittedFigure):
 
         return vmin, vmax
 
-    def create_figure(self, max_size=None, min_size=2, widget=None, **kwargs):
+    def create_figure(self, max_size=None, min_size=2, **kwargs):
         """Create matplotlib figure
 
         The figure size is automatically computed by default, taking into
@@ -308,7 +308,7 @@ class ImagePlot(BlittedFigure):
             kwargs["figsize"] = figsize.clip(min_size, max_size)
         if "disable_xyscale_keys" not in kwargs:
             kwargs["disable_xyscale_keys"] = True
-        super().create_figure(widget=widget, **kwargs)
+        super().create_figure(**kwargs)
 
     def create_axis(self):
         self.ax = self.figure.add_subplot(111)
@@ -322,7 +322,7 @@ class ImagePlot(BlittedFigure):
         if self.axes_off:
             self.ax.axis('off')
 
-    def plot(self, widget=None, data_function_kwargs={}, **kwargs):
+    def plot(self, data_function_kwargs={}, **kwargs):
         """Plot the figure
 
         Arguments:
@@ -331,7 +331,7 @@ class ImagePlot(BlittedFigure):
         self.data_function_kwargs = data_function_kwargs
         self.configure()
         if self.figure is None:
-            self.create_figure(widget=widget)
+            self.create_figure(widget=kwargs.pop('widget', None))
             self.create_axis()
 
         if (not self.axes_manager or self.axes_manager.navigation_size == 0):

--- a/hyperspy/drawing/image.py
+++ b/hyperspy/drawing/image.py
@@ -50,9 +50,10 @@ class ImagePlot(BlittedFigure):
 
     Attributes
     ----------
-    data_fuction : function or method
+    data_function : function or method
         A function that returns a 2D array when called without any
         arguments.
+    widget: ipywidgets output widget to place the figure in
     %s
     pixel_units : {None, string}
         The pixel units for the scale bar.
@@ -62,8 +63,13 @@ class ImagePlot(BlittedFigure):
 
     """ % PLOT2D_DOCSTRING
 
+<<<<<<< HEAD
     def __init__(self, title=""):
         super(ImagePlot, self).__init__()
+=======
+    def __init__(self, widget=None):
+        super(ImagePlot, self).__init__(widget=widget)
+>>>>>>> 270d5a349 (changed to be able to take signal_widget and navigation_widget as arguments to s.plot)
         self.data_function = None
         self.data_function_kwargs = {}
 
@@ -275,7 +281,7 @@ class ImagePlot(BlittedFigure):
 
         return vmin, vmax
 
-    def create_figure(self, max_size=None, min_size=2, **kwargs):
+    def create_figure(self, max_size=None, min_size=2, widget=None, **kwargs):
         """Create matplotlib figure
 
         The figure size is automatically computed by default, taking into
@@ -307,7 +313,7 @@ class ImagePlot(BlittedFigure):
             kwargs["figsize"] = figsize.clip(min_size, max_size)
         if "disable_xyscale_keys" not in kwargs:
             kwargs["disable_xyscale_keys"] = True
-        super().create_figure(**kwargs)
+        super().create_figure(widget=widget, **kwargs)
 
     def create_axis(self):
         self.ax = self.figure.add_subplot(111)
@@ -321,11 +327,16 @@ class ImagePlot(BlittedFigure):
         if self.axes_off:
             self.ax.axis('off')
 
-    def plot(self, data_function_kwargs={}, **kwargs):
+    def plot(self, widget=None, data_function_kwargs={}, **kwargs):
+        """Plot the figure
+
+        Arguments:
+        widget: ipywidgets output widget to place the figure in
+        """
         self.data_function_kwargs = data_function_kwargs
         self.configure()
         if self.figure is None:
-            self.create_figure()
+            self.create_figure(widget=widget)
             self.create_axis()
 
         if (not self.axes_manager or self.axes_manager.navigation_size == 0):

--- a/hyperspy/drawing/mpl_he.py
+++ b/hyperspy/drawing/mpl_he.py
@@ -23,17 +23,8 @@ from traits.api import Undefined
 import matplotlib as mpl
 from ipywidgets.widgets import HBox
 from hyperspy.drawing import widgets, signal1d, image
-<<<<<<< HEAD
 from hyperspy.defaults_parser import preferences
-
-=======
-try:
-    # IPython is a dependency of ipympl
-    # display is only used during widget plotting with ipympl
-    from IPython.display import display
-except ImportError:
-    pass
->>>>>>> added basic support for horizontal plotting with the ipympl backend
+from IPython.display import display
 
 _logger = logging.getLogger(__name__)
 

--- a/hyperspy/drawing/mpl_he.py
+++ b/hyperspy/drawing/mpl_he.py
@@ -21,7 +21,7 @@ import logging
 
 from traits.api import Undefined
 import matplotlib as mpl
-from ipywidgets.widgets import HBox
+from ipywidgets.widgets import HBox, VBox
 from hyperspy.drawing import widgets, signal1d, image
 from hyperspy.defaults_parser import preferences
 from IPython.display import display
@@ -194,18 +194,24 @@ class MPL_HyperExplorer(object):
                     self.pointer.disconnect, [])
         self.plot_signal(**kwargs)
 
-        if "ipympl" in mpl.get_backend():
+        if "ipympl" in mpl.get_backend() and preferences.Plot.enable_ipympl_plotting:
             # Then we can use the widget backend for two figures horizontally
-            if not self.navigator_plot:
-                display(self.signal_plot.figure.canvas)
-            else:
-                nav = self.navigator_plot.figure
-                sig = self.signal_plot.figure
-                # auto vertical margins makes the figures align to their "middles"
-                nav.canvas.layout.margin = "auto 0px auto 0px"
-                sig.canvas.layout.margin = "auto 0px auto 0px"
-                box = HBox([nav.canvas, sig.canvas])
-                display(box)
+            plot_style = preferences.Plot.ipympl_plot_style
+            if plot_style != "dontshow":
+                # if "dontshow", user will display figures themselves later in custom manner
+                if not self.navigator_plot:
+                    display(self.signal_plot.figure.canvas)
+                else:
+                    nav = self.navigator_plot.figure
+                    sig = self.signal_plot.figure
+                    # auto vertical margins makes the figures align to their "middles"
+                    nav.canvas.layout.margin = "auto 0px auto 0px"
+                    sig.canvas.layout.margin = "auto 0px auto 0px"
+                    if plot_style == "horizontal":
+                        box = HBox([nav.canvas, sig.canvas])
+                    else:
+                        box = VBox([nav.canvas, sig.canvas])
+                    display(box)
 
 
     def assign_pointer(self):

--- a/hyperspy/drawing/mpl_he.py
+++ b/hyperspy/drawing/mpl_he.py
@@ -197,7 +197,6 @@ class MPL_HyperExplorer(object):
         if "ipympl" in mpl.get_backend():
             # Then we can use the widget backend for two figures horizontally
             if not self.navigator_plot:
-                # this is equivalent of s.plot() in interactive mode
                 display(self.signal_plot.figure.canvas)
             else:
                 nav = self.navigator_plot.figure

--- a/hyperspy/drawing/mpl_he.py
+++ b/hyperspy/drawing/mpl_he.py
@@ -183,6 +183,8 @@ class MPL_HyperExplorer(object):
                 self.signal_data_function_kwargs[key] = kwargs.pop(key)
 
         navigator_kwds = kwargs.pop('navigator_kwds', {})
+        SEEHERE = kwargs.pop('SEEHERE', {})
+
         # widgets can be specified to contain the figure
         navigator_widget = navigator_kwds.get('widget', None)
         signal_widget = kwargs.get('widget', None)
@@ -199,6 +201,8 @@ class MPL_HyperExplorer(object):
             navigator_widget = Output() if not navigator_widget else navigator_widget
             signal_widget = Output() if not signal_widget else signal_widget
             navigator_kwds['widget'] = navigator_widget
+            SEEHERE['THIS ISNT'] = "VISIBLE ON FIRST PLOT"
+
             kwargs['widget'] = signal_widget
 
         if self.pointer is None:

--- a/hyperspy/drawing/mpl_he.py
+++ b/hyperspy/drawing/mpl_he.py
@@ -205,11 +205,14 @@ class MPL_HyperExplorer(object):
                     nav = self.navigator_plot.figure
                     sig = self.signal_plot.figure
                     # auto vertical margins makes the figures align to their "middles"
-                    nav.canvas.layout.margin = "auto 0px auto 0px"
-                    sig.canvas.layout.margin = "auto 0px auto 0px"
+
                     if plot_style == "horizontal":
+                        nav.canvas.layout.margin = "auto 0px auto 0px"
+                        sig.canvas.layout.margin = "auto 0px auto 0px"
                         box = HBox([nav.canvas, sig.canvas])
                     else:
+                        nav.canvas.layout.margin = "0px auto 0px auto"
+                        sig.canvas.layout.margin = "0px auto 0px auto"
                         box = VBox([nav.canvas, sig.canvas])
                     display(box)
 

--- a/hyperspy/drawing/mpl_he.py
+++ b/hyperspy/drawing/mpl_he.py
@@ -20,10 +20,20 @@ from functools import partial
 import logging
 
 from traits.api import Undefined
-
+import matplotlib as mpl
+from ipywidgets.widgets import HBox
 from hyperspy.drawing import widgets, signal1d, image
+<<<<<<< HEAD
 from hyperspy.defaults_parser import preferences
 
+=======
+try:
+    # IPython is a dependency of ipympl
+    # display is only used during widget plotting with ipympl
+    from IPython.display import display
+except ImportError:
+    pass
+>>>>>>> added basic support for horizontal plotting with the ipympl backend
 
 _logger = logging.getLogger(__name__)
 
@@ -192,6 +202,21 @@ class MPL_HyperExplorer(object):
                 self.navigator_plot.events.closed.connect(
                     self.pointer.disconnect, [])
         self.plot_signal(**kwargs)
+
+        if "ipympl" in mpl.get_backend():
+            # Then we can use the widget backend for two figures horizontally
+            if not self.navigator_plot:
+                # this is equivalent of s.plot() in interactive mode
+                display(self.signal_plot.figure.canvas)
+            else:
+                nav = self.navigator_plot.figure
+                sig = self.signal_plot.figure
+                # auto vertical margins makes the figures align to their "middles"
+                nav.canvas.layout.margin = "auto 0px auto 0px"
+                sig.canvas.layout.margin = "auto 0px auto 0px"
+                box = HBox([nav.canvas, sig.canvas])
+                display(box)
+
 
     def assign_pointer(self):
         if self.navigator_data_function is None:

--- a/hyperspy/drawing/mpl_he.py
+++ b/hyperspy/drawing/mpl_he.py
@@ -49,11 +49,7 @@ class MPL_HyperExplorer(object):
         self.pointer = None
         self._pointer_nav_dim = None
 
-<<<<<<< HEAD
-    def plot_signal(self, **kwargs):
-=======
-    def plot_signal(self, signal_widget=None):
->>>>>>> 270d5a349 (changed to be able to take signal_widget and navigation_widget as arguments to s.plot)
+    def plot_signal(self, signal_widget=None, **kwargs):
         # This method should be implemented by the subclasses.
         # Doing nothing is good enough for signal_dimension==0 though.
         if self.axes_manager.signal_dimension == 0:
@@ -63,8 +59,7 @@ class MPL_HyperExplorer(object):
             for axis in self.axes_manager.signal_axes:
                 axis.offset = -axis.high_value / 2.
 
-<<<<<<< HEAD
-    def plot_navigator(self, title=None, **kwargs):
+    def plot_navigator(self, title=None, navigator_widget=None, **kwargs):
         """
         Parameters
         ----------
@@ -76,22 +71,6 @@ class MPL_HyperExplorer(object):
             :py:meth:`hyperspy.drawing.signal1d.Signal1DLine`.
 
         """
-=======
-    def plot_navigator(self,
-                       colorbar=True,
-                       scalebar=True,
-                       scalebar_color="white",
-                       axes_ticks=None,
-                       saturated_pixels=None,
-                       vmin=None,
-                       vmax=None,
-                       no_nans=False,
-                       centre_colormap="auto",
-                       title=None,
-                       min_aspect=0.1,
-                       navigator_widget=None,
-                       **kwds):
->>>>>>> 270d5a349 (changed to be able to take signal_widget and navigation_widget as arguments to s.plot)
         if self.axes_manager.navigation_dimension == 0:
             return
         if self.navigator_data_function is None:
@@ -163,16 +142,9 @@ class MPL_HyperExplorer(object):
                             partial(axis.events.index_changed.disconnect,
                                     imf.update), [])
 
-<<<<<<< HEAD
             if "cmap" not in kwargs.keys() or kwargs['cmap'] is None:
                 kwargs["cmap"] = preferences.Plot.cmap_navigator
-            imf.plot(**kwargs)
-=======
-            imf.title = title
-            if "cmap" not in kwds.keys() or kwds['cmap'] is None:
-                kwds["cmap"] = preferences.Plot.cmap_navigator
-            imf.plot(widget=navigator_widget, **kwds)
->>>>>>> 270d5a349 (changed to be able to take signal_widget and navigation_widget as arguments to s.plot)
+            imf.plot(widget=navigator_widget, **kwargs)
             self.pointer.set_mpl_ax(imf.ax)
             self.navigator_plot = imf
 
@@ -233,22 +205,10 @@ class MPL_HyperExplorer(object):
                 self.pointer = pointer(self.axes_manager)
                 self.pointer.color = 'red'
                 self.pointer.connect_navigate()
-<<<<<<< HEAD
-            self.plot_navigator(**kwargs.pop('navigator_kwds', {}))
+            self.plot_navigator(navigator_widget=navigator_widget, **kwargs.pop('navigator_kwds', {}))
             if pointer is not None:
                 self.navigator_plot.events.closed.connect(
                     self.pointer.disconnect, [])
-        self.plot_signal(**kwargs)
-
-        if "ipympl" in mpl.get_backend() and preferences.Plot.enable_ipympl_plotting:
-            # Then we can use the widget backend for two figures horizontally
-            plot_style = preferences.Plot.ipympl_plot_style
-            if plot_style != "hidden":
-                # if "hidden", user will display figures themselves later in custom manner
-                if not self.navigator_plot:
-                    display(self.signal_plot.figure.canvas)
-=======
-            self.plot_navigator(navigator_widget=navigator_widget, **kwargs.pop('navigator_kwds', {}))
         self.plot_signal(signal_widget=signal_widget, **kwargs)
 
         if display_both_widgets_now:
@@ -262,7 +222,6 @@ class MPL_HyperExplorer(object):
                     navigator_widget.layout.margin = margin
                     signal_widget.layout.margin = margin
                     box = HBox([navigator_widget, signal_widget])
->>>>>>> 270d5a349 (changed to be able to take signal_widget and navigation_widget as arguments to s.plot)
                 else:
                     margin = "0px auto 0px auto"
                     navigator_widget.layout.margin = margin

--- a/hyperspy/drawing/mpl_he.py
+++ b/hyperspy/drawing/mpl_he.py
@@ -197,8 +197,8 @@ class MPL_HyperExplorer(object):
         if "ipympl" in mpl.get_backend() and preferences.Plot.enable_ipympl_plotting:
             # Then we can use the widget backend for two figures horizontally
             plot_style = preferences.Plot.ipympl_plot_style
-            if plot_style != "dontshow":
-                # if "dontshow", user will display figures themselves later in custom manner
+            if plot_style != "hidden":
+                # if "hidden", user will display figures themselves later in custom manner
                 if not self.navigator_plot:
                     display(self.signal_plot.figure.canvas)
                 else:

--- a/hyperspy/drawing/mpl_hie.py
+++ b/hyperspy/drawing/mpl_hie.py
@@ -23,45 +23,21 @@ from hyperspy.defaults_parser import preferences
 
 class MPL_HyperImage_Explorer(MPL_HyperExplorer):
 
-<<<<<<< HEAD
-    def plot_signal(self, **kwargs):
+    def plot_signal(self, signal_widget=None, **kwargs):
         """
         Parameters
         ----------
+        signal_widget : widget or None
+            ipywidgets output widget to place the figure in (optional)
         **kwargs : dict
             The kwargs are passed to plot method of the image figure.
-=======
-    def plot_signal(self,
-                    colorbar=True,
-                    scalebar=True,
-                    scalebar_color="white",
-                    axes_ticks=None,
-                    axes_off=False,
-                    saturated_pixels=None,
-                    vmin=None,
-                    vmax=None,
-                    no_nans=False,
-                    centre_colormap="auto",
-                    norm="auto",
-                    min_aspect=0.1,
-                    gamma=1.0,
-                    linthresh=0.01,
-                    linscale=0.1,
-                    signal_widget=None,
-                    **kwargs
-                    ):
-        """Plot image.
-
-        Parameters
-        ----------
-        %s
-        %s
-        widget: ipywidgets output widget to place the figure in
->>>>>>> 270d5a349 (changed to be able to take signal_widget and navigation_widget as arguments to s.plot)
 
         """
+        if self.signal_plot is not None:
+            self.signal_plot.plot(widget=signal_widget, **kwargs)
+            return
         super().plot_signal()
-        imf = image.ImagePlot(widget = signal_widget)
+        imf = image.ImagePlot()
         imf.axes_manager = self.axes_manager
         imf.data_function = self.signal_data_function
         imf.title = self.signal_title + " Signal"
@@ -78,7 +54,7 @@ class MPL_HyperImage_Explorer(MPL_HyperExplorer):
         kwargs['data_function_kwargs'] = self.signal_data_function_kwargs
         if "cmap" not in kwargs.keys() or kwargs['cmap'] is None:
             kwargs["cmap"] = preferences.Plot.cmap_signal
-        imf.plot(**kwargs)
+        imf.plot(widget=signal_widget, **kwargs)
         self.signal_plot = imf
 
         if imf.figure is not None:

--- a/hyperspy/drawing/mpl_hie.py
+++ b/hyperspy/drawing/mpl_hie.py
@@ -23,18 +23,17 @@ from hyperspy.defaults_parser import preferences
 
 class MPL_HyperImage_Explorer(MPL_HyperExplorer):
 
-    def plot_signal(self, signal_widget=None, **kwargs):
+    def plot_signal(self, **kwargs):
         """
         Parameters
         ----------
-        signal_widget : widget or None
-            ipywidgets output widget to place the figure in (optional)
         **kwargs : dict
             The kwargs are passed to plot method of the image figure.
 
         """
+
         if self.signal_plot is not None:
-            self.signal_plot.plot(widget=signal_widget, **kwargs)
+            self.signal_plot.plot(**kwargs)
             return
         super().plot_signal()
         imf = image.ImagePlot()
@@ -54,7 +53,7 @@ class MPL_HyperImage_Explorer(MPL_HyperExplorer):
         kwargs['data_function_kwargs'] = self.signal_data_function_kwargs
         if "cmap" not in kwargs.keys() or kwargs['cmap'] is None:
             kwargs["cmap"] = preferences.Plot.cmap_signal
-        imf.plot(widget=signal_widget, **kwargs)
+        imf.plot(**kwargs)
         self.signal_plot = imf
 
         if imf.figure is not None:

--- a/hyperspy/drawing/mpl_hie.py
+++ b/hyperspy/drawing/mpl_hie.py
@@ -23,16 +23,45 @@ from hyperspy.defaults_parser import preferences
 
 class MPL_HyperImage_Explorer(MPL_HyperExplorer):
 
+<<<<<<< HEAD
     def plot_signal(self, **kwargs):
         """
         Parameters
         ----------
         **kwargs : dict
             The kwargs are passed to plot method of the image figure.
+=======
+    def plot_signal(self,
+                    colorbar=True,
+                    scalebar=True,
+                    scalebar_color="white",
+                    axes_ticks=None,
+                    axes_off=False,
+                    saturated_pixels=None,
+                    vmin=None,
+                    vmax=None,
+                    no_nans=False,
+                    centre_colormap="auto",
+                    norm="auto",
+                    min_aspect=0.1,
+                    gamma=1.0,
+                    linthresh=0.01,
+                    linscale=0.1,
+                    signal_widget=None,
+                    **kwargs
+                    ):
+        """Plot image.
+
+        Parameters
+        ----------
+        %s
+        %s
+        widget: ipywidgets output widget to place the figure in
+>>>>>>> 270d5a349 (changed to be able to take signal_widget and navigation_widget as arguments to s.plot)
 
         """
         super().plot_signal()
-        imf = image.ImagePlot()
+        imf = image.ImagePlot(widget = signal_widget)
         imf.axes_manager = self.axes_manager
         imf.data_function = self.signal_data_function
         imf.title = self.signal_title + " Signal"

--- a/hyperspy/drawing/mpl_hse.py
+++ b/hyperspy/drawing/mpl_hse.py
@@ -73,12 +73,14 @@ class MPL_HyperSignal1D_Explorer(MPL_HyperExplorer):
         else:
             self.remove_right_pointer()
 
-    def plot_signal(self, **kwargs):
+    def plot_signal(self, signal_widget=None, **kwargs):
         super().plot_signal()
         # Create the figure
         self.axis = self.axes_manager.signal_axes[0]
-        sf = signal1d.Signal1DFigure(title=self.signal_title +
-                                     " Signal")
+        sf = signal1d.Signal1DFigure(
+            title=self.signal_title + " Signal",
+            widget=signal_widget
+            )
         sf.axis = self.axis
         if sf.ax is None:
             sf.create_axis()

--- a/hyperspy/drawing/mpl_hse.py
+++ b/hyperspy/drawing/mpl_hse.py
@@ -73,13 +73,13 @@ class MPL_HyperSignal1D_Explorer(MPL_HyperExplorer):
         else:
             self.remove_right_pointer()
 
-    def plot_signal(self, signal_widget=None, **kwargs):
+    def plot_signal(self, **kwargs):
         super().plot_signal()
         # Create the figure
         self.axis = self.axes_manager.signal_axes[0]
         sf = signal1d.Signal1DFigure(
             title=self.signal_title + " Signal",
-            widget=signal_widget
+            **kwargs
             )
         sf.axis = self.axis
         if sf.ax is None:

--- a/hyperspy/drawing/signal1d.py
+++ b/hyperspy/drawing/signal1d.py
@@ -40,7 +40,7 @@ class Signal1DFigure(BlittedFigure):
     """
     """
 
-    def __init__(self, title=""):
+    def __init__(self, title="", widget=None):
         super(Signal1DFigure, self).__init__()
         self.figure = None
         self.ax = None
@@ -54,7 +54,7 @@ class Signal1DFigure(BlittedFigure):
         self.xlabel = ''
         self.ylabel = ''
         self.title = title
-        self.create_figure()
+        self.create_figure(widget=widget)
         self.create_axis()
 
         # Color cycles

--- a/hyperspy/drawing/signal1d.py
+++ b/hyperspy/drawing/signal1d.py
@@ -40,7 +40,7 @@ class Signal1DFigure(BlittedFigure):
     """
     """
 
-    def __init__(self, title="", widget=None):
+    def __init__(self, title="", **kwargs):
         super(Signal1DFigure, self).__init__()
         self.figure = None
         self.ax = None
@@ -54,7 +54,7 @@ class Signal1DFigure(BlittedFigure):
         self.xlabel = ''
         self.ylabel = ''
         self.title = title
-        self.create_figure(widget=widget)
+        self.create_figure(widget=kwargs.pop('widget', None))
         self.create_axis()
 
         # Color cycles

--- a/hyperspy/drawing/tiles.py
+++ b/hyperspy/drawing/tiles.py
@@ -40,7 +40,7 @@ class HistogramTilePlot(BlittedFigure):
 
     def plot(self, db, **kwargs):
         if self.figure is None:
-            self.create_figure()
+            self.create_figure(widget=kwargs.pop('widget', None))
         ncomps = len(db)
 
         if not ncomps:

--- a/hyperspy/drawing/utils.py
+++ b/hyperspy/drawing/utils.py
@@ -29,7 +29,6 @@ import warnings
 import numpy as np
 import logging
 from functools import partial
-=======
 import hyperspy as hs
 from hyperspy.defaults_parser import preferences
 

--- a/hyperspy/drawing/utils.py
+++ b/hyperspy/drawing/utils.py
@@ -151,8 +151,9 @@ def create_figure(window_title=None,
     fig : plt.figure
 
     """
-    if "ipympl" in mpl.get_backend():
-        # this output is currently not used, instead we get at the figure canvas widgets themselves later
+    if "ipympl" in mpl.get_backend() and preferences.Plot.enable_ipympl_plotting:
+        # this output is currently not used, just used for hiding.
+        # instead we get at the figure canvas widgets themselves later
         output_widget = ipywidgets.widgets.Output()
         with output_widget:
             fig = plt.figure(**kwargs)

--- a/hyperspy/drawing/utils.py
+++ b/hyperspy/drawing/utils.py
@@ -28,8 +28,11 @@ from matplotlib.backend_bases import key_press_handler
 import warnings
 import numpy as np
 import logging
+<<<<<<< HEAD
 from functools import partial
 import ipywidgets
+=======
+>>>>>>> 270d5a349 (changed to be able to take signal_widget and navigation_widget as arguments to s.plot)
 
 import hyperspy as hs
 from hyperspy.defaults_parser import preferences
@@ -131,6 +134,7 @@ def centre_colormap_values(vmin, vmax):
 def create_figure(window_title=None,
                   _on_figure_window_close=None,
                   disable_xyscale_keys=False,
+                  widget=None,
                   **kwargs):
     """Create a matplotlib figure.
 
@@ -145,16 +149,18 @@ def create_figure(window_title=None,
     disable_xyscale_keys : bool, optional
         Disable the `k`, `l` and `L` shortcuts which toggle the x or y axis
         between linear and log scale. Default False.
+    widget : ipywidgets output widget to place the figure in
 
     Returns
     -------
     fig : plt.figure
 
     """
-    if "ipympl" in mpl.get_backend() and preferences.Plot.enable_ipympl_plotting:
+    if "ipympl" in mpl.get_backend() and preferences.Plot.enable_widget_plotting:
         # this output is currently not used, just used for hiding.
         # instead we get at the figure canvas widgets themselves later
-        output_widget = ipywidgets.widgets.Output()
+        from ipywidgets.widgets import Output
+        output_widget = widget if widget else Output()
         with output_widget:
             fig = plt.figure(**kwargs)
     else:

--- a/hyperspy/drawing/utils.py
+++ b/hyperspy/drawing/utils.py
@@ -150,7 +150,15 @@ def create_figure(window_title=None,
     fig : plt.figure
 
     """
+    mpl_was_interactive = False
+    if "ipympl" in mpl.get_backend():
+        # turn off matplotlib interactive to not draw figure if widget mode
+        if mpl.is_interactive():
+            mpl_was_interactive = True
+            plt.ioff()
     fig = plt.figure(**kwargs)
+    if mpl_was_interactive:
+        plt.ion() # turn interactive back on
     if window_title is not None:
         # remove non-alphanumeric characters to prevent file saving problems
         # This is a workaround for:

--- a/hyperspy/drawing/utils.py
+++ b/hyperspy/drawing/utils.py
@@ -28,12 +28,8 @@ from matplotlib.backend_bases import key_press_handler
 import warnings
 import numpy as np
 import logging
-<<<<<<< HEAD
 from functools import partial
-import ipywidgets
 =======
->>>>>>> 270d5a349 (changed to be able to take signal_widget and navigation_widget as arguments to s.plot)
-
 import hyperspy as hs
 from hyperspy.defaults_parser import preferences
 

--- a/hyperspy/drawing/utils.py
+++ b/hyperspy/drawing/utils.py
@@ -29,6 +29,7 @@ import warnings
 import numpy as np
 import logging
 from functools import partial
+import ipywidgets
 
 import hyperspy as hs
 from hyperspy.defaults_parser import preferences
@@ -150,15 +151,14 @@ def create_figure(window_title=None,
     fig : plt.figure
 
     """
-    mpl_was_interactive = False
     if "ipympl" in mpl.get_backend():
-        # turn off matplotlib interactive to not draw figure if widget mode
-        if mpl.is_interactive():
-            mpl_was_interactive = True
-            plt.ioff()
-    fig = plt.figure(**kwargs)
-    if mpl_was_interactive:
-        plt.ion() # turn interactive back on
+        # this output is currently not used, instead we get at the figure canvas widgets themselves later
+        output_widget = ipywidgets.widgets.Output()
+        with output_widget:
+            fig = plt.figure(**kwargs)
+    else:
+        output_widget = None
+        fig = plt.figure(**kwargs)
     if window_title is not None:
         # remove non-alphanumeric characters to prevent file saving problems
         # This is a workaround for:

--- a/hyperspy/drawing/utils.py
+++ b/hyperspy/drawing/utils.py
@@ -151,15 +151,10 @@ def create_figure(window_title=None,
     fig : plt.figure
 
     """
-    if "ipympl" in mpl.get_backend() and preferences.Plot.enable_widget_plotting:
-        # this output is currently not used, just used for hiding.
-        # instead we get at the figure canvas widgets themselves later
-        from ipywidgets.widgets import Output
-        output_widget = widget if widget else Output()
-        with output_widget:
+    if widget:
+        with widget:
             fig = plt.figure(**kwargs)
     else:
-        output_widget = None
         fig = plt.figure(**kwargs)
     if window_title is not None:
         # remove non-alphanumeric characters to prevent file saving problems

--- a/hyperspy/roi.py
+++ b/hyperspy/roi.py
@@ -411,7 +411,7 @@ class BaseInteractiveROI(BaseROI):
         self._update_widgets(exclude=(widget,))
         self.events.changed.trigger(self)
 
-    def add_widget(self, signal, axes=None, widget=None,
+    def add_widget(self, signal, axes=None,  widget=None,
                    color='green', **kwargs):
         """Add a widget to visually represent the ROI, and connect it so any
         changes in either are reflected in the other. Note that only one

--- a/setup.py
+++ b/setup.py
@@ -69,6 +69,7 @@ install_req = ['scipy>=1.1',
                'prettytable',
                'tifffile>=2018.10.18',
                'numba',
+               'IPython',
                ]
 
 extras_require = {


### PR DESCRIPTION
### Description of the change
I've added support for plotting side-by-side horizontally using the `%matplotlib widget` backend. (`%matplotlib ipympl` is equivalent, but the former looks more user-friendly).

I've basically placed `fig.canvas` from the navigator and signal inside a ipywidgets `HBox` and `display`ed that.

I've also added two additional plotting styles:

-  'vertical' style, which differs from the regular plotting style by being centered in the browser. 
- 'hidden' style, which doesn't show (but does create) the plot, so that a user can grab the widget canvases themselves in order to create fun plot layouts.
```python
# displaying either of these will show the plot in a different cell
# and can be wrapped in other widgets
# hs.preferences.Plot.enable_ipympl_plotting = True
# hs.preferences.Plot.ipympl_plot_style = 'hidden'
s._plot.navigator_plot.figure.canvas
s._plot.signal_plot.figure.canvas
```

Note that it requires a recent version of ipympl, but not version 0.5.3! (0.5.6 was released today)

### Progress of the PR
- [x] basic support added
- [x] refinements
- [x] updated preferences
- [ ] update user guide
- [ ] add tests,
- [x] ready for review.

### Minimal example of the bug fix or the new feature
```python
%matplotlib widget
import hyperspy.api as hs
import numpy as np
s = hs.signals.Signal1D(np.random.random((64, 64, 256)))
hs.preferences.Plot.enable_widget_plotting = True
# hs.preferences.Plot.ipympl_plot_style = 'horizontal' | 'vertical' | 'hidden' # defaults to horizontal
s.plot()
```

Example on one of my spectrum images:
![image](https://user-images.githubusercontent.com/2721423/76900905-8131d380-689a-11ea-9797-84f88b553e6d.png)