### PR TITLE
Support for axis midpoint_value and midpoint_index

### DIFF
--- a/hyperspy/axes.py
+++ b/hyperspy/axes.py
@@ -212,9 +212,11 @@ class DataAxis(t.HasTraits, UnitConversion):
     size = t.CInt()
     low_value = t.Float()
     high_value = t.Float()
+    midpoint_value = t.Float()
     value = t.Range('low_value', 'high_value')
     low_index = t.Int(0)
     high_index = t.Int()
+    midpoint_index = t.Int()
     slice = t.Instance(slice)
     navigate = t.Bool(t.Undefined)
     index = t.Range('low_index', 'high_index')
@@ -473,6 +475,8 @@ class DataAxis(t.HasTraits, UnitConversion):
         if len(self.axis) != 0:
             self.low_value, self.high_value = (
                 self.axis.min(), self.axis.max())
+            self.midpoint_value = self.low_value + (self.high_value - self.low_value) / 2
+            self.midpoint_index = self.value2index(self.midpoint_value)
 
     def _update_slice(self, value):
         if value is False:

--- a/hyperspy/axes.py
+++ b/hyperspy/axes.py
@@ -212,7 +212,6 @@ class DataAxis(t.HasTraits, UnitConversion):
     size = t.CInt()
     low_value = t.Float()
     high_value = t.Float()
-    midpoint_value = t.Float()
     value = t.Range('low_value', 'high_value')
     low_index = t.Int(0)
     high_index = t.Int()
@@ -470,13 +469,17 @@ class DataAxis(t.HasTraits, UnitConversion):
     def update_index_bounds(self):
         self.high_index = self.size - 1
 
+    def fraction_value(self, fraction):
+        return self.low_value + (self.high_value - self.low_value) * fraction
+    
+    def fraction_index(self, fraction):
+        return self.value2index(self.fraction_value(fraction))
+
     def update_axis(self):
         self.axis = generate_axis(self.offset, self.scale, self.size)
         if len(self.axis) != 0:
             self.low_value, self.high_value = (
                 self.axis.min(), self.axis.max())
-            self.midpoint_value = self.low_value + (self.high_value - self.low_value) / 2
-            self.midpoint_index = self.value2index(self.midpoint_value)
 
     def _update_slice(self, value):
         if value is False:

--- a/hyperspy/tests/axes/test_axes_manager.py
+++ b/hyperspy/tests/axes/test_axes_manager.py
@@ -134,6 +134,8 @@ class TestAxesManagerScaleOffset:
         axes.scale = scale
         assert axes.low_value == (data[0] * scale + offset)
         assert axes.high_value == (data[-1] * scale + offset)
+        assert axes.fraction_value(0) == axes.low_value
+        assert axes.fraction_value(1) == axes.high_value
 
 
 class TestAxesManagerExtent:

--- a/hyperspy/tests/axes/test_axes_manager.py
+++ b/hyperspy/tests/axes/test_axes_manager.py
@@ -93,6 +93,8 @@ class TestAxesManagerScaleOffset:
         axes = s.axes_manager[0]
         assert axes.low_value == data[0]
         assert axes.high_value == data[-1]
+        assert axes.midpoint_value == data[0] + (data[-1] - data[0])/2
+
 
     def test_change_scale(self):
         data = arange(132)
@@ -103,6 +105,8 @@ class TestAxesManagerScaleOffset:
             axes.scale = scale_value
             assert axes.low_value == data[0] * scale_value
             assert axes.high_value == data[-1] * scale_value
+            assert axes.midpoint_value == (data[0] + (data[-1] - data[0])/2) * scale_value
+
 
     def test_change_offset(self):
         data = arange(81)
@@ -113,6 +117,7 @@ class TestAxesManagerScaleOffset:
             axes.offset = offset_value
             assert axes.low_value == (data[0] + offset_value)
             assert axes.high_value == (data[-1] + offset_value)
+            assert axes.midpoint_value == data[0] + (data[-1] - data[0])/2 + offset_value
 
     def test_change_offset_scale(self):
         data = arange(11)
@@ -123,6 +128,7 @@ class TestAxesManagerScaleOffset:
         axes.scale = scale
         assert axes.low_value == (data[0] * scale + offset)
         assert axes.high_value == (data[-1] * scale + offset)
+        assert axes.midpoint_value == (data[0] + (data[-1] - data[0])/2 * scale) + offset
 
 
 class TestAxesManagerExtent:

--- a/hyperspy/tests/axes/test_axes_manager.py
+++ b/hyperspy/tests/axes/test_axes_manager.py
@@ -93,7 +93,12 @@ class TestAxesManagerScaleOffset:
         axes = s.axes_manager[0]
         assert axes.low_value == data[0]
         assert axes.high_value == data[-1]
-        assert axes.midpoint_value == data[0] + (data[-1] - data[0])/2
+
+        assert axes.fraction_value(0) == axes.low_value
+        assert axes.fraction_value(1) == axes.high_value
+        assert axes.fraction_value(1/4) == data[0] + (data[-1] - data[0])/4
+        assert axes.fraction_value(5/4) == data[0] + (data[-1] - data[0]) * 5/4
+        assert axes.fraction_value(-1) == data[0] + (data[-1] - data[0]) * -1
 
 
     def test_change_scale(self):
@@ -105,8 +110,8 @@ class TestAxesManagerScaleOffset:
             axes.scale = scale_value
             assert axes.low_value == data[0] * scale_value
             assert axes.high_value == data[-1] * scale_value
-            assert axes.midpoint_value == (data[0] + (data[-1] - data[0])/2) * scale_value
-
+            assert axes.fraction_value(0) == axes.low_value
+            assert axes.fraction_value(1) == axes.high_value
 
     def test_change_offset(self):
         data = arange(81)
@@ -117,7 +122,8 @@ class TestAxesManagerScaleOffset:
             axes.offset = offset_value
             assert axes.low_value == (data[0] + offset_value)
             assert axes.high_value == (data[-1] + offset_value)
-            assert axes.midpoint_value == data[0] + (data[-1] - data[0])/2 + offset_value
+            assert axes.fraction_value(0) == axes.low_value
+            assert axes.fraction_value(1) == axes.high_value
 
     def test_change_offset_scale(self):
         data = arange(11)
@@ -128,7 +134,6 @@ class TestAxesManagerScaleOffset:
         axes.scale = scale
         assert axes.low_value == (data[0] * scale + offset)
         assert axes.high_value == (data[-1] * scale + offset)
-        assert axes.midpoint_value == (data[0] + (data[-1] - data[0])/2 * scale) + offset
 
 
 class TestAxesManagerExtent:


### PR DESCRIPTION
### Description of the change
There have been several times I've wanted to be able to quickly get hold of the position between the `low_value` and `high_value` of an axis in the `axes_manager`. This PR adds that, and the index, in the form of `midpoint_value` and `midpoint_index`.

### Progress of the PR
- [x] Change implemented (can be split into several points),
- [ ] update user guide (if appropriate),
- [x] add tests,
- [x] ready for review.

### Minimal example of the bug fix or the new feature
```python
data = np.random.random((20, 20))
s = hs.signals.Signal2D(data)
s.axes_manager[0].offset = 15
s.axes_manager[0].scale = 3
print("s.axes_manager[0].midpoint_value:", s.axes_manager[0].midpoint_value)
print("s.axes_manager[0].midpoint_index:", s.axes_manager[0].midpoint_index)

# s.axes_manager[0].midpoint_value: 43.5
# s.axes_manager[0].midpoint_index: 10
```
Note that this example can be useful to update the user guide.

