### PR TITLE
Relocate get_edges_near_energy()

### DIFF
--- a/doc/user_guide/eels.rst
+++ b/doc/user_guide/eels.rst
@@ -50,14 +50,6 @@ they are arranged in the order closest to 849 eV.
     >>> get_edges_near_energy(849, width=6)
     ['La_M4', 'Fe_L1']
 
-The same functionality is also available as a method in `EELS` signal.
-
-.. code-block:: python
-
-    >>> import hyperspy.api as hs
-    >>> s = hs.datasets.artificial_data.get_core_loss_eels_signal()
-    >>> s.get_edges_near_energy(532)
-    ['O_K', 'Pd_M3', 'Sb_M5', 'Sb_M4']
 
 Thickness estimation
 ^^^^^^^^^^^^^^^^^^^^

--- a/doc/user_guide/eels.rst
+++ b/doc/user_guide/eels.rst
@@ -50,6 +50,14 @@ they are arranged in the order closest to 849 eV.
     >>> get_edges_near_energy(849, width=6)
     ['La_M4', 'Fe_L1']
 
+The same functionality is also available as a method in `EELS` signal.
+
+.. code-block:: python
+
+    >>> import hyperspy.api as hs
+    >>> s = hs.datasets.artificial_data.get_core_loss_eels_signal()
+    >>> s.get_edges_near_energy(532)
+    ['O_K', 'Pd_M3', 'Sb_M5', 'Sb_M4']
 
 Thickness estimation
 ^^^^^^^^^^^^^^^^^^^^

--- a/doc/user_guide/eels.rst
+++ b/doc/user_guide/eels.rst
@@ -33,21 +33,21 @@ information is stored in the :py:attr:`~.signal.BaseSignal.metadata`
 attribute (see :ref:`metadata_structure`). This information is saved to file
 when saving in the hspy format (HyperSpy's HDF5 specification).
 
-A method :py:meth:`~._signals.eels.EELSSpectrum_mixin.get_edges_near_energy`
-can be helpful to identify possible elements in the sample.
-:py:meth:`~._signals.eels.EELSSpectrum_mixin.get_edges_near_energy` returns a
-list of edges arranged in the order closest to the specified energy within a
-window, both measured in eV. The size of the window can be controlled by the
-argument `width` (default as 10)--- If the specified energy is 849 eV and the
-width is 6 eV, it returns a list of edges with onset energy between 846 eV to
-852 eV and they are arranged in the order closest to 849 eV.
+An utility function :py:meth:`~.misc.eels.tools.get_edges_near_energy` can be
+helpful to identify possible elements in the sample.
+:py:meth:`~.misc.eels.tools.get_edges_near_energy` returns a list of edges
+arranged in the order closest to the specified energy within a window, both
+measured in eV. The size of the window can be controlled by the argument
+`width` (default as 10)--- If the specified energy is 849 eV and the width is
+6 eV, it returns a list of edges with onset energy between 846 eV to 852 eV and
+they are arranged in the order closest to 849 eV.
 
 .. code-block:: python
 
-    >>> s = hs.datasets.artificial_data.get_core_loss_eels_signal()
-    >>> s.get_edges_near_energy(532)
+    >>> from hyperspy.misc.eels.tools import get_edges_near_energy
+    >>> get_edges_near_energy(532)
     ['O_K', 'Pd_M3', 'Sb_M5', 'Sb_M4']
-    >>> s.get_edges_near_energy(849, width=6)
+    >>> get_edges_near_energy(849, width=6)
     ['La_M4', 'Fe_L1']
 
 

--- a/hyperspy/_signals/eels.py
+++ b/hyperspy/_signals/eels.py
@@ -32,6 +32,7 @@ from hyperspy.defaults_parser import preferences
 from hyperspy.components1d import PowerLaw
 from hyperspy.misc.utils import isiterable, underline
 from hyperspy.misc.math_tools import optimal_fft_size
+from hyperspy.misc.eels.tools import get_edges_near_energy
 from hyperspy.misc.eels.electron_inelastic_mean_free_path import iMFP_Iakoubovskii, iMFP_angular_correction
 from hyperspy.ui_registry import add_gui_method, DISPLAY_DT, TOOLKIT_DT
 from hyperspy.docstrings.signal1d import CROP_PARAMETER_DOC
@@ -154,6 +155,27 @@ class EELSSpectrum_mixin:
                             self.subshells.add(
                                 '%s_%s' % (element, shell))
                             e_shells.append(subshell)
+
+    def get_edges_near_energy(self, energy, width=10):
+        """Find edges near a given energy that are within the given energy 
+        window.
+        
+        Parameters
+        ----------
+        energy : float
+            Energy to search, in eV
+        width : float
+            Width of window, in eV, around energy in which to find nearby 
+            energies, i.e. a value of 1 eV (the default) means to 
+            search +/- 0.5 eV. The default is 10.
+        
+        Returns
+        -------
+        edges : list
+            All edges that are within the given energy window, sorted by 
+            energy difference to the given energy.
+        """    
+        return get_edges_near_energy(energy, width=width)
 
     def estimate_zero_loss_peak_centre(self, mask=None):
         """Estimate the posision of the zero-loss peak.

--- a/hyperspy/_signals/eels.py
+++ b/hyperspy/_signals/eels.py
@@ -155,50 +155,6 @@ class EELSSpectrum_mixin:
                                 '%s_%s' % (element, shell))
                             e_shells.append(subshell)
 
-    def get_edges_near_energy(self, energy, width=10):
-        """Find edges near a given energy that are within the given energy 
-        window.
-        
-        Parameters
-        ----------
-        energy : float
-            Energy to search, in eV
-        width : float
-            Width of window, in eV, around energy in which to find nearby 
-            energies, i.e. a value of 1 eV (the default) means to 
-            search +/- 0.5 eV. The default is 10.
-        
-        Returns
-        -------
-        edges : list
-            All edges that are within the given energy window, sorted by 
-            energy difference to the given energy.
-        """        
-        
-        if width < 0:
-            raise ValueError("Provided width needs to be >= 0.")
-        
-        Emin, Emax = energy - width/2, energy + width/2            
-
-        # find all subshells that have its energy within range
-        valid_edges = []
-        for element, element_info in elements_db.items():
-            try:
-                for shell, shell_info in element_info[
-                    'Atomic_properties']['Binding_energies'].items():
-                    if shell[-1] != 'a' and \
-                        Emin <= shell_info['onset_energy (eV)'] <= Emax:
-                        subshell = '{}_{}'.format(element, shell)
-                        Ediff = np.abs(shell_info['onset_energy (eV)'] - energy)
-                        valid_edges.append((subshell, Ediff))           
-            except KeyError:
-                continue 
-            
-        # Sort by energy difference and return only the edges
-        edges = [edge for edge, _ in sorted(valid_edges, key=lambda x: x[1])]
-        
-        return edges
-
     def estimate_zero_loss_peak_centre(self, mask=None):
         """Estimate the posision of the zero-loss peak.
 

--- a/hyperspy/_signals/eels.py
+++ b/hyperspy/_signals/eels.py
@@ -156,27 +156,6 @@ class EELSSpectrum_mixin:
                                 '%s_%s' % (element, shell))
                             e_shells.append(subshell)
 
-    def get_edges_near_energy(self, energy, width=10):
-        """Find edges near a given energy that are within the given energy 
-        window.
-        
-        Parameters
-        ----------
-        energy : float
-            Energy to search, in eV
-        width : float
-            Width of window, in eV, around energy in which to find nearby 
-            energies, i.e. a value of 1 eV (the default) means to 
-            search +/- 0.5 eV. The default is 10.
-        
-        Returns
-        -------
-        edges : list
-            All edges that are within the given energy window, sorted by 
-            energy difference to the given energy.
-        """    
-        return get_edges_near_energy(energy, width=width)
-
     def estimate_zero_loss_peak_centre(self, mask=None):
         """Estimate the posision of the zero-loss peak.
 

--- a/hyperspy/tests/signal/test_eels.py
+++ b/hyperspy/tests/signal/test_eels.py
@@ -290,8 +290,6 @@ class TestRebin:
         assert s2.axes_manager[0].offset == 1.5
         assert s2.axes_manager[1].offset == 2.5
         assert s2.axes_manager[2].offset == s.axes_manager[2].offset
-<<<<<<< a8ae0eda2fbf3eee4a514e0bac0ea5e1f87bb3c0
-
 
 @lazifyTestClass
 class Test_Estimate_Thickness:

--- a/hyperspy/tests/signal/test_eels.py
+++ b/hyperspy/tests/signal/test_eels.py
@@ -290,6 +290,7 @@ class TestRebin:
         assert s2.axes_manager[0].offset == 1.5
         assert s2.axes_manager[1].offset == 2.5
         assert s2.axes_manager[2].offset == s.axes_manager[2].offset
+<<<<<<< a8ae0eda2fbf3eee4a514e0bac0ea5e1f87bb3c0
 
 
 @lazifyTestClass
@@ -344,29 +345,3 @@ class Test_Estimate_Thickness:
         del self.s.metadata.Acquisition_instrument
         with pytest.raises(RuntimeError):
             self.s.estimate_thickness(zlp=self.zlp, density=3.6)
-
-
-class TestGetNearEdgeEnergy:
-
-    def setup_method(self, method):
-        # Create a dummy spectrum
-        s = signals.EELSSpectrum(np.ones(1024))
-        self.signal = s
-
-    def test_single_edge(self):
-        s = self.signal
-        edges = s.get_edges_near_energy(532, width=0)
-        assert len(edges) == 1
-        assert edges == ['O_K']
-
-    def test_multiple_edges(self):
-        s = self.signal
-        edges = s.get_edges_near_energy(640, width=100)
-        assert len(edges) == 12
-        assert edges == ['Mn_L3','I_M4','Cd_M2','Mn_L2','V_L1','I_M5','Cd_M3',
-                         'In_M3','Xe_M5','Ag_M2','F_K','Xe_M4']
-        
-    def test_negative_energy_width(self):
-        s = self.signal
-        with pytest.raises(Exception):
-            s.get_edges_near_energy(849, width=-5)

--- a/hyperspy/tests/utils/test_eels.py
+++ b/hyperspy/tests/utils/test_eels.py
@@ -1,0 +1,37 @@
+# Copyright 2007-2020 The HyperSpy developers
+#
+# This file is part of  HyperSpy.
+#
+#  HyperSpy is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+#  HyperSpy is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with  HyperSpy.  If not, see <http://www.gnu.org/licenses/>.
+
+import numpy as np
+import pytest
+
+from hyperspy.misc.eels.tools import get_edges_near_energy
+
+def test_single_edge():
+    edges = get_edges_near_energy(532, width=0)
+    assert len(edges) == 1
+    assert edges == ['O_K']
+
+def test_multiple_edges():
+    edges = get_edges_near_energy(640, width=100)
+    assert len(edges) == 12
+    assert edges == ['Mn_L3','I_M4','Cd_M2','Mn_L2','V_L1','I_M5','Cd_M3',
+                     'In_M3','Xe_M5','Ag_M2','F_K','Xe_M4']
+    
+def test_negative_energy_width():
+    with pytest.raises(Exception):
+        get_edges_near_energy(849, width=-5)
+        


### PR DESCRIPTION
### Description of the change
This is actually just relocating the new get_edges_near_energy method (implemented in #2387) from EELS signal class to EELS utility function, as the operation of the method does not depend on any EELS signal. This will be much more convenient for users to use this function (no need to create any dummy signal).

No content is changed. Since I don't know how to reopen/restore the old PR, I decide to open a new one for this. Sorry for the clustering. 

### Progress of the PR
- [x] Change implemented,
- [x] update user guide (if appropriate),
- [x] add tests,
- [x] ready for review.

### Minimal example of the bug fix or the new feature
```python
>>> from hyperspy.misc.eels.tools import get_edges_near_energy
>>> get_edges_near_energy(532)
['O_K', 'Pd_M3', 'Sb_M5', 'Sb_M4']
```
