### PR TITLE
Fix warnings always occurring with leastsq

### DIFF
--- a/hyperspy/model.py
+++ b/hyperspy/model.py
@@ -1146,7 +1146,7 @@ class BaseModel(list):
                     pcov = np.zeros((len(self.p0), len(self.p0)), dtype=float)
                     pcov.fill(np.inf)
                     warn_cov = True
-                elif pcov.min() < 0:
+                elif pcov.diagonal().min() < 0:
                     # Usually indicative of numerical overflow
                     # (covariance should be positive)
                     pcov.fill(np.inf)

--- a/hyperspy/tests/model/test_model.py
+++ b/hyperspy/tests/model/test_model.py
@@ -31,32 +31,6 @@ from hyperspy.exceptions import VisibleDeprecationWarning
 RTOL = 1E-6
 
 
-def test_leastsq_covar_est(caplog):
-    g = hs.model.components2D.Gaussian2D(
-        centre_x=-5.0, centre_y=-5.0, sigma_x=1.0, sigma_y=2.0
-    )
-    x = np.arange(-10, 10, 0.01)
-    y = np.arange(-10, 10, 0.01)
-    X, Y = np.meshgrid(x, y)
-    im = hs.signals.Signal2D(g.function(X, Y))
-    im.axes_manager[0].scale = 0.01
-    im.axes_manager[0].offset = -10
-    im.axes_manager[1].scale = 0.01
-    im.axes_manager[1].offset = -10
-
-    m = im.create_model()
-    gt = hs.model.components2D.Gaussian2D(
-        centre_x=-4.5, centre_y=-4.5, sigma_x=0.5, sigma_y=1.5
-    )
-    m.append(gt)
-
-    with caplog.at_level(logging.WARNING):
-        m.fit()
-
-    assert "Covariance of the parameters could not be estimated" in caplog.text
-    assert np.all(np.isinf(m.p_std))
-
-
 class TestModelJacobians:
 
     def setup_method(self, method):


### PR DESCRIPTION
Fixes a bug introduced with #2405, which prevented calculating std on parameters fitted with leastsq and raised a warning with basically all fitting done with leastsq.
Fixes #2419

Would normally go to _patch, but _minor hasn't been merged into it yet, so the code doesn't exist there yet.