### PR TITLE
Implemented Arctan + EELSArctan as expressions

### DIFF
--- a/doc/user_guide/model.rst
+++ b/doc/user_guide/model.rst
@@ -103,6 +103,7 @@ The following general components are currently available for one-dimensional mod
 
 The following components developed with specific signal types in mind are currently available for one-dimensional models:
 
+* :py:class:`~._components.eels_arctan.EELSArctan`
 * :py:class:`~._components.eels_double_power_law.DoublePowerLaw`
 * :py:class:`~._components.eels_cl_edge.EELSCLEdge`
 * :py:class:`~._components.pes_core_line_shape.PESCoreLineShape`

--- a/hyperspy/_components/arctan.py
+++ b/hyperspy/_components/arctan.py
@@ -29,7 +29,8 @@ class Arctan(Expression):
 
     .. math::
     
-        f(x) = A \cdot \arctan\left[ k \left( x-x_0 \right)\right]
+        f(x) = A \cdot \arctan \left[ k \left( x-x_0 \right) \right]
+
 
     ============ =============
     Variable      Parameter 
@@ -39,11 +40,17 @@ class Arctan(Expression):
     :math:`x_0`   x0 
     ============ =============
 
+
     Parameters
     -----------
     A : float
+        Amplitude parameter. :math:`\lim_{x\to -\infty}f(x)=-A` and 
+        :math:`\lim_{x\to\infty}f(x)=A`
     k : float
+        Slope (steepness of the step). The larger :math:`k`, the sharper the 
+        step.
     x0 : float
+        Center parameter (position of zero crossing :math:`f(x_0)=0`).
 
     """
 

--- a/hyperspy/_components/eels_arctan.py
+++ b/hyperspy/_components/eels_arctan.py
@@ -22,14 +22,48 @@ import numpy as np
 
 from hyperspy._components.expression import Expression
 
-
 class Arctan(Expression):
-
-    r"""Arctan function component.
-
+    # Legacy class to be removed in v2.0
+    """This is the legacy Arctan component dedicated to EELS measurements
+    that will renamed to `EELSArctan` in v2.0. To use the new Arctan component 
+    set `minimum_at_zero=False`. See the documentation of 
+    :meth:`hyperspy._components.acrtan.Arctan` for details on 
+    the usage of the new Arctan component.
+    
     .. math::
     
         f(x) = A \cdot \arctan\left[ k \left( x-x_0 \right)\right]
+    
+    EELSArctan (`minimum_at_zero=True`) shifts the function by pi/2 in the y 
+    direction
+    
+    """
+
+    def __init__(self, minimum_at_zero=True, **kwargs):
+        if minimum_at_zero:
+            from hyperspy.misc.utils import deprecation_warning
+            msg = (
+                "The API of the `Arctan` component will change in v2.0. "
+                "This component will become `EELSArctan`."
+                "To use the new API set `minimum_at_zero=False`.")
+            deprecation_warning(msg)
+
+            self.__class__ = EELSArctan
+            self.__init__(**kwargs)
+        else:
+            from hyperspy._components.arctan import Arctan
+            self.__class__ = Arctan
+            self.__init__(**kwargs)
+
+
+class EELSArctan(Expression):
+
+    r"""Arctan function component for EELS (with minimum at zero).
+
+    .. math::
+    
+        f(x) = A \cdot \left{\frac{\pi}{2} + 
+               \arctan\left[ k \left( x-x_0 \right)\right]\right}
 
     ============ =============
     Variable      Parameter 
@@ -51,8 +85,8 @@ class Arctan(Expression):
         # Not to break scripts once we remove the legacy Arctan
         if "minimum_at_zero" in kwargs:
             del kwargs["minimum_at_zero"]
-        super(Arctan, self).__init__(
-            expression="A * arctan(k * (x - x0))",
+        super(EELSArctan, self).__init__(
+            expression="A * (pi /2 + arctan(k * (x - x0)))",
             name="Arctan",
             A=A,
             k=k,

--- a/hyperspy/_components/eels_arctan.py
+++ b/hyperspy/_components/eels_arctan.py
@@ -39,7 +39,7 @@ class Arctan(Expression):
     
     """
 
-    def __init__(self, minimum_at_zero=True, **kwargs):
+    def __init__(self, minimum_at_zero=False, **kwargs):
         if minimum_at_zero:
             from hyperspy.misc.utils import deprecation_warning
             msg = (

--- a/hyperspy/_components/eels_arctan.py
+++ b/hyperspy/_components/eels_arctan.py
@@ -24,19 +24,17 @@ from hyperspy._components.expression import Expression
 
 class Arctan(Expression):
     # Legacy class to be removed in v2.0
-    """This is the legacy Arctan component dedicated to EELS measurements
-    that will renamed to `EELSArctan` in v2.0. To use the new Arctan component 
+    r"""This is the legacy Arctan component dedicated to EELS measurements
+    that will renamed to `EELSArctan` in v2.0. 
+
+    To use the new Arctan component 
     set `minimum_at_zero=False`. See the documentation of 
-    :meth:`hyperspy._components.acrtan.Arctan` for details on 
-    the usage of the new Arctan component.
-    
-    .. math::
-    
-        f(x) = A \cdot \arctan\left[ k \left( x-x_0 \right)\right]
-    
-    EELSArctan (`minimum_at_zero=True`) shifts the function by pi/2 in the y 
-    direction
-    
+    :meth:`hyperspy._components.arctan.Arctan` for details on 
+    the usage.
+
+    The EELS version :meth:`hyperspy._components.eels_arctan.EELSArctan` 
+    (`minimum_at_zero=True`) shifts the function by A in the y direction
+
     """
 
     def __init__(self, minimum_at_zero=False, **kwargs):
@@ -62,8 +60,9 @@ class EELSArctan(Expression):
 
     .. math::
     
-        f(x) = A \cdot \left{\frac{\pi}{2} + 
-               \arctan\left[ k \left( x-x_0 \right)\right]\right}
+        f(x) = A \cdot \left( \frac{\pi}{2} +
+               \arctan \left[ k \left( x-x_0 \right) \right] \right)
+
 
     ============ =============
     Variable      Parameter 
@@ -73,11 +72,17 @@ class EELSArctan(Expression):
     :math:`x_0`   x0 
     ============ =============
 
+
     Parameters
     -----------
     A : float
+        Amplitude parameter. :math:`\lim_{x\to -\infty}f(x)=0` and 
+        :math:`\lim_{x\to\infty}f(x)=2A`
     k : float
+        Slope (steepness of the step). The larger :math:`k`, the sharper the 
+        step.
     x0 : float
+        Center parameter (:math:`f(x_0)=A`).
 
     """
 

--- a/hyperspy/_components/eels_arctan.py
+++ b/hyperspy/_components/eels_arctan.py
@@ -43,7 +43,7 @@ class Arctan(Expression):
             msg = (
                 "The API of the `Arctan` component will change in v2.0. "
                 "This component will become `EELSArctan`."
-                "To use the new API set `minimum_at_zero=False`.")
+                "To use the new API, omit the `minimum_at_zero` option.")
             deprecation_warning(msg)
 
             self.__class__ = EELSArctan

--- a/hyperspy/hyperspy_extension.yaml
+++ b/hyperspy/hyperspy_extension.yaml
@@ -142,8 +142,8 @@ signals:
 
 components1D:
   Arctan:
+    module: hyperspy._components.eels_arctan
     class: Arctan
-    module: hyperspy._components.arctan
   Bleasdale:
     module: hyperspy._components.bleasdale
     class: Bleasdale
@@ -153,6 +153,9 @@ components1D:
   DoublePowerLaw:
     module: hyperspy._components.eels_double_power_law
     class: DoublePowerLaw
+  EELSArctan:
+    module: hyperspy._components.eels_arctan
+    class: EELSArctan
   EELSCLEdge:
     module: hyperspy._components.eels_cl_edge
     class: EELSCLEdge

--- a/hyperspy/tests/component/test_EELSarctan.py
+++ b/hyperspy/tests/component/test_EELSarctan.py
@@ -20,31 +20,12 @@ import numpy as np
 from numpy.testing import assert_allclose
 import pytest
 
-from hyperspy.components1d import Arctan
+from hyperspy.components1d import EELSArctan
 from hyperspy.signals import Signal1D
 
 
-def test_function():
-    g = Arctan()
-    g.A.value = 10
-    g.k.value = 2
-    g.x0.value = 1
-    assert_allclose(g.function(0), -11.07148718)
-    assert_allclose(g.function(1), 0)
-    assert_allclose(g.function(1e4), 10*np.pi/2,1e-4)
-
-# Legacy tests
-def test_function_legacyF():
-    g = Arctan(minimum_at_zero=False)
-    g.A.value = 10
-    g.k.value = 2
-    g.x0.value = 1
-    assert_allclose(g.function(0), -11.07148718)
-    assert_allclose(g.function(1), 0)
-    assert_allclose(g.function(1e4), 10*np.pi/2,1e-4)
-
-def test_function_legacyT():
-    g = Arctan(minimum_at_zero=True)
+def test_function2():
+    g = EELSArctan()
     g.A.value = 10
     g.k.value = 2
     g.x0.value = 1

--- a/hyperspy/tests/component/test_arctan.py
+++ b/hyperspy/tests/component/test_arctan.py
@@ -1,0 +1,54 @@
+# -*- coding: utf-8 -*-
+# Copyright 2007-2020 The HyperSpy developers
+#
+# This file is part of  HyperSpy.
+#
+#  HyperSpy is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+#  HyperSpy is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with  HyperSpy.  If not, see <http://www.gnu.org/licenses/>.
+
+import numpy as np
+from numpy.testing import assert_allclose
+import pytest
+
+from hyperspy.components1d import Arctan
+from hyperspy.components1d import EELSArctan
+from hyperspy.signals import Signal1D
+
+
+def test_function1():
+    g = Arctan(minimum_at_zero=False)
+    g.A.value = 10
+    g.k.value = 2
+    g.x0.value = 1
+    assert_allclose(g.function(0), -11.07148718)
+    assert_allclose(g.function(1), 0)
+    assert_allclose(g.function(1e4), 10*np.pi/2,1e-4)
+
+def test_function2():
+    g = EELSArctan()
+    g.A.value = 10
+    g.k.value = 2
+    g.x0.value = 1
+    assert_allclose(g.function(0), 4.63647609)
+    assert_allclose(g.function(1), 10*np.pi/2)
+    assert_allclose(g.function(1e4), 10*np.pi,1e-4)
+
+# Legacy test
+def test_function3():
+    g = Arctan(minimum_at_zero=True)
+    g.A.value = 10
+    g.k.value = 2
+    g.x0.value = 1
+    assert_allclose(g.function(0), 4.63647609)
+    assert_allclose(g.function(1), 10*np.pi/2)
+    assert_allclose(g.function(1e4), 10*np.pi,1e-4)

--- a/hyperspy/tests/mva/test_bss.py
+++ b/hyperspy/tests/mva/test_bss.py
@@ -29,17 +29,21 @@ from hyperspy.signals import BaseSignal
 
 def are_bss_components_equivalent(c1_list, c2_list, atol=1e-4):
     """Check if two list of components are equivalent.
+
     To be equivalent they must differ by a max of `atol` except
     for an arbitrary -1 factor.
+
     Parameters
     ----------
     c1_list, c2_list: list of Signal instances.
         The components to check.
     atol: float
         Absolute tolerance for the amount that they can differ.
+
     Returns
     -------
     bool
+
     """
     matches = 0
     for c1 in c1_list:
@@ -308,7 +312,6 @@ class TestBSS2D:
 
         mask_sig = s._get_signal_signal(dtype="bool")
         mask_sig.unfold()
-        mask_sig.data[:] = False
         mask_sig.isig[5] = True
         mask_sig.fold()
 
@@ -343,24 +346,12 @@ class TestBSS2D:
             diff_axes=["x"],
             mask=self.mask_sig,
         )
-        matrix = self.s.learning_results.unmixing_matrix.copy()
-        self.mask_sig.change_dtype("float")
-        self.mask_sig.data[self.mask_sig.data == 1] = np.nan
-        self.mask_sig.fold()
-        self.mask_sig = self.mask_sig.derivative(axis="x")
-        self.mask_sig.data[np.isnan(self.mask_sig.data)] = 1
-        self.mask_sig.change_dtype("bool")
-        self.s.blind_source_separation(
-            3, diff_order=0, fun="exp", on_loadings=False,
-            factors=factors.derivative(axis="x", order=1),
-            mask=self.mask_sig)
         np.testing.assert_allclose(
-            matrix, self.s.learning_results.unmixing_matrix, atol=1e-4
+            matrix, self.s.learning_results.unmixing_matrix, atol=1e-6
         )
 
     def test_diff_axes_string_without_mask(self):
-        factors = self.s.get_decomposition_factors().inav[:3].derivative(
-            axis="x", order=1)
+        factors = self.s.get_decomposition_factors().inav[:3].diff(axis="x", order=1)
         self.s.blind_source_separation(
             3, diff_order=0, fun="exp", on_loadings=False, factors=factors
         )
@@ -373,8 +364,7 @@ class TestBSS2D:
         )
 
     def test_diff_axes_without_mask(self):
-        factors = self.s.get_decomposition_factors().inav[:3].derivative(
-            axis="y", order=1)
+        factors = self.s.get_decomposition_factors().inav[:3].diff(axis="y", order=1)
         self.s.blind_source_separation(
             3, diff_order=0, fun="exp", on_loadings=False, factors=factors
         )

--- a/hyperspy/tests/mva/test_bss.py
+++ b/hyperspy/tests/mva/test_bss.py
@@ -29,21 +29,17 @@ from hyperspy.signals import BaseSignal
 
 def are_bss_components_equivalent(c1_list, c2_list, atol=1e-4):
     """Check if two list of components are equivalent.
-
     To be equivalent they must differ by a max of `atol` except
     for an arbitrary -1 factor.
-
     Parameters
     ----------
     c1_list, c2_list: list of Signal instances.
         The components to check.
     atol: float
         Absolute tolerance for the amount that they can differ.
-
     Returns
     -------
     bool
-
     """
     matches = 0
     for c1 in c1_list:
@@ -312,6 +308,7 @@ class TestBSS2D:
 
         mask_sig = s._get_signal_signal(dtype="bool")
         mask_sig.unfold()
+        mask_sig.data[:] = False
         mask_sig.isig[5] = True
         mask_sig.fold()
 
@@ -346,12 +343,24 @@ class TestBSS2D:
             diff_axes=["x"],
             mask=self.mask_sig,
         )
+        matrix = self.s.learning_results.unmixing_matrix.copy()
+        self.mask_sig.change_dtype("float")
+        self.mask_sig.data[self.mask_sig.data == 1] = np.nan
+        self.mask_sig.fold()
+        self.mask_sig = self.mask_sig.derivative(axis="x")
+        self.mask_sig.data[np.isnan(self.mask_sig.data)] = 1
+        self.mask_sig.change_dtype("bool")
+        self.s.blind_source_separation(
+            3, diff_order=0, fun="exp", on_loadings=False,
+            factors=factors.derivative(axis="x", order=1),
+            mask=self.mask_sig)
         np.testing.assert_allclose(
-            matrix, self.s.learning_results.unmixing_matrix, atol=1e-6
+            matrix, self.s.learning_results.unmixing_matrix, atol=1e-4
         )
 
     def test_diff_axes_string_without_mask(self):
-        factors = self.s.get_decomposition_factors().inav[:3].diff(axis="x", order=1)
+        factors = self.s.get_decomposition_factors().inav[:3].derivative(
+            axis="x", order=1)
         self.s.blind_source_separation(
             3, diff_order=0, fun="exp", on_loadings=False, factors=factors
         )
@@ -364,7 +373,8 @@ class TestBSS2D:
         )
 
     def test_diff_axes_without_mask(self):
-        factors = self.s.get_decomposition_factors().inav[:3].diff(axis="y", order=1)
+        factors = self.s.get_decomposition_factors().inav[:3].derivative(
+            axis="y", order=1)
         self.s.blind_source_separation(
             3, diff_order=0, fun="exp", on_loadings=False, factors=factors
         )

--- a/hyperspy/tests/mva/test_bss.py
+++ b/hyperspy/tests/mva/test_bss.py
@@ -205,7 +205,6 @@ def test_sklearn_convergence_warning():
             diff_order=1,
             on_loadings=True,
             tol=1e-15,
-            max_iter=3,
         )
 
 

--- a/hyperspy/tests/mva/test_bss.py
+++ b/hyperspy/tests/mva/test_bss.py
@@ -205,6 +205,7 @@ def test_sklearn_convergence_warning():
             diff_order=1,
             on_loadings=True,
             tol=1e-15,
+            max_iter=3,
         )
 
 


### PR DESCRIPTION
### Description of the change
Implemented Arctan as Expression as proposed in https://github.com/hyperspy/hyperspy/issues/2251#issuecomment-529929541
* New component `EELSArctan` replaces `minimum_at_zero=True` option
* `Arctan` component will default to the former `minimum_at_zero=False`
* legacy feature supports old way of calling the functions (up to v2?) and raises warning if `Arctan` is called with `minimum_at_zero=True` 

### Progress of the PR
- [X] Change implemented (can be split into several points),
- [X] update docstring (if appropriate),
- [X] update user guide (if appropriate),
- [X] add tests,
- [X] ready for review.

### Minimal example of the bug fix or the new feature
```python
>>> import hyperspy.api as hs
>>> import numpy as np
>>> arctan1 = hs.model.components1D.Arctan(A=10., k=5, x0=1, minimum_at_zero=True)
>>> x = np.arange(arctan1.x0.value-5,arctan1.x0.value+5,step=0.01)
>>> s = hs.signals.Signal1D(arctan1.function(x))
>>> s.axes_manager.signal_axes[0].axis = x
>>> s.plot()
```
Note that this example can be useful to update the user guide.

