### PR TITLE
Address various warnings in test suite

### DIFF
--- a/hyperspy/_components/power_law.py
+++ b/hyperspy/_components/power_law.py
@@ -144,7 +144,7 @@ class PowerLaw(Expression):
             log = np.log
         with np.errstate(divide='raise'):
             try:
-                r = 2 * log(I1 / I2) / log(x2 / x1)
+                r = 2 * (log(I1) - log(I2)) / (log(x2) - log(x1))
                 k = 1 - r
                 A = k * I2 / (x2 ** k - x3 ** k)
                 if s._lazy:
@@ -154,8 +154,8 @@ class PowerLaw(Expression):
                     r = np.nan_to_num(r)
                     A = np.nan_to_num(A)
             except (RuntimeWarning, FloatingPointError):
-                _logger.warning('Power law paramaters estimation failed '
-                                'because of a "divide by zero" error.')
+                _logger.warning('Power-law parameter estimation failed '
+                                'because of a "divide-by-zero" error.')
                 return False
         if only_current is True:
             self.r.value = r

--- a/hyperspy/drawing/image.py
+++ b/hyperspy/drawing/image.py
@@ -415,10 +415,8 @@ class ImagePlot(BlittedFigure):
                 norm = LogNorm(vmin=vmin, vmax=vmax)
             elif norm == 'symlog':
                 norm = SymLogNorm(linthresh=self.linthresh,
-                                  linscale=self.linscale,
-                                  vmin=vmin,
-                                  vmax=vmax,
-                                  base=np.e)
+                                linscale=self.linscale,
+                                vmin=vmin, vmax=vmax)
             elif inspect.isclass(norm) and issubclass(norm, Normalize):
                 norm = norm(vmin=vmin, vmax=vmax)
             elif norm not in ['auto', 'linear']:

--- a/hyperspy/drawing/image.py
+++ b/hyperspy/drawing/image.py
@@ -415,8 +415,10 @@ class ImagePlot(BlittedFigure):
                 norm = LogNorm(vmin=vmin, vmax=vmax)
             elif norm == 'symlog':
                 norm = SymLogNorm(linthresh=self.linthresh,
-                                linscale=self.linscale,
-                                vmin=vmin, vmax=vmax)
+                                  linscale=self.linscale,
+                                  vmin=vmin,
+                                  vmax=vmax,
+                                  base=np.e)
             elif inspect.isclass(norm) and issubclass(norm, Normalize):
                 norm = norm(vmin=vmin, vmax=vmax)
             elif norm not in ['auto', 'linear']:

--- a/hyperspy/model.py
+++ b/hyperspy/model.py
@@ -29,7 +29,7 @@ import dill
 import scipy
 import scipy.odr as odr
 from scipy.optimize import (leastsq, least_squares,
-                            minimize, differential_evolution)
+                            minimize, differential_evolution, OptimizeWarning)
 from scipy.linalg import svd
 from contextlib import contextmanager
 
@@ -1115,16 +1115,16 @@ class BaseModel(list):
                     ls_b = self.free_parameters_boundaries
                     ls_b = ([a if a is not None else -np.inf for a, b in ls_b],
                             [b if b is not None else np.inf for a, b in ls_b])
-                    output = \
-                        least_squares(self._errfunc, self.p0[:],
-                                      args=args, bounds=ls_b, **kwargs)
+                    output = least_squares(self._errfunc, self.p0[:],
+                                           args=args, bounds=ls_b, **kwargs)
                     self.p0 = output.x
+                    ysize = len(output.fun)
+                    cost = 2 * output.cost  # res.cost is half sum of squares
 
                     # Do Moore-Penrose inverse, discarding zero singular values
                     # to get pcov (as per scipy.optimize.curve_fit())
                     _, s, VT = svd(output.jac, full_matrices=False)
-                    threshold = np.finfo(float).eps * \
-                        max(output.jac.shape) * s[0]
+                    threshold = np.finfo(float).eps * max(output.jac.shape) * s[0]
                     s = s[s > threshold]
                     VT = VT[:s.size]
                     pcov = np.dot(VT.T / s**2, VT)
@@ -1133,19 +1133,37 @@ class BaseModel(list):
                     # This replicates the original "leastsq"
                     # behaviour in earlier versions of HyperSpy
                     # using the Levenberg-Marquardt algorithm
-                    output = \
-                        leastsq(self._errfunc, self.p0[:], Dfun=jacobian,
-                                col_deriv=1, args=args, full_output=True,
-                                **kwargs)
-                    self.p0, pcov = output[0:2]
+                    output = leastsq(self._errfunc, self.p0[:], Dfun=jacobian,
+                                     col_deriv=1, args=args, full_output=True,
+                                     **kwargs)
+                    self.p0, pcov, infodict, errmsg, ier = output
+                    ysize = len(infodict['fvec'])
+                    cost = np.sum(infodict['fvec'] ** 2)
 
-                signal_len = sum([axis.size
-                                  for axis in self.axes_manager.signal_axes])
-                if (signal_len > len(self.p0)) and pcov is not None:
-                    pcov *= ((self._errfunc(self.p0, *args) ** 2).sum() /
-                             (len(args[0]) - len(self.p0)))
+                warn_cov = False
 
-                    self.p_std = np.sqrt(np.diag(pcov))
+                if pcov is None:
+                    # Indeterminate covariance
+                    pcov = np.zeros((len(self.p0), len(self.p0)), dtype=float)
+                    pcov.fill(np.inf)
+                    warn_cov = True
+                elif pcov.min() < 0:
+                    # Usually indicative of numerical overflow
+                    # (covariance should be positive)
+                    pcov.fill(np.inf)
+                    warn_cov = True
+                elif (ysize > self.p0.size):
+                    pcov *= cost / (ysize - self.p0.size)
+                else:
+                    pcov.fill(np.inf)
+                    warn_cov = True
+
+                if warn_cov:
+                    warnings.warn("Covariance of the parameters could not be estimated", OptimizeWarning)
+
+                # Calculate standard deviation
+                self.p_std = np.sqrt(np.diag(pcov))
+
                 self.fit_output = output
 
             elif fitter == "odr":

--- a/hyperspy/model.py
+++ b/hyperspy/model.py
@@ -28,8 +28,7 @@ import numpy as np
 import dill
 import scipy
 import scipy.odr as odr
-from scipy.optimize import (leastsq, least_squares,
-                            minimize, differential_evolution, OptimizeWarning)
+from scipy.optimize import leastsq, least_squares, minimize, differential_evolution
 from scipy.linalg import svd
 from contextlib import contextmanager
 
@@ -1159,7 +1158,7 @@ class BaseModel(list):
                     warn_cov = True
 
                 if warn_cov:
-                    warnings.warn("Covariance of the parameters could not be estimated", OptimizeWarning)
+                    _logger.warning("Covariance of the parameters could not be estimated")
 
                 # Calculate standard deviation
                 self.p_std = np.sqrt(np.diag(pcov))

--- a/hyperspy/model.py
+++ b/hyperspy/model.py
@@ -1158,7 +1158,12 @@ class BaseModel(list):
                     warn_cov = True
 
                 if warn_cov:
-                    _logger.warning("Covariance of the parameters could not be estimated")
+                    _logger.warning(
+                        "Covariance of the parameters could not be estimated. "
+                        "Estimated parameter standard deviations will be np.inf. "
+                        "This could indicate that the model is a poor description "
+                        "of the data."
+                    )
 
                 # Calculate standard deviation
                 self.p_std = np.sqrt(np.diag(pcov))

--- a/hyperspy/samfire.py
+++ b/hyperspy/samfire.py
@@ -341,7 +341,7 @@ class Samfire:
         Parameters
         ----------
         filename: {str, None}
-            the filename. If None, a default value of "backup\_"+signal_title
+            the filename. If None, a default value of "backup_"+signal_title
             is used.
         on_count: bool
             if True (default), only saves on the required count of steps

--- a/hyperspy/tests/component/test_components.py
+++ b/hyperspy/tests/component/test_components.py
@@ -45,7 +45,7 @@ def get_components1d_name_list():
     return components1d_name_list
 
 
-@pytest.mark.filterwarnings("ignore:The API of the `Polynomial`")
+@pytest.mark.filterwarnings("ignore:The API of the")
 @pytest.mark.parametrize('component_name', get_components1d_name_list())
 def test_creation_components1d(component_name):
     s = hs.signals.Signal1D(np.zeros(1024))

--- a/hyperspy/tests/component/test_components.py
+++ b/hyperspy/tests/component/test_components.py
@@ -45,6 +45,9 @@ def get_components1d_name_list():
     return components1d_name_list
 
 
+@pytest.mark.filterwarnings("ignore:invalid value encountered in true_divide:RuntimeWarning")
+@pytest.mark.filterwarnings("ignore:divide by zero encountered in true_divide:RuntimeWarning")
+@pytest.mark.filterwarnings("ignore:invalid value encountered in cos:RuntimeWarning")
 @pytest.mark.filterwarnings("ignore:The API of the")
 @pytest.mark.parametrize('component_name', get_components1d_name_list())
 def test_creation_components1d(component_name):

--- a/hyperspy/tests/component/test_pesvoigt.py
+++ b/hyperspy/tests/component/test_pesvoigt.py
@@ -25,6 +25,7 @@ import pytest
 from hyperspy.signals import Signal1D
 from hyperspy.components1d import PESVoigt
 from hyperspy.utils import stack
+from hyperspy.exceptions import VisibleDeprecationWarning
 
 #Legacy test, to be removed in v2.0
 from hyperspy.components1d import Voigt
@@ -68,13 +69,17 @@ def test_estimate_parameters_binned(only_current, binned, lazy):
     assert_allclose(g2.centre.value, 1, 1e-3)
 
 
-#Legacy test, to be removed in v2.0
 def test_legacy():
-    g = Voigt(legacy=True)
-    g.area.value = 5
-    g.FWHM.value = 0.5
-    g.gamma.value = 0.2
-    g.centre.value = 1
-    assert_allclose(g.function(0), 0.35380168)
-    assert_allclose(g.function(1), 5.06863535)
+    """Legacy test, to be removed in v2.0."""
+    with pytest.warns(
+        VisibleDeprecationWarning,
+        match="API of the `Voigt` component will change",
+    ):
+        g = Voigt(legacy=True)
+        g.area.value = 5
+        g.FWHM.value = 0.5
+        g.gamma.value = 0.2
+        g.centre.value = 1
+        assert_allclose(g.function(0), 0.35380168)
+        assert_allclose(g.function(1), 5.06863535)
 

--- a/hyperspy/tests/io/test_hdf5.py
+++ b/hyperspy/tests/io/test_hdf5.py
@@ -377,7 +377,7 @@ class TestPassingArgs:
         BaseSignal([1, 2, 3]).save(self.filename, compression_opts=8)
 
     def test_compression_opts(self):
-        f = h5py.File(self.filename)
+        f = h5py.File(self.filename, mode='r+')
         d = f['Experiments/__unnamed__/data']
         assert d.compression_opts == 8
         assert d.compression == 'gzip'

--- a/hyperspy/tests/io/test_usid.py
+++ b/hyperspy/tests/io/test_usid.py
@@ -225,6 +225,7 @@ def gen_2dim(all_pos=False, s2f_aux=True):
 # ################ HyperSpy Signal to h5USID ##################################
 
 
+@pytest.mark.filterwarnings("ignore:This dataset does not have an N-dimensional form:UserWarning")
 class TestHS2USIDallKnown:
 
     def test_n_pos_0_spec(self):
@@ -318,6 +319,7 @@ class TestHS2USIDallKnown:
                                  empty_spec=False, dset_path=new_dset_path)
 
 
+@pytest.mark.filterwarnings("ignore:This dataset does not have an N-dimensional form:UserWarning")
 class TestHS2USIDlazy:
 
     def test_base_nd(self):
@@ -332,6 +334,7 @@ class TestHS2USIDlazy:
                                  empty_spec=False, axes_defined=False)
 
 
+@pytest.mark.filterwarnings("ignore:This dataset does not have an N-dimensional form:UserWarning")
 class TestHS2USIDedgeAxes:
 
     def test_no_axes(self):
@@ -393,7 +396,7 @@ class TestHS2USIDedgeAxes:
 
 # ################## h5USID to HyperSpy Signal(s)  ############################
 
-
+@pytest.mark.filterwarnings("ignore:This dataset does not have an N-dimensional form:UserWarning")
 class TestUSID2HSbase:
 
     def test_n_pos_0_spec(self):
@@ -453,6 +456,7 @@ class TestUSID2HSbase:
         self.base_n_pos_m_spec(True)
 
 
+@pytest.mark.filterwarnings("ignore:This dataset does not have an N-dimensional form:UserWarning")
 class TestUSID2HSdtype:
     
     def test_complex(self):
@@ -523,6 +527,7 @@ class TestUSID2HSdtype:
                                  invalid_axes=True)
 
 
+@pytest.mark.filterwarnings("ignore:This dataset does not have an N-dimensional form:UserWarning")
 class TestUSID2HSmultiDsets:
 
     def test_pick_specific(self):

--- a/hyperspy/tests/model/test_eelsmodel.py
+++ b/hyperspy/tests/model/test_eelsmodel.py
@@ -25,6 +25,14 @@ import hyperspy.api as hs
 from hyperspy.decorators import lazifyTestClass
 
 
+# Dask does not always work nicely with np.errstate,
+# see: https://github.com/dask/dask/issues/3245, so
+# filter out divide-by-zero warnings that only appear
+# when the test is lazy. When the test is not lazy,
+# internal use of np.errstate means the warnings never
+# appear in the first place.
+@pytest.mark.filterwarnings("ignore:invalid value encountered in subtract:RuntimeWarning")
+@pytest.mark.filterwarnings("ignore:divide by zero encountered in log:RuntimeWarning")
 @lazifyTestClass
 class TestCreateEELSModel:
 

--- a/hyperspy/tests/mva/test_bss.py
+++ b/hyperspy/tests/mva/test_bss.py
@@ -277,6 +277,8 @@ class TestBSS1D:
             self.s.get_bss_factors(), s2.get_bss_loadings()
         )
 
+
+    @pytest.mark.filterwarnings("ignore:FastICA did not converge")
     @pytest.mark.parametrize("on_loadings", [True, False])
     @pytest.mark.parametrize("diff_order", [0, 1])
     def test_mask_diff_order(self, on_loadings, diff_order):

--- a/hyperspy/tests/signal/test_assign_subclass.py
+++ b/hyperspy/tests/signal/test_assign_subclass.py
@@ -55,7 +55,7 @@ def test_assignment_class():
                 signal_type=case.sig_type,
                 lazy=False) is
             getattr(hs.signals, case.cls))
-        lazyclass = 'Lazy' + case.cls if case.cls is not 'BaseSignal' \
+        lazyclass = 'Lazy' + case.cls if case.cls != 'BaseSignal' \
             else 'LazySignal'
         assert (
             assign_signal_subclass(


### PR DESCRIPTION
### Description of the change
There are a few warnings polluting the `pytest` report that are easily solved on `RELEASE_next_minor` - this PR address that, such that the remaining warnings are clearer for solving in future.

- Fix NMF convergence warnings and factor out data generation
- Fix H5py deprecation warning
- Fix Voigt API warnings
- Fix warnings from strings

I also looked at correctly raising warnings for parameter covariance estimation as per the approach taken in [`scipy.optimize.curve_fit()`](https://github.com/scipy/scipy/blob/v1.4.1/scipy/optimize/minpack.py#L511-L813) - rather than raising the unclear:
```
hyperspy/model.py:1134: RuntimeWarning: invalid value encountered in sqrt
    self.p_std = np.sqrt(np.diag(pcov))
```
when the parameter covariance is ill-defined, it now raises:
```
hyperspy/model.py:1162: OptimizeWarning: Covariance of the parameters could not be estimated
    warnings.warn("Covariance of the parameters could not be estimated", OptimizeWarning)
```
As it stands, this last point actually greatly _increases_ the number of warnings in the test suite. @ericpre / @francisco-dlp I would welcome a suggestion on how to proceed (for example, filtering out this warning if desired).

### Progress of the PR
- [x] Change implemented
- [x] ready for review

