### PR TITLE
Tidy up test suite and fix dependencies

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -56,7 +56,7 @@ steps:
 
 - bash: |
     source activate $ENV_NAME
-    pip install --no-deps .
+    pip install --no-deps -e .
     conda list
   displayName: Install package
 

--- a/conda_environment.yml
+++ b/conda_environment.yml
@@ -3,20 +3,21 @@ channels:
 - defaults
 - conda-forge
 dependencies:
-# Minimal dependencies in alphabetical order
 - dask
 - dill
 - h5py
 - imageio
 - ipyparallel
-- matplotlib
+- matplotlib-base
 - mrcz
 - natsort
+- numba
 - numexpr
 - numpy
 - pint
 - PTable
 - python-dateutil
+- pyusid
 - pyyaml
 - requests
 - scikit-image

--- a/conda_environment_dev.yml
+++ b/conda_environment_dev.yml
@@ -6,6 +6,7 @@ dependencies:
 # We pin freetype and matplotlib for the image comparison
 - freetype=2.9
 - matplotlib=3.1
+- cython
 - pytest
 - pytest-mpl
 

--- a/hyperspy/axes.py
+++ b/hyperspy/axes.py
@@ -25,7 +25,6 @@ import traits.api as t
 from traits.trait_errors import TraitError
 import pint
 import logging
-import itertools
 
 from hyperspy.events import Events, Event
 from hyperspy.misc.utils import isiterable, ordinal
@@ -631,9 +630,9 @@ class DataAxis(t.HasTraits, UnitConversion):
         self._set_quantity(value, 'offset')
 
 def serpentine_iter(shape):
-    '''Similar to np.ndindex, but yields indices 
+    '''Similar to np.ndindex, but yields indices
     in serpentine pattern, like snake game
-    
+
     Code by Stackoverflow user Paul Panzer,
     from https://stackoverflow.com/questions/57366966/
     '''
@@ -777,7 +776,7 @@ class AxesManager(t.HasTraits):
         self._update_attributes()
         self._update_trait_handlers()
         self._index = None  # index for the iterpath
-        # Can use serpentine or flyback scan pattern 
+        # Can use serpentine or flyback scan pattern
         # for the axes manager indexing
         self._iterpath = 'flyback'
 
@@ -997,8 +996,8 @@ class AxesManager(t.HasTraits):
                 # for some reason. This is possibly expensive, as it needs
                 # to calculate all previous values first
                 # self._iterpath_generator = itertools.islice(
-                #     serpentine_iter(self._navigation_shape_in_array), 
-                #     self._index, 
+                #     serpentine_iter(self._navigation_shape_in_array),
+                #     self._index,
                 #     None)
                 val = next(self._iterpath_generator)[::-1]
             else:
@@ -1541,11 +1540,21 @@ class AxesManager(t.HasTraits):
         self._axes = list(new_axes)
 
     def gui_navigation_sliders(self, title="", display=True, toolkit=None):
-        return get_gui(self=self.navigation_axes,
-                       toolkey="hyperspy.navigation_sliders",
-                       display=display,
-                       toolkit=toolkit,
-                       title=title)
+        # With traits 6.1 and traitsui 7.0, we have this deprecation warning,
+        # which is fine to filter
+        # https://github.com/enthought/traitsui/issues/883
+        with warnings.catch_warnings():
+            warnings.filterwarnings("ignore", category=DeprecationWarning,
+                                    message="'TraitPrefixList'",
+                                    module='traitsui')
+            warnings.filterwarnings("ignore", category=DeprecationWarning,
+                                    message="'TraitMap'",
+                                    module='traits')
+            return get_gui(self=self.navigation_axes,
+                           toolkey="hyperspy.navigation_sliders",
+                           display=display,
+                           toolkit=toolkit,
+                           title=title)
     gui_navigation_sliders.__doc__ = \
         """
         Navigation sliders to control the index of the navigation axes.

--- a/hyperspy/drawing/image.py
+++ b/hyperspy/drawing/image.py
@@ -416,13 +416,13 @@ class ImagePlot(BlittedFigure):
 
                 norm = LogNorm(vmin=vmin, vmax=vmax)
             elif norm == 'symlog':
-                kwargs = {}
+                sym_log_kwargs = {}
                 if LooseVersion(matplotlib.__version__) >= LooseVersion("3.2"):
-                    kwargs['base'] = 10
+                    sym_log_kwargs['base'] = 10
                 norm = SymLogNorm(linthresh=self.linthresh,
-                                linscale=self.linscale,
-                                vmin=vmin, vmax=vmax,
-                                **kwargs)
+                                  linscale=self.linscale,
+                                  vmin=vmin, vmax=vmax,
+                                  **sym_log_kwargs)
             elif inspect.isclass(norm) and issubclass(norm, Normalize):
                 norm = norm(vmin=vmin, vmax=vmax)
             elif norm not in ['auto', 'linear']:

--- a/hyperspy/drawing/image.py
+++ b/hyperspy/drawing/image.py
@@ -19,12 +19,14 @@
 import math
 
 import numpy as np
+import matplotlib
 import matplotlib.pyplot as plt
 from matplotlib.colors import Normalize, LogNorm, SymLogNorm, PowerNorm
 from traits.api import Undefined
 import logging
 import inspect
 import copy
+from distutils.version import LooseVersion
 
 from hyperspy.drawing import widgets
 from hyperspy.drawing import utils
@@ -414,9 +416,13 @@ class ImagePlot(BlittedFigure):
 
                 norm = LogNorm(vmin=vmin, vmax=vmax)
             elif norm == 'symlog':
+                kwargs = {}
+                if LooseVersion(matplotlib.__version__) >= LooseVersion("3.2"):
+                    kwargs['base'] = 10
                 norm = SymLogNorm(linthresh=self.linthresh,
                                 linscale=self.linscale,
-                                vmin=vmin, vmax=vmax)
+                                vmin=vmin, vmax=vmax,
+                                **kwargs)
             elif inspect.isclass(norm) and issubclass(norm, Normalize):
                 norm = norm(vmin=vmin, vmax=vmax)
             elif norm not in ['auto', 'linear']:
@@ -468,7 +474,7 @@ class ImagePlot(BlittedFigure):
                         'vmax': vmax,
                         'norm': norm}
 
-                    
+
                 )
             new_args.update(kwargs)
             self.ax.imshow(data,

--- a/hyperspy/tests/__init__.py
+++ b/hyperspy/tests/__init__.py
@@ -20,7 +20,7 @@ import os
 import warnings
 
 from hyperspy.defaults_parser import preferences
-preferences.General.show_progressbar = False
+preferences.General.show_progressbar = True
 
 # Check if we should fail on external deprecation messages
 fail_on_external = os.environ.pop('FAIL_ON_EXTERNAL_DEPRECATION', False)

--- a/hyperspy/tests/component/test_components.py
+++ b/hyperspy/tests/component/test_components.py
@@ -84,7 +84,7 @@ class TestPowerLaw:
     @pytest.mark.parametrize(("only_current", "binned"), TRUE_FALSE_2_TUPLE)
     def test_estimate_parameters(self, only_current, binned):
         self.m.signal.metadata.Signal.binned = binned
-        s = self.m.as_signal(show_progressbar=None, parallel=False)
+        s = self.m.as_signal(parallel=False)
         assert s.metadata.Signal.binned == binned
         g = hs.model.components1D.PowerLaw()
         g.estimate_parameters(s, None, None, only_current=only_current)
@@ -103,7 +103,7 @@ class TestPowerLaw:
 
     def test_EDS_missing_data(self):
         g = hs.model.components1D.PowerLaw()
-        s = self.m.as_signal(show_progressbar=None, parallel=False)
+        s = self.m.as_signal(parallel=False)
         s2 = hs.signals.EDSTEMSpectrum(s.data)
         g.estimate_parameters(s2, None, None)
 
@@ -140,7 +140,7 @@ class TestDoublePowerLaw:
     @pytest.mark.parametrize(("binned"), (True, False))
     def test_fit(self, binned):
         self.m.signal.metadata.Signal.binned = binned
-        s = self.m.as_signal(show_progressbar=None, parallel=False)
+        s = self.m.as_signal(parallel=False)
         assert s.metadata.Signal.binned == binned
         g = hs.model.components1D.DoublePowerLaw()
         # Fix the ratio parameter to test the fit
@@ -166,14 +166,14 @@ class TestOffset:
     @pytest.mark.parametrize(("only_current", "binned"), TRUE_FALSE_2_TUPLE)
     def test_estimate_parameters(self, only_current, binned):
         self.m.signal.metadata.Signal.binned = binned
-        s = self.m.as_signal(show_progressbar=None, parallel=False)
+        s = self.m.as_signal(parallel=False)
         assert s.metadata.Signal.binned == binned
         o = hs.model.components1D.Offset()
         o.estimate_parameters(s, None, None, only_current=only_current)
         assert_allclose(o.offset.value, 10)
 
     def test_function_nd(self):
-        s = self.m.as_signal(show_progressbar=None, parallel=False)
+        s = self.m.as_signal(parallel=False)
         s = hs.stack([s] * 2)
         o = hs.model.components1D.Offset()
         o.estimate_parameters(s, None, None, only_current=False)
@@ -212,7 +212,7 @@ class TestDeprecatedPolynomial:
     @pytest.mark.parametrize(("only_current", "binned"), TRUE_FALSE_2_TUPLE)
     def test_estimate_parameters(self, only_current, binned):
         self.m.signal.metadata.Signal.binned = binned
-        s = self.m.as_signal(show_progressbar=None, parallel=False)
+        s = self.m.as_signal(parallel=False)
         assert s.metadata.Signal.binned == binned
         g = hs.model.components1D.Polynomial(order=2)
         g.estimate_parameters(s, None, None, only_current=only_current)
@@ -222,7 +222,7 @@ class TestDeprecatedPolynomial:
 
     def test_2d_signal(self):
         # This code should run smoothly, any exceptions should trigger failure
-        s = self.m_2d.as_signal(show_progressbar=None, parallel=False)
+        s = self.m_2d.as_signal(parallel=False)
         model = Model1D(s)
         p = hs.model.components1D.Polynomial(order=2)
         model.append(p)
@@ -233,7 +233,7 @@ class TestDeprecatedPolynomial:
     @pytest.mark.filterwarnings("ignore:The API of the `Polynomial`")
     def test_3d_signal(self):
         # This code should run smoothly, any exceptions should trigger failure
-        s = self.m_3d.as_signal(show_progressbar=None, parallel=False)
+        s = self.m_3d.as_signal(parallel=False)
         model = Model1D(s)
         p = hs.model.components1D.Polynomial(order=2)
         model.append(p)
@@ -300,7 +300,7 @@ class TestPolynomial:
     @pytest.mark.parametrize(("only_current", "binned"), TRUE_FALSE_2_TUPLE)
     def test_estimate_parameters(self,  only_current, binned):
         self.m.signal.metadata.Signal.binned = binned
-        s = self.m.as_signal(show_progressbar=None, parallel=False)
+        s = self.m.as_signal(parallel=False)
         s.metadata.Signal.binned = binned
         p = hs.model.components1D.Polynomial(order=2, legacy=False)
         p.estimate_parameters(s, None, None, only_current=only_current)
@@ -315,7 +315,7 @@ class TestPolynomial:
 
     def test_2d_signal(self):
         # This code should run smoothly, any exceptions should trigger failure
-        s = self.m_2d.as_signal(show_progressbar=None, parallel=False)
+        s = self.m_2d.as_signal(parallel=False)
         model = Model1D(s)
         p = hs.model.components1D.Polynomial(order=2, legacy=False)
         model.append(p)
@@ -326,7 +326,7 @@ class TestPolynomial:
 
     def test_3d_signal(self):
         # This code should run smoothly, any exceptions should trigger failure
-        s = self.m_3d.as_signal(show_progressbar=None, parallel=False)
+        s = self.m_3d.as_signal(parallel=False)
         model = Model1D(s)
         p = hs.model.components1D.Polynomial(order=2, legacy=False)
         model.append(p)
@@ -336,7 +336,7 @@ class TestPolynomial:
         np.testing.assert_allclose(p.a0.map['values'], 3)
 
     def test_function_nd(self):
-        s = self.m.as_signal(show_progressbar=None, parallel=False)
+        s = self.m.as_signal(parallel=False)
         s = hs.stack([s]*2)
         p = hs.model.components1D.Polynomial(order=2, legacy=False)
         p.estimate_parameters(s, None, None, only_current=False)
@@ -360,7 +360,7 @@ class TestGaussian:
     @pytest.mark.parametrize(("only_current", "binned"), TRUE_FALSE_2_TUPLE)
     def test_estimate_parameters_binned(self, only_current, binned):
         self.m.signal.metadata.Signal.binned = binned
-        s = self.m.as_signal(show_progressbar=None, parallel=False)
+        s = self.m.as_signal(parallel=False)
         assert s.metadata.Signal.binned == binned
         g = hs.model.components1D.Gaussian()
         g.estimate_parameters(s, None, None, only_current=only_current)
@@ -371,7 +371,7 @@ class TestGaussian:
     @pytest.mark.parametrize("binned", (True, False))
     def test_function_nd(self, binned):
         self.m.signal.metadata.Signal.binned = binned
-        s = self.m.as_signal(show_progressbar=None, parallel=False)
+        s = self.m.as_signal(parallel=False)
         s2 = hs.stack([s] * 2)
         g = hs.model.components1D.Gaussian()
         g.estimate_parameters(s2, None, None, only_current=False)
@@ -427,7 +427,7 @@ def test_expression_symbols():
     with pytest.raises(ValueError):
         hs.model.components1D.Expression(expression="10", name="offset")
     with pytest.raises(ValueError):
-        hs.model.components1D.Expression(expression="10*offset", name="Offset")    
+        hs.model.components1D.Expression(expression="10*offset", name="Offset")
 
 
 def test_expression_substitution():

--- a/hyperspy/tests/datasets/test_eelsdb.py
+++ b/hyperspy/tests/datasets/test_eelsdb.py
@@ -22,9 +22,13 @@ from hyperspy.misc.eels.eelsdb import eelsdb
 from requests.exceptions import SSLError
 import warnings
 
+
 def eelsdb_down():
     try:
-        request = requests.get('http://api.eelsdb.eu', verify=False)
+        _ = requests.get('http://api.eelsdb.eu', verify=True)
+        return False
+    except SSLError:
+        _ = requests.get('http://api.eelsdb.eu', verify=False)
         return False
     except requests.exceptions.ConnectionError:
         return True

--- a/hyperspy/tests/drawing/test_figure.py
+++ b/hyperspy/tests/drawing/test_figure.py
@@ -72,7 +72,7 @@ class TestCloseFigure():
         if sig_dim == 1:
             Signal = Signal1D
         elif sig_dim == 2:
-            Signal = Signal2D            
+            Signal = Signal2D
         s = Signal(np.arange(pow(10, total_dim)).reshape([10]*total_dim))
         s.plot(navigator=navigator)
         s._plot.close()

--- a/hyperspy/tests/drawing/test_plot_signal_tools.py
+++ b/hyperspy/tests/drawing/test_plot_signal_tools.py
@@ -42,8 +42,7 @@ def test_plot_BackgroundRemoval():
                            background_type='Power Law',
                            polynomial_order=2,
                            fast=True,
-                           plot_remainder=True,
-                           show_progressbar=None)
+                           plot_remainder=True)
 
     br.span_selector.set_initial((105, 115))
     br.span_selector.onmove_callback()

--- a/hyperspy/tests/io/test_hdf5.py
+++ b/hyperspy/tests/io/test_hdf5.py
@@ -660,19 +660,6 @@ def test_strings_from_py2():
     assert s.metadata.Sample.elements.dtype.char == "U"
 
 
-@pytest.mark.skipif(LooseVersion(dask.__version__) >= LooseVersion('0.14.1'),
-                    reason='Fixed in later dask versions')
-def test_lazy_metadata_arrays(tmpfilepath):
-    s = BaseSignal([1, 2, 3])
-    s.metadata.array = np.arange(10.)
-    s.save(tmpfilepath)
-    l = load(tmpfilepath + ".hspy", lazy=True)
-    # Can't deepcopy open hdf5 file handles
-    with pytest.raises(TypeError):
-        l.deepcopy()
-    del l
-
-
 def test_save_ragged_array(tmpfilepath):
     a = np.array([0, 1])
     b = np.array([0, 1, 2])
@@ -689,4 +676,4 @@ def test_load_missing_extension(caplog):
     s = load(path)
     assert "This file contains a signal provided by the hspy_ext_missing" in caplog.text
     with pytest.raises(ImportError):
-       m = s.models.restore("a") 
+       _ = s.models.restore("a")

--- a/hyperspy/tests/model/test_model.py
+++ b/hyperspy/tests/model/test_model.py
@@ -964,8 +964,7 @@ class TestModelSignalVariance:
 
     def test_std1_red_chisq(self):
         # HyperSpy 2.0: remove setting iterpath='serpentine'
-        self.m.multifit(fitter="leastsq", method="ls", show_progressbar=None,
-                        iterpath='serpentine')
+        self.m.multifit(fitter="leastsq", method="ls", iterpath='serpentine')
         np.testing.assert_allclose(self.m.red_chisq.data[0], 0.813109,
                                    atol=1e-5)
         np.testing.assert_allclose(self.m.red_chisq.data[1], 0.697727,
@@ -995,8 +994,7 @@ class TestMultifit:
 
     def test_fetch_only_fixed_false(self):
         # HyperSpy 2.0: remove setting iterpath='serpentine'
-        self.m.multifit(fetch_only_fixed=False, show_progressbar=None,
-                        iterpath='serpentine')
+        self.m.multifit(fetch_only_fixed=False, iterpath='serpentine')
         np.testing.assert_array_almost_equal(self.m[0].r.map['values'],
                                              [3., 100.])
         np.testing.assert_array_almost_equal(self.m[0].A.map['values'],
@@ -1004,8 +1002,7 @@ class TestMultifit:
 
     def test_fetch_only_fixed_true(self):
         # HyperSpy 2.0: remove setting iterpath='serpentine'
-        self.m.multifit(fetch_only_fixed=True, show_progressbar=None,
-                        iterpath='serpentine')
+        self.m.multifit(fetch_only_fixed=True, iterpath='serpentine')
         np.testing.assert_array_almost_equal(self.m[0].r.map['values'],
                                              [3., 3.])
         np.testing.assert_array_almost_equal(self.m[0].A.map['values'],
@@ -1017,8 +1014,7 @@ class TestMultifit:
         np.testing.assert_allclose(rs.data, np.array([2., 100.]))
         assert not "Signal.Noise_properties.variance" in rs.metadata
         # HyperSpy 2.0: remove setting iterpath='serpentine'
-        self.m.multifit(fetch_only_fixed=True, show_progressbar=None,
-                        iterpath='serpentine')
+        self.m.multifit(fetch_only_fixed=True, iterpath='serpentine')
         rs = self.m[0].r.as_signal(field="values")
         assert "Signal.Noise_properties.variance" in rs.metadata
         assert isinstance(rs.metadata.Signal.Noise_properties.variance,
@@ -1031,8 +1027,7 @@ class TestMultifit:
         m[0].A.value = 2.
         m[0].A.bmin = 3.
         # HyperSpy 2.0: remove setting iterpath='serpentine'
-        m.multifit(fitter='mpfit', bounded=True, show_progressbar=None,
-                   iterpath='serpentine')
+        m.multifit(fitter='mpfit', bounded=True, iterpath='serpentine')
         np.testing.assert_array_almost_equal(self.m[0].r.map['values'],
                                              [3., 3.])
         np.testing.assert_array_almost_equal(self.m[0].A.map['values'],
@@ -1045,8 +1040,7 @@ class TestMultifit:
         m[0].A.value = 2.
         m[0].A.bmin = 3.
         # HyperSpy 2.0: remove setting iterpath='serpentine'
-        m.multifit(fitter='leastsq', bounded=True, show_progressbar=None,
-                   iterpath='serpentine')
+        m.multifit(fitter='leastsq', bounded=True, iterpath='serpentine')
         np.testing.assert_array_almost_equal(self.m[0].r.map['values'],
                                              [3., 3.])
         np.testing.assert_array_almost_equal(self.m[0].A.map['values'],
@@ -1055,13 +1049,13 @@ class TestMultifit:
     def test_None_iterpath(self):
         'To be removed with hyperspy 2.0, where serpentine is default.'
         with pytest.warns(VisibleDeprecationWarning):
-            self.m.multifit(show_progressbar=None) # iterpath = None by default
+            self.m.multifit() # iterpath = None by default
 
     def test_flyback_iterpath(self):
-        self.m.multifit(iterpath='flyback', show_progressbar=None)
+        self.m.multifit(iterpath='flyback')
 
     def test_serpentine_iterpath(self):
-        self.m.multifit(iterpath='serpentine', show_progressbar=None)
+        self.m.multifit(iterpath='serpentine')
 
 
 class TestStoreCurrentValues:
@@ -1181,31 +1175,28 @@ class TestAsSignal:
     @pytest.mark.parallel
     def test_threaded_identical(self):
         # all components
-        s = self.m.as_signal(show_progressbar=False, parallel=True)
-        s1 = self.m.as_signal(show_progressbar=False, parallel=False)
+        s = self.m.as_signal(parallel=True)
+        s1 = self.m.as_signal(parallel=False)
         np.testing.assert_allclose(s1.data, s.data)
 
         # more complicated
         self.m[0].active_is_multidimensional = True
         self.m[0]._active_array[0] = False
         for component in [0, 1]:
-            s = self.m.as_signal(component_list=[component],
-                                 show_progressbar=False, parallel=True)
-            s1 = self.m.as_signal(component_list=[component],
-                                  show_progressbar=False, parallel=False)
+            s = self.m.as_signal(component_list=[component], parallel=True)
+            s1 = self.m.as_signal(component_list=[component], parallel=False)
             np.testing.assert_allclose(s1.data, s.data)
 
     @pytest.mark.parametrize('parallel',
                              [pytest.param(True, marks=pytest.mark.parallel), False])
     def test_all_components_simple(self, parallel):
-        s = self.m.as_signal(show_progressbar=False, parallel=parallel)
+        s = self.m.as_signal(parallel=parallel)
         assert np.all(s.data == 4.)
 
     @pytest.mark.parametrize('parallel',
                              [pytest.param(True, marks=pytest.mark.parallel), False])
     def test_one_component_simple(self, parallel):
-        s = self.m.as_signal(component_list=[0], show_progressbar=False,
-                             parallel=parallel)
+        s = self.m.as_signal(component_list=[0], parallel=parallel)
         assert np.all(s.data == 2.)
         assert self.m[1].active
 
@@ -1214,11 +1205,11 @@ class TestAsSignal:
     def test_all_components_multidim(self, parallel):
         self.m[0].active_is_multidimensional = True
 
-        s = self.m.as_signal(show_progressbar=False, parallel=parallel)
+        s = self.m.as_signal(parallel=parallel)
         assert np.all(s.data == 4.)
 
         self.m[0]._active_array[0] = False
-        s = self.m.as_signal(show_progressbar=False, parallel=parallel)
+        s = self.m.as_signal(parallel=parallel)
         np.testing.assert_array_equal(
             s.data, np.array([np.ones((2, 5)) * 2, np.ones((2, 5)) * 4]))
         assert self.m[0].active_is_multidimensional
@@ -1228,24 +1219,20 @@ class TestAsSignal:
     def test_one_component_multidim(self, parallel):
         self.m[0].active_is_multidimensional = True
 
-        s = self.m.as_signal(component_list=[0], show_progressbar=False,
-                             parallel=parallel)
+        s = self.m.as_signal(component_list=[0], parallel=parallel)
         assert np.all(s.data == 2.)
         assert self.m[1].active
         assert not self.m[1].active_is_multidimensional
 
-        s = self.m.as_signal(component_list=[1], show_progressbar=False,
-                             parallel=parallel)
+        s = self.m.as_signal(component_list=[1], parallel=parallel)
         np.testing.assert_equal(s.data, 2.)
         assert self.m[0].active_is_multidimensional
 
         self.m[0]._active_array[0] = False
-        s = self.m.as_signal(component_list=[1], show_progressbar=False,
-                             parallel=parallel)
+        s = self.m.as_signal(component_list=[1], parallel=parallel)
         assert np.all(s.data == 2.)
 
-        s = self.m.as_signal(component_list=[0], show_progressbar=False,
-                             parallel=parallel)
+        s = self.m.as_signal(component_list=[0], parallel=parallel)
         np.testing.assert_array_equal(s.data, np.array([np.zeros((2, 5)),
                                                         np.ones((2, 5)) * 2]))
 
@@ -1319,11 +1306,9 @@ def test_as_signal_parallel():
     m.append(hs.model.components1D.PowerLaw())
     m.set_signal_range(2, 5)
     # HyperSpy 2.0: remove setting iterpath='serpentine'
-    m.multifit(show_progressbar=False, iterpath='serpentine')
+    m.multifit(iterpath='serpentine')
 
-    s1 = m.as_signal(out_of_range_to_nan=True, parallel=True,
-                     show_progressbar=False)
-    s2 = m.as_signal(out_of_range_to_nan=True, parallel=True,
-                     show_progressbar=False)
+    s1 = m.as_signal(out_of_range_to_nan=True, parallel=True)
+    s2 = m.as_signal(out_of_range_to_nan=True, parallel=True)
 
     np.testing.assert_allclose(s1, s2)

--- a/hyperspy/tests/samfire/test_goodness_of_fit_tests.py
+++ b/hyperspy/tests/samfire/test_goodness_of_fit_tests.py
@@ -71,7 +71,7 @@ class TestInformationCriteria:
         m = Signal1D(np.arange(30).reshape((3, 10))).create_model()
         m.append(Lorentzian())
         # HyperSpy 2.0: remove setting iterpath='serpentine'
-        m.multifit(show_progressbar=False, iterpath='serpentine')
+        m.multifit(iterpath='serpentine')
         self.m = m
         # have to be imported here, as otherwise crashes nosetools
         from hyperspy.samfire_utils.goodness_of_fit_tests.information_theory \

--- a/hyperspy/tests/samfire/test_samfire.py
+++ b/hyperspy/tests/samfire/test_samfire.py
@@ -106,7 +106,7 @@ def generate_test_model():
         gs03.A.map['values'][mask] *= 0.
         gs03.A.map['is_set'][:] = True
 
-        s11 = m0.as_signal(show_progressbar=False, parallel=False)
+        s11 = m0.as_signal(parallel=False)
         if total is None:
             total = s11.data.copy()
             lor_map = gs01.centre.map['values'].copy()

--- a/hyperspy/tests/signal/test_1D_tools.py
+++ b/hyperspy/tests/signal/test_1D_tools.py
@@ -48,7 +48,7 @@ class TestAlignTools:
 
     def test_estimate_shift(self):
         s = self.signal
-        eshifts = -1 * s.estimate_shift1D(show_progressbar=None)
+        eshifts = -1 * s.estimate_shift1D()
         np.testing.assert_allclose(
             eshifts, self.ishifts * self.scale, atol=1e-3)
 
@@ -59,7 +59,7 @@ class TestAlignTools:
         s.shift1D(-
                   1 *
                   self.ishifts[:, np.newaxis] *
-                  self.scale, show_progressbar=None)
+                  self.scale)
         assert m.data_changed.called
         i_zlp = s.axes_manager.signal_axes[0].value2index(0)
         assert np.allclose(s.data[:, i_zlp], 12)
@@ -74,7 +74,7 @@ class TestAlignTools:
 
     def test_align(self):
         s = self.signal
-        s.align1D(show_progressbar=None)
+        s.align1D()
         i_zlp = s.axes_manager.signal_axes[0].value2index(0)
         assert np.allclose(s.data[:, i_zlp], 12)
         # Check that at the edges of the spectrum the value == to the
@@ -112,7 +112,7 @@ class TestShift1D:
 
     def test_crop_left(self):
         s = self.s
-        s.shift1D(np.array((0.01)), crop=True, show_progressbar=None)
+        s.shift1D(np.array((0.01)), crop=True)
         assert (
             tuple(
                 s.axes_manager[0].axis) == tuple(
@@ -121,7 +121,7 @@ class TestShift1D:
 
     def test_crop_right(self):
         s = self.s
-        s.shift1D(np.array((-0.01)), crop=True, show_progressbar=None)
+        s.shift1D(np.array((-0.01)), crop=True)
         assert (
             tuple(
                 s.axes_manager[0].axis) == tuple(
@@ -194,18 +194,18 @@ class TestInterpolateInBetween:
         s = self.s.inav[0]
         m = mock.Mock()
         s.events.data_changed.connect(m.data_changed)
-        s.interpolate_in_between(8, 12, show_progressbar=None)
+        s.interpolate_in_between(8, 12)
         np.testing.assert_array_equal(s.data, np.arange(20))
         assert m.data_changed.called
 
     def test_single_spectrum_in_units(self):
         s = self.s.inav[0]
-        s.interpolate_in_between(0.8, 1.2, show_progressbar=None)
+        s.interpolate_in_between(0.8, 1.2)
         np.testing.assert_array_equal(s.data, np.arange(20))
 
     def test_two_spectra(self):
         s = self.s
-        s.interpolate_in_between(8, 12, show_progressbar=None)
+        s.interpolate_in_between(8, 12)
         np.testing.assert_array_equal(s.data, np.arange(40).reshape(2, 20))
 
     def test_delta_int(self):
@@ -255,8 +255,7 @@ class TestEstimatePeakWidth:
     def test_full_range(self):
         width, left, right = self.s.estimate_peak_width(
             window=None,
-            return_interval=True,
-            show_progressbar=None)
+            return_interval=True)
         np.testing.assert_allclose(width.data, 0.7065102,
                                    rtol=self.rtol, atol=self.atol)
         np.testing.assert_allclose(left.data, 1.6467449,
@@ -270,20 +269,18 @@ class TestEstimatePeakWidth:
     def test_too_narrow_range(self):
         width, left, right = self.s.estimate_peak_width(
             window=0.5,
-            return_interval=True,
-            show_progressbar=None)
+            return_interval=True)
         assert np.isnan(width.data).all()
         assert np.isnan(left.data).all()
         assert np.isnan(right.data).all()
 
     def test_two_peaks(self):
         s = self.s.deepcopy()
-        s.shift1D(np.array([1.0]), show_progressbar=None)
+        s.shift1D(np.array([1.0]))
         self.s = self.s.isig[10:] + s
         width, left, right = self.s.estimate_peak_width(
             window=None,
-            return_interval=True,
-            show_progressbar=None)
+            return_interval=True)
         assert np.isnan(width.data).all()
         assert np.isnan(left.data).all()
         assert np.isnan(right.data).all()
@@ -323,7 +320,6 @@ class TestSmoothing:
                 return_sorted=False,)
         self.s.smooth_lowess(smoothing_parameter=frac,
                              number_of_iterations=it,
-                             show_progressbar=None,
                              parallel=parallel)
         np.testing.assert_allclose(self.s.data, data,
                                    rtol=self.rtol, atol=self.atol)
@@ -338,7 +334,6 @@ class TestSmoothing:
                 im=data[i, :],
                 weight=weight,)
         self.s.smooth_tv(smoothing_parameter=weight,
-                         show_progressbar=None,
                          parallel=parallel)
         np.testing.assert_allclose(data, self.s.data,
                                    rtol=self.rtol, atol=self.atol)

--- a/hyperspy/tests/signal/test_complex_signal.py
+++ b/hyperspy/tests/signal/test_complex_signal.py
@@ -91,8 +91,7 @@ def test_get_unwrapped_phase_1D(parallel, lazy):
     if lazy:
         s = s.as_lazy()
     s.axes_manager.set_signal_dimension(1)
-    phase_unwrapped = s.unwrapped_phase(seed=42, show_progressbar=False,
-                                        parallel=parallel)
+    phase_unwrapped = s.unwrapped_phase(seed=42, parallel=parallel)
     assert (
         phase_unwrapped.metadata.General.title ==
         'unwrapped phase(Untitled Signal)')
@@ -107,8 +106,7 @@ def test_get_unwrapped_phase_2D(parallel, lazy):
     s = hs.signals.ComplexSignal(np.ones_like(phase) * np.exp(1j * phase))
     if lazy:
         s = s.as_lazy()
-    phase_unwrapped = s.unwrapped_phase(seed=42, show_progressbar=False,
-                                        parallel=parallel)
+    phase_unwrapped = s.unwrapped_phase(seed=42, parallel=parallel)
     assert (
         phase_unwrapped.metadata.General.title ==
         'unwrapped phase(Untitled Signal)')
@@ -123,8 +121,7 @@ def test_get_unwrapped_phase_3D(parallel, lazy):
     s = hs.signals.ComplexSignal(np.ones_like(phase) * np.exp(1j * phase))
     if lazy:
         s = s.as_lazy()
-    phase_unwrapped = s.unwrapped_phase(seed=42, show_progressbar=False,
-                                        parallel=parallel)
+    phase_unwrapped = s.unwrapped_phase(seed=42, parallel=parallel)
     assert (
         phase_unwrapped.metadata.General.title ==
         'unwrapped phase(Untitled Signal)')

--- a/hyperspy/tests/signal/test_eels.py
+++ b/hyperspy/tests/signal/test_eels.py
@@ -150,8 +150,7 @@ class TestAlignZLP:
         s = self.signal
         s.align_zero_loss_peak(
             calibrate=True,
-            print_stats=False,
-            show_progressbar=None)
+            print_stats=False)
         zlpc = s.estimate_zero_loss_peak_centre()
         np.testing.assert_allclose(zlpc.data.mean(), 0)
         np.testing.assert_allclose(zlpc.data.std(), 0)
@@ -163,7 +162,6 @@ class TestAlignZLP:
         s.align_zero_loss_peak(
             calibrate=True,
             print_stats=False,
-            show_progressbar=None,
             mask=mask)
         zlpc = s.estimate_zero_loss_peak_centre(mask=mask)
         np.testing.assert_allclose(np.nanmean(zlpc.data), 0,
@@ -175,8 +173,7 @@ class TestAlignZLP:
         s = self.signal
         s.align_zero_loss_peak(
             calibrate=False,
-            print_stats=False,
-            show_progressbar=None)
+            print_stats=False)
         zlpc = s.estimate_zero_loss_peak_centre()
         np.testing.assert_allclose(zlpc.data.std(), 0, atol=10e-3)
 
@@ -185,8 +182,7 @@ class TestAlignZLP:
         s2 = s.deepcopy()
         s.align_zero_loss_peak(calibrate=True,
                                print_stats=False,
-                               also_align=[s2],
-                               show_progressbar=None)
+                               also_align=[s2])
         zlpc = s2.estimate_zero_loss_peak_centre()
         assert zlpc.data.mean() == 0
         assert zlpc.data.std() == 0
@@ -210,8 +206,7 @@ class TestAlignZLP:
         original_size = s.axes_manager.signal_axes[0].size
         s.align_zero_loss_peak(
             crop=False,
-            print_stats=False,
-            show_progressbar=None)
+            print_stats=False)
         assert original_size == s.axes_manager.signal_axes[0].size
 
 
@@ -353,7 +348,7 @@ class Test_Print_Edges_Near_Energy:
     def test_at_532eV(self):
         s = self.signal
         table_ascii = s.print_edges_near_energy(532)
-        
+
         assert table_ascii.__repr__() == ('+-------+-------------------+------'
         '-----+-----------------+\n|  edge | onset energy (eV) | relevance '
         '|   description   |\n+-------+-------------------+-----------+'

--- a/hyperspy/tests/signal/test_kramers_kronig_transform.py
+++ b/hyperspy/tests/signal/test_kramers_kronig_transform.py
@@ -63,7 +63,7 @@ class Test2D:
         vpm.intensity.map['is_set'][:] = True
         vpm.plasmon_energy.map['is_set'][:] = True
         vpm.fwhm.map['is_set'][:] = True
-        s.data = (m.as_signal(show_progressbar=None) * k).data
+        s.data = (m.as_signal() * k).data
 
         # Create ZLP
         z = s.deepcopy()

--- a/hyperspy/tests/signal/test_map_method.py
+++ b/hyperspy/tests/signal/test_map_method.py
@@ -37,8 +37,7 @@ class TestImage:
                              [pytest.param(True, marks=pytest.mark.parallel), False])
     def test_constant_sigma(self, parallel):
         s = self.im
-        s.map(gaussian_filter, sigma=1, show_progressbar=None,
-              parallel=parallel, ragged=self.ragged)
+        s.map(gaussian_filter, sigma=1, parallel=parallel, ragged=self.ragged)
         np.testing.assert_allclose(s.data, np.array(
             [[[1.68829507, 2.2662213, 2.84414753],
               [3.42207377, 4., 4.57792623],
@@ -52,8 +51,7 @@ class TestImage:
                              [pytest.param(True, marks=pytest.mark.parallel), False])
     def test_constant_sigma_navdim0(self, parallel):
         s = self.im.inav[0]
-        s.map(gaussian_filter, sigma=1, show_progressbar=None,
-              parallel=parallel, ragged=self.ragged)
+        s.map(gaussian_filter, sigma=1, parallel=parallel, ragged=self.ragged)
         np.testing.assert_allclose(s.data, np.array(
             [[1.68829507, 2.2662213, 2.84414753],
              [3.42207377, 4., 4.57792623],
@@ -68,8 +66,7 @@ class TestImage:
         sigmas.axes_manager.set_signal_dimension(0)
 
         s.map(gaussian_filter,
-              sigma=sigmas, show_progressbar=None,
-              parallel=parallel, ragged=self.ragged)
+              sigma=sigmas, parallel=parallel, ragged=self.ragged)
         np.testing.assert_allclose(s.data, np.array(
             [[[0., 1., 2.],
                 [3., 4., 5.],
@@ -87,9 +84,8 @@ class TestImage:
         sigma = hs.signals.BaseSignal(np.array([1, ]))
         sigma.axes_manager.set_signal_dimension(0)
 
-        s.map(gaussian_filter,
-              sigma=sigma, show_progressbar=None,
-              parallel=parallel, ragged=self.ragged)
+        s.map(gaussian_filter, sigma=sigma, parallel=parallel,
+              ragged=self.ragged)
         np.testing.assert_allclose(s.data, np.array(
             [[[1.68829507, 2.2662213, 2.84414753],
               [3.42207377, 4., 4.57792623],
@@ -103,8 +99,8 @@ class TestImage:
                              [pytest.param(True, marks=pytest.mark.parallel), False])
     def test_axes_argument(self, parallel):
         s = self.im
-        s.map(rotate, angle=45, reshape=False, show_progressbar=None,
-              parallel=parallel, ragged=self.ragged)
+        s.map(rotate, angle=45, reshape=False, parallel=parallel,
+              ragged=self.ragged)
         np.testing.assert_allclose(s.data, np.array(
             [[[0., 2.23223305, 0.],
               [0.46446609, 4., 7.53553391],
@@ -119,8 +115,8 @@ class TestImage:
     def test_different_shapes(self, parallel):
         s = self.im
         angles = hs.signals.BaseSignal([0, 45])
-        s.map(rotate, angle=angles.T, reshape=True, show_progressbar=None,
-              parallel=parallel, ragged=True)
+        s.map(rotate, angle=angles.T, reshape=True, parallel=parallel,
+              ragged=True)
         # the dtype
         assert s.data.dtype is np.dtype('O')
         # the special slicing
@@ -152,8 +148,8 @@ class TestSignal1D:
         s = self.s
         m = mock.Mock()
         s.events.data_changed.connect(m.data_changed)
-        s.map(gaussian_filter1d, sigma=1, show_progressbar=None,
-              parallel=parallel, ragged=self.ragged)
+        s.map(gaussian_filter1d, sigma=1, parallel=parallel,
+              ragged=self.ragged)
         np.testing.assert_allclose(s.data, np.array(
             ([[0.42207377, 1., 1.57792623],
               [3.42207377, 4., 4.57792623]])))
@@ -165,8 +161,7 @@ class TestSignal1D:
         s = self.s
         m = mock.Mock()
         s.events.data_changed.connect(m.data_changed)
-        s.map(lambda A, B: A - B, B=s, show_progressbar=None,
-              parallel=parallel, ragged=self.ragged)
+        s.map(lambda A, B: A - B, B=s, parallel=parallel, ragged=self.ragged)
         np.testing.assert_allclose(s.data, np.zeros_like(s.data))
         assert m.data_changed.called
 
@@ -176,8 +171,8 @@ class TestSignal1D:
         s = self.s
         m = mock.Mock()
         s.events.data_changed.connect(m.data_changed)
-        s.map(lambda A, B: A - B, B=s.inav[0], show_progressbar=None,
-              parallel=parallel, ragged=self.ragged)
+        s.map(lambda A, B: A - B, B=s.inav[0], parallel=parallel,
+              ragged=self.ragged)
         np.testing.assert_allclose(s.data, np.array(
             ([[0., 0., 0.],
               [3., 3., 3.]])))
@@ -188,7 +183,6 @@ class TestSignal1D:
     def test_dtype(self, parallel):
         s = self.s
         s.map(lambda data: np.sqrt(np.complex128(data)),
-              show_progressbar=None,
               parallel=parallel, ragged=self.ragged)
         assert s.data.dtype is np.dtype('complex128')
 
@@ -207,8 +201,7 @@ class TestSignal0D:
         s = self.s
         m = mock.Mock()
         s.events.data_changed.connect(m.data_changed)
-        s.map(lambda x, e: x ** e, e=2, show_progressbar=None,
-              parallel=parallel, ragged=self.ragged)
+        s.map(lambda x, e: x ** e, e=2, parallel=parallel, ragged=self.ragged)
         np.testing.assert_allclose(
             s.data, (np.arange(0., 6) ** 2).reshape((2, 3)))
         assert m.data_changed.called
@@ -219,8 +212,7 @@ class TestSignal0D:
         s = self.s.inav[1, 1]
         m = mock.Mock()
         s.events.data_changed.connect(m.data_changed)
-        s.map(lambda x, e: x ** e, e=2, show_progressbar=None,
-              parallel=parallel, ragged=self.ragged)
+        s.map(lambda x, e: x ** e, e=2, parallel=parallel, ragged=self.ragged)
         np.testing.assert_allclose(s.data, self.s.inav[1, 1].data ** 2)
         assert m.data_changed.called
 

--- a/hyperspy/tests/signal/test_remove_background.py
+++ b/hyperspy/tests/signal/test_remove_background.py
@@ -49,8 +49,7 @@ class TestRemoveBackground1DGaussian:
         self.signal.metadata.Signal.binned = binning
         s1 = self.signal.remove_background(
             signal_range=(None, None),
-            background_type='Gaussian',
-            show_progressbar=None)
+            background_type='Gaussian')
         assert np.allclose(s1.data, np.zeros(len(s1.data)))
 
     def test_background_remove_gaussian_full_fit(self, binning):
@@ -79,8 +78,7 @@ class TestRemoveBackground1DLorentzian:
         # Fast is not accurate
         s1 = self.signal.remove_background(
             signal_range=(None, None),
-            background_type='Lorentzian',
-            show_progressbar=None)
+            background_type='Lorentzian')
         assert np.allclose(np.zeros(len(s1.data)), s1.data, atol=0.2)
 
     def test_background_remove_lorentzian_full_fit(self):
@@ -112,8 +110,7 @@ class TestRemoveBackground1DPowerLaw:
     def test_background_remove_pl(self):
         s1 = self.signal.remove_background(
             signal_range=(None, None),
-            background_type='PowerLaw',
-            show_progressbar=None)
+            background_type='PowerLaw')
         # since we compare to zero, rtol can't be used (see np.allclose doc)
         assert np.allclose(s1.data, np.zeros(len(s1.data)), atol=self.atol)
         assert s1.axes_manager.navigation_dimension == 0
@@ -122,8 +119,7 @@ class TestRemoveBackground1DPowerLaw:
         s1 = self.signal_noisy.remove_background(
             signal_range=(110.0, 190.0),
             background_type='PowerLaw',
-            zero_fill=True,
-            show_progressbar=None)
+            zero_fill=True)
         # since we compare to zero, rtol can't be used (see np.allclose doc)
         assert np.allclose(s1.isig[10:], np.zeros(len(s1.data[10:])),
                            atol=self.atol_zero_fill)
@@ -133,8 +129,7 @@ class TestRemoveBackground1DPowerLaw:
         self.signal.change_dtype("int")
         s1 = self.signal.remove_background(
             signal_range=(None, None),
-            background_type='PowerLaw',
-            show_progressbar=None)
+            background_type='PowerLaw')
         # since we compare to zero, rtol can't be used (see np.allclose doc)
         assert np.allclose(s1.data, np.zeros(len(s1.data)), atol=self.atol)
 
@@ -143,8 +138,7 @@ class TestRemoveBackground1DPowerLaw:
         s1 = self.signal_noisy.remove_background(
             signal_range=(110.0, 190.0),
             background_type='PowerLaw',
-            zero_fill=True,
-            show_progressbar=None)
+            zero_fill=True)
         # since we compare to zero, rtol can't be used (see np.allclose doc)
         assert np.allclose(s1.isig[10:], np.zeros(len(s1.data[10:])),
                            atol=self.atol_zero_fill)
@@ -169,8 +163,7 @@ class TestRemoveBackground1DSkewNormal:
         # Fast is not accurate
         s1 = self.signal.remove_background(
             signal_range=(None, None),
-            background_type='SkewNormal',
-            show_progressbar=None)
+            background_type='SkewNormal')
         assert np.allclose(np.zeros(len(s1.data)), s1.data, atol=0.2)
 
     def test_background_remove_skewnormal_full_fit(self):
@@ -200,7 +193,6 @@ class TestRemoveBackground1DVoigt:
         s1 = self.signal.remove_background(
             signal_range=(None, None),
             background_type='Voigt',
-            show_progressbar=None,
             fast=False)
         assert np.allclose(np.zeros(len(s1.data)), s1.data)
 
@@ -229,8 +221,7 @@ class TestRemoveBackground1DExponential:
         # Fast is not accurate
         s1 = self.signal.remove_background(
             signal_range=(None, None),
-            background_type='Exponential',
-            show_progressbar=None)
+            background_type='Exponential')
         assert np.allclose(np.zeros(len(s1.data)), s1.data, atol=self.atol)
 
     def test_background_remove_exponential_full_fit(self):

--- a/setup.py
+++ b/setup.py
@@ -66,7 +66,7 @@ install_req = ['scipy>=0.15',
                'imageio',
                'pyyaml',
                'PTable',
-               'tifffile>=2018.10.18',
+               'tifffile[all]>=2018.10.18',
                ]
 
 extras_require = {


### PR DESCRIPTION
Now that we have less warning in the test suite (thanks @tjof2), we can actually notice them!

### Progress of the PR
- [x] Re-enable using progressbar in the test suite, since the issue with tqdm (close #2077) seems to be gone,
- [x] remove specifying `show_progressbar`,
- [x] tweak tifffile depencendy requirement (add imagecodecs required for the phenom reader),
- [x] add optional dependencies on azure pipelines,
- [x] fix deprecation warning with matplotlib >=3.2,
- [x] remove unnecessary test for dask<=0.14.1,
- [x] don't skip bruker test on azure pipeline,
- [x] fix time occasional test failure in hdf5/usid reader,
- [x] filter deprecation warning with traits/traitsui - see https://github.com/enthought/traitsui/issues/883.
- [x] ready for review.

