### PR TITLE
Fix live time change for EDS signals when summing along signal dimension

### DIFF
--- a/hyperspy/_signals/eds.py
+++ b/hyperspy/_signals/eds.py
@@ -166,19 +166,23 @@ class EDS_mixin:
     def sum(self, axis=None, out=None):
         if axis is None:
             axis = self.axes_manager.navigation_axes
-        # modify time spend per spectrum
         s = super().sum(axis=axis, out=out)
         s = out or s
-        mp = None
-        if s.metadata.get_item("Acquisition_instrument.SEM"):
-            mp = s.metadata.Acquisition_instrument.SEM
-            mp_old = self.metadata.Acquisition_instrument.SEM
-        elif s.metadata.get_item("Acquisition_instrument.TEM"):
-            mp = s.metadata.Acquisition_instrument.TEM
-            mp_old = self.metadata.Acquisition_instrument.TEM
-        if mp is not None and mp.has_item('Detector.EDS.live_time'):
-            mp.Detector.EDS.live_time = mp_old.Detector.EDS.live_time * \
-                self.data.size / s.data.size
+
+        # Update live time by the change in navigation axes dimensions
+        time_factor = (
+               np.prod([ax.size for ax in s.axes_manager.navigation_axes])
+               / np.prod([ax.size for ax in self.axes_manager.navigation_axes])
+            )
+        aimd = s.metadata.Acquisition_instrument
+        if "SEM.Detector.EDS.live_time" in aimd:
+            aimd.SEM.Detector.EDS.live_time *= time_factor
+        elif "TEM.Detector.EDS.live_time" in aimd:
+            aimd.TEM.Detector.EDS.live_time *= time_factor
+        else:
+            _logger.info("Live_time could not be found in the metadata and "
+                         "has not been updated.")
+
         if out is None:
             return s
     sum.__doc__ = Signal1D.sum.__doc__

--- a/hyperspy/_signals/eds.py
+++ b/hyperspy/_signals/eds.py
@@ -171,8 +171,8 @@ class EDS_mixin:
 
         # Update live time by the change in navigation axes dimensions
         time_factor = (
-               np.prod([ax.size for ax in s.axes_manager.navigation_axes])
-               / np.prod([ax.size for ax in self.axes_manager.navigation_axes])
+               np.prod([ax.size for ax in self.axes_manager.navigation_axes])
+               / np.prod([ax.size for ax in s.axes_manager.navigation_axes])
             )
         aimd = s.metadata.Acquisition_instrument
         if "SEM.Detector.EDS.live_time" in aimd:

--- a/hyperspy/_signals/eds.py
+++ b/hyperspy/_signals/eds.py
@@ -174,14 +174,16 @@ class EDS_mixin:
                np.prod([ax.size for ax in self.axes_manager.navigation_axes])
                / np.prod([ax.size for ax in s.axes_manager.navigation_axes])
             )
-        aimd = s.metadata.Acquisition_instrument
-        if "SEM.Detector.EDS.live_time" in aimd:
-            aimd.SEM.Detector.EDS.live_time *= time_factor
-        elif "TEM.Detector.EDS.live_time" in aimd:
-            aimd.TEM.Detector.EDS.live_time *= time_factor
-        else:
-            _logger.info("Live_time could not be found in the metadata and "
-                         "has not been updated.")
+        aimd = s.metadata.get_item('Acquisition_instrument', None)
+        if aimd is not None:
+            aimd = s.metadata.Acquisition_instrument
+            if "SEM.Detector.EDS.live_time" in aimd:
+                aimd.SEM.Detector.EDS.live_time *= time_factor
+            elif "TEM.Detector.EDS.live_time" in aimd:
+                aimd.TEM.Detector.EDS.live_time *= time_factor
+            else:
+                _logger.info("Live_time could not be found in the metadata and "
+                             "has not been updated.")
 
         if out is None:
             return s

--- a/hyperspy/tests/signal/test_eds_sem.py
+++ b/hyperspy/tests/signal/test_eds_sem.py
@@ -262,6 +262,9 @@ class Test_get_lines_intensity:
                                     plot_result=False,
                                     integration_windows=5)[0]
         assert sAl.axes_manager.signal_dimension == 0
+        np.testing.assert_allclose(
+            sAl.metadata.Acquisition_instrument.SEM.Detector.EDS.live_time,
+            s.metadata.Acquisition_instrument.SEM.Detector.EDS.live_time)
         np.testing.assert_allclose(24.99516, sAl.data[0, 0, 0], atol=1e-3)
         sAl = s.inav[0].get_lines_intensity(
             ["Al_Ka"], plot_result=False, integration_windows=5)[0]

--- a/hyperspy/tests/signal/test_eds_sem.py
+++ b/hyperspy/tests/signal/test_eds_sem.py
@@ -15,7 +15,6 @@
 # You should have received a copy of the GNU General Public License
 # along with  HyperSpy.  If not, see <http://www.gnu.org/licenses/>.
 
-import sys
 import pytest
 
 import numpy as np
@@ -50,7 +49,7 @@ class Test_metadata:
         sSum = s.sum(0)
         assert (
             sSum.metadata.Acquisition_instrument.SEM.Detector.EDS.live_time ==
-            3.1 * 2)
+            s.metadata.Acquisition_instrument.SEM.Detector.EDS.live_time * 2)
         # Check that metadata is unchanged
         print(old_metadata, s.metadata)      # Capture for comparison on error
         assert (old_metadata.as_dictionary() ==
@@ -62,7 +61,7 @@ class Test_metadata:
         sSum = s.sum((0, 1))
         assert (
             sSum.metadata.Acquisition_instrument.SEM.Detector.EDS.live_time ==
-            3.1 *
+            s.metadata.Acquisition_instrument.SEM.Detector.EDS.live_time *
             2 * 4)
         # Check that metadata is unchanged
         print(old_metadata, s.metadata)      # Capture for comparison on error
@@ -72,19 +71,18 @@ class Test_metadata:
     def test_sum_live_time_out_arg(self):
         s = self.signal
         sSum = s.sum(0)
-        s.metadata.Acquisition_instrument.SEM.Detector.EDS.live_time = 4.2
+        sSum.metadata.Acquisition_instrument.SEM.Detector.EDS.live_time = 4.2
         s_resum = s.sum(0)
         r = s.sum(0, out=sSum)
         assert r is None
         assert (
             s_resum.metadata.Acquisition_instrument.SEM.Detector.EDS.live_time ==
-            sSum.metadata.Acquisition_instrument.SEM.Detector.EDS.live_time)
+            s.metadata.Acquisition_instrument.SEM.Detector.EDS.live_time * 2)
         np.testing.assert_allclose(s_resum.data, sSum.data)
 
     def test_rebin_live_time(self):
         s = self.signal
         old_metadata = s.metadata.deepcopy()
-        dim = s.axes_manager.shape
         s = s.rebin(scale=[2, 2, 1])
         assert (
             s.metadata.Acquisition_instrument.SEM.Detector.EDS.live_time ==
@@ -193,7 +191,7 @@ class Test_metadata:
         s.metadata.Acquisition_instrument.SEM.Stage.tilt_beta = 15.5
         np.testing.assert_allclose(s.get_take_off_angle(), 24.202671071140102)
 
-    def test_take_off_angle_azimuth(self):
+    def test_take_off_angle_alpha(self):
         s = self.signal
         s.metadata.Acquisition_instrument.SEM.Stage.tilt_alpha = None
         with pytest.raises(ValueError, match="alpha"):

--- a/hyperspy/tests/signal/test_eds_tem.py
+++ b/hyperspy/tests/signal/test_eds_tem.py
@@ -47,7 +47,7 @@ class Test_metadata:
         sSum = s.sum(0)
         assert (
             sSum.metadata.Acquisition_instrument.TEM.Detector.EDS.live_time ==
-            3.1 * 2)
+            s.metadata.Acquisition_instrument.TEM.Detector.EDS.live_time * 2)
         # Check that metadata is unchanged
         print(old_metadata, s.metadata)      # Capture for comparison on error
         assert (old_metadata.as_dictionary() ==
@@ -59,7 +59,8 @@ class Test_metadata:
         sSum = s.sum((0, 1))
         assert (
             sSum.metadata.Acquisition_instrument.TEM.Detector.EDS.live_time ==
-            3.1 * 2 * 4)
+            s.metadata.Acquisition_instrument.TEM.Detector.EDS.live_time
+            * 2 * 4)
         # Check that metadata is unchanged
         print(old_metadata, s.metadata)      # Capture for comparison on error
         assert (old_metadata.as_dictionary() ==
@@ -74,7 +75,7 @@ class Test_metadata:
         assert r is None
         assert (
             s_resum.metadata.Acquisition_instrument.TEM.Detector.EDS.live_time ==
-            sSum.metadata.Acquisition_instrument.TEM.Detector.EDS.live_time)
+            s.metadata.Acquisition_instrument.TEM.Detector.EDS.live_time * 2)
         np.testing.assert_allclose(s_resum.data, sSum.data)
 
     def test_rebin_live_time(self):


### PR DESCRIPTION
### Description of the change
Fixes issue #2362 - live time is getting changed when summing along the signal axis for EDS data (should only change when summing along navigation axes).

### Progress of the PR
- [x] Change implemented,
- [x] ready for review.

### Minimal example of the bug fix or the new feature
```python
s = hs.datasets.example_signals.EDS_TEM_Spectrum()
s.set_microscope_parameters(live_time=1)
lines = s.get_lines_intensity()
print(s.metadata.Acquisition_instrument.TEM.Detector.EDS.live_time)
print(lines[0].metadata.Acquisition_instrument.TEM.Detector.EDS.live_time)
```

