### PR TITLE
Offset docstring correction

### DIFF
--- a/hyperspy/_components/offset.py
+++ b/hyperspy/_components/offset.py
@@ -29,7 +29,7 @@ class Offset(Component):
 
     .. math::
     
-        f(x) = k + x
+        f(x) = k
 
     ============ =============
     Variable      Parameter 


### PR DESCRIPTION
Small correction, but could otherwise be confusing.

Offset docstring currently is "f(x) = k+x", when it should be "f(x) = k"