### PR TITLE
Fix log(0) errors in estimate_elbow_position

### DIFF
--- a/hyperspy/learn/mva.py
+++ b/hyperspy/learn/mva.py
@@ -1363,41 +1363,51 @@ class MVA():
         del self._data_before_treatments
 
     def _estimate_elbow_position(self, curve_values):
-        """
-        Estimate the elbow position of a scree plot curve
+        """Estimate the elbow position of a scree plot curve.
+
         Used to estimate the number of significant components in
-        a PCA variance ratio plot or other "elbow" type curves
+        a PCA variance ratio plot or other "elbow" type curves.
+
+        Find a line between first and last point on the scree plot.
+        With a classic elbow scree plot, this line more or less
+        defines a triangle. The elbow should be the point which
+        is the furthest distance from this line.
 
         Parameters
         ----------
-        curve_values : :class:`numpy.ndarray`
+        curve_values : numpy array
+            Explained variance ratio values that form the scree plot.
 
         Returns
         -------
         elbow position : int
             Index of the elbow position in the input array,
             as suggested in :ref:`[Satopää2011] <Satopää2011>`
+
         """
         maxpoints = min(20, len(curve_values) - 1)
-        # Find a line between first and last point
-        # With a classic elbow scree plot the line from first to last
-        # more or less defines a triangle
-        # The elbow should be the point which is the
-        # furthest distance from this line
 
-        y2 = np.log(curve_values[maxpoints])
-        x2 = maxpoints
-        y1 = np.log(curve_values[0])
+        # Clipping the curve_values from below with a v.small
+        # number avoids warnings below when taking np.log(0)
+        curve_values_adj = np.clip(curve_values, 1e-30, None)
+
         x1 = 0
-        # loop through the curve values and calculate
-        distance = np.zeros(maxpoints)
-        for i in range(maxpoints):
-            y0 = np.log(curve_values[i])
-            x0 = i
-            distance[i] = np.abs((x2 - x1) * (y1 - y0) - (x1 - x0) * (y2 - y1)) /\
-                np.math.sqrt((x2 - x1)**2 + (y2 - y1)**2)
+        x2 = maxpoints
+
+        y1 = np.log(curve_values_adj[0])
+        y2 = np.log(curve_values_adj[maxpoints])
+
+        xs = np.arange(maxpoints)
+        ys = np.log(curve_values_adj[:maxpoints])
+
+        numer = np.abs((x2 - x1) * (y1 - ys) - (x1 - xs) * (y2 - y1))
+        denom = np.sqrt((x2 - x1) ** 2 + (y2 - y1) ** 2)
+        distance = np.nan_to_num(numer / denom)
+
         # Point with the largest distance is the "elbow"
+        # (remember that np.argmax returns the FIRST instance)
         elbow_position = np.argmax(distance)
+
         return elbow_position
 
 


### PR DESCRIPTION
### Description of the change

Fixes warnings that can be raised by `s.decomposition()` when the smallest element of the explained variance ratio vector is v.small or zero. Scenarios where the element can be zero are unlikely in standard PCA (save for floating point issues), but for example `ORPCA` applies an explicit clip to small singular values.

```bash
  /home/travis/miniconda/envs/testenv/lib/python3.8/site-packages/hyperspy/learn/mva.py:1291: RuntimeWarning: divide by zero encountered in log
    y2 = np.log(curve_values[maxpoints])
  /home/travis/miniconda/envs/testenv/lib/python3.8/site-packages/hyperspy/learn/mva.py:1300: RuntimeWarning: invalid value encountered in double_scalars
    distance[i] = np.abs((x2 - x1) * (y1 - y0) - (x1 - x0) * (y2 - y1)) /\
```

The PR also tidies up the docstring, and the code to avoid looping when we can vectorize.

### Progress of the PR
- [x] Change implemented
- [x] Update docstring
- [x] Ready for review.


