### PR TITLE
Revised FEI stream reader, see Issue #2385

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,6 +43,7 @@ hyperspy/io_plugins/unbcf_fast.c
 hyperspy/misc/etc/test_compilers.obj
 /.cache/
 /.spyproject/
+.venv
 
 ### Code ###
 # Visual Studio Code - https://code.visualstudio.com/

--- a/hyperspy/misc/io/fei_stream_readers.py
+++ b/hyperspy/misc/io/fei_stream_readers.py
@@ -22,6 +22,8 @@ import sparse
 
 from hyperspy.decorators import jit_ifnumba
 
+# to account for the uncertainty on pixel mapping
+pixel_offset = 0
 
 class DenseSliceCOO(sparse.COO):
     """Just like sparse.COO, but returning a dense array on indexing/slicing"""
@@ -54,18 +56,22 @@ def stream_to_sparse_COO_array(
 
     """
     shape = (None, spatial_shape[0], spatial_shape[1], channels)
-    coords, data, shape = _stream_to_scipy_sparse_COO(stream_data, shape,
+    if sum_frames:
+        coords, data, shape = _stream_to_sparse_summed(stream_data, shape,
                             rebin_energy=rebin_energy,
-                            first_frame=first_frame, last_frame=last_frame,
-                            summed=sum_frames)
+                            first_frame=first_frame, last_frame=last_frame,)
+    else:
+        coords, data, shape = _stream_to_sparse(stream_data, shape,
+                            rebin_energy=rebin_energy,
+                            first_frame=first_frame, last_frame=last_frame,)
     dense_sparse = DenseSliceCOO(coords=coords, data=data, shape=shape)
     dask_sparse = da.from_array(dense_sparse, chunks="auto")
     return dask_sparse
 
 
 @jit_ifnumba()
-def _stream_to_scipy_sparse_COO(stream, shape, rebin_energy=1,
-                                first_frame=0, last_frame=None, summed=True):
+def _stream_to_sparse(stream, shape, rebin_energy=1,
+                                first_frame=0, last_frame=None):
     """
     Vectorized implementation of stream to sparse conversion. Returns
     coordinates, data, and shape to be turned to a COO matrix
@@ -87,25 +93,24 @@ def _stream_to_scipy_sparse_COO(stream, shape, rebin_energy=1,
 
     Returns
     -------
-    coords : (frames, ydim, xdim, channel) or (ydim, xdim, channel) array
-        coordinates where counts are to be added. shape depends on summed.
+    coords : (frames, ydim, xdim, channel) array
+        coordinates where counts are to be added. 
     counts : 1D array
         just an array of ones representing counts
-    final_shape: 4 or 3 tuple
-        (frames, ydim, xdim, channel) or (ydim, xdim, channel)
+    final_shape: 4 tuple
+        (frames, ydim, xdim, channel)
     """
     frms, ydim, xdim, chnx = shape
     # the indexes where counts are registered
     count_channel_regs = np.argwhere(stream != 65535)[:, 0]
     # the pixel index to which these counts must be mapped
     pixel_indexes = (count_channel_regs - np.arange(count_channel_regs.shape[0])
-                     - 1)
+                     - pixel_offset)
     channels = stream[count_channel_regs]//rebin_energy
     # calculate number of frames if it's none
-    # if the last frame is incomplete, it will not be counted!
     if frms is None:
         pxl_count = stream.shape[0] - count_channel_regs.shape[0]
-        frms = pxl_count // xdim // ydim
+        frms = int(np.ceil(pxl_count / xdim / ydim))
     # remove pixel indexes below first frame and above last frame
     first_index = 0  # defaults
     last_index = frms*ydim*xdim
@@ -119,19 +124,76 @@ def _stream_to_scipy_sparse_COO(stream, shape, rebin_energy=1,
     pixel_indexes = pixel_indexes[filt]
     channels = channels[filt]
     # if the frames are to be summed the pixel indexes are updated
-    if summed:
-        final_shape = (ydim, xdim, chnx//rebin_energy)
-        pixel_indexes = pixel_indexes % frms
-        coords = (pixel_indexes//xdim,
-                  pixel_indexes%xdim,
+    final_shape = (last_frame-first_frame, ydim, xdim,
+                       chnx//rebin_energy)
+    coords = (pixel_indexes//(xdim*ydim)-first_frame,
+                  pixel_indexes%(xdim*ydim)//xdim,
+                  pixel_indexes%(xdim*ydim)%xdim,
                   channels)
+    counts = np.ones(channels.shape[0], dtype=stream.dtype)
+    return coords, counts, final_shape
+
+
+@jit_ifnumba()
+def _stream_to_sparse_summed(stream, shape, rebin_energy=1,
+                                       first_frame=0, last_frame=None):
+    """
+    Vectorized implementation of stream to sparse conversion. Returns
+    coordinates, data, and shape to be turned to a COO matrix
+
+    Parameters
+    ----------
+    stream: np.array
+        Velox emd stream data
+    shape: (number of frames, y dimension, x dimension, number of channels)
+        number of frames can be none
+    rebin_energy: int, optional
+        factor to rebin energy axis, must be divisor of number of channels
+    first_frame: int, optional
+        first frame to consider
+    last_frame: int, optional
+        last frame to consider
+    summed: bool, optional
+        Add up data from all frames to one spectrum image
+
+    Returns
+    -------
+    coords : (ydim, xdim, channel) array
+        coordinates where counts are to be added. shape depends on summed.
+    counts : 1D array
+        just an array of ones representing counts
+    final_shape: 3 tuple
+        (ydim, xdim, channel)
+    """
+    frms, ydim, xdim, chnx = shape
+    # the indexes where counts are registered
+    count_channel_regs = np.argwhere(stream != 65535)[:, 0]
+    # the pixel index to which these counts must be mapped
+    pixel_indexes = (count_channel_regs - np.arange(count_channel_regs.shape[0])
+                     - pixel_offset)
+    channels = stream[count_channel_regs]//rebin_energy
+    # calculate number of frames if it's none
+    if frms is None:
+        pxl_count = stream.shape[0] - count_channel_regs.shape[0]
+        frms = int(np.ceil(pxl_count / xdim / ydim))
+    # remove pixel indexes below first frame and above last frame
+    first_index = 0  # defaults
+    last_index = frms*ydim*xdim
+    if first_frame>0:
+        first_index = first_frame*ydim*xdim
+    if last_frame is not None:
+        last_index = last_frame*ydim*xdim
     else:
-        final_shape = (last_frame-first_frame, shape[1], shape[2],
-                       shape[3]//rebin_energy)
-        coords = (pixel_indexes//frms-first_frame,
-                  pixel_indexes%frms//xdim,
-                  pixel_indexes%frms%xdim,
-                  channels)
+        last_frame = frms
+    filt = (pixel_indexes>=first_index) & (pixel_indexes<last_index)
+    pixel_indexes = pixel_indexes[filt]
+    channels = channels[filt]
+    # if the frames are to be summed the pixel indexes are updated
+    final_shape = (ydim, xdim, chnx//rebin_energy)
+    pixel_indexes = pixel_indexes % (xdim*ydim) 
+    coords = (pixel_indexes//xdim,
+                pixel_indexes%xdim,
+                channels)
     counts = np.ones(channels.shape[0], dtype=stream.dtype)
     return coords, counts, final_shape
 
@@ -161,10 +223,14 @@ def stream_to_array(
 
     """
     shape = (None, spatial_shape[0], spatial_shape[1], channels)
-    coords, data, shape = _stream_to_scipy_sparse_COO(stream, shape,
+    if sum_frames:
+        coords, data, shape = _stream_to_sparse_summed(stream, shape,
                             rebin_energy=rebin_energy,
-                            first_frame=first_frame, last_frame=last_frame,
-                            summed=sum_frames)
+                            first_frame=first_frame, last_frame=last_frame,)
+    else:
+        coords, data, shape = _stream_to_sparse(stream, shape,
+                            rebin_energy=rebin_energy,
+                            first_frame=first_frame, last_frame=last_frame,)
     return DenseSliceCOO(coords=coords, data=data, shape=shape).todense()
 
 
@@ -181,6 +247,8 @@ def array_to_stream(array):
     channels = array.shape[-1]
     flat_array = array.ravel()
     stream_data = []
+    if pixel_offset == 1:
+        stream_data.append(65535)
     channel = 0
     for value in flat_array:
         for j in range(value):

--- a/hyperspy/misc/io/fei_stream_readers.py
+++ b/hyperspy/misc/io/fei_stream_readers.py
@@ -35,172 +35,6 @@ class DenseSliceCOO(sparse.COO):
             return obj
 
 
-@jit_ifnumba()
-def _stream_to_sparse_COO_array_sum_frames(
-        stream_data, last_frame, shape, channels, rebin_energy=1, first_frame=0):
-    navigation_index = 0
-    frame_number = 0
-    ysize, xsize = shape
-    frame_size = xsize * ysize
-    # workaround for empty stream, numba "doesn't support" empty list, see
-    # https://github.com/numba/numba/pull/2184
-    # add first element and remove it at the end
-    data_list = [0]
-    coords_list = [(0, 0, 0)]
-    data = 0
-    count_channel = None
-    for value in stream_data:
-        if frame_number < first_frame:
-            if value != 65535:  # Same spectrum
-                continue
-            else:
-                navigation_index += 1
-                if navigation_index == frame_size:
-                    frame_number += 1
-                    navigation_index = 0
-                continue
-        # when we reach the end of the frame, reset the navigation index to 0
-        if navigation_index == frame_size:
-            navigation_index = 0
-            frame_number += 1
-            if frame_number == last_frame:
-                break
-        # if different of ‘65535’, add a count to the corresponding channel
-        if value != 65535:  # Same spectrum
-            if data:
-                if value == count_channel:  # Same channel, add a count
-                    data += 1
-                else:  # a new channel, same spectrum—requires new coord
-                    # Store previous channel
-                    coords_list.append((
-                        int(navigation_index // xsize),
-                        int(navigation_index % xsize),
-                        int(count_channel // rebin_energy))
-                    )
-                    data_list.append(data)
-                    # Add a count to new channel
-                    data = 1
-                    # Update count channel as this is a new channel
-                    count_channel = value
-
-            else:  # First non-zero channel of spectrum
-                data = 1
-                # Update count channel as this is a new channel
-                count_channel = value
-
-        else:  # Advances one pixel
-            if data:  # Only store coordinates if the spectrum was not empty
-                coords_list.append((
-                    int(navigation_index // xsize),
-                    int(navigation_index % xsize),
-                    int(count_channel // rebin_energy))
-                )
-                data_list.append(data)
-            navigation_index += 1
-            data = 0
-
-    # Store data  at the end if any (there is no final 65535 to mark the end
-    # of the stream)
-    if data:  # Only store coordinates if the spectrum was not empty
-        coords_list.append((
-            int(navigation_index // xsize),
-            int(navigation_index % xsize),
-            int(count_channel // rebin_energy))
-        )
-        data_list.append(data)
-
-    final_shape = (ysize, xsize, channels // rebin_energy)
-    # Remove first element, see comments above
-    coords = np.array(coords_list)[1:].T
-    data = np.array(data_list)[1:]
-    return coords, data, final_shape
-
-
-@jit_ifnumba()
-def _stream_to_sparse_COO_array(
-        stream_data, last_frame, shape, channels, rebin_energy=1, first_frame=0):
-    navigation_index = 0
-    frame_number = 0
-    ysize, xsize = shape
-    frame_size = xsize * ysize
-    # workaround for empty stream, numba "doesn't support" empty list, see
-    # https://github.com/numba/numba/pull/2184
-    # add first element and remove it at the end
-    data_list = [0]
-    coords = [(0, 0, 0, 0)]
-    data = 0
-    count_channel = None
-    for value in stream_data:
-        if frame_number < first_frame:
-            if value != 65535:  # Same spectrum
-                continue
-            else:
-                navigation_index += 1
-                if navigation_index == frame_size:
-                    frame_number += 1
-                    navigation_index = 0
-                continue
-        # when we reach the end of the frame, reset the navigation index to 0
-        if navigation_index == frame_size:
-            navigation_index = 0
-            frame_number += 1
-            if frame_number == last_frame:
-                break
-        # if different of ‘65535’, add a count to the corresponding channel
-        if value != 65535:  # Same spectrum
-            if data:
-                if value == count_channel:  # Same channel, add a count
-                    data += 1
-                else:  # a new channel, same spectrum—requires new coord
-                    # Store previous channel
-                    coords.append((
-                        frame_number - first_frame,
-                        int(navigation_index // xsize),
-                        int(navigation_index % xsize),
-                        int(count_channel // rebin_energy))
-                    )
-                    data_list.append(data)
-                    # Add a count to new channel
-                    data = 1
-                    # Update count channel as this is a new channel
-                    count_channel = value
-
-            else:  # First non-zero channel of spectrum
-                data = 1
-                # Update count channel as this is a new channel
-                count_channel = value
-
-        else:  # Advances one pixel
-            if data:  # Only store coordinates if the spectrum was not empty
-                coords.append((
-                    frame_number - first_frame,
-                    int(navigation_index // xsize),
-                    int(navigation_index % xsize),
-                    int(count_channel // rebin_energy))
-                )
-                data_list.append(data)
-            navigation_index += 1
-            data = 0
-
-    # Store data at the end if any (there is no final 65535 to mark the end of
-    # the stream)
-    if data:  # Only store coordinates if the spectrum was not empty
-        coords.append((
-            frame_number - first_frame,
-            int(navigation_index // xsize),
-            int(navigation_index % xsize),
-            int(count_channel // rebin_energy))
-        )
-        data_list.append(data)
-
-    final_shape = (last_frame - first_frame, ysize, xsize,
-                   channels // rebin_energy)
-    # Remove first element, see comments above
-    coords = np.array(coords)[1:].T
-    data = np.array(data_list)[1:]
-    return coords, data, final_shape
-
-
 def stream_to_sparse_COO_array(
         stream_data, spatial_shape, channels, last_frame, rebin_energy=1,
         sum_frames=True, first_frame=0, ):
@@ -219,77 +53,87 @@ def stream_to_sparse_COO_array(
         If True, sum all the frames
 
     """
-    if sum_frames:
-        coords, data, shape = _stream_to_sparse_COO_array_sum_frames(
-            stream_data=stream_data,
-            shape=spatial_shape,
-            channels=channels,
-            rebin_energy=rebin_energy,
-            first_frame=first_frame,
-            last_frame=last_frame,
-        )
-    else:
-        coords, data, shape = _stream_to_sparse_COO_array(
-            stream_data=stream_data,
-            shape=spatial_shape,
-            channels=channels,
-            rebin_energy=rebin_energy,
-            first_frame=first_frame,
-            last_frame=last_frame,
-        )
+    shape = (None, spatial_shape[0], spatial_shape[1], channels)
+    coords, data, shape = _stream_to_scipy_sparse_COO(stream_data, shape,
+                            rebin_energy=rebin_energy,
+                            first_frame=first_frame, last_frame=last_frame,
+                            summed=sum_frames)
     dense_sparse = DenseSliceCOO(coords=coords, data=data, shape=shape)
     dask_sparse = da.from_array(dense_sparse, chunks="auto")
     return dask_sparse
 
 
 @jit_ifnumba()
-def _fill_array_with_stream_sum_frames(spectrum_image, stream,
-                                       first_frame, last_frame, rebin_energy=1):
-    # jit speeds up this function by a factor of ~ 30
-    navigation_index = 0
-    frame_number = 0
-    shape = spectrum_image.shape
-    for count_channel in np.nditer(stream):
-        # when we reach the end of the frame, reset the navigation index to 0
-        if navigation_index == (shape[0] * shape[1]):
-            navigation_index = 0
-            frame_number += 1
-            # break the for loop when we reach the last frame we want to read
-            if frame_number == last_frame:
-                break
-        # if different of ‘65535’, add a count to the corresponding channel
-        if count_channel != 65535:
-            if first_frame <= frame_number:
-                spectrum_image[navigation_index // shape[1],
-                               navigation_index % shape[1],
-                               count_channel // rebin_energy] += 1
-        else:
-            navigation_index += 1
+def _stream_to_scipy_sparse_COO(stream, shape, rebin_energy=1,
+                                first_frame=0, last_frame=None, summed=True):
+    """
+    Vectorized implementation of stream to sparse conversion. Returns
+    coordinates, data, and shape to be turned to a COO matrix
 
+    Parameters
+    ----------
+    stream: np.array
+        Velox emd stream data
+    shape: (number of frames, y dimension, x dimension, number of channels)
+        number of frames can be none
+    rebin_energy: int, optional
+        factor to rebin energy axis, must be divisor of number of channels
+    first_frame: int, optional
+        first frame to consider
+    last_frame: int, optional
+        last frame to consider
+    summed: bool, optional
+        Add up data from all frames to one spectrum image
 
-@jit_ifnumba()
-def _fill_array_with_stream(spectrum_image, stream, first_frame,
-                            last_frame, rebin_energy=1):
-    navigation_index = 0
-    frame_number = 0
-    shape = spectrum_image.shape
-    for count_channel in np.nditer(stream):
-        # when we reach the end of the frame, reset the navigation index to 0
-        if navigation_index == (shape[1] * shape[2]):
-            navigation_index = 0
-            frame_number += 1
-            # break the for loop when we reach the last frame we want to read
-            if frame_number == last_frame:
-                break
-        # if different of ‘65535’, add a count to the corresponding channel
-        if count_channel != 65535:
-            if first_frame <= frame_number:
-                spectrum_image[frame_number - first_frame,
-                               navigation_index // shape[2],
-                               navigation_index % shape[2],
-                               count_channel // rebin_energy] += 1
-        else:
-            navigation_index += 1
+    Returns
+    -------
+    coords : (frames, ydim, xdim, channel) or (ydim, xdim, channel) array
+        coordinates where counts are to be added. shape depends on summed.
+    counts : 1D array
+        just an array of ones representing counts
+    final_shape: 4 or 3 tuple
+        (frames, ydim, xdim, channel) or (ydim, xdim, channel)
+    """
+    frms, ydim, xdim, chnx = shape
+    # the indexes where counts are registered
+    count_channel_regs = np.argwhere(stream != 65535)[:, 0]
+    # the pixel index to which these counts must be mapped
+    pixel_indexes = (count_channel_regs - np.arange(count_channel_regs.shape[0])
+                     - 1)
+    channels = stream[count_channel_regs]//rebin_energy
+    # calculate number of frames if it's none
+    # if the last frame is incomplete, it will not be counted!
+    if frms is None:
+        pxl_count = stream.shape[0] - count_channel_regs.shape[0]
+        frms = pxl_count // xdim // ydim
+    # remove pixel indexes below first frame and above last frame
+    first_index = 0  # defaults
+    last_index = frms*ydim*xdim
+    if first_frame>0:
+        first_index = first_frame*ydim*xdim
+    if last_frame is not None:
+        last_index = last_frame*ydim*xdim
+    else:
+        last_frame = frms
+    filt = (pixel_indexes>=first_index) & (pixel_indexes<last_index)
+    pixel_indexes = pixel_indexes[filt]
+    channels = channels[filt]
+    # if the frames are to be summed the pixel indexes are updated
+    if summed:
+        final_shape = (ydim, xdim, chnx//rebin_energy)
+        pixel_indexes = pixel_indexes % frms
+        coords = (pixel_indexes//xdim,
+                  pixel_indexes%xdim,
+                  channels)
+    else:
+        final_shape = (last_frame-first_frame, shape[1], shape[2],
+                       shape[3]//rebin_energy)
+        coords = (pixel_indexes//frms-first_frame,
+                  pixel_indexes%frms//xdim,
+                  pixel_indexes%frms%xdim,
+                  channels)
+    counts = np.ones(channels.shape[0], dtype=stream.dtype)
+    return coords, counts, final_shape
 
 
 def stream_to_array(
@@ -316,34 +160,12 @@ def stream_to_array(
         stream.
 
     """
-
-    frames = last_frame - first_frame
-    if not sum_frames:
-        if spectrum_image is None:
-            spectrum_image = np.zeros(
-                (frames, spatial_shape[0], spatial_shape[1],
-                 int(channels / rebin_energy)),
-                dtype=dtype)
-
-            _fill_array_with_stream(
-                spectrum_image=spectrum_image,
-                stream=stream,
-                first_frame=first_frame,
-                last_frame=last_frame,
-                rebin_energy=rebin_energy)
-    else:
-        if spectrum_image is None:
-            spectrum_image = np.zeros(
-                (spatial_shape[0], spatial_shape[1],
-                 int(channels / rebin_energy)),
-                dtype=dtype)
-        _fill_array_with_stream_sum_frames(
-            spectrum_image=spectrum_image,
-            stream=stream,
-            first_frame=first_frame,
-            last_frame=last_frame,
-            rebin_energy=rebin_energy)
-    return spectrum_image
+    shape = (None, spatial_shape[0], spatial_shape[1], channels)
+    coords, data, shape = _stream_to_scipy_sparse_COO(stream, shape,
+                            rebin_energy=rebin_energy,
+                            first_frame=first_frame, last_frame=last_frame,
+                            summed=sum_frames)
+    return DenseSliceCOO(coords=coords, data=data, shape=shape).todense()
 
 
 @jit_ifnumba()

--- a/hyperspy/tests/misc/test_fei_stream_readers.py
+++ b/hyperspy/tests/misc/test_fei_stream_readers.py
@@ -41,12 +41,12 @@ def test_dense_stream(lazy):
             stream, spatial_shape=(3, 4), sum_frames=False, channels=5,
             last_frame=2)
         arrs = arrs.compute()
-        assert (arrs == arr).all()
+        np.testing.assert_equal(arr, arrs)
     else:
         arrs = stream_to_array(
             stream, spatial_shape=(3, 4), sum_frames=False, channels=5,
             last_frame=2)
-        assert (arrs == arr).all()
+        np.testing.assert_equal(arr, arrs)
 
 
 @pytest.mark.parametrize("lazy", (True, False))
@@ -58,13 +58,12 @@ def test_empty_stream(lazy):
             stream, spatial_shape=(3, 4), sum_frames=False, channels=5,
             last_frame=2)
         arrs = arrs.compute()
-        assert not arrs.any()
+        np.testing.assert_equal(arr, arrs)
     else:
         arrs = stream_to_array(
             stream, spatial_shape=(3, 4), sum_frames=False, channels=5,
             last_frame=2)
-        assert not arrs.any()
-
+        np.testing.assert_equal(arr, arrs)
 
 @pytest.mark.parametrize("lazy", (True, False))
 def test_sparse_stream(lazy):
@@ -78,9 +77,9 @@ def test_sparse_stream(lazy):
             stream, spatial_shape=(3, 4), sum_frames=False, channels=5,
             last_frame=2)
         arrs = arrs.compute()
-        assert (arrs == arr).all()
+        np.testing.assert_equal(arr, arrs)
     else:
         arrs = stream_to_array(
             stream, spatial_shape=(3, 4), sum_frames=False, channels=5,
             last_frame=2)
-        assert (arrs == arr).all()
+        np.testing.assert_equal(arr, arrs)


### PR DESCRIPTION
### Description of the change
A few months ago on my other computer, reading of FEI Velox emd was excruciatingly slow with Hyperspy and was not compatible with files produced in older Velox versions. Couldn't really figure out the issue so I started writing my own functions to read the format with `h5py`. I haven't been able to reproduce these issues in another install on another computer, which is kind  of frustrating - my emd files now read fast and the old ones now also work. **So now I'm not 100% sure my contribution is actually an improvement in terms of performance. But it does make the code look cleaner.**

- Main thing I changed was the `misc/io/fei_stream_readers`. This file had 4 different functions that converted the spectrum stream into a sparse or full matrix. I condensed this into one vectorized one `_stream_to_scipy_sparse_COO` and edited the functions that call the 4 previous versions. The function is a modification of what I describe in the issue to make it compatible with the various arguments. The function does rely on the entire `stream` matrix to be read into memory. 
  - I added the `jit_ifnumba` decorator but I'm not sure whether this will work on my implementation
  - So far I was unable to run the tests as I ran into  #2402 which prevented me from running the tests locally. I did some informal tests with the code copied into a jupyter notebook and there it seems to work as expected.

- added one line to .gitignore to ignore my virtual environment

### Progress of the PR

### Minimal example of the bug fix or the new feature
No new feature or bug fix, code just looks cleaner and 4 functions are condensed into 1

