### PR TITLE
Fix import error with scikit-image 0.17.0

### DIFF
--- a/hyperspy/_signals/signal2d.py
+++ b/hyperspy/_signals/signal2d.py
@@ -22,7 +22,11 @@ import numpy.ma as ma
 import dask.array as da
 import scipy as sp
 import logging
-from skimage.feature.register_translation import _upsampled_dft
+try:
+    # For scikit-image >= 0.17.0
+    from skimage.registration._phase_cross_correlation import _upsampled_dft
+except ModuleNotFoundError:
+    from skimage.feature.register_translation import _upsampled_dft
 
 from hyperspy.defaults_parser import preferences
 from hyperspy.external.progressbar import progressbar


### PR DESCRIPTION
There is an API changes in the last release of scikit-image:
https://github.com/scikit-image/scikit-image/blob/master/doc/release/release_0.17.rst#api-changes

### Progress of the PR
- [x] make import of `_upsampled_dft` compatible with scikit-image 0.17
- [x] ready for review.
