### PR TITLE
 updated FDA in user guide + add. corrections

### DIFF
--- a/doc/user_guide/axes.rst
+++ b/doc/user_guide/axes.rst
@@ -309,7 +309,7 @@ Corresponding output of :py:class:`~.axes.AxesManager`:
                 Name |   size |           offset |            scale |  units
     ================ | ====== | ================ | ================ | ======
     ---------------- | ------ | ---------------- | ---------------- | ------
-                     |    500 | non uniform axis | non uniform axis |       
+                     |    500 | non-uniform axis | non-uniform axis |       
 
 
 Initializing ``x`` with ``offset`` and ``scale``:
@@ -328,7 +328,7 @@ Initializing ``x`` with ``offset`` and ``scale``:
        19.52380952, 19.43396226, 19.34579439, 19.25925926, 19.17431193])
 
 
-Initializing ``x`` as non uniform :py:class:`~.axes.DataAxis`:
+Initializing ``x`` as non-uniform :py:class:`~.axes.DataAxis`:
 
 .. code-block:: python
 
@@ -345,7 +345,7 @@ Initializing ``x`` as non uniform :py:class:`~.axes.DataAxis`:
         11.2345679 ])
 
 
-(Non uniform) Data axis
+(non-uniform) Data axis
 ^^^^^^^^^^^^^^^^^^^^^^^
 
 A :py:class:`~.axes.DataAxis` is the most flexible type of axis. The axis
@@ -374,7 +374,7 @@ Corresponding output of :py:class:`~.axes.AxesManager`:
                 Name |   size |           offset |            scale |  units
     ================ | ====== | ================ | ================ | ======
     ---------------- | ------ | ---------------- | ---------------- | ------
-                     |     12 | non uniform axis | non uniform axis |       
+                     |     12 | non-uniform axis | non-uniform axis |       
 
 
 Defining a new axis

--- a/hyperspy/axes.py
+++ b/hyperspy/axes.py
@@ -101,7 +101,7 @@ def _create_axis(**kwargs):
     A DataAxis, FunctionalDataAxis or a UniformDataAxis
 
     """
-    if 'axis' in kwargs.keys():  # non uniform axis
+    if 'axis' in kwargs.keys():  # non-uniform axis
         axis_class = DataAxis
     elif 'expression' in kwargs.keys():  # Functional axis
         axis_class = FunctionalDataAxis
@@ -1749,7 +1749,7 @@ class AxesManager(t.HasTraits):
         text = ('<Axes manager, axes: %s>\n' %
                 self._get_dimension_str())
         ax_signature_uniform = "% 16s | %6g | %6s | %7.2g | %7.2g | %6s "
-        ax_signature_non_uniform = "% 16s | %6g | %6s | non uniform axis | %6s "
+        ax_signature_non_uniform = "% 16s | %6g | %6s | non-uniform axis | %6s "
         signature = "% 16s | %6s | %6s | %7s | %7s | %6s "
         text += signature % ('Name', 'size', 'index', 'offset', 'scale',
                              'units')
@@ -1806,8 +1806,8 @@ class AxesManager(t.HasTraits):
                 return format_row(ax.name, ax.size, index, ax.offset,
                                   ax.scale, ax.units)
             else:
-                return format_row(ax.name, ax.size, index, "non uniform axis",
-                                  "non uniform axis", ax.units)
+                return format_row(ax.name, ax.size, index, "non-uniform axis",
+                                  "non-uniform axis", ax.units)
 
         if self.navigation_axes:
             text += "<table style='width:100%'>\n"

--- a/hyperspy/signal.py
+++ b/hyperspy/signal.py
@@ -4029,7 +4029,7 @@ class BaseSignal(FancySlicing,
             if isinstance(value, BaseSignal):
                 ndkwargs += ((key, value),)
 
-        # TODO: Consider support for non uniform signal axis
+        # TODO: Consider support for non-uniform signal axis
         if any([not ax.is_uniform for ax in self.axes_manager.signal_axes]):
             _logger.warning(
                 "At least one axis of the signal is non-uniform. Can your "


### PR DESCRIPTION
- I updated the user guide to the new concept of FunctionalDataAxis with `x` being an axis itself.
- replaced occurences of 'non uniform' by 'non-uniform'

**Progress of the PR**
- [X] Change implemented
- [X] Ready for review
