### PR TITLE
BUGFIX somebody forgot a print('here') statement.

### DIFF
--- a/hyperspy/drawing/utils.py
+++ b/hyperspy/drawing/utils.py
@@ -704,7 +704,6 @@ def plot_images(images,
                                 'match the number of images')
                 arg = [default_value] * n
         elif colorbar != 'single':
-            print('here')
             arg = [arg] * n
         return arg
 


### PR DESCRIPTION
### Description of the change
Somebody forgot a print('here') statement.
- Three 'here' strings were printed when running `hs.plot.plot_images` 
- It seems there was a misplaced `print` statement
- If this is the case, this PR removes the bug.

### Progress of the PR
- [ x ] Change implemented (can be split into several points),
- [ ] update docstring (if appropriate),
- [ ] update user guide (if appropriate),
- [ ] add tests,
- [ x ] ready for review.

### Minimal example of the bug fix or the new feature
```python
>>> import hyperspy.api as hs
>>> import numpy as np
>>> imgs = hs.signals.Signal2D(np.arange([2, 128, 128]))
>>> hs.plot.plot_images(imgs) # does not print 'here' three times
```

