### PR TITLE
Get EELS edges from a given energy window

### DIFF
--- a/doc/user_guide/eels.rst
+++ b/doc/user_guide/eels.rst
@@ -33,6 +33,21 @@ information is stored in the :py:attr:`~.signal.BaseSignal.metadata`
 attribute (see :ref:`metadata_structure`). This information is saved to file
 when saving in the hspy format (HyperSpy's HDF5 specification).
 
+A method :py:meth:`~._signals.eels.EELSSpectrum_mixin.get_edges_near_energy`
+can be helpful to identify possible elements in the sample.
+:py:meth:`~._signals.eels.EELSSpectrum_mixin.get_edges_near_energy` returns a
+list of edges arranged in the order closest to the specified energy within a
+window.
+
+.. code-block:: python
+
+    >>> s = hs.datasets.artificial_data.get_core_loss_eels_signal()
+    >>> s.get_edges_near_energy(532)
+    ['O_K']
+    >>> s.get_edges_near_energy(849, width=6)
+    ['La_M4', 'Fe_L1']
+
+
 Thickness estimation
 ^^^^^^^^^^^^^^^^^^^^
 
@@ -201,9 +216,9 @@ image
 
 .. NOTE::
 
-    `m.smart_fit()` and `m.multifit(kind='smart')` are methods specific to the EELS model.         
+    `m.smart_fit()` and `m.multifit(kind='smart')` are methods specific to the EELS model.
     The fitting procedure acts in iterative manner along the energy-loss-axis.
-    First it fits only the background up to the first edge. It continues by deactivating all edges except the first one, then performs the fit. 
+    First it fits only the background up to the first edge. It continues by deactivating all edges except the first one, then performs the fit.
     Then it only activates the the first two, fits, and repeats this until all edges are fitted simultanously.
 
     Other, non-EELSCLEdge components, are never deactivated, and fitted on every iteration.

--- a/doc/user_guide/eels.rst
+++ b/doc/user_guide/eels.rst
@@ -37,13 +37,16 @@ A method :py:meth:`~._signals.eels.EELSSpectrum_mixin.get_edges_near_energy`
 can be helpful to identify possible elements in the sample.
 :py:meth:`~._signals.eels.EELSSpectrum_mixin.get_edges_near_energy` returns a
 list of edges arranged in the order closest to the specified energy within a
-window.
+window, both measured in eV. The size of the window can be controlled by the
+argument `width` (default as 10)--- If the specified energy is 849 eV and the
+width is 6 eV, it returns a list of edges with onset energy between 846 eV to
+852 eV and they are arranged in the order closest to 849 eV.
 
 .. code-block:: python
 
     >>> s = hs.datasets.artificial_data.get_core_loss_eels_signal()
     >>> s.get_edges_near_energy(532)
-    ['O_K']
+    ['O_K', 'Pd_M3', 'Sb_M5', 'Sb_M4']
     >>> s.get_edges_near_energy(849, width=6)
     ['La_M4', 'Fe_L1']
 

--- a/hyperspy/_signals/eels.py
+++ b/hyperspy/_signals/eels.py
@@ -154,6 +154,47 @@ class EELSSpectrum_mixin:
                                 '%s_%s' % (element, shell))
                             e_shells.append(subshell)
 
+    def get_edges_near_energy(self, energy, width=1):
+        """Find edges near a given energy that are within the given energy 
+        window.
+        
+        Parameters
+        ----------
+        energy : float
+            Energy to search, in eV
+        width : float
+            Width of window, in eV, around energy in which to find nearby 
+            energies, i.e. a value of 1 eV (the default) means to 
+            search +/- 0.5 eV.
+        
+        Returns
+        -------
+        edges : list
+            All edges that are within the given energy window, sorted by 
+            energy difference to the given energy.
+        """        
+        
+        Emin, Emax = energy - width/2, energy + width/2            
+
+        # find all subshells that have its energy within range
+        valid_edges = []
+        for element, element_info in elements_db.items():
+            try:
+                for shell, shell_info in element_info[
+                    'Atomic_properties']['Binding_energies'].items():
+                    if shell[-1] != 'a' and \
+                        Emin <= shell_info['onset_energy (eV)'] <= Emax:
+                        subshell = '{}_{}'.format(element, shell)
+                        Ediff = np.abs(shell_info['onset_energy (eV)'] - energy)
+                        valid_edges.append((subshell, Ediff))           
+            except KeyError:
+                continue 
+            
+        # Sort by energy difference and return only the edges
+        edges = [edge for edge, _ in sorted(valid_edges, key=lambda x: x[1])]
+        
+        return edges
+
     def estimate_zero_loss_peak_centre(self, mask=None):
         """Estimate the posision of the zero-loss peak.
 

--- a/hyperspy/_signals/eels.py
+++ b/hyperspy/_signals/eels.py
@@ -154,7 +154,7 @@ class EELSSpectrum_mixin:
                                 '%s_%s' % (element, shell))
                             e_shells.append(subshell)
 
-    def get_edges_near_energy(self, energy, width=1):
+    def get_edges_near_energy(self, energy, width=10):
         """Find edges near a given energy that are within the given energy 
         window.
         
@@ -165,7 +165,7 @@ class EELSSpectrum_mixin:
         width : float
             Width of window, in eV, around energy in which to find nearby 
             energies, i.e. a value of 1 eV (the default) means to 
-            search +/- 0.5 eV.
+            search +/- 0.5 eV. The default is 10.
         
         Returns
         -------

--- a/hyperspy/_signals/eels.py
+++ b/hyperspy/_signals/eels.py
@@ -174,6 +174,9 @@ class EELSSpectrum_mixin:
             energy difference to the given energy.
         """        
         
+        if width < 0:
+            raise ValueError("Provided width needs to be >= 0.")
+        
         Emin, Emax = energy - width/2, energy + width/2            
 
         # find all subshells that have its energy within range

--- a/hyperspy/tests/signal/test_eels.py
+++ b/hyperspy/tests/signal/test_eels.py
@@ -286,3 +286,29 @@ class TestRebin:
         assert s2.axes_manager[0].offset == 1.5
         assert s2.axes_manager[1].offset == 2.5
         assert s2.axes_manager[2].offset == s.axes_manager[2].offset
+
+class TestGetNearEdgeEnergy:
+
+    def setup_method(self, method):
+        # Create a dummy spectrum
+        s = signals.EELSSpectrum(np.ones(1024))
+        self.signal = s
+
+    def test_single_edge(self):
+        s = self.signal
+        edges = s.get_edges_near_energy(532, width=0)
+        assert len(edges) == 1
+        assert edges == ['O_K']
+
+    def test_multiple_edges(self):
+        s = self.signal
+        edges = s.get_edges_near_energy(640, width=100)
+        assert len(edges) == 12
+        assert edges == ['Mn_L3','I_M4','Cd_M2','Mn_L2','V_L1','I_M5','Cd_M3',
+                         'In_M3','Xe_M5','Ag_M2','F_K','Xe_M4']
+        
+    def test_negative_energy_width(self):
+        s = self.signal
+        with pytest.raises(Exception):
+            s.get_edges_near_energy(849, width=-5)
+        


### PR DESCRIPTION
### Description of the change
A method to get EELS edges from a given energy window, similar to the one in EDS (get_xray_lines_near_energy). 

### Progress of the PR
- [x] Change implemented (can be split into several points),
- [x] update docstring (if appropriate),
- [x] update user guide (if appropriate),
- [x] add tests,
- [x] ready for review.

### Minimal example of the new feature
```python
>>> from hyperspy import signals
>>> s = signals.EELSSpectrum(np.ones(1024)) #dummy spectrum
>>> s.get_edges_near_energy(532)
['O_K']
>>>  s.get_edges_near_energy(532, width=10)
['O_K', 'Pd_M3', 'Sb_M5', 'Sb_M4']
```


