### PR TITLE
Linear fitting

### DIFF
--- a/doc/user_guide/big_data.rst
+++ b/doc/user_guide/big_data.rst
@@ -265,6 +265,17 @@ instead:
     >>> s.plot(navigator='slider')
 
 
+.. _FitBigData-label:
+
+Model fitting
+-------------
+Most curve-fitting functionality will automatically work on models created from
+lazily loaded signals. HyperSpy extracts the relevant chunk from the signal and fits to that.
+
+The linear 'lstsq' optimizer supports fitting the entire dataset in a vectorised manner
+using `dask.linalg.lstsq`. This can give potentially enormous performance benefits over fitting 
+with a nonlinear fitter, but comes with the restrictions explained in normal Model fitting section.
+
 Practical tips
 --------------
 

--- a/doc/user_guide/big_data.rst
+++ b/doc/user_guide/big_data.rst
@@ -272,9 +272,9 @@ Model fitting
 Most curve-fitting functionality will automatically work on models created from
 lazily loaded signals. HyperSpy extracts the relevant chunk from the signal and fits to that.
 
-The linear 'lstsq' optimizer supports fitting the entire dataset in a vectorised manner
-using `dask.linalg.lstsq`. This can give potentially enormous performance benefits over fitting 
-with a nonlinear fitter, but comes with the restrictions explained in normal Model fitting section.
+The linear ``'lstsq'`` optimizer supports fitting the entire dataset in a vectorised manner
+using :py:func:`dask.array.linalg.lstsq`. This can give potentially enormous performance benefits over fitting 
+with a nonlinear fitter, but comes with the restrictions explained in the :ref:`linear fitting<linear_fitting-label>` section.
 
 Practical tips
 --------------

--- a/doc/user_guide/model.rst
+++ b/doc/user_guide/model.rst
@@ -1082,6 +1082,7 @@ the 2D-polynomial ``y = a*x**2+b*y**2+c*x+d*y+e`` is entirely linear.
 
 If all components in a model are linear, then a linear optimizer can be used to
 solve the problem as a linear regression problem! This can be done using two approaches:
+
 - the standard pixel-by-pixel approach as used by the *nonlinear* optimizers
 - fit the entire dataset in one vectorised operation, which will be much faster (up to 1000 times).
   However, there is a caveat: all fixed parameters must have the same value across the dataset in

--- a/doc/user_guide/model.rst
+++ b/doc/user_guide/model.rst
@@ -690,40 +690,42 @@ whether the optimizers find a local or global optima.
 
 .. table:: Features of supported curve-fitting optimizers.
 
-+--------------------------------------+--------+-----------+---------+----------------+--------+--------+
-| Optimizer                            | Bounds | Gradients | Errors | Loss function  | Type   | Linear |
-+======================================+========+===========+=========+================+========+========+
-| ``"lm"`` (default)                   |  Yes   | Yes       | Yes     | Only ``"ls"``  | local  | No     |
-+--------------------------------------+--------+-----------+---------+----------------+--------+--------+
-| ``"trf"``                            |  Yes   | Yes       | Yes     | Only ``"ls"``  | local  | No     |
-+--------------------------------------+--------+-----------+---------+----------------+--------+--------+
-| ``"dogbox"``                         |  Yes   | Yes       | Yes     | Only ``"ls"``  | local  | No     |
-+--------------------------------------+--------+-----------+---------+----------------+--------+--------+
-| ``"odr"``                            |  No    | Yes       | Yes     | Only ``"ls"``  | local  | No     |
-+--------------------------------------+--------+-----------+---------+----------------+--------+--------+
-| ``"lstsq"``                          |  No    | No        | Yes *** | Only ``"ls"``  | global | Yes    |
-+--------------------------------------+--------+-----------+---------+----------------+--------+--------+
-| ``"ridge_regression"``               |  No    | No        | Yes *** | Only ``"ls"``  | global | Yes    |
-+--------------------------------------+--------+-----------+---------+----------------+--------+--------+
-| :py:func:`scipy.optimize.minimize`   |  Yes * | Yes *     | No      | All            | local  | No     |
-+--------------------------------------+--------+-----------+---------+----------------+--------+--------+
-| ``"Differential Evolution"``         |  Yes   | No        | No      | All            | global | No     |
-+--------------------------------------+--------+-----------+---------+----------------+--------+--------+
-| ``"Dual Annealing"`` **              |  Yes   | No        | No      | All            | global | No     |
-+--------------------------------------+--------+-----------+---------+----------------+--------+--------+
-| ``"SHGO"`` **                        |  Yes   | No        | No      | All            | global | No     |
-+--------------------------------------+--------+-----------+---------+----------------+--------+--------+
+    +-----------------------------------+----------+-----------+----------+---------------+--------+--------+
+    | Optimizer                         | Bounds   | Gradients | Errors   | Loss function | Type   | Linear |
+    +===================================+==========+===========+==========+===============+========+========+
+    | ``"lm"`` (default)                |  Yes     | Yes       | Yes      | Only ``"ls"`` | local  | No     |
+    +-----------------------------------+----------+-----------+----------+---------------+--------+--------+
+    | ``"trf"``                         |  Yes     | Yes       | Yes      | Only ``"ls"`` | local  | No     |
+    +-----------------------------------+----------+-----------+----------+---------------+--------+--------+
+    | ``"dogbox"``                      |  Yes     | Yes       | Yes      | Only ``"ls"`` | local  | No     |
+    +-----------------------------------+----------+-----------+----------+---------------+--------+--------+
+    | ``"odr"``                         |  No      | Yes       | Yes      | Only ``"ls"`` | local  | No     |
+    +-----------------------------------+----------+-----------+----------+---------------+--------+--------+
+    | ``"lstsq"``                       |  No      | No        | Yes [1]_ | Only ``"ls"`` | global | Yes    |
+    +-----------------------------------+----------+-----------+----------+---------------+--------+--------+
+    | ``"ridge_regression"``            |  No      | No        | Yes [1]_ | Only ``"ls"`` | global | Yes    |
+    +-----------------------------------+----------+-----------+----------+---------------+--------+--------+
+    | :py:func:`scipy.optimize.minimize`| Yes [2]_ | Yes [2]_  | No       | All           | local  | No     |
+    +-----------------------------------+----------+-----------+----------+---------------+--------+--------+
+    | ``"Differential Evolution"``      |  Yes     | No        | No       | All           | global | No     |
+    +-----------------------------------+----------+-----------+----------+---------------+--------+--------+
+    | ``"Dual Annealing"`` [3]_         |  Yes     | No        | No       | All           | global | No     |
+    +-----------------------------------+----------+-----------+----------+---------------+--------+--------+
+    | ``"SHGO"`` [3]_                   |  Yes     | No        | No       | All           | global | No     |
+    +-----------------------------------+----------+-----------+----------+---------------+--------+--------+
 
-.. note::
+.. rubric:: Footnotes
 
-    \* **All** of the fitting algorithms available in :py:func:`scipy.optimize.minimize` are currently
-    supported by HyperSpy; however, only some of them support bounds and/or gradients. For more information,
-    please see the `SciPy documentation <http://docs.scipy.org/doc/scipy/reference/optimize.html>`_.
+.. [1] Requires the :py:meth:`~hyperspy.model.BaseModel.multifit` ``calculate_errors = True`` argument
+       in most cases. See the documentation below on Multiple Linear Least Squares fitting for more info.
 
-    \*\* Requires ``scipy >= 1.2.0``.
+.. [2] **All** of the fitting algorithms available in :py:func:`scipy.optimize.minimize` are currently
+       supported by HyperSpy; however, only some of them support bounds and/or gradients. For more information,
+       please see the `SciPy documentation <http://docs.scipy.org/doc/scipy/reference/optimize.html>`_.
 
-    \*\*\* Requires the ``py:meth:`~hyperspy.model.BaseModel.multifit`` ``calculate_errors = True`` argument
-    in most cases. See the documentation below on Multiple Linear Least Squares fitting for more info.
+.. [3] Requires ``scipy >= 1.2.0``.
+
+
 
 The default optimizer in HyperSpy is ``"lm"``, which stands for the `Levenberg-Marquardt
 algorithm <https://en.wikipedia.org/wiki/Levenberg%E2%80%93Marquardt_algorithm>`_. In
@@ -1041,11 +1043,27 @@ on the ``centre`` parameter.
              sigma |  True | 0.00999184 | 2.68064163 |       None |       None
             centre |  True | 9.99980788 | 2.68064070 |        7.0 |       14.0
 
-Multiple linear least squares fitting
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+.. _linear_fitting-label:
+
+Linear fitting
+^^^^^^^^^^^^^^
+Linear fitting can be used to address some of the drawbacks of non-linear optimization:
+
+- it doesn't suffer of the *starting parameters* issue, which can sometimes be problematic
+  with nonlinear fitting. Since linear fitting uses linear algebra to find the
+  solution (find the parameter values of the model), the solution is unique solution,
+  while nonlinear optimization uses an iterative approach and therefore relies
+  on the initial values of the parameters.
+- it is fast, because in favorable situations, all pixels can be fitted simultaneously,
+  but also because it is not iterative - it does the calculation only one time instead of
+  10-100 iterations, depending on fast the non-linear optimizer will converge.
+
+However, linear fitting can *only* fit linear model and will be able to fit estimate
+parameter which varies *non-linearly*.
+
 A component is considered linear when its free parameters scale the component only 
 in the y-axis. For the example function ``y = a*x**b``, ``a`` is a linear parameter whilst ``b`` 
-is not. If `b.free = False`, then the component is linear. 
+is not. If ``b.free = False``, then the component is linear. 
 Components can also be made up of several linear parts. For instance, 
 the 2D-polynomial ``y = a*x**2+b*y**2+c*x+d*y+e`` is entirely linear.
 
@@ -1057,9 +1075,9 @@ the 2D-polynomial ``y = a*x**2+b*y**2+c*x+d*y+e`` is entirely linear.
 If all components in a model are linear, then a linear optimizer can be used to
 solve the problem as a linear regression problem! This can be done in the standard
 pixel-by-pixel approach used by the other *nonlinear* optimizers in HyperSpy, but
-the main advantage comes in being able to fit the entire dataset in one vectorised
-operation. This can be over a thousand times faster than regular nonlinear fitting, but
-comes with one caveat: All fixed parameters must have the same value across 
+it is also possible to fit the entire dataset in one vectorised operation, which
+will be much faster and it can up a thousand times faster than nonlinear fitting, but
+comes with one caveat: all fixed parameters must have the same value across 
 the dataset. That means a gaussian sigma parameter may not have been manually set 
 to vary across the dataset. This is because in order to save on memory, the components
 are calculated once for the current navigation indices and used to fit to all 
@@ -1074,13 +1092,13 @@ pixels in the navigator.
 
 There are three implementations of linear fitting in hyperspy: 
 The 'lstsq' optimizer is the recommended linear optimizer, and supports fitting lazy
-signals. The 'ridge_regression' optimizer supports regularization (see `Scikit-Learn's documentation 
-<https://scikit-learn.org/stable/modules/generated/sklearn.linear_model.Ridge.html>`_ for arguments to
-py:meth:`~hyperspy.model.BaseModel.fit`), but does not support lazy signals. 
+signals. The 'ridge_regression' optimizer supports regularization (see
+:py:class:`sklearn.linear_model.Ridge` for arguments to pass to
+:py:meth:`~hyperspy.model.BaseModel.fit`), but does not support lazy signals. 
 
 Standard errors for the parameters are by default not calculated when the entire dataset is fitted at once.
 This is due to the much larger memory requirement of that operation. If errors are required,
-either give ``calculate_errors=True`` as an argument to py:meth:`~hyperspy.model.BaseModel.multifit`, or rerun py:meth:`~hyperspy.model.BaseModel.multifit` with a nonlinear
+either give ``calculate_errors=True`` as an argument to :py:meth:`~hyperspy.model.BaseModel.multifit`, or rerun :py:meth:`~hyperspy.model.BaseModel.multifit` with a nonlinear
 optimizer (which will now run much faster).
 
 None of the linear optimizers currently support bounds.

--- a/doc/user_guide/model.rst
+++ b/doc/user_guide/model.rst
@@ -1055,22 +1055,22 @@ Linear least squares
 
 Linear fitting can be used to address some of the drawbacks of non-linear optimization:
 
-- it doesn't suffer of the *starting parameters* issue, which can sometimes be problematic
+- it doesn't suffer from the *starting parameters* issue, which can sometimes be problematic
   with nonlinear fitting. Since linear fitting uses linear algebra to find the
-  solution (find the parameter values of the model), the solution is unique solution,
+  solution (find the parameter values of the model), the solution is a unique solution,
   while nonlinear optimization uses an iterative approach and therefore relies
   on the initial values of the parameters.
-- it is fast, because in favorable situations, the signal can be fitted in a vectorized
+- it is fast, because i) in favorable situations, the signal can be fitted in a vectorized
   fashion, `i. e.` the signal is fitted in a single run instead of iterating over
-  the navigation dimension, but also because it is not iterative - it does the
+  the navigation dimension; ii) it is not iterative, `i. e.` it does the
   calculation only one time instead of 10-100 iterations, depending on fast
   the non-linear optimizer will converge.
 
-However, linear fitting can *only* fit linear model and will be able to fit estimate
+However, linear fitting can *only* fit linear models and will not be able to fit
 parameter which varies *non-linearly*.
 
 A component is considered linear when its free parameters scale the component only 
-in the y-axis. For the example function ``y = a*x**b``, ``a`` is a linear parameter whilst ``b`` 
+in the y-axis. For the exemplary function ``y = a*x**b``, ``a`` is a linear parameter, whilst ``b`` 
 is not. If ``b.free = False``, then the component is linear. 
 Components can also be made up of several linear parts. For instance, 
 the 2D-polynomial ``y = a*x**2+b*y**2+c*x+d*y+e`` is entirely linear.
@@ -1081,15 +1081,12 @@ the 2D-polynomial ``y = a*x**2+b*y**2+c*x+d*y+e`` is entirely linear.
     all nonlinear parameters to be ``free = False`` is to use ``m.set_parameters_not_free(only_nonlinear=True)``
 
 If all components in a model are linear, then a linear optimizer can be used to
-solve the problem as a linear regression problem! This can be done in the standard
-pixel-by-pixel approach used by the other *nonlinear* optimizers in HyperSpy, but
-it is also possible to fit the entire dataset in one vectorised operation, which
-will be much faster and it can up a thousand times faster than nonlinear fitting, but
-comes with one caveat: all fixed parameters must have the same value across 
-the dataset. That means a gaussian sigma parameter may not have been manually set 
-to vary across the dataset. This is because in order to save on memory, the components
-are calculated once for the current navigation indices and used to fit to all 
-pixels in the navigator.
+solve the problem as a linear regression problem! This can be done using two approaches:
+- the standard pixel-by-pixel approach as used by the *nonlinear* optimizers
+- fit the entire dataset in one vectorised operation, which will be much faster (up to 1000 times).
+  However, there is a caveat: all fixed parameters must have the same value across the dataset in
+  order to avoid creating a very large matrice, whose size will scale with the number of different
+  values of the non-free parameters.
 
 .. note::
 
@@ -1114,7 +1111,7 @@ is fitted in vectorized fashion, because it has large memory requirement.
 If errors are required, either give ``calculate_errors=True`` as an argument
 to :py:meth:`~hyperspy.model.BaseModel.multifit`, or rerun
 :py:meth:`~hyperspy.model.BaseModel.multifit` with a nonlinear optimizer,
-which should run fast since the parameters are already optimised.
+which should run fast since the parameters are already optimized.
 
 None of the linear optimizers currently support bounds.
 

--- a/doc/user_guide/model.rst
+++ b/doc/user_guide/model.rst
@@ -1069,15 +1069,15 @@ Linear fitting can be used to address some of the drawbacks of non-linear optimi
 However, linear fitting can *only* fit linear models and will not be able to fit
 parameters which vary *non-linearly*.
 
-A component is considered linear when its free parameters scale the component only 
-in the y-axis. For the exemplary function ``y = a*x**b``, ``a`` is a linear parameter, whilst ``b`` 
-is not. If ``b.free = False``, then the component is linear. 
-Components can also be made up of several linear parts. For instance, 
+A component is considered linear when its free parameters scale the component only
+in the y-axis. For the exemplary function ``y = a*x**b``, ``a`` is a linear parameter, whilst ``b``
+is not. If ``b.free = False``, then the component is linear.
+Components can also be made up of several linear parts. For instance,
 the 2D-polynomial ``y = a*x**2+b*y**2+c*x+d*y+e`` is entirely linear.
 
 .. note::
 
-    After creating a model with values for the nonlinear parameters, a quick way to set 
+    After creating a model with values for the nonlinear parameters, a quick way to set
     all nonlinear parameters to be ``free = False`` is to use ``m.set_parameters_not_free(only_nonlinear=True)``
 
 To check if a parameter is linear, use the model or component method
@@ -1098,23 +1098,23 @@ solve the problem as a linear regression problem! This can be done using two app
 
     A good example of a linear model in the electron-microscopy field is an Energy-Dispersive
     X-ray Spectroscopy (EDS) dataset, which typically consists of a polynomial background and
-    Gaussian peaks with well-defined energy (``Gaussian.centre``) and peak widths 
+    Gaussian peaks with well-defined energy (``Gaussian.centre``) and peak widths
     (``Gaussian.sigma``). This dataset can be fit extremely fast with a linear optimizer.
 
 There are two implementations of linear least squares fitting in hyperspy:
 
-- the ``'lstsq'`` optimizer, which uses :py:func:`numpy.linalg.lstsq`, or 
+- the ``'lstsq'`` optimizer, which uses :py:func:`numpy.linalg.lstsq`, or
   :py:func:`dask.array.linalg.lstsq` for lazy signals.
 - the ``'ridge_regression'`` optimizer, which supports regularization
   (see :py:class:`sklearn.linear_model.Ridge` for arguments to pass to
-  :py:meth:`~hyperspy.model.BaseModel.fit`), but does not support lazy signals. 
+  :py:meth:`~hyperspy.model.BaseModel.fit`), but does not support lazy signals.
 
 As for non-linear least squares fitting, :ref:`weighted least squares <weighted_least_squares-label>`
 is supported.
 
 In the following example, we first generate a 300x300 navigation signal of varying total intensity,
 and then populate it with an EDS spectrum at each point. The signal can be fitted with a polynomial
-background and a gaussian for each peak. Hyperspy automatically adds these to the model, and fixes
+background and a Gaussian for each peak. Hyperspy automatically adds these to the model, and fixes
 the ``centre`` and ``sigma`` parameters to known values. Fitting this model with a non-linear optimizer
 can about half an hour on a decent workstation. With a linear optimizer, it takes seconds.
 
@@ -1128,7 +1128,7 @@ can about half an hour on a decent workstation. With a linear optimizer, it take
 
 Standard errors for the parameters are by default not calculated when the dataset
 is fitted in vectorized fashion, because it has large memory requirement.
-If errors are required, either give ``calculate_errors=True`` as an argument
+If errors are required, either pass ``calculate_errors=True`` as an argument
 to :py:meth:`~hyperspy.model.BaseModel.multifit`, or rerun
 :py:meth:`~hyperspy.model.BaseModel.multifit` with a nonlinear optimizer,
 which should run fast since the parameters are already optimized.

--- a/doc/user_guide/model.rst
+++ b/doc/user_guide/model.rst
@@ -690,25 +690,29 @@ whether the optimizers find a local or global optima.
 
 .. table:: Features of supported curve-fitting optimizers.
 
-    +--------------------------------------+--------+-----------+--------+----------------+--------+
-    | Optimizer                            | Bounds | Gradients | Errors | Loss function  | Type   |
-    +======================================+========+===========+========+================+========+
-    | ``"lm"`` (default)                   |  Yes   | Yes       | Yes    | Only ``"ls"``  | local  |
-    +--------------------------------------+--------+-----------+--------+----------------+--------+
-    | ``"trf"``                            |  Yes   | Yes       | Yes    | Only ``"ls"``  | local  |
-    +--------------------------------------+--------+-----------+--------+----------------+--------+
-    | ``"dogbox"``                         |  Yes   | Yes       | Yes    | Only ``"ls"``  | local  |
-    +--------------------------------------+--------+-----------+--------+----------------+--------+
-    | ``"odr"``                            |  No    | Yes       | Yes    | Only ``"ls"``  | local  |
-    +--------------------------------------+--------+-----------+--------+----------------+--------+
-    | :py:func:`scipy.optimize.minimize`   |  Yes * | Yes *     | No     | All            | local  |
-    +--------------------------------------+--------+-----------+--------+----------------+--------+
-    | ``"Differential Evolution"``         |  Yes   | No        | No     | All            | global |
-    +--------------------------------------+--------+-----------+--------+----------------+--------+
-    | ``"Dual Annealing"`` **              |  Yes   | No        | No     | All            | global |
-    +--------------------------------------+--------+-----------+--------+----------------+--------+
-    | ``"SHGO"`` **                        |  Yes   | No        | No     | All            | global |
-    +--------------------------------------+--------+-----------+--------+----------------+--------+
++--------------------------------------+--------+-----------+---------+----------------+--------+--------+
+| Optimizer                            | Bounds | Gradients | Errors | Loss function  | Type   | Linear |
++======================================+========+===========+=========+================+========+========+
+| ``"lm"`` (default)                   |  Yes   | Yes       | Yes     | Only ``"ls"``  | local  | No     |
++--------------------------------------+--------+-----------+---------+----------------+--------+--------+
+| ``"trf"``                            |  Yes   | Yes       | Yes     | Only ``"ls"``  | local  | No     |
++--------------------------------------+--------+-----------+---------+----------------+--------+--------+
+| ``"dogbox"``                         |  Yes   | Yes       | Yes     | Only ``"ls"``  | local  | No     |
++--------------------------------------+--------+-----------+---------+----------------+--------+--------+
+| ``"odr"``                            |  No    | Yes       | Yes     | Only ``"ls"``  | local  | No     |
++--------------------------------------+--------+-----------+---------+----------------+--------+--------+
+| ``"lstsq"``                          |  No    | No        | Yes *** | Only ``"ls"``  | global | Yes    |
++--------------------------------------+--------+-----------+---------+----------------+--------+--------+
+| ``"ridge_regression"``               |  No    | No        | Yes *** | Only ``"ls"``  | global | Yes    |
++--------------------------------------+--------+-----------+---------+----------------+--------+--------+
+| :py:func:`scipy.optimize.minimize`   |  Yes * | Yes *     | No      | All            | local  | No     |
++--------------------------------------+--------+-----------+---------+----------------+--------+--------+
+| ``"Differential Evolution"``         |  Yes   | No        | No      | All            | global | No     |
++--------------------------------------+--------+-----------+---------+----------------+--------+--------+
+| ``"Dual Annealing"`` **              |  Yes   | No        | No      | All            | global | No     |
++--------------------------------------+--------+-----------+---------+----------------+--------+--------+
+| ``"SHGO"`` **                        |  Yes   | No        | No      | All            | global | No     |
++--------------------------------------+--------+-----------+---------+----------------+--------+--------+
 
 .. note::
 
@@ -717,6 +721,9 @@ whether the optimizers find a local or global optima.
     please see the `SciPy documentation <http://docs.scipy.org/doc/scipy/reference/optimize.html>`_.
 
     \*\* Requires ``scipy >= 1.2.0``.
+
+    \*\*\* Requires the ``py:meth:`~hyperspy.model.BaseModel.multifit`` ``calculate_errors = True`` argument
+    in most cases. See the documentation below on Multiple Linear Least Squares fitting for more info.
 
 The default optimizer in HyperSpy is ``"lm"``, which stands for the `Levenberg-Marquardt
 algorithm <https://en.wikipedia.org/wiki/Levenberg%E2%80%93Marquardt_algorithm>`_. In
@@ -1034,6 +1041,49 @@ on the ``centre`` parameter.
              sigma |  True | 0.00999184 | 2.68064163 |       None |       None
             centre |  True | 9.99980788 | 2.68064070 |        7.0 |       14.0
 
+Multiple linear least squares fitting
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+A component is considered linear when its free parameters scale the component only 
+in the y-axis. For the example function ``y = a*x**b``, ``a`` is a linear parameter whilst ``b`` 
+is not. If `b.free = False`, then the component is linear. 
+Components can also be made up of several linear parts. For instance, 
+the 2D-polynomial ``y = a*x**2+b*y**2+c*x+d*y+e`` is entirely linear.
+
+.. note::
+
+    After creating a model with values for the nonlinear parameters, a quick way to set 
+    all nonlinear parameters to be ``free = False`` is to use ``m.set_parameters_not_free(only_nonlinear=True)``
+
+If all components in a model are linear, then a linear optimizer can be used to
+solve the problem as a linear regression problem! This can be done in the standard
+pixel-by-pixel approach used by the other *nonlinear* optimizers in HyperSpy, but
+the main advantage comes in being able to fit the entire dataset in one vectorised
+operation. This can be over a thousand times faster than regular nonlinear fitting, but
+comes with one caveat: All fixed parameters must have the same value across 
+the dataset. That means a gaussian sigma parameter may not have been manually set 
+to vary across the dataset. This is because in order to save on memory, the components
+are calculated once for the current navigation indices and used to fit to all 
+pixels in the navigator.
+
+.. note::
+
+    A good example of a linear model in the electron-microscopy field is an Energy-Dispersive
+    X-ray Spectroscopy (EDS) dataset, which typically consists of a polynomial background and
+    Gaussian peaks with well-defined energy (``Gaussian.centre``) and peak widths 
+    (``Gaussian.sigma``). This dataset can be fit extremely fast with a linear optimizer.
+
+There are three implementations of linear fitting in hyperspy: 
+The 'lstsq' optimizer is the recommended linear optimizer, and supports fitting lazy
+signals. The 'ridge_regression' optimizer supports regularization (see `Scikit-Learn's documentation 
+<https://scikit-learn.org/stable/modules/generated/sklearn.linear_model.Ridge.html>`_ for arguments to
+py:meth:`~hyperspy.model.BaseModel.fit`), but does not support lazy signals. 
+
+Standard errors for the parameters are by default not calculated when the entire dataset is fitted at once.
+This is due to the much larger memory requirement of that operation. If errors are required,
+either give ``calculate_errors=True`` as an argument to py:meth:`~hyperspy.model.BaseModel.multifit`, or rerun py:meth:`~hyperspy.model.BaseModel.multifit` with a nonlinear
+optimizer (which will now run much faster).
+
+None of the linear optimizers currently support bounds.
 
 Optimization results
 ^^^^^^^^^^^^^^^^^^^^
@@ -1429,6 +1479,13 @@ on individual components.
 * :py:meth:`~.model.BaseModel.set_parameters_not_free`
 * :py:meth:`~.model.BaseModel.set_parameters_free`
 * :py:meth:`~.model.BaseModel.set_parameters_value`
+
+
+.. _ModelFitBigData-label:
+
+Fitting big data
+----------------
+See the section in :ref:`signal.binned` working with big data.
 
 .. _SAMFire-label:
 

--- a/doc/user_guide/model.rst
+++ b/doc/user_guide/model.rst
@@ -1067,7 +1067,7 @@ Linear fitting can be used to address some of the drawbacks of non-linear optimi
   the non-linear optimizer will converge.
 
 However, linear fitting can *only* fit linear models and will not be able to fit
-parameter which varies *non-linearly*.
+parameters which vary *non-linearly*.
 
 A component is considered linear when its free parameters scale the component only 
 in the y-axis. For the exemplary function ``y = a*x**b``, ``a`` is a linear parameter, whilst ``b`` 

--- a/hyperspy/_components/bleasdale.py
+++ b/hyperspy/_components/bleasdale.py
@@ -55,6 +55,8 @@ class Bleasdale(Expression):
             module=module,
             autodoc=False,
             compute_gradients=False,
+            linear_parameter_list=['b'],
+            check_parameter_linearity=False,
             **kwargs)
 
     def grad_a(self, x):

--- a/hyperspy/_components/eels_cl_edge.py
+++ b/hyperspy/_components/eels_cl_edge.py
@@ -87,11 +87,12 @@ class EELSCLEdge(Component):
 
     def __init__(self, element_subshell, GOS=None):
         # Declare the parameters
-        Component.__init__(self,
-                           ['intensity',
-                            'fine_structure_coeff',
-                            'effective_angle',
-                            'onset_energy'])
+        Component.__init__(
+            self,
+            ['intensity', 'fine_structure_coeff', 'effective_angle',
+             'onset_energy'],
+            linear_parameter_list=['intensity']
+            )
         if isinstance(element_subshell, dict):
             self.element = element_subshell['element']
             self.subshell = element_subshell['subshell']
@@ -131,9 +132,6 @@ class EELSCLEdge(Component):
         self.intensity.value = 1
         self.intensity.bmin = 0.
         self.intensity.bmax = None
-
-        # Linearity
-        self.intensity._is_linear = True
 
         self._whitelist['GOS'] = ('init', GOS)
         if GOS == 'Hartree-Slater':

--- a/hyperspy/_components/eels_cl_edge.py
+++ b/hyperspy/_components/eels_cl_edge.py
@@ -132,6 +132,9 @@ class EELSCLEdge(Component):
         self.intensity.bmin = 0.
         self.intensity.bmax = None
 
+        # Linearity
+        self.intensity._is_linear = True
+
         self._whitelist['GOS'] = ('init', GOS)
         if GOS == 'Hartree-Slater':
             self._whitelist['element_subshell'] = (

--- a/hyperspy/_components/eels_double_power_law.py
+++ b/hyperspy/_components/eels_double_power_law.py
@@ -80,13 +80,11 @@ class DoublePowerLaw(Expression):
             autodoc=False,
             module=module,
             compute_gradients=compute_gradients,
+            linear_parameter_list=['A'],
+            check_parameter_linearity=False,
             **kwargs,
         )
-
-        self.origin.free = False
-        self.shift.value = 20.
-        self.shift.free = False
-
+    
         # Boundaries
         self.A.bmin = 0.
         self.A.bmax = None
@@ -94,7 +92,7 @@ class DoublePowerLaw(Expression):
         self.r.bmax = 5.
 
         self.isbackground = True
-        self.convolved = False
+        self.convolved = True
 
     def function_nd(self, axis):
         """%s

--- a/hyperspy/_components/expression.py
+++ b/hyperspy/_components/expression.py
@@ -116,7 +116,7 @@ class Expression(Component):
     check_parameter_linearity : bool
         If `True`, automatically check if each parameter is linear and set
         its corresponding attribute accordingly. If `False`, the default is to 
-        set all parameters, except for those who are specify in
+        set all parameters, except for those who are specified in
         ``linear_parameter_list``.
         
     **kwargs
@@ -353,7 +353,7 @@ class Expression(Component):
         term are fixed.
 
         The 'constant' part of a component is any part that doesn't change
-        when the free parameters is changed.
+        when the free parameters are changed.
         """
         free_linear_parameters = [
             # Use `_free` private attribute not to interfere with twin
@@ -422,8 +422,6 @@ class Expression(Component):
         model = self.model
         function = part['function']
         parameters = [para.value for para in part['parameters']]
-        nav_shape = model.axes_manager._navigation_shape_in_array
-        signal_shape = model.axes_manager._signal_shape_in_array
         
         if model.convolved and self.convolved:
             data = convolve_component_values(
@@ -432,15 +430,14 @@ class Expression(Component):
             axes = [ax.axis for ax in model.axes_manager.signal_axes]
             mesh = np.meshgrid(*axes)
             data = function(*mesh, *parameters)
-            if np.shape(data) == ():
-                data = data * \
-                    np.ones(signal_shape)[np.where(model.channel_switches)]
-            elif np.shape(data) == nav_shape:
-                data = data[..., None] * \
-                    np.ones(signal_shape)[np.where(model.channel_switches)]
+            slice_ = np.where(model.channel_switches)
+            if len(np.shape(data)) == 0:
+                # For calculation of constant term of the component
+                signal_shape = model.axes_manager._signal_shape_in_array
+                data = data * np.ones(signal_shape)[slice_]
             else:
-                data = data[np.where(model.channel_switches)]
-                data = np.moveaxis(data, 0, -1)
+                data = np.moveaxis(data[slice_], 0, -1)
+
         return data
 
 

--- a/hyperspy/_components/expression.py
+++ b/hyperspy/_components/expression.py
@@ -344,7 +344,7 @@ class Expression(Component):
         """
         free_linear_parameters = [
             # Use `_free` private attribute not to interfere with twin
-            p.name for p in self.parameters if p.linear and p._free
+            p.name for p in self.parameters if p._linear and p._free
             ]
 
         # Check linearity by multiplying a parameter by a factor and testing

--- a/hyperspy/_components/expression.py
+++ b/hyperspy/_components/expression.py
@@ -443,12 +443,13 @@ def check_parameter_linearity(expr, name):
     "Check whether expression is linear for a given parameter"
     symbol = sympy.Symbol(name)
     try:
-        if not sympy.Eq(sympy.diff(expr, symbol, 2), 0):
+        if not sympy.diff(expr, symbol, 2) == 0:
             return False
-    except (TypeError, AttributeError):
-        # TypeError occurs if the parameter is nonlinear
+    except AttributeError:
         # AttributeError occurs if the expression cannot be parsed
         # for instance some expressions with where.
+        warnings.warn(f"The linearity of the parameter {name} can't be "
+                      "determined.", UserWarning)
         return False
     return True
 

--- a/hyperspy/_components/lorentzian.py
+++ b/hyperspy/_components/lorentzian.py
@@ -99,7 +99,7 @@ class Lorentzian(Expression):
         # We use `_gamma` internally to workaround the use of the `gamma`
         # function in sympy
         super().__init__(
-            expression="A / pi * (_gamma / ((x - centre)**2 + _gamma**2))",
+            expression="A / pi * (gamma_ / ((x - centre)**2 + gamma_**2))",
             name="Lorentzian",
             A=A,
             gamma=gamma,
@@ -107,7 +107,7 @@ class Lorentzian(Expression):
             position="centre",
             module=module,
             autodoc=False,
-            rename_pars={"_gamma": "gamma"},
+            rename_pars={"gamma_": "gamma"},
             **kwargs)
 
         # Boundaries

--- a/hyperspy/_components/offset.py
+++ b/hyperspy/_components/offset.py
@@ -45,7 +45,7 @@ class Offset(Component):
     """
 
     def __init__(self, offset=0.):
-        Component.__init__(self, ('offset',))
+        Component.__init__(self, ('offset',), ['offset'])
         self.offset.free = True
         self.offset.value = offset
 
@@ -54,9 +54,6 @@ class Offset(Component):
 
         # Gradients
         self.offset.grad = self.grad_offset
-
-        # Linearity
-        self.offset._is_linear = True
 
     def function(self, x):
         return self._function(x, self.offset.value)

--- a/hyperspy/_components/offset.py
+++ b/hyperspy/_components/offset.py
@@ -55,6 +55,9 @@ class Offset(Component):
         # Gradients
         self.offset.grad = self.grad_offset
 
+        # Linearity
+        self.offset._is_linear = True
+
     def function(self, x):
         return self._function(x, self.offset.value)
 
@@ -133,3 +136,12 @@ class Offset(Component):
         return self._function(x, o)
 
     function_nd.__doc__ %= FUNCTION_ND_DOCSTRING
+
+    @property
+    def _constant_term(self):
+        "Get value of constant term of component"
+        # First get currently constant parameters
+        if self.offset.free:
+            return 0
+        else:
+            return self.offset.value

--- a/hyperspy/_components/pes_see.py
+++ b/hyperspy/_components/pes_see.py
@@ -78,6 +78,8 @@ class SEE(Expression):
             module=module,
             autodoc=False,
             compute_gradients=compute_gradients,
+            linear_parameter_list=['A'],
+            check_parameter_linearity=False,
             **kwargs,
         )
 

--- a/hyperspy/_components/power_law.py
+++ b/hyperspy/_components/power_law.py
@@ -73,7 +73,7 @@ class PowerLaw(Expression):
             module=module,
             autodoc=False,
             compute_gradients=compute_gradients,
-            linear_override=['A'],
+            linear_parameter_list=['A'],
             **kwargs,
         )
 

--- a/hyperspy/_components/power_law.py
+++ b/hyperspy/_components/power_law.py
@@ -16,8 +16,9 @@
 # You should have received a copy of the GNU General Public License
 # along with HyperSpy. If not, see <http://www.gnu.org/licenses/>.
 
-import numpy as np
 import logging
+
+import numpy as np
 
 from hyperspy._components.expression import Expression
 
@@ -74,6 +75,7 @@ class PowerLaw(Expression):
             autodoc=False,
             compute_gradients=compute_gradients,
             linear_parameter_list=['A'],
+            check_parameter_linearity=False,
             **kwargs,
         )
 

--- a/hyperspy/_components/power_law.py
+++ b/hyperspy/_components/power_law.py
@@ -73,6 +73,7 @@ class PowerLaw(Expression):
             module=module,
             autodoc=False,
             compute_gradients=compute_gradients,
+            linear_override=['A'],
             **kwargs,
         )
 

--- a/hyperspy/_components/scalable_fixed_pattern.py
+++ b/hyperspy/_components/scalable_fixed_pattern.py
@@ -71,7 +71,7 @@ class ScalableFixedPattern(Component):
     def __init__(self, signal1D, yscale=1.0, xscale=1.0,
                  shift=0.0, interpolate=True):
 
-        Component.__init__(self, ['yscale', 'xscale', 'shift'])
+        Component.__init__(self, ['yscale', 'xscale', 'shift'], ['yscale'])
 
         self._position = self.shift
         self._whitelist['signal1D'] = ('init,sig', signal1D)
@@ -87,8 +87,6 @@ class ScalableFixedPattern(Component):
         self.isbackground = True
         self.convolved = False
         self.interpolate = interpolate
-        
-        self.yscale._is_linear = True
 
     @property
     def interpolate(self):

--- a/hyperspy/_components/scalable_fixed_pattern.py
+++ b/hyperspy/_components/scalable_fixed_pattern.py
@@ -87,6 +87,8 @@ class ScalableFixedPattern(Component):
         self.isbackground = True
         self.convolved = False
         self.interpolate = interpolate
+        
+        self.yscale._is_linear = True
 
     @property
     def interpolate(self):

--- a/hyperspy/_components/voigt.py
+++ b/hyperspy/_components/voigt.py
@@ -17,7 +17,6 @@
 # along with HyperSpy. If not, see <http://www.gnu.org/licenses/>.
 
 import math
-import numpy as np
 from packaging.version import Version
 import sympy
 
@@ -96,12 +95,12 @@ class Voigt(Expression):
         if Version(sympy.__version__) < Version("1.3"):
             raise ImportError("The `Voigt` component requires "
                               "SymPy >= 1.3")
-        # We use `_gamma` internally to workaround the use of the `gamma`
+        # We use `gamma_` internally to workaround the use of the `gamma`
         # function in sympy
         super().__init__(
             expression="area * real(V); \
                 V = wofz(z) / (sqrt(2.0 * pi) * sigma); \
-                z = (x - centre + 1j * _gamma) / (sigma * sqrt(2.0))",
+                z = (x - centre + 1j * gamma_) / (sigma * sqrt(2.0))",
             name="Voigt",
             centre=centre,
             area=area,
@@ -110,7 +109,7 @@ class Voigt(Expression):
             position="centre",
             module=module,
             autodoc=False,
-            rename_pars={"_gamma": "gamma"},
+            rename_pars={"gamma_": "gamma"},
             **kwargs,
         )
 

--- a/hyperspy/_components/volume_plasmon_drude.py
+++ b/hyperspy/_components/volume_plasmon_drude.py
@@ -68,6 +68,8 @@ class VolumePlasmonDrude(Expression):
             module=module,
             autodoc=False,
             compute_gradients=compute_gradients,
+            linear_parameter_list=['intensity'],
+            check_parameter_linearity=False,
             **kwargs,
         )
 

--- a/hyperspy/component.py
+++ b/hyperspy/component.py
@@ -966,8 +966,8 @@ class Component(t.HasTraits):
             shape = [1, ]
         if (not isinstance(self._active_array, np.ndarray)
                 or self._active_array.shape != shape):
-            _logger.debug('Creating _active_array for {}.\n\tCurrent array '
-                          'is:\n{}'.format(self, self._active_array))
+            _logger.debug(f'Creating _active_array for {self}.\n\tCurrent '
+                          f'array is:\n{self._active_array}')
             self._active_array = np.ones(shape, dtype=bool)
 
     def _create_arrays(self):

--- a/hyperspy/component.py
+++ b/hyperspy/component.py
@@ -34,7 +34,7 @@ from hyperspy.misc.export_dictionary import export_to_dictionary, \
 from hyperspy.events import Events, Event
 from hyperspy.ui_registry import add_gui_method
 from IPython.display import display_pretty, display
-from hyperspy.misc.model_tools import current_component_values
+from hyperspy.misc.model_tools import current_component_values, get_top_parent_twin
 from hyperspy.misc.utils import get_object_package_info
 
 import logging
@@ -1327,6 +1327,15 @@ class Component(t.HasTraits):
             not_convolved = self._constant_term * np.ones(signal_shape)
             data = not_convolved
         return data.T[np.where(model.channel_switches)[::-1]].T
+
+    def _top_parent_twins_are_active(self):
+        'Check that the top parent twins of the components parameters are active'
+        active = True
+        for para in self.parameters:
+            if not get_top_parent_twin(para).component.active:
+                active = False
+        return active
+
 
 def convolve_component_values(component_values, model):
     '''Convolve component with model convolution axis

--- a/hyperspy/component.py
+++ b/hyperspy/component.py
@@ -174,6 +174,8 @@ class Parameter(t.HasTraits):
                            'self': ('id', None),
                            }
         self._slicing_whitelist = {'map': 'inav'}
+        self._is_linear = False
+        self._is_linear_override = False
 
     def _load_dictionary(self, dictionary):
         """Load data from dictionary.
@@ -1068,7 +1070,7 @@ class Component(t.HasTraits):
             self.fetch_stored_values()
         return s
 
-    def set_parameters_free(self, parameter_name_list=None):
+    def set_parameters_free(self, parameter_name_list=None, only_linear=False, only_nonlinear=False):
         """
         Sets parameters in a component to free.
 
@@ -1078,12 +1080,19 @@ class Component(t.HasTraits):
             If None, will set all the parameters to free.
             If list of strings, will set all the parameters with the same name
             as the strings in parameter_name_list to free.
+        only_linear : bool
+            If True, only sets a parameter free if it is linear
+        only_nonlinear : bool
+            If True, only sets a parameter free if it is nonlinear
+        
 
         Examples
         --------
         >>> v1 = hs.model.components1D.Voigt()
         >>> v1.set_parameters_free()
         >>> v1.set_parameters_free(parameter_name_list=['area','centre'])
+        >>> v1.set_parameters_free(linear=True)
+
 
         See also
         --------
@@ -1091,6 +1100,9 @@ class Component(t.HasTraits):
         hyperspy.model.BaseModel.set_parameters_free
         hyperspy.model.BaseModel.set_parameters_not_free
         """
+
+        if only_linear and only_nonlinear:
+            raise ValueError("To set all parameters free, set both only_linear and _nonlinear to False.")
 
         parameter_list = []
         if not parameter_name_list:
@@ -1101,9 +1113,16 @@ class Component(t.HasTraits):
                     parameter_list.append(_parameter)
 
         for _parameter in parameter_list:
-            _parameter.free = True
+            if not only_linear and not only_nonlinear:
+                _parameter.free = True
+            elif only_linear and _parameter._is_linear:
+                _parameter.free = True
+            elif only_nonlinear and not _parameter._is_linear:
+                _parameter.free = True
+            else:
+                pass
 
-    def set_parameters_not_free(self, parameter_name_list=None):
+    def set_parameters_not_free(self, parameter_name_list=None, only_linear=False, only_nonlinear=False):
         """
         Sets parameters in a component to not free.
 
@@ -1113,12 +1132,17 @@ class Component(t.HasTraits):
             If None, will set all the parameters to not free.
             If list of strings, will set all the parameters with the same name
             as the strings in parameter_name_list to not free.
-
+        only_linear : bool
+            If True, only sets a parameter not free if it is linear
+        only_nonlinear : bool
+            If True, only sets a parameter not free if it is nonlinear
         Examples
         --------
         >>> v1 = hs.model.components1D.Voigt()
         >>> v1.set_parameters_not_free()
         >>> v1.set_parameters_not_free(parameter_name_list=['area','centre'])
+        >>> v1.set_parameters_not_free(only_linear=True)
+
 
         See also
         --------
@@ -1126,6 +1150,9 @@ class Component(t.HasTraits):
         hyperspy.model.BaseModel.set_parameters_free
         hyperspy.model.BaseModel.set_parameters_not_free
         """
+
+        if only_linear and only_nonlinear:
+            raise ValueError("To set all parameters not free, set both only_linear and _nonlinear to False.")
 
         parameter_list = []
         if not parameter_name_list:
@@ -1136,7 +1163,14 @@ class Component(t.HasTraits):
                     parameter_list.append(_parameter)
 
         for _parameter in parameter_list:
-            _parameter.free = False
+            if not only_linear and not only_nonlinear:
+                _parameter.free = False
+            elif only_linear and _parameter._is_linear:
+                _parameter.free = False
+            elif only_nonlinear and not _parameter._is_linear:
+                _parameter.free = False
+            else:
+                pass
 
     def _estimate_parameters(self, signal):
         if self._axes_manager != signal.axes_manager:
@@ -1240,6 +1274,71 @@ class Component(t.HasTraits):
         else:
             display_pretty(current_component_values(
                 self, only_free=only_free))
+
+
+    @property
+    def is_linear(self):
+        """Loops through the components free parameters,
+        checks that they are linear"""
+        linear = True
+        for para in self.free_parameters:
+            if not para._is_linear:
+                linear = False
+        return linear
+
+    @property
+    def linear_parameters(self):
+        "Get list of all linear parameters in component"
+        return [para for para in self.free_parameters if para._is_linear]
+
+    @property
+    def nonlinear_parameters(self):
+        "Get list of all nonlinear parameters in component"
+        return [para for para in self.free_parameters if not para._is_linear]
+
+    @property
+    def _constant_term(self):
+        """Get value of any (non-free) constant term of the component.
+        Returns 0 for most components."""
+        return 0
+
+    def _compute_component(self):
+        model = self.model
+        if model.convolved and self.convolved:
+            # TODO: Model2D doesn't support a 2D convolution axis (yet)
+            data = convolve_component_values(
+                self.function(model.convolution_axis), 
+                model=model)
+        else:
+            axes = [ax.axis for ax in model.axes_manager.signal_axes]
+            mesh = np.meshgrid(*axes)
+            not_convolved = self.function(*mesh)
+            data = not_convolved
+        return data.T[np.where(model.channel_switches)[::-1]].T
+
+    def _compute_constant_term(self):
+        'Gets the value of any (non-free) constant term, with convolution'
+        model = self.model
+        if model.convolved and self.convolved:
+            convolved = convolve_component_values(self._constant_term, model=model)
+            data = convolved
+        else:
+            signal_shape = model.axes_manager.signal_shape[::-1]
+            not_convolved = self._constant_term * np.ones(signal_shape)
+            data = not_convolved
+        return data.T[np.where(model.channel_switches)[::-1]].T
+
+def convolve_component_values(component_values, model):
+    '''Convolve component with model convolution axis
+
+    Multiply by np.ones in order to handle case where component_values is a single constant'''
+
+    sig = component_values * np.ones(model.convolution_axis.shape)
+
+    ll = model.low_loss(model.axes_manager)
+    convolved = np.convolve(sig, ll, mode="valid")
+
+    return convolved
 
 
 def _get_scaling_factor(signal, axis, parameter):

--- a/hyperspy/component.py
+++ b/hyperspy/component.py
@@ -177,10 +177,6 @@ class Parameter(t.HasTraits):
                            }
         self._slicing_whitelist = {'map': 'inav'}
 
-    @property
-    def linear(self):
-        return self._linear
-
     def _load_dictionary(self, dictionary):
         """Load data from dictionary.
 
@@ -1142,9 +1138,9 @@ class Component(t.HasTraits):
         for _parameter in parameter_list:
             if not only_linear and not only_nonlinear:
                 _parameter.free = True
-            elif only_linear and _parameter.linear:
+            elif only_linear and _parameter._linear:
                 _parameter.free = True
-            elif only_nonlinear and not _parameter.linear:
+            elif only_nonlinear and not _parameter._linear:
                 _parameter.free = True
             else:
                 pass
@@ -1195,9 +1191,9 @@ class Component(t.HasTraits):
         for _parameter in parameter_list:
             if not only_linear and not only_nonlinear:
                 _parameter.free = False
-            elif only_linear and _parameter.linear:
+            elif only_linear and _parameter._linear:
                 _parameter.free = False
-            elif only_nonlinear and not _parameter.linear:
+            elif only_nonlinear and not _parameter._linear:
                 _parameter.free = False
             else:
                 pass
@@ -1313,7 +1309,7 @@ class Component(t.HasTraits):
     def linear(self):
         """A component is linear if its free parameters are linear."""
         if self._nfree_param == 1:
-            return self.free_parameters[0].linear
+            return self.free_parameters[0]._linear
         else:
             return False
 

--- a/hyperspy/component.py
+++ b/hyperspy/component.py
@@ -1299,8 +1299,7 @@ class Component(t.HasTraits):
         if fancy:
             display(current_component_values(self, only_free=only_free))
         else:
-            display_pretty(current_component_values(
-                self, only_free=only_free))
+            display_pretty(current_component_values(self, only_free=only_free))
 
     @property
     def _constant_term(self):

--- a/hyperspy/component.py
+++ b/hyperspy/component.py
@@ -1084,7 +1084,7 @@ class Component(t.HasTraits):
             If True, only sets a parameter free if it is linear
         only_nonlinear : bool
             If True, only sets a parameter free if it is nonlinear
-        
+
 
         Examples
         --------
@@ -1178,9 +1178,10 @@ class Component(t.HasTraits):
             self._create_arrays()
 
     def as_dictionary(self, fullcopy=True):
-        """Returns component as a dictionary. For more information on method
+        """
+        Returns component as a dictionary. For more information on method
         and conventions, see
-        py:meth:`~hyperspy.misc.export_dictionary.export_to_dictionary`
+        :py:meth:`~hyperspy.misc.export_dictionary.export_to_dictionary`
 
         Parameters
         ----------
@@ -1212,7 +1213,8 @@ class Component(t.HasTraits):
         return dic
 
     def _load_dictionary(self, dic):
-        """Load data from dictionary.
+        """
+        Load data from dictionary.
 
         Parameters
         ----------
@@ -1261,7 +1263,9 @@ class Component(t.HasTraits):
                     \ndictionary['_id_name'] = %s" % (self._id_name, dic['_id_name']))
 
     def print_current_values(self, only_free=False, fancy=True):
-        """Prints the current values of the component's parameters.
+        """
+        Prints the current values of the component's parameters.
+
         Parameters
         ----------
         only_free : bool
@@ -1278,8 +1282,10 @@ class Component(t.HasTraits):
 
     @property
     def is_linear(self):
-        """Loops through the components free parameters,
-        checks that they are linear"""
+        """
+        Loops through the components free parameters, checks that they are
+        linear.
+        """
         linear = True
         for para in self.free_parameters:
             if not para._is_linear:
@@ -1288,18 +1294,20 @@ class Component(t.HasTraits):
 
     @property
     def linear_parameters(self):
-        "Get list of all linear parameters in component"
+        """Get list of all linear parameters in component."""
         return [para for para in self.free_parameters if para._is_linear]
 
     @property
     def nonlinear_parameters(self):
-        "Get list of all nonlinear parameters in component"
+        """Get list of all nonlinear parameters in component."""
         return [para for para in self.free_parameters if not para._is_linear]
 
     @property
     def _constant_term(self):
-        """Get value of any (non-free) constant term of the component.
-        Returns 0 for most components."""
+        """
+        Get value of any (non-free) constant term of the component.
+        Returns 0 for most components.
+        """
         return 0
 
     def _compute_component(self):
@@ -1307,7 +1315,7 @@ class Component(t.HasTraits):
         if model.convolved and self.convolved:
             # TODO: Model2D doesn't support a 2D convolution axis (yet)
             data = convolve_component_values(
-                self.function(model.convolution_axis), 
+                self.function(model.convolution_axis),
                 model=model)
         else:
             axes = [ax.axis for ax in model.axes_manager.signal_axes]

--- a/hyperspy/component.py
+++ b/hyperspy/component.py
@@ -1108,14 +1108,12 @@ class Component(t.HasTraits):
         only_nonlinear : bool
             If True, only sets a parameter free if it is nonlinear
 
-
         Examples
         --------
         >>> v1 = hs.model.components1D.Voigt()
         >>> v1.set_parameters_free()
         >>> v1.set_parameters_free(parameter_name_list=['area','centre'])
         >>> v1.set_parameters_free(linear=True)
-
 
         See also
         --------
@@ -1125,7 +1123,10 @@ class Component(t.HasTraits):
         """
 
         if only_linear and only_nonlinear:
-            raise ValueError("To set all parameters free, set both only_linear and _nonlinear to False.")
+            raise ValueError(
+                "To set all parameters free, set both `only_linear` and "
+                "`only_nonlinear` to False."
+                )
 
         parameter_list = []
         if not parameter_name_list:
@@ -1142,8 +1143,6 @@ class Component(t.HasTraits):
                 _parameter.free = True
             elif only_nonlinear and not _parameter._linear:
                 _parameter.free = True
-            else:
-                pass
 
     def set_parameters_not_free(self, parameter_name_list=None,
                                 only_linear=False, only_nonlinear=False):
@@ -1195,8 +1194,6 @@ class Component(t.HasTraits):
                 _parameter.free = False
             elif only_nonlinear and not _parameter._linear:
                 _parameter.free = False
-            else:
-                pass
 
     def _estimate_parameters(self, signal):
         if self._axes_manager != signal.axes_manager:
@@ -1306,14 +1303,6 @@ class Component(t.HasTraits):
                 self, only_free=only_free))
 
     @property
-    def linear(self):
-        """A component is linear if its free parameters are linear."""
-        if self._nfree_param == 1:
-            return self.free_parameters[0]._linear
-        else:
-            return False
-
-    @property
     def _constant_term(self):
         """
         Get value of any (non-free) constant term of the component.
@@ -1322,7 +1311,7 @@ class Component(t.HasTraits):
         return 0
 
     def _compute_constant_term(self):
-        'Gets the value of any (non-free) constant term, with convolution'
+        """Gets the value of any (non-free) constant term, with convolution"""
         model = self.model
         if model.convolved and self.convolved:
             data = convolve_component_values(self._constant_term, model=model)
@@ -1333,9 +1322,12 @@ class Component(t.HasTraits):
 
 
 def convolve_component_values(component_values, model):
-    '''Convolve component with model convolution axis
+    """
+    Convolve component with model convolution axis.
 
-    Multiply by np.ones in order to handle case where component_values is a single constant'''
+    Multiply by np.ones in order to handle case where component_values is a
+    single constant
+    """
 
     sig = component_values * np.ones(model.convolution_axis.shape)
 

--- a/hyperspy/external/progressbar.py
+++ b/hyperspy/external/progressbar.py
@@ -18,7 +18,6 @@
 
 from packaging.version import Version
 from tqdm import __version__ as tqdm_version
-from dask.callbacks import Callback
 
 if Version(tqdm_version) >= Version("4.36.0"):
     # API change for 5.0 https://github.com/tqdm/tqdm/pull/800

--- a/hyperspy/external/progressbar.py
+++ b/hyperspy/external/progressbar.py
@@ -18,6 +18,7 @@
 
 from packaging.version import Version
 from tqdm import __version__ as tqdm_version
+from dask.callbacks import Callback
 
 if Version(tqdm_version) >= Version("4.36.0"):
     # API change for 5.0 https://github.com/tqdm/tqdm/pull/800

--- a/hyperspy/misc/model_tools.py
+++ b/hyperspy/misc/model_tools.py
@@ -243,32 +243,3 @@ def calc_covariance(target_signal, coefficients, component_data,
 def std_err_from_cov(covariance):
     "Get standard error coefficients from the diagonal of the covariance"
     return np.sqrt(np.diagonal(covariance, axis1=-2, axis2=-1))
-
-
-def parameter_map_values_all_identical(para):
-    """Returns True if the parameter has identical values for all
-    navigation indices, otherwise False.
-    """
-    return (para.map['values'] == para.map['values'].item(0)).all()
-
-
-def all_set_non_free_para_have_identical_values(model):
-    """Returns True and an empty list if the all parameters in the model that
-    are not free have identical values in their respective navigation
-    indices AND have `is_set` equal to True.
-
-    Otherwise returns False and a list of the parameters with
-    non-identical values.
-
-    This function is used with linear fitting to check whether to use the
-    faster method across the entire navigation space simultaneously, or the
-    slower index-by-index fitting which supports parameters having fixed
-    values that vary from index to index.
-    """
-    nonfree_parameters = [
-        p for c in model.active_components for p in c.parameters if not p.free
-        ]
-    non_identical_parameters = [
-        p for p in nonfree_parameters
-        if not np.all(p.map['values'] == p.map['values'][0])
-        ]

--- a/hyperspy/misc/model_tools.py
+++ b/hyperspy/misc/model_tools.py
@@ -247,15 +247,6 @@ def get_top_parent_twin(parameter):
         return parameter
 
 
-def check_top_parent_twins_are_active(component):
-    'Check that the top parent twins of the components parameters are active'
-    active = True
-    for para in component.parameters:
-        if not get_top_parent_twin(para).component.active:
-            active = False
-    return active
-
-
 def parameter_map_values_all_identical(para):
     """Returns True if the parameter has identical values for all
     navigation indices, otherwise False.

--- a/hyperspy/misc/model_tools.py
+++ b/hyperspy/misc/model_tools.py
@@ -20,23 +20,29 @@ import numpy as np
 import dask.array as da
 
 def _is_iter(val):
-    "Checks if value is a list or tuple"
+    """Checks if value is a list or tuple."""
     return isinstance(val, tuple) or isinstance(val, list)
 
 
 def _iter_join(val):
-    "Joins values of iterable parameters for the fancy view, unless it equals None, then blank"
+    """
+    Joins values of iterable parameters for the fancy view, unless it equals
+    None, then blank
+    """
     return "(" + ", ".join(["{:6g}".format(v) for v in val]) + ")" if val is not None else ""
 
 
 def _non_iter(val):
-    "Returns formatted string for a value unless it equals None, then blank"
+    """
+    Returns formatted string for a value unless it equals None, then blank
+    """
     return "{:6g}".format(val) if val is not None else ""
 
 
 class current_component_values():
-    """Convenience class that makes use of __repr__ methods for nice printing in the notebook
-    of the properties of parameters of a component
+    """
+    Convenience class that makes use of __repr__ methods for nice printing in
+    the notebook of the properties of parameters of a component.
 
     Parameters
     ----------
@@ -44,8 +50,9 @@ class current_component_values():
     only_free : bool, default False
         If True: Only include the free parameters in the view
     only_active : bool, default False
-        If True: Helper for current_model_values. Only include active components in the view.
-        Always shows values if used on an individual component.
+        If True: Helper for current_model_values. Only include active
+        components in the view. Always shows values if used on an individual
+        component.
      """
 
     def __init__(self, component, only_free=False, only_active=False):
@@ -153,8 +160,9 @@ class current_component_values():
 
 
 class current_model_values():
-    """Convenience class that makes use of __repr__ methods for nice printing in the notebook
-    of the properties of parameters in components in a model
+    """
+    Convenience class that makes use of __repr__ methods for nice printing in
+    the notebook of the properties of parameters in components in a model.
 
     Parameters
     ----------
@@ -200,25 +208,28 @@ class current_model_values():
         return html
 
 
-def calc_covariance(target_signal, coefficients, component_data,
-                    residual=None, lazy=False):
-    """Calculate covariance matrix after having performed Linear Regression
+def _calculate_covariance(target_signal, coefficients, component_data,
+                         residual=None, lazy=False):
+    """
+    Calculate covariance matrix after having performed Linear Regression.
 
     Parameters
     ----------
 
     target_signal : array-like, shape (N,) or (M, N)
-        The signal array to be fit to
+        The signal array to be fit to.
     coefficients : array-like, shape C or (M, C)
+        The fitted coefficients.
     component_data : array-like, shape N or (C, N)
+        The component data.
     residual : array-like, shape (0,) or (M,)
         The residual sum of squares, optional. Calculated if None.
     lazy : bool
-        Whether the signal is lazy
+        Whether the signal is lazy.
 
     Notes
     -----
-    Explanation the array shapes in HyperSpy terms:
+    Explanation of the array shapes in HyperSpy terms:
     N : flattened signal shape
     M : flattened navigation shape
     C : number of components
@@ -248,8 +259,3 @@ def calc_covariance(target_signal, coefficients, component_data,
     k = coefficients.shape[-1]  # the number of components
     covariance = (1 / (n - k)) * (residual * inv_fit_dot.T).T
     return covariance
-
-
-def std_err_from_cov(covariance):
-    "Get standard error coefficients from the diagonal of the covariance"
-    return np.sqrt(np.diagonal(covariance, axis1=-2, axis2=-1))

--- a/hyperspy/misc/model_tools.py
+++ b/hyperspy/misc/model_tools.py
@@ -60,11 +60,12 @@ class current_component_values():
         # Number of digits for each label for the terminal-style view.
         size = {
             'name': 14,
-            'free': 5,
+            'free': 7,
             'value': 10,
             'std': 10,
             'bmin': 10,
             'bmax': 10,
+            'linear':6,
         }
         # Using nested string formatting for flexibility in future updates
         signature = "{{:>{name}}} | {{:>{free}}} | {{:>{value}}} | {{:>{std}}} | {{:>{bmin}}} | {{:>{bmax}}}".format(
@@ -84,6 +85,7 @@ class current_component_values():
         text += "\n"
         for para in self.parameters:
             if not self.only_free or self.only_free and para.free:
+                free = para.free if para.twin is None else 'Twinned'
                 if _is_iter(para.value):
                     # iterables (polynomial.value) must be handled separately
                     # `blank` results in a column of spaces
@@ -94,14 +96,14 @@ class current_component_values():
                     for i, (v, s, bn, bx) in enumerate(
                             zip(para.value, std, bmin, bmax)):
                         if i == 0:
-                            text += signature.format(para.name[:size['name']], str(para.free)[:size['free']], str(
+                            text += signature.format(para.name[:size['name']], str(free)[:size['free']], str(
                                 v)[:size['value']], str(s)[:size['std']], str(bn)[:size['bmin']], str(bx)[:size['bmax']])
                         else:
                             text += signature.format("", "", str(v)[:size['value']], str(
                                 s)[:size['std']], str(bn)[:size['bmin']], str(bx)[:size['bmax']])
                         text += "\n"
                 else:
-                    text += signature.format(para.name[:size['name']], str(para.free)[:size['free']], str(para.value)[
+                    text += signature.format(para.name[:size['name']], str(free)[:size['free']], str(para.value)[
                                              :size['value']], str(para.std)[:size['std']], str(para.bmin)[:size['bmin']], str(para.bmax)[:size['bmax']])
                     text += "\n"
         return text
@@ -118,6 +120,7 @@ class current_component_values():
         text += para_head
         for para in self.parameters:
             if not self.only_free or self.only_free and para.free:
+                free = para.free if para.twin is None else 'Twinned'
                 if _is_iter(para.value):
                     # iterables (polynomial.value) must be handled separately
                     # This should be removed with hyperspy 2.0 as Polynomial
@@ -134,7 +137,7 @@ class current_component_values():
 
                 text += """<tr><td>{0}</td><td>{1}</td><td>{2}</td>
                     <td>{3}</td><td>{4}</td><td>{5}</td></tr>""".format(
-                        para.name, para.free, value, std, bmin, bmax)
+                        para.name, free, value, std, bmin, bmax)
         text += "</table>"
         return text
 

--- a/hyperspy/misc/model_tools.py
+++ b/hyperspy/misc/model_tools.py
@@ -68,7 +68,7 @@ class current_component_values():
             'linear':6,
         }
         # Using nested string formatting for flexibility in future updates
-        signature = "{{:>{name}}} | {{:>{free}}} | {{:>{value}}} | {{:>{std}}} | {{:>{bmin}}} | {{:>{bmax}}}".format(
+        signature = "{{:>{name}}} | {{:>{free}}} | {{:>{value}}} | {{:>{std}}} | {{:>{bmin}}} | {{:>{bmax}}} | {{:>{linear}}}".format(
             **size)
 
         if self.only_active:
@@ -78,14 +78,15 @@ class current_component_values():
                 self.__class__.__name__, self.name, self.active)
         text += "\n"
         text += signature.format("Parameter Name",
-                                 "Free", "Value", "Std", "Min", "Max")
+                                 "Free", "Value", "Std", "Min", "Max", "Linear")
         text += "\n"
         text += signature.format("=" * size['name'], "=" * size['free'], "=" *
-                                 size['value'], "=" * size['std'], "=" * size['bmin'], "=" * size['bmax'],)
+                                 size['value'], "=" * size['std'], "=" * size['bmin'], "=" * size['bmax'], "=" * size['linear'],)
         text += "\n"
         for para in self.parameters:
             if not self.only_free or self.only_free and para.free:
                 free = para.free if para.twin is None else 'Twinned'
+                ln = para._linear
                 if _is_iter(para.value):
                     # iterables (polynomial.value) must be handled separately
                     # `blank` results in a column of spaces
@@ -96,15 +97,23 @@ class current_component_values():
                     for i, (v, s, bn, bx) in enumerate(
                             zip(para.value, std, bmin, bmax)):
                         if i == 0:
-                            text += signature.format(para.name[:size['name']], str(free)[:size['free']], str(
-                                v)[:size['value']], str(s)[:size['std']], str(bn)[:size['bmin']], str(bx)[:size['bmax']])
+                            text += signature.format(
+                                para.name[:size['name']], str(free)[:size['free']],
+                                str(v)[:size['value']], str(s)[:size['std']],
+                                str(bn)[:size['bmin']], str(bx)[:size['bmax']],
+                                str(ln)[:size['linear']])
                         else:
-                            text += signature.format("", "", str(v)[:size['value']], str(
-                                s)[:size['std']], str(bn)[:size['bmin']], str(bx)[:size['bmax']])
+                            text += signature.format(
+                                "", "", str(v)[:size['value']], str(s)[:size['std']],
+                                str(bn)[:size['bmin']], str(bx)[:size['bmax']],
+                                str(ln)[:size['linear']])
                         text += "\n"
                 else:
-                    text += signature.format(para.name[:size['name']], str(free)[:size['free']], str(para.value)[
-                                             :size['value']], str(para.std)[:size['std']], str(para.bmin)[:size['bmin']], str(para.bmax)[:size['bmax']])
+                    text += signature.format(
+                        para.name[:size['name']], str(free)[:size['free']],
+                        str(para.value)[:size['value']], str(para.std)[:size['std']],
+                        str(para.bmin)[:size['bmin']], str(para.bmax)[:size['bmax']],
+                        str(ln)[:size['linear']])
                     text += "\n"
         return text
 
@@ -116,11 +125,12 @@ class current_component_values():
                 self.__class__.__name__, self.name, self.active)
 
         para_head = """<table style="width:100%"><tr><th>Parameter Name</th><th>Free</th>
-            <th>Value</th><th>Std</th><th>Min</th><th>Max</th></tr>"""
+            <th>Value</th><th>Std</th><th>Min</th><th>Max</th><th>Linear</th></tr>"""
         text += para_head
         for para in self.parameters:
             if not self.only_free or self.only_free and para.free:
                 free = para.free if para.twin is None else 'Twinned'
+                linear = para._linear
                 if _is_iter(para.value):
                     # iterables (polynomial.value) must be handled separately
                     # This should be removed with hyperspy 2.0 as Polynomial
@@ -136,8 +146,8 @@ class current_component_values():
                     bmax = _non_iter(para.bmax)
 
                 text += """<tr><td>{0}</td><td>{1}</td><td>{2}</td>
-                    <td>{3}</td><td>{4}</td><td>{5}</td></tr>""".format(
-                        para.name, free, value, std, bmin, bmax)
+                    <td>{3}</td><td>{4}</td><td>{5}</td><td>{6}</td></tr>""".format(
+                        para.name, free, value, std, bmin, bmax, linear)
         text += "</table>"
         return text
 

--- a/hyperspy/misc/model_tools.py
+++ b/hyperspy/misc/model_tools.py
@@ -214,16 +214,16 @@ def calc_covariance(target_signal, coefficients, component_data,
     residual : array-like, shape (0,) or (M,)
         The residual sum of squares, optional. Calculated if None.
     lazy : bool
-        Whether the signal is a lazy
+        Whether the signal is lazy
 
     Notes
     -----
-    Explanation the array shapes in hyperspy terms:
+    Explanation the array shapes in HyperSpy terms:
     N : flattened signal shape
     M : flattened navigation shape
     C : number of components
 
-    See https://stats.stackexchange.com/questions/62470 for more info on
+    See https://stats.stackexchange.com/questions/62470 for more info on the
     algorithm
     """
     if target_signal.ndim > 1:

--- a/hyperspy/misc/model_tools.py
+++ b/hyperspy/misc/model_tools.py
@@ -16,6 +16,8 @@
 # You should have received a copy of the GNU General Public License
 # along with HyperSpy. If not, see <http://www.gnu.org/licenses/>.
 
+import numpy as np
+import dask.array as da
 
 def _is_iter(val):
     "Checks if value is a list or tuple"
@@ -183,3 +185,106 @@ class current_model_values():
                         only_active=self.only_active
                         )._repr_html_()
         return html
+
+def calc_covariance(target_signal, coefficients, component_data, residual=None, lazy=False):
+        '''Calculate covariance matrix after having performed Linear Regression
+
+        Parameters
+        ----------
+
+        target_signal : array-like, shape (N,) or (M, N)
+            The signal array to be fit to
+        coefficients : array-like, shape C or (M, C)
+        component_data : array-like, shape N or (C, N)
+        residual : array-like, shape (0,) or (M,)
+            The residual sum of squares, optional. Calculated if None.
+        lazy : bool
+            Whether the signal is a lazy
+
+        Notes
+        -----
+        Explanation the array shapes in hyperspy terms:
+        N : flattened signal shape
+        M : flattened navigation shape
+        C : number of components
+
+        See https://stats.stackexchange.com/questions/62470 for more info on algorithm
+        '''
+        if len(target_signal.shape) > 1: # model._linear_ndfit is True
+            fit = coefficients[..., None, :] * component_data.T[None]
+        else:
+            fit = coefficients * component_data.T
+        if residual is None:
+            residual = ((target_signal - fit.sum(-1))**2).sum(-1)
+        fit_dot = np.matmul(fit.swapaxes(-2, -1), fit)
+
+        # Prefer to find another way than matrix inverse
+        # if target_signal shape is 1D, then fit_dot is 2D and numpy going to dask.linalg.inv is fine.
+        # If target_signal shape is 2D, then dask.linalg.inv will fail because fit_dot is 3D.
+        if lazy and len(target_signal.shape) != 1: 
+            inv_fit_dot = da.map_blocks(np.linalg.inv, fit_dot, chunks=fit_dot.chunks)
+        else:
+            inv_fit_dot = np.linalg.inv(fit_dot)
+
+        n = fit.shape[-2] # the signal axis length
+        k = coefficients.shape[-1]  # the number of components
+        covariance = (1 / (n - k)) * (residual * inv_fit_dot.T).T
+        return covariance
+
+def std_err_from_cov(covariance):
+    "Get standard error coefficients from the diagonal of the covariance"
+    return np.sqrt(np.diagonal(covariance, axis1=-2, axis2=-1))
+
+def get_top_parent_twin(parameter):
+    "Get the top parent twin, if there is one"
+    if parameter.twin:
+        return get_top_parent_twin(parameter.twin)
+    else:
+        return parameter
+
+def check_top_parent_twins_are_active(component):
+    'Check that the top parent twins of the components parameters are active'
+    active = True
+    for para in component.parameters:
+        if not get_top_parent_twin(para).component.active:
+            active = False
+    return active
+    
+def parameter_map_values_all_identical(para):
+    """Returns True if the parameter has identical values for all 
+    navigation indices, otherwise False.
+    """
+    return (para.map['values'] == para.map['values'].item(0)).all()
+
+def all_set_non_free_para_have_identical_values(model):
+    """Returns True and an empty list if the all parameters in the model that
+    are not free have identical values in their respective navigation
+    indices AND have `is_set` equal to True.
+    
+    Otherwise returns False and a list of the parameters with 
+    non-identical values.
+
+    This function is used with linear fitting to check whether to use the faster
+    method across the entire navigation space simultaneously, or the slower
+    index-by-index fitting which supports parameters having fixed values that vary
+    from index to index.
+    """
+
+    model._set_twinned_lists()
+    non_identical_para = []
+    is_identical = True
+    for comp in model:
+        if comp.active:
+            for para in comp.parameters:
+                if not para.free:
+                    if not para in model._twinned_parameters:
+                        if not (~para.map['is_set']).all():
+                            if para.map['is_set'].all():
+                                if not parameter_map_values_all_identical(para):
+                                    is_identical = False
+                                    non_identical_para.append(para)
+                            else:
+                                is_identical = False
+                                non_identical_para.append(para)
+
+    return is_identical, non_identical_para

--- a/hyperspy/model.py
+++ b/hyperspy/model.py
@@ -1056,22 +1056,22 @@ class BaseModel(list):
                         "`Expression` component."
                         )
                 free, fixed = component._separate_pseudocomponents()
-                for parameter in free_parameters:
+                for p in free_parameters:
                     # Use the index in the `parameters` list as reference
                     # to defined the position in the numpy array
-                    index = parameters.index(parameter)
+                    index = parameters.index(p)
                     comp_values[index] = component._compute_expression_part(
-                        free[parameter.name]
+                        free[p.name]
                         )
                     constant_term += component._compute_expression_part(fixed)
 
             elif len(free_parameters) == 1:
-                parameter = free_parameters[0]
-                if parameter.twin:
+                p = free_parameters[0]
+                if p.twin:
                     # to get the correct `comp_values` index, we need the twin
-                    parameter = twin_parameters_mapping[parameter]
+                    p = twin_parameters_mapping[p]
 
-                index = parameters.index(parameter)
+                index = parameters.index(p)
                 comp_value = self.__call__(
                     component_list=[component], binned=False
                     )

--- a/hyperspy/model.py
+++ b/hyperspy/model.py
@@ -957,14 +957,15 @@ class BaseModel(list):
             'ridge_regression' - Supports regularisation, doesn't support lazy
             signal.
         calculate_errors : bool, default is False
+            If True, calculate the errors.
         only_current : bool, default is True
             Fit the current index only, instead of the whole navigation space.
         kwargs : dict, optional
             Keywords argument are passed to
             :py:func:`sklearn.linear_model.ridge_regression`.
 
-        Developer Notes
-        ---------------
+        Notes
+        -----
         More linear optimizers can be added in future, but note that in order
         to support simultaneous fitting across the dataset, the optimizer must
         support "two-dimensional y" - see the ``b`` parameter in
@@ -973,8 +974,9 @@ class BaseModel(list):
         Currently, the overhead in calculating the component data takes about
         100 times longer than actually running :py:func:`np.linalg.lstsq`.
         That means that going pixel-by-pixel, calculating the component data
-        each time is not faster than the normal nonlinear methods. Linear fitting
-        is hence currently only useful for fitting a dataset in the vectorised manner.
+        each time is not faster than the normal nonlinear methods. Linear
+        fitting is hence currently only useful for fitting a dataset in the
+        vectorised manner.
         """
 
         signal_axes = self.signal.axes_manager.signal_axes

--- a/hyperspy/model.py
+++ b/hyperspy/model.py
@@ -60,8 +60,7 @@ from hyperspy.misc.export_dictionary import (
     )
 from hyperspy.misc.model_tools import (
     current_model_values,
-    calc_covariance,
-    std_err_from_cov
+    _calculate_covariance,
     )
 from hyperspy.misc.slicing import copy_slice_from_whitelist
 from hyperspy.misc.utils import (
@@ -1158,15 +1157,15 @@ class BaseModel(list):
         # is specified in multifit. This is because it is a very large
         # calculation and can eat all our ram, even when run lazily.
         if calculate_errors:
-            fit_output["covar"] = calc_covariance(
+            covariance = _calculate_covariance(
                 target_signal=target_signal,
                 coefficients=coefficient_array,
                 component_data=comp_values,
                 residual=residual,
                 lazy=self.signal._lazy)
-            fit_output["perror"] = abs(fit_output["x"]) * std_err_from_cov(
-                fit_output["covar"]
-            )
+            std_error = np.sqrt(np.diagonal(covariance, axis1=-2, axis2=-1))
+            fit_output["covar"] = covariance
+            fit_output["perror"] = abs(fit_output["x"]) * std_error
 
         if not only_current:
             # The nav shape will have been flattened. We reshape it here.

--- a/hyperspy/model.py
+++ b/hyperspy/model.py
@@ -28,6 +28,7 @@ from functools import partial
 
 import dill
 import numpy as np
+import dask
 import dask.array as da
 import scipy
 import scipy.odr as odr

--- a/hyperspy/models/edsmodel.py
+++ b/hyperspy/models/edsmodel.py
@@ -250,11 +250,15 @@ class EDSModel(Model1D):
             component.name = xray_line
             self.append(component)
             self.xray_lines.append(component)
-            self[xray_line].A.map[
-                'values'] = self.signal.isig[line_energy].data * \
-                line_FWHM / self.signal.axes_manager[-1].scale
-            self[xray_line].A.map['is_set'] = (
-                np.ones(self.signal.isig[line_energy].data.shape) == 1)
+            if self.signal._lazy:
+                # For lazy signal, use a default value to avoid having
+                # to do out-of-core computation
+                component.A.map['values'] = 10
+            else:
+                component.A.map[
+                    'values'] = self.signal.isig[line_energy].data * \
+                    line_FWHM / self.signal.axes_manager[-1].scale
+            component.A.map['is_set'] = True
             component.A.ext_force_positive = True
             for li in elements_db[element]['Atomic_properties']['Xray_lines']:
                 if line[0] in li and line != li:

--- a/hyperspy/models/eelsmodel.py
+++ b/hyperspy/models/eelsmodel.py
@@ -121,7 +121,7 @@ class EELSModel(Model1D):
         NotImplementedError
             If the signal axis is a non-uniform axis.
         """
-        super(EELSModel, self).append(component)
+        super().append(component)
         if isinstance(component, EELSCLEdge):
             # Test that signal axis is uniform
             if not self.axes_manager[-1].is_uniform:
@@ -140,7 +140,7 @@ class EELSModel(Model1D):
     append.__doc__ = Model1D.append.__doc__
 
     def remove(self, component):
-        super(EELSModel, self).remove(component)
+        super().remove(component)
         self._classify_components()
 
     remove.__doc__ = Model1D.remove.__doc__

--- a/hyperspy/models/model1d.py
+++ b/hyperspy/models/model1d.py
@@ -379,19 +379,22 @@ class Model1D(BaseModel):
     remove.__doc__ = BaseModel.remove.__doc__
 
     def __call__(self, non_convolved=False, onlyactive=False,
-                 component_list=None):
+                 component_list=None, binned=None):
         """Returns the corresponding model for the current coordinates
 
         Parameters
         ----------
         non_convolved : bool
             If True it will return the deconvolved model
-        only_active : bool
+        onlyactive : bool
             If True, only the active components will be used to build the
             model.
         component_list : list or None
             If None, the sum of all the components is returned. If list, only
             the provided components are returned
+        binned : bool or None
+            Specify if the binned attribute of the signal axes needs to be
+            taken into account.
 
         cursor: 1 or 2
 
@@ -430,9 +433,13 @@ class Model1D(BaseModel):
                 self.low_loss(self.axes_manager),
                 sum_convolved, mode="valid")
             to_return = to_return[self.channel_switches]
-        if is_binned(self.signal):
-        # in v2 replace by
-        #if self.signal.axes_manager[-1].is_binned:
+
+        if binned is None:
+            # in v2 replace by
+            # if self.signal.axes_manager[-1].is_binned:
+            binned = is_binned(self.signal)
+
+        if binned:
             if self.signal.axes_manager[-1].is_uniform:
                 to_return *= self.signal.axes_manager[-1].scale
             else:

--- a/hyperspy/models/model1d.py
+++ b/hyperspy/models/model1d.py
@@ -28,7 +28,6 @@ from hyperspy.exceptions import WrongObjectError, SignalDimensionError
 from hyperspy.decorators import interactive_range_selector
 from hyperspy.drawing.widgets import LabelWidget, VerticalLineWidget
 from hyperspy.events import EventSuppressor
-from hyperspy.exceptions import SignalDimensionError, WrongObjectError
 from hyperspy.model import BaseModel, ModelComponents, ModelSpecialSlicers
 from hyperspy.signal_tools import SpanSelectorInSignal1D
 from hyperspy.ui_registry import DISPLAY_DT, TOOLKIT_DT, add_gui_method
@@ -393,7 +392,7 @@ class Model1D(BaseModel):
             If None, the sum of all the components is returned. If list, only
             the provided components are returned
         binned : bool or None
-            Specify if the binned attribute of the signal axes needs to be
+            Specify whether the binned attribute of the signal axes needs to be
             taken into account.
 
         cursor: 1 or 2

--- a/hyperspy/models/model2d.py
+++ b/hyperspy/models/model2d.py
@@ -148,7 +148,7 @@ class Model2D(BaseModel):
         non_convolved : bool
             Not Implemented for Model2D
         onlyactive : bool
-            If true, only the active components will be used to build the
+            If True, only the active components will be used to build the
             model.
         component_list : list or None
             If None, the sum of all the components is returned. If list, only
@@ -164,7 +164,7 @@ class Model2D(BaseModel):
             component_list = self
         if not isinstance(component_list, (list, tuple)):
             raise ValueError(
-                "'Component_list' parameter need to be a list or None."
+                "'Component_list' parameter needs to be a list or None."
                 )
 
         if onlyactive:

--- a/hyperspy/models/model2d.py
+++ b/hyperspy/models/model2d.py
@@ -139,30 +139,49 @@ class Model2D(BaseModel):
         else:
             raise WrongObjectError(str(type(value)), 'Signal2D')
 
-    def __call__(self, non_convolved=True, onlyactive=False):
+    def __call__(self, non_convolved=True, onlyactive=False,
+                 component_list=None, binned=None):
         """Returns the corresponding 2D model for the current coordinates
 
         Parameters
         ----------
-        only_active : bool
+        non_convolved : bool
+            Not Implemented for Model2D
+        onlyactive : bool
             If true, only the active components will be used to build the
             model.
+        component_list : list or None
+            If None, the sum of all the components is returned. If list, only
+            the provided components are returned
+        binned : None
+            Not Implemented for Model2D
 
         Returns
         -------
         numpy array
         """
+        if component_list is None:
+            component_list = self
+        if not isinstance(component_list, (list, tuple)):
+            raise ValueError(
+                "'Component_list' parameter need to be a list or None."
+                )
+
+        if onlyactive:
+            component_list = [
+                component for component in component_list if component.active]
 
         sum_ = np.zeros_like(self.xaxis)
         if onlyactive is True:
-            for component in self:  # Cut the parameters list
+            for component in component_list:  # Cut the parameters list
                 if component.active:
                     np.add(sum_, component.function(self.xaxis, self.yaxis),
                            sum_)
         else:
-            for component in self:  # Cut the parameters list
+            for component in component_list:  # Cut the parameters list
                 np.add(sum_, component.function(self.xaxis, self.yaxis),
                        sum_)
+
         return sum_[self.channel_switches]
 
     def _errfunc(self, param, y, weights=None):

--- a/hyperspy/tests/component/test_component.py
+++ b/hyperspy/tests/component/test_component.py
@@ -287,6 +287,7 @@ def test_get_scaling_parameter(is_binned, non_uniform, dim):
     else:
         assert scaling_factor == 1
 
+
 class TestLinearProperties:
     def setup_method(self, method):
         self.C = Component(['one', 'two'])
@@ -294,9 +295,7 @@ class TestLinearProperties:
         self.G = Gaussian()
 
     def test_properties(self):
-        assert not self.C.linear_parameters
-        assert len(self.C.nonlinear_parameters) == 2
-        assert not self.P._is_linear
+        assert not self.P.linear
 
     def test_set_parameters_not_free_only_both(self):
         with pytest.raises(ValueError, match="set both only_linear"):
@@ -307,10 +306,23 @@ class TestLinearProperties:
             self.C.set_parameters_free(only_linear=True, only_nonlinear=True)
 
     def test_set_parameters_passing_parameters(self):
-        self.G.set_parameters_free(only_linear=True)
-        self.G.set_parameters_not_free(only_linear=True)
+        G = self.G
+        assert G.A.free
+        assert G.centre.free
+        assert G.sigma.free
 
-    def test_is_linear(self):
-        assert self.G.is_linear == False
-        self.G.set_parameters_not_free(only_nonlinear=True)
-        assert self.G.is_linear == True
+        G.set_parameters_free(only_linear=True)
+        assert G.A.free
+        assert G.centre.free
+        assert G.sigma.free
+
+        G.set_parameters_not_free(only_linear=True)
+        assert not G.A.free
+        assert G.centre.free
+        assert G.sigma.free
+
+        G.set_parameters_not_free(only_nonlinear=True)
+        G.set_parameters_free(only_linear=True)
+        assert G.A.free
+        assert not G.centre.free
+        assert not G.sigma.free

--- a/hyperspy/tests/component/test_component.py
+++ b/hyperspy/tests/component/test_component.py
@@ -198,6 +198,10 @@ class TestGeneralMethods:
         assert self.c.one.free
         assert self.c.two.free
 
+    def test_set_parameters_free_only_linear_only_nonlinear(self):
+        with pytest.raises(ValueError):
+            self.c.set_parameters_free(only_linear=True, only_nonlinear=True)
+
     def test_set_parameters_free_name(self):
         self.c.set_parameters_free(['one'])
         assert self.c.one.free
@@ -207,6 +211,12 @@ class TestGeneralMethods:
         self.c.set_parameters_not_free()
         assert not self.c.one.free
         assert not self.c.two.free
+
+    def test_set_parameters_not_free_only_linear_only_nonlinear(self):
+        with pytest.raises(ValueError):
+            self.c.set_parameters_not_free(
+                only_linear=True, only_nonlinear=True
+                )
 
     def test_set_parameters_not_free_name(self):
         self.c.one.free = True

--- a/hyperspy/tests/component/test_component.py
+++ b/hyperspy/tests/component/test_component.py
@@ -21,10 +21,8 @@ from unittest import mock
 
 import numpy as np
 
-from hyperspy.component import Component, Parameter
-from hyperspy._components.gaussian import Gaussian
 from hyperspy.axes import AxesManager
-from hyperspy.component import Component, _get_scaling_factor
+from hyperspy.component import Component, Parameter, _get_scaling_factor
 from hyperspy._signals.signal1d import Signal1D
 
 
@@ -288,41 +286,11 @@ def test_get_scaling_parameter(is_binned, non_uniform, dim):
         assert scaling_factor == 1
 
 
-class TestLinearProperties:
-    def setup_method(self, method):
-        self.C = Component(['one', 'two'])
-        self.P = Parameter()
-        self.G = Gaussian()
+def test_linear_parameter_initialisation():
 
-    def test_properties(self):
-        assert not self.P.linear
+    C = Component(['one', 'two'], ['one'])
+    P = Parameter()
 
-    def test_set_parameters_not_free_only_both(self):
-        with pytest.raises(ValueError, match="set both only_linear"):
-            self.C.set_parameters_not_free(only_linear=True, only_nonlinear=True)
-
-    def test_set_parameters_free_only_both(self):
-        with pytest.raises(ValueError, match="set both only_linear"):
-            self.C.set_parameters_free(only_linear=True, only_nonlinear=True)
-
-    def test_set_parameters_passing_parameters(self):
-        G = self.G
-        assert G.A.free
-        assert G.centre.free
-        assert G.sigma.free
-
-        G.set_parameters_free(only_linear=True)
-        assert G.A.free
-        assert G.centre.free
-        assert G.sigma.free
-
-        G.set_parameters_not_free(only_linear=True)
-        assert not G.A.free
-        assert G.centre.free
-        assert G.sigma.free
-
-        G.set_parameters_not_free(only_nonlinear=True)
-        G.set_parameters_free(only_linear=True)
-        assert G.A.free
-        assert not G.centre.free
-        assert not G.sigma.free
+    assert C.one.linear
+    assert not C.two.linear
+    assert not P.linear

--- a/hyperspy/tests/component/test_component.py
+++ b/hyperspy/tests/component/test_component.py
@@ -291,6 +291,6 @@ def test_linear_parameter_initialisation():
     C = Component(['one', 'two'], ['one'])
     P = Parameter()
 
-    assert C.one.linear
-    assert not C.two.linear
-    assert not P.linear
+    assert C.one._linear
+    assert not C.two._linear
+    assert not P._linear

--- a/hyperspy/tests/component/test_component_print_current.py
+++ b/hyperspy/tests/component/test_component_print_current.py
@@ -93,7 +93,7 @@ class TestSetParameters:
     @pytest.mark.parametrize("fancy", (True, False))
     def test_model_current_model_values(self, fancy):
         self.model.print_current_values(fancy=fancy)
-        
+
     @pytest.mark.parametrize("fancy", (True, False))
     def test_component_print_current_values(self, fancy):
         self.model[0].print_current_values(fancy=fancy)
@@ -108,7 +108,10 @@ class TestSetParameters:
 
     def test_zero_in_normal_print(self):
         "Ensure parameters with value=0 are printed too"
-        assert "            a0 |  True |          0 |" in str(current_component_values(self.model[0]).__repr__)
+        assert "            a0 |    True |          0 |" in str(current_component_values(self.model[0]).__repr__)
+
+    def test_twinned_in_print(self):
+        assert "             A | Twinned |" in str(current_component_values(self.model[2]).__repr__()).split('\n')[4]
 
     def test_related_tools(self):
         assert _is_iter([1,2,3])

--- a/hyperspy/tests/component/test_component_set_parameters.py
+++ b/hyperspy/tests/component/test_component_set_parameters.py
@@ -54,3 +54,27 @@ class TestSetParameters:
         free_parameters = len(g.free_parameters)
         parameters = len(g.parameters) - 2
         assert free_parameters == parameters
+
+    def test_set_parameters_not_free_linearity(self):
+        g = self.gaussian
+
+        g.set_parameters_not_free(only_nonlinear=True)
+        assert not g.sigma.free
+        assert not g.centre.free
+        assert g.A.free
+
+        g.set_parameters_not_free(only_linear=True)
+        assert not g.sigma.free
+        assert not g.centre.free
+        assert not g.A.free
+        
+        g.set_parameters_free(only_linear=True)
+        assert not g.sigma.free
+        assert not g.centre.free
+        assert g.A.free
+
+        g.set_parameters_free(only_nonlinear=True)
+        g.set_parameters_not_free(only_linear=True)
+        assert g.sigma.free
+        assert g.centre.free
+        assert not g.A.free

--- a/hyperspy/tests/component/test_component_set_parameters.py
+++ b/hyperspy/tests/component/test_component_set_parameters.py
@@ -67,7 +67,7 @@ class TestSetParameters:
         assert not g.sigma.free
         assert not g.centre.free
         assert not g.A.free
-        
+
         g.set_parameters_free(only_linear=True)
         assert not g.sigma.free
         assert not g.centre.free

--- a/hyperspy/tests/component/test_components.py
+++ b/hyperspy/tests/component/test_components.py
@@ -27,7 +27,6 @@ from hyperspy import components1d
 from hyperspy.component import Component
 from hyperspy.misc.test_utils import ignore_warning
 from hyperspy.models.model1d import Model1D
-from hyperspy._components.expression import extract_constant_part_of_expression
 
 TRUE_FALSE_2_TUPLE = [p for p in itertools.product((True, False), repeat=2)]
 
@@ -152,6 +151,8 @@ class TestDoublePowerLaw:
         g = hs.model.components1D.DoublePowerLaw()
         # Fix the ratio parameter to test the fit
         g.ratio.free = False
+        g.shift.free = False
+        g.origin.free = False
         g.ratio.value = 200
         m = s.create_model()
         m.append(g)
@@ -425,86 +426,6 @@ class TestGaussian:
         factor = axis.scale if binned else 1
         np.testing.assert_allclose(g.function_nd(axis.axis) * factor, s2.data)
 
-
-class TestExpression:
-
-    def setup_method(self, method):
-        self.g = hs.model.components1D.Expression(
-            expression="height * exp(-(x - x0) ** 2 * 4 * log(2)/ fwhm ** 2)",
-            name="Gaussian",
-            position="x0",
-            height=1,
-            fwhm=1,
-            x0=0,
-            module="numpy")
-
-    def test_name(self):
-        assert self.g.name == "Gaussian"
-
-    def test_position(self):
-        assert self.g._position is self.g.x0
-
-    def test_f(self):
-        assert self.g.function(0) == 1
-
-    def test_grad_height(self):
-        np.testing.assert_allclose(
-            self.g.grad_height(2),
-            1.5258789062500007e-05)
-
-    def test_grad_x0(self):
-        np.testing.assert_allclose(
-            self.g.grad_x0(2),
-            0.00016922538587889289)
-
-    def test_grad_fwhm(self):
-        np.testing.assert_allclose(
-            self.g.grad_fwhm(2),
-            0.00033845077175778578)
-
-    def test_function_nd(self):
-        assert self.g.function_nd(0) == 1
-
-
-def test_expression_symbols():
-    with pytest.raises(ValueError):
-        hs.model.components1D.Expression(expression="10.0", name="offset")
-    with pytest.raises(ValueError):
-        hs.model.components1D.Expression(expression="10", name="offset")
-    with pytest.raises(ValueError):
-        hs.model.components1D.Expression(expression="10*offset", name="Offset")
-
-
-def test_expression_substitution():
-    expr = 'A / B; A = x+2; B = x-c'
-    comp = hs.model.components1D.Expression(expr, name='testcomp',
-                                            autodoc=True,
-                                            c=2)
-    assert ''.join(p.name for p in comp.parameters) == 'c'
-    assert comp.function(1) == -3
-
-
-def test_expression_extract():
-    const, not_const = extract_constant_part_of_expression("a*x+b",)
-    assert str(const) == 'a*x + b'
-    assert str(not_const) == '0'
-
-    const, not_const = extract_constant_part_of_expression("a*x+b-3", "a", "b")
-    assert str(const) == '-3'
-    assert str(not_const) == 'a*x + b'
-
-
-def test_separate_pseudocomponents():
-    A = hs.model.components1D.Expression("a*b*x+c**2*x", "test")
-    free, fixed = A._separate_pseudocomponents()
-    assert list(free.keys()) == ['a', 'b', 'c']
-    assert list(fixed.keys()) == ['function', 'parameters']
-
-    A.a.free = False
-    A.b.free = False
-
-    free, fixed = A._separate_pseudocomponents()
-    assert list(free.keys()) == ['c']
 
 
 class TestScalableFixedPattern:

--- a/hyperspy/tests/component/test_components.py
+++ b/hyperspy/tests/component/test_components.py
@@ -609,9 +609,9 @@ class TestScalableFixedPattern:
         fp = hs.model.components1D.ScalableFixedPattern(
             s1, interpolate=interpolate
             )
-        assert fp.yscale.linear
-        assert not fp.xscale.linear
-        assert not fp.shift.linear
+        assert fp.yscale._linear
+        assert not fp.xscale._linear
+        assert not fp.shift._linear
 
         m = s.create_model()
         m.append(fp)
@@ -621,9 +621,9 @@ class TestScalableFixedPattern:
         m2._load_dictionary(model_dict)
         assert m2[0].interpolate == interpolate
         np.testing.assert_allclose(m2[0].signal.data, s1.data)
-        assert m2[0].yscale.linear
-        assert not m2[0].xscale.linear
-        assert not m2[0].shift.linear
+        assert m2[0].yscale._linear
+        assert not m2[0].xscale._linear
+        assert not m2[0].shift._linear
 
 
 class TestHeavisideStep:

--- a/hyperspy/tests/component/test_components.py
+++ b/hyperspy/tests/component/test_components.py
@@ -27,6 +27,7 @@ from hyperspy import components1d
 from hyperspy.component import Component
 from hyperspy.misc.test_utils import ignore_warning
 from hyperspy.models.model1d import Model1D
+from hyperspy._components.expression import extract_constant_part_of_expression
 
 TRUE_FALSE_2_TUPLE = [p for p in itertools.product((True, False), repeat=2)]
 
@@ -473,6 +474,32 @@ def test_expression_substitution():
     assert ''.join(p.name for p in comp.parameters) == 'c'
     assert comp.function(1) == -3
 
+
+def test_expression_extract():
+    const, not_const = extract_constant_part_of_expression("a*x+b",)
+    assert str(const) == 'a*x + b'
+    assert str(not_const) == '0'
+
+def test_expression_extract():
+    const, not_const = extract_constant_part_of_expression("a*x+b",)
+    assert str(const) == 'a*x + b'
+    assert str(not_const) == '0'
+
+    const, not_const = extract_constant_part_of_expression("a*x+b-3", "a", "b")
+    assert str(const) == '-3'
+    assert str(not_const) == 'a*x + b'
+
+def test_separate_pseudocomponents():
+    A = hs.model.components1D.Expression("a*b*x+c**2*x", "test")
+    free, fixed = A._separate_pseudocomponents()
+    assert list(free.keys()) == ['a', 'b', 'c']
+    assert list(fixed.keys()) == ['function', 'parameters']
+
+    A.a.free = False
+    A.b.free = False
+
+    free, fixed = A._separate_pseudocomponents()
+    assert list(free.keys()) == ['c']
 
 class TestScalableFixedPattern:
 

--- a/hyperspy/tests/component/test_exponential.py
+++ b/hyperspy/tests/component/test_exponential.py
@@ -89,3 +89,15 @@ def test_function_nd(binned, lazy):
 
     assert g2._axes_manager[-1].is_binned == binned
     np.testing.assert_allclose(g2.function_nd(axis.axis) * factor, s2.data, rtol=0.05)
+
+
+class TestLinearExponential:
+    def setup_method(self, method):
+        self.E = Exponential()
+
+    def test_properties(self):
+        assert self.E.A._is_linear
+        assert not self.E.tau._is_linear
+
+        assert len(self.E.linear_parameters) == 1
+        assert len(self.E.nonlinear_parameters) == 1

--- a/hyperspy/tests/component/test_exponential.py
+++ b/hyperspy/tests/component/test_exponential.py
@@ -96,8 +96,5 @@ class TestLinearExponential:
         self.E = Exponential()
 
     def test_properties(self):
-        assert self.E.A._is_linear
-        assert not self.E.tau._is_linear
-
-        assert len(self.E.linear_parameters) == 1
-        assert len(self.E.nonlinear_parameters) == 1
+        assert self.E.A.linear
+        assert not self.E.tau.linear

--- a/hyperspy/tests/component/test_exponential.py
+++ b/hyperspy/tests/component/test_exponential.py
@@ -96,5 +96,5 @@ class TestLinearExponential:
         self.E = Exponential()
 
     def test_properties(self):
-        assert self.E.A.linear
-        assert not self.E.tau.linear
+        assert self.E.A._linear
+        assert not self.E.tau._linear

--- a/hyperspy/tests/component/test_expression.py
+++ b/hyperspy/tests/component/test_expression.py
@@ -1,0 +1,148 @@
+# -*- coding: utf-8 -*-
+# Copyright 2007-2022 The HyperSpy developers
+#
+# This file is part of HyperSpy.
+#
+# HyperSpy is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# HyperSpy is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with HyperSpy. If not, see <http://www.gnu.org/licenses/>.
+
+import numpy as np
+import pytest
+
+import hyperspy.api as hs
+
+class TestExpression:
+
+    def setup_method(self, method):
+        self.g = hs.model.components1D.Expression(
+            expression="height * exp(-(x - x0) ** 2 * 4 * log(2)/ fwhm ** 2)",
+            name="Gaussian",
+            position="x0",
+            height=1,
+            fwhm=1,
+            x0=0,
+            module="numpy")
+
+    def test_name(self):
+        assert self.g.name == "Gaussian"
+
+    def test_position(self):
+        assert self.g._position is self.g.x0
+
+    def test_f(self):
+        assert self.g.function(0) == 1
+
+    def test_grad_height(self):
+        np.testing.assert_allclose(
+            self.g.grad_height(2),
+            1.5258789062500007e-05)
+
+    def test_grad_x0(self):
+        np.testing.assert_allclose(
+            self.g.grad_x0(2),
+            0.00016922538587889289)
+
+    def test_grad_fwhm(self):
+        np.testing.assert_allclose(
+            self.g.grad_fwhm(2),
+            0.00033845077175778578)
+
+    def test_function_nd(self):
+        assert self.g.function_nd(0) == 1
+
+
+def test_expression_symbols():
+    with pytest.raises(ValueError):
+        hs.model.components1D.Expression(expression="10.0", name="offset")
+    with pytest.raises(ValueError):
+        hs.model.components1D.Expression(expression="10", name="offset")
+    with pytest.raises(ValueError):
+        hs.model.components1D.Expression(expression="10*offset", name="Offset")
+
+
+def test_expression_substitution():
+    expr = 'A / B; A = x+2; B = x-c'
+    comp = hs.model.components1D.Expression(expr, name='testcomp',
+                                            autodoc=True,
+                                            c=2)
+    assert ''.join(p.name for p in comp.parameters) == 'c'
+    assert comp.function(1) == -3
+
+
+def test_separate_pseudocomponents():
+    A = hs.model.components1D.Expression("a*b*x+c**2*x", "test")
+    free, fixed = A._separate_pseudocomponents()
+    assert list(free.keys()) == ['a', 'b', 'c']
+    assert list(fixed.keys()) == ['function', 'parameters']
+
+    A.a.free = False
+    A.b.free = False
+
+    free, fixed = A._separate_pseudocomponents()
+    assert list(free.keys()) == ['c']
+
+
+def test_separate_pseudocomponents_expression_rename_parameters():
+    l = hs.model.components1D.Lorentzian()
+    free, fixed = l._separate_pseudocomponents()
+    assert list(free.keys()) == ['A', 'centre', 'gamma']
+    assert list(fixed.keys()) == ['function', 'parameters']
+
+    l.centre.free = False
+    l.gamma.free = False
+
+    free, fixed = l._separate_pseudocomponents()
+    assert list(free.keys()) == ['A']
+    
+
+def test_linear_rename_parameters():
+    # with the lorentzian component, the gamma component is rename
+    l = hs.model.components1D.Lorentzian()
+    assert l.A._linear
+    assert not l.gamma._linear
+    assert not l.centre._linear
+
+    g = hs.model.components1D.Expression(
+            expression="height * exp(-(x - x0) ** 2 * 4 * log(2)/ fwhm ** 2)",
+            name="Gaussian",
+            rename_pars={'height':'O'}
+            )
+    assert not hasattr(g, 'height')
+    assert g.O._linear
+    assert not g.fwhm._linear
+    assert not g.x0._linear
+    
+
+def test_constant_term_rename_parameters():
+    g = hs.model.components1D.Expression(
+            expression="height * exp(-(x - x0) ** 2 * 4 * log(2)/ fwhm ** 2) + 10",
+            name="Gaussian",
+            fwhm=1.0,
+            )
+    assert g._constant_term == 10.
+
+    g = hs.model.components1D.Expression(
+            expression="height * exp(-(x - x0) ** 2 * 4 * log(2)/ fwhm ** 2) + 10",
+            name="Gaussian",
+            rename_pars={'height':'O'},
+            fwhm=1.0,
+            )
+    assert g._constant_term == 10.
+
+    g = hs.model.components1D.Expression(
+            expression="height * exp(-(x - x0) ** 2 * 4 * log(2)/ fwhm ** 2) + 10",
+            name="Gaussian",
+            rename_pars={'x0':'O'},
+            fwhm=1.0,
+            )
+    assert g._constant_term == 10.

--- a/hyperspy/tests/component/test_powerlaw.py
+++ b/hyperspy/tests/component/test_powerlaw.py
@@ -41,9 +41,9 @@ def test_linear_override():
     g = PowerLaw()
     for para in g.parameters:
         if para is g.A:
-            assert para.linear
+            assert para._linear
         else:
-            assert not para.linear
+            assert not para._linear
 
 
 @pytest.mark.parametrize(("lazy"), (True, False))

--- a/hyperspy/tests/component/test_powerlaw.py
+++ b/hyperspy/tests/component/test_powerlaw.py
@@ -36,15 +36,15 @@ def test_function():
     assert g.function(2) == 1
     assert g.function(1) == 0.25
 
+
 def test_linear_override():
     g = PowerLaw()
     for para in g.parameters:
         if para is g.A:
-            assert para._is_linear
-            assert para._is_linear_override
+            assert para.linear
         else:
-            assert not para._is_linear
-            assert not para._is_linear_override
+            assert not para.linear
+
 
 @pytest.mark.parametrize(("lazy"), (True, False))
 @pytest.mark.parametrize(("only_current", "binned"), TRUE_FALSE_2_TUPLE)
@@ -66,6 +66,7 @@ def test_estimate_parameters_binned(only_current, binned, lazy):
     # error of the estimate function is rather large, esp. when binned=FALSE
     np.testing.assert_allclose(g1.A.value, g2.A.value * factor, rtol=0.05)
     assert abs(g2.r.value - g1.r.value) <= 2e-2
+
 
 @pytest.mark.parametrize(("lazy"), (True, False))
 @pytest.mark.parametrize(("binned"), (True, False))

--- a/hyperspy/tests/component/test_powerlaw.py
+++ b/hyperspy/tests/component/test_powerlaw.py
@@ -36,6 +36,16 @@ def test_function():
     assert g.function(2) == 1
     assert g.function(1) == 0.25
 
+def test_linear_override():
+    g = PowerLaw()
+    for para in g.parameters:
+        if para is g.A:
+            assert para._is_linear
+            assert para._is_linear_override
+        else:
+            assert not para._is_linear
+            assert not para._is_linear_override
+
 @pytest.mark.parametrize(("lazy"), (True, False))
 @pytest.mark.parametrize(("only_current", "binned"), TRUE_FALSE_2_TUPLE)
 def test_estimate_parameters_binned(only_current, binned, lazy):

--- a/hyperspy/tests/drawing/test_plot_model.py
+++ b/hyperspy/tests/drawing/test_plot_model.py
@@ -161,3 +161,12 @@ def test_plot_component():
     assert ax.get_ylim() == (-0.1, 49.0)
     m.append(p)
     m.signal._plot.close()
+
+
+@pytest.mark.parametrize(("only_free"), [False, True])
+@pytest.mark.parametrize(("only_active"), [False, True])
+def test_plot_results(only_free, only_active):
+    m = hs.signals.Signal1D(np.arange(100).reshape(2, 50)).create_model()
+    m.append(hs.model.components1D.Gaussian(A=250, sigma=5, centre=20))
+    m.plot_results(only_free=only_free, only_active=only_active)
+    

--- a/hyperspy/tests/model/test_constant.py
+++ b/hyperspy/tests/model/test_constant.py
@@ -16,35 +16,51 @@
 # You should have received a copy of the GNU General Public License
 # along with  HyperSpy.  If not, see <http://www.gnu.org/licenses/>.
 
-from hyperspy.components1d import Expression, Gaussian
-from hyperspy._signals.signal1d import Signal1D
 import numpy as np
 
+from hyperspy.components1d import Expression
+from hyperspy._signals.signal1d import Signal1D
+
+
 class TestLinearFitting:
+
     def setup_method(self, method):
-        self.s = Signal1D(np.zeros((4,5, 20)))
+        self.s = Signal1D(np.zeros((4, 5, 20)))
         self.m = self.s.create_model()
+
+    def test_constant_term_without_model(self):
+        expression = "a * x + b"
+        g = Expression(
+            expression,
+            name="test_constant",
+            a = 20.0,
+            b = 4.0)
+        assert g._constant_term == 0
+        self.m.append(g)
+        assert g._constant_term == 0
 
     def test_constant_from_expression(self):
         expression = "a * x + b"
         g = Expression(
-            expression, 
+            expression,
             name="test_constant",
             a = 20.0,
             b = 4.0)
-        self.m.append(g)
         g.b.free = False
+        assert g._constant_term == 4.0
+        self.m.append(g)
         assert g._constant_term == 4.0
 
     def test_constant_from_expression2(self):
         expression = "A * exp(-(x-centre)**2/(2*sigma**2))"
         h = Expression(
-            expression, 
+            expression,
             name="test_constant2",
             A = 20.0,
             centre = 4.0,
             sigma = 1.0)
         self.m.append(h)
+
         assert h._constant_term == 0
         h.centre.free = False
         h.sigma.free = False

--- a/hyperspy/tests/model/test_constant.py
+++ b/hyperspy/tests/model/test_constant.py
@@ -1,0 +1,51 @@
+# -*- coding: utf-8 -*-
+# Copyright 2007-2016 The HyperSpy developers
+#
+# This file is part of  HyperSpy.
+#
+#  HyperSpy is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+#  HyperSpy is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with  HyperSpy.  If not, see <http://www.gnu.org/licenses/>.
+
+from hyperspy.components1d import Expression, Gaussian
+from hyperspy._signals.signal1d import Signal1D
+import numpy as np
+
+class TestLinearFitting:
+    def setup_method(self, method):
+        self.s = Signal1D(np.zeros((4,5, 20)))
+        self.m = self.s.create_model()
+
+    def test_constant_from_expression(self):
+        expression = "a * x + b"
+        g = Expression(
+            expression, 
+            name="test_constant",
+            a = 20.0,
+            b = 4.0)
+        self.m.append(g)
+        g.b.free = False
+        assert g._constant_term == 4.0
+
+    def test_constant_from_expression2(self):
+        expression = "A * exp(-(x-centre)**2/(2*sigma**2))"
+        h = Expression(
+            expression, 
+            name="test_constant2",
+            A = 20.0,
+            centre = 4.0,
+            sigma = 1.0)
+        self.m.append(h)
+        assert h._constant_term == 0
+        h.centre.free = False
+        h.sigma.free = False
+        assert h._constant_term == 0

--- a/hyperspy/tests/model/test_eelsmodel.py
+++ b/hyperspy/tests/model/test_eelsmodel.py
@@ -96,7 +96,7 @@ class TestCreateEELSModel:
 class TestEELSModel:
 
     def setup_method(self, method):
-        s = hs.signals.EELSSpectrum(np.zeros(200))
+        s = hs.signals.EELSSpectrum(np.ones(200))
         s.set_microscope_parameters(100, 10, 10)
         s.axes_manager[-1].offset = 150
         s.add_elements(("B", "C"))
@@ -183,6 +183,12 @@ class TestEELSModel:
     def test_get_start_energy_below(self):
         assert (self.m._get_start_energy(100) ==
                 150)
+
+    def test_remove_components(self):
+        comp = self.m[1]
+        assert len(self.m) == 3
+        self.m.remove(comp)
+        assert len(self.m) == 2
 
 
 @lazifyTestClass

--- a/hyperspy/tests/model/test_fit_component.py
+++ b/hyperspy/tests/model/test_fit_component.py
@@ -197,7 +197,10 @@ class TestFitSI:
 
 @lazifyTestClass
 class TestStdWithMultipleFitters:
-    'Test that error estimation is approximately the same for all fitters, with both positive and negative components'
+    """
+    Test that error estimation is approximately the same for all
+    fitters, with both positive and negative components
+    """
 
     def setup_method(self, method):
         np.random.seed(1)

--- a/hyperspy/tests/model/test_fit_component.py
+++ b/hyperspy/tests/model/test_fit_component.py
@@ -231,6 +231,11 @@ class TestStdWithMultipleFitters:
     def test_fitters(self, optimizer):
         if optimizer == "ridge_regression":
             pytest.importorskip("sklearn")
-        self.m.fit(optimizer=optimizer)
-        np.testing.assert_almost_equal(self.g1.A.std, 0.29659216)
-        np.testing.assert_almost_equal(self.g1.A.std, self.g2.A.std)
+
+        if self.m.signal._lazy and optimizer == "ridge_regression":
+            with pytest.raises(ValueError):
+                self.m.fit(optimizer=optimizer)
+        else:
+            self.m.fit(optimizer=optimizer)
+            np.testing.assert_almost_equal(self.g1.A.std, 0.29659216)
+            np.testing.assert_almost_equal(self.g1.A.std, self.g2.A.std)

--- a/hyperspy/tests/model/test_fitting.py
+++ b/hyperspy/tests/model/test_fitting.py
@@ -289,7 +289,7 @@ class TestModelFitBinnedGlobal:
 
     # See https://github.com/scipy/scipy/issues/14589
     @pytest.mark.xfail(Version(scipy.__version__) >= Version("1.8.0"),
-                       reason="Regression introduced in 1.8.0.")
+                       reason="Regression introduced in scipy 1.8.0.")
     def test_fit_shgo(self):
         pytest.importorskip("scipy", minversion="1.2.0")
         self.m.fit(optimizer="SHGO", loss_function="ls", bounded=True)

--- a/hyperspy/tests/model/test_linear_model.py
+++ b/hyperspy/tests/model/test_linear_model.py
@@ -1,3 +1,21 @@
+# -*- coding: utf-8 -*-
+# Copyright 2007-2022 The HyperSpy developers
+#
+# This file is part of HyperSpy.
+#
+# HyperSpy is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# HyperSpy is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with HyperSpy. If not, see <http://www.gnu.org/licenses/>.
+
 import numpy as np
 import pytest
 
@@ -284,7 +302,7 @@ class TestWarningSlowMultifit:
         m = self.m
         m.convolved = True
         with pytest.warns(UserWarning,
-                          match="convolution is not supported for"):
+                          match="convolution is not supported"):
             m.multifit(optimizer='lstsq')
 
     def test_active_is_multidimensional_all_active(self):

--- a/hyperspy/tests/model/test_linear_model.py
+++ b/hyperspy/tests/model/test_linear_model.py
@@ -1,0 +1,599 @@
+import numpy as np
+import pytest
+
+from hyperspy._signals.signal1d import Signal1D
+from hyperspy._signals.signal2d import Signal2D
+
+from hyperspy.component import Component
+from hyperspy.components1d import Gaussian, Expression, Offset
+from hyperspy.components2d import Gaussian2D
+
+from hyperspy.datasets.example_signals import EDS_SEM_Spectrum
+from hyperspy.datasets.artificial_data import get_low_loss_eels_signal
+from hyperspy.datasets.artificial_data import get_core_loss_eels_signal
+from hyperspy.misc.model_tools import get_top_parent_twin, check_top_parent_twins_are_active
+from hyperspy.decorators import lazifyTestClass
+from hyperspy.misc.model_tools import parameter_map_values_all_identical, all_set_non_free_para_have_identical_values
+
+class TestModelFitBinned:
+
+    def setup_method(self, method):
+        np.random.seed(1)
+        s = Signal1D(
+            np.random.normal(
+                scale=2,
+                size=10000)).get_histogram()
+        s.axes_manager[-1].binned = True
+        g = Gaussian()
+        m = s.create_model()
+        m.append(g)
+        g.sigma.value = 1
+        g.centre.value = 0.5
+        g.A.value = 1e3
+        self.m = m
+
+    def test_model_is_not_linear(self):
+        """
+        Model is not currently linear as Gaussian sigma and centre parameters
+        are free
+        """
+        assert self.m.nonlinear_parameters
+
+    def test_fit_linear(self):
+        self.m[0].sigma.free = False
+        self.m[0].centre.free = False
+        self.m.fit(optimizer='lstsq')
+        np.testing.assert_allclose(self.m[0].A.value, 6132.640632924692, 1)
+        np.testing.assert_allclose(self.m[0].centre.value, 0.5)
+        np.testing.assert_allclose(self.m[0].sigma.value, 1)
+
+@lazifyTestClass
+class TestMultiFitLinear:
+
+    def setup_method(self):
+        np.random.seed(1)
+        x = np.random.random(30)
+        shape = np.random.random((2,3,1))
+        X = shape*x
+        self.s = Signal1D(X)
+        self.m = self.s.create_model()
+
+    def test_gaussian(self):
+        m = self.m
+        L = Gaussian(centre=15.)
+        L.centre.free = L.sigma.free = False
+        m.append(L)
+
+        m.fit(optimizer='lstsq')
+        single = m.as_signal()
+        m.assign_current_values_to_all()
+        m.multifit(optimizer='lstsq', iterpath='serpentine')
+        multi = m.as_signal()
+
+        np.testing.assert_almost_equal(
+            single.inav[0,0].data, multi.inav[0,0].data)
+
+    def test_map_values_std_isset(self):
+        m = self.m
+        L = Gaussian(centre=15.)
+        L.centre.free = L.sigma.free = False
+        m.append(L)
+
+        m.multifit(iterpath="serpentine")
+        nonlinear = L.A.map.copy()
+
+        L.A.map['is_set'] = False
+        m.multifit(optimizer='lstsq', calculate_errors=True)
+        linear = L.A.map.copy()
+
+        np.testing.assert_almost_equal(nonlinear['values'], linear['values'])
+        np.testing.assert_almost_equal(nonlinear['std'], linear['std'])
+        np.testing.assert_almost_equal(nonlinear['is_set'], linear['is_set'])
+
+        m.multifit(optimizer='lstsq', calculate_errors=False)
+        np.testing.assert_equal(L.A.map['std'], np.nan)
+
+    def test_offset(self):
+        m = self.m
+        L = Offset(offset=1.)
+        m.append(L)
+
+        m.fit(optimizer='lstsq')
+        single = m.as_signal()
+        m.assign_current_values_to_all()
+        m.multifit(optimizer='lstsq', iterpath='serpentine')
+        multi = m.as_signal()
+        # compare fits from first pixel
+        np.testing.assert_almost_equal(
+            single.inav[0,0].data, multi.inav[0,0].data)
+
+    def test_channel_switches(self):
+        m = self.m
+        m.channel_switches[5:-5] = False
+        L = Gaussian(centre=15.)
+        L.centre.free = L.sigma.free = False
+        m.append(L)
+
+        m.fit(optimizer='lstsq')
+        single = m.as_signal()
+        m.assign_current_values_to_all()
+        m.multifit(optimizer='lstsq', iterpath='serpentine')
+        multi = m.as_signal()
+
+        np.testing.assert_almost_equal(
+            single.inav[0,0].data, multi.inav[0,0].data)
+
+        m.fit()
+        single_nonlinear = m.as_signal()
+        np.testing.assert_almost_equal(
+            single.inav[0,0].data, single_nonlinear.inav[0,0].data)
+
+class TestLinearFitting:
+    def setup_method(self, method):
+        self.s = EDS_SEM_Spectrum().isig[5.0:15.0]
+        self.m = self.s.create_model(auto_background=False)
+        self.c = Expression('a*x+b', 'line with offset')
+        self.m.append(self.c)
+
+    def test_linear_fitting_with_offset(self):
+        m = self.m
+        m.fit(optimizer='lstsq')
+        linear = m.as_signal()
+        np.testing.assert_allclose(m.p0, np.array([933.2343071493418, 47822.98004150301, -5867.611808815612, 56805.518919752234]))
+
+        # Repeat test with offset fixed
+        self.c.b.free = False
+        m.fit(optimizer='lstsq')
+        linear = m.as_signal()
+        np.testing.assert_allclose(m.p0, np.array([933.2343071496773, 47822.98004150315, -5867.611808815624]))
+
+    def test_fixed_offset_value(self):
+        self.m.fit(optimizer='lstsq')
+        c = self.c
+        c.b.free = False
+        constant = c._compute_constant_term()
+        np.testing.assert_array_almost_equal(constant, c.b.value)
+
+    def test_constant(self):
+        self.c.b.value = -5
+        self.c.b.free = False
+        assert self.c._constant_term == self.c.b.value
+
+@lazifyTestClass
+class TestFitAlgorithms:
+    def setup_method(self, method):
+        s = EDS_SEM_Spectrum().isig[5.0:15.0]
+        self.m = s.create_model(auto_background=False)
+        self.c = Expression('a*x+b', 'line with offset')
+        self.m.append(self.c)
+        self.m.fit()
+        self.nonlinear_fit = self.m.as_signal()
+        self.nonlinear_std = [para.std for para in (self.m.linear_parameters + self.m.nonlinear_parameters) if para.std]
+
+    def test_compare_lstsq(self):
+        m = self.m
+        m.fit(optimizer='lstsq')
+        lstsq_fit = m.as_signal()
+        np.testing.assert_array_almost_equal(self.nonlinear_fit.data, lstsq_fit.data)
+        linear_std = [para.std for para in (self.m.linear_parameters + self.m.nonlinear_parameters) if para.std]
+        np.testing.assert_array_almost_equal(self.nonlinear_std, linear_std, decimal=4)
+
+    def test_nonactive_component(self):
+        m = self.m
+        m[1].active = False
+        m.fit(optimizer='lstsq')
+        linear_fit = m.as_signal()
+        m.fit()
+        nonlinear_fit = m.as_signal()
+        np.testing.assert_array_almost_equal(nonlinear_fit.data, linear_fit.data)
+
+    def test_compare_ridge(self):
+        pytest.importorskip("sklearn")
+        m = self.m
+        if m.signal._lazy:
+            with pytest.warns(UserWarning, match="'ridge_regression' optimizer on a lazy signal"):
+                m.fit(optimizer='ridge_regression')
+        else:
+            m.fit(optimizer='ridge_regression')
+        ridge_fit = m.as_signal()
+        np.testing.assert_array_almost_equal(self.nonlinear_fit.data, ridge_fit.data)
+        linear_std = [para.std for para in (self.m.linear_parameters + self.m.nonlinear_parameters) if para.std]
+        np.testing.assert_array_almost_equal(self.nonlinear_std, linear_std, decimal=4)
+
+@lazifyTestClass
+class TestLinearEELSFitting:
+    def setup_method(self, method):
+        self.ll = get_low_loss_eels_signal()
+        self.cl = get_core_loss_eels_signal()
+        self.cl.add_elements(('Mn',))
+        self.m = self.cl.create_model(auto_background=False)
+        self.m[0].onset_energy.value = 673.
+        self.m_convolved = self.cl.create_model(auto_background=False, ll=self.ll)
+        self.m_convolved[0].onset_energy.value = 673.
+
+    def test_convolved_and_std_error(self):
+        m = self.m_convolved
+        m.fit(optimizer='lstsq')
+        linear = m.as_signal()
+        std_linear = m.p_std
+        m.fit(optimizer='lm')
+        lm = m.as_signal()
+        std_lm = m.p_std
+        diff = linear - lm
+        np.testing.assert_almost_equal(diff.data.sum(), 0.0, decimal=2)
+        np.testing.assert_almost_equal(std_linear, std_lm, decimal=5)
+
+    def test_nonconvolved(self):
+        m = self.m
+        m.fit(optimizer='lstsq')
+        linear = m.as_signal()
+        m.fit(optimizer='lm')
+        lm = m.as_signal()
+        diff = linear - lm
+        np.testing.assert_almost_equal(diff.data.sum(), 0.0, decimal=2)
+
+class TestLinearModel2D:
+    def setup_method(self, method):
+        low, high = -10, 10
+        N = 100
+        self.x = self.y = np.linspace(low, high, N)
+        self.mesh = np.meshgrid(self.x, self.y)
+
+    def test_model2D_one_component(self):
+        G1 = Gaussian2D(30, 5.0, 4.0, 0, 0)
+
+        data = G1.function(*self.mesh)
+        s = Signal2D(data)
+        s.axes_manager[-2].offset = self.x[0]
+        s.axes_manager[-1].offset = self.y[0]
+
+        s.axes_manager[-2].scale = self.x[1] - self.x[0]
+        s.axes_manager[-1].scale = self.y[1] - self.y[0]
+
+        m = s.create_model()
+        m.append(G1)
+
+        G1.set_parameters_not_free()
+        G1.A.free = True
+
+        m.fit(optimizer='lstsq')
+        diff = (s - m.as_signal(show_progressbar=False))
+        np.testing.assert_almost_equal(diff.data.sum(), 0.0)
+        np.testing.assert_almost_equal(m.p_std[0], 0.0)
+
+    def test_model2D_linear_many_gaussians(self):
+        gausslow, gausshigh = -8, 8
+        gauss_step = 8
+        X, Y = self.mesh
+        z = np.zeros(X.shape)
+        g = Gaussian2D()
+        for i in np.arange(gausslow, gausshigh+1, gauss_step):
+            for j in np.arange(gausslow, gausshigh+1, gauss_step):
+                g.centre_x.value = i
+                g.centre_y.value = j
+                g.A.value = 10
+                z += g.function(X, Y)
+
+        s = Signal2D(z)
+        s.axes_manager[-2].offset = self.x[0]
+        s.axes_manager[-1].offset = self.y[0]
+
+        s.axes_manager[-2].scale = self.x[1] - self.x[0]
+        s.axes_manager[-1].scale = self.y[1] - self.y[0]
+
+        m = s.create_model()
+        for i in np.arange(gausslow, gausshigh+1, gauss_step):
+            for j in np.arange(gausslow, gausshigh+1, gauss_step):
+                g = Gaussian2D(centre_x = i, centre_y=j)
+                g.set_parameters_not_free()
+                g.A.free = True
+                m.append(g)
+
+        m.fit(optimizer='lstsq')
+        np.testing.assert_array_almost_equal(s.data, m.as_signal().data)
+
+    def test_model2D_polyexpression(self):
+        poly = "a*x**2 + b*x - c*y**2 + d*y + e"
+        P = Expression(poly, 'poly')
+        P.a.value = 6
+        P.b.value = 5
+        P.c.value = 4
+        P.d.value = 3
+        P.e.value = 2
+        
+        data = P.function(*self.mesh)
+        s = Signal2D(data)
+
+        m = s.create_model()
+        m.append(P)
+        m.fit(optimizer='lstsq')
+        diff = (s - m.as_signal(show_progressbar=False))
+        np.testing.assert_almost_equal(diff.data.sum(), 0.0, decimal=2)
+        np.testing.assert_almost_equal(m.p_std, 0.0, decimal=2)
+
+class TestLinearFitTwins:
+    def setup_method(self, method):
+        from hyperspy._components.gaussian import Gaussian
+        from hyperspy._signals.signal1d import Signal1D
+        g1 = Gaussian(centre=10)
+        g2 = Gaussian(centre=20)
+        g3 = Gaussian(centre=30)
+
+        g3.A.twin = g2.A
+        g3.A.twin_function_expr = "-0.5*x"
+        g2.A.twin = g1.A
+        g2.A.twin_function_expr = "-0.5*x"
+
+        g1.A.value = 20
+        x = np.linspace(0, 50, 1000)
+
+        y = g1.function(x) + g2.function(x) + g3.function(x)
+        s = Signal1D(y)
+        s.axes_manager[-1].scale = x[1] - x[0]
+
+        gs = [g1, g2, g3]
+        m = s.create_model()
+        m.extend(gs)
+        self.s, self.m, self.gs = s, m, gs
+
+    def test_get_parent_twin(self):
+        assert get_top_parent_twin(self.gs[2].A) is self.gs[0].A
+        assert get_top_parent_twin(self.gs[1].A) is self.gs[0].A
+        assert get_top_parent_twin(self.gs[0].A) is self.gs[0].A
+
+    def test_top_parent_twins_are_active(self):
+        assert check_top_parent_twins_are_active(self.gs[0])
+        assert check_top_parent_twins_are_active(self.gs[1])
+        assert check_top_parent_twins_are_active(self.gs[2])
+
+        self.gs[2].active = False
+        assert check_top_parent_twins_are_active(self.gs[0])
+        assert check_top_parent_twins_are_active(self.gs[1])
+        assert not check_top_parent_twins_are_active(self.gs[2])
+
+        self.gs[0].active = False
+        assert not check_top_parent_twins_are_active(self.gs[0])
+        assert not check_top_parent_twins_are_active(self.gs[1])
+        assert not check_top_parent_twins_are_active(self.gs[2])
+
+    def test_without_twins(self):
+        for g in self.gs:
+            g.sigma.free = False
+            g.centre.free = False
+            g.A.twin = None
+
+        self.gs[0].A.value = 1
+        self.m.fit(optimizer='lstsq')
+
+        np.testing.assert_almost_equal(self.gs[0].A.value, 20)
+        np.testing.assert_almost_equal(self.gs[1].A.value, -10)
+        np.testing.assert_almost_equal(self.gs[2].A.value, 5)
+        np.testing.assert_array_almost_equal((self.s - self.m.as_signal()).data, 0)
+
+    def test_with_twins(self):
+        for g in self.gs:
+            g.sigma.free = False
+            g.centre.free = False
+
+        self.gs[0].A.value = 1
+        self.m.fit(optimizer='lstsq')
+        
+        np.testing.assert_almost_equal(self.gs[0].A.value, 20)
+        np.testing.assert_almost_equal(self.gs[1].A.value, -10)
+        np.testing.assert_almost_equal(self.gs[2].A.value, 5)
+        np.testing.assert_array_almost_equal((self.s - self.m.as_signal()).data, 0)
+
+class TestCompute:
+    def setup_method(self):
+        self.s = Signal1D(np.random.random(10))
+        m = self.s.create_model()
+        self.lin = Expression("a*x + b", name='linear')
+        m.append(self.lin)
+
+    def test_compute_component_zero(self):
+        np.testing.assert_array_almost_equal(self.lin._compute_component(), 0)
+
+    def test_compute_component(self):
+        self.lin.a.value = 2
+        self.lin.b.value = 3
+        np.testing.assert_array_almost_equal(self.lin._compute_component(), 2*np.arange(self.s.axes_manager[-1].size) + 3)
+
+    def test_compute_constant(self):
+        self.lin.a.value = 2
+        self.lin.b.value = 3
+        self.lin.b.free = False
+        np.testing.assert_array_almost_equal(self.lin._compute_constant_term(), 3)
+
+@lazifyTestClass
+class TestLinearEdgeCases:
+    def setup_method(self, method):
+        s = EDS_SEM_Spectrum().isig[5.0:15.0]
+        self.m = s.create_model(auto_background=False)
+        self.c = Expression('a*x+b', 'line with offset')
+        self.m.append(self.c)
+        self.m.fit()
+        self.nonlinear_fit = self.m.as_signal()
+        self.nonlinear_std = [para.std for para in (self.m.linear_parameters + self.m.nonlinear_parameters) if para.std]
+
+    def test_no_free_parameters(self):
+        self.m.set_parameters_not_free()
+        with pytest.raises(AttributeError, match="Model does not contain any free components!"):
+            self.m.fit(optimizer="lstsq")
+    
+    def test_free_nonlinear_parameters(self):
+        self.m[1].sigma.free = True
+        with pytest.raises(AttributeError, match=str(self.m[1].sigma)):
+            self.m.fit(optimizer="lstsq")
+
+    def test_force_fake_linear_optimizer(self):
+        with pytest.raises(ValueError, match="not supported"):
+            self.m._linear_fitting(optimizer="foo")
+    
+    def test_append_linear_comp_not_in_model(self):
+        with pytest.raises(AssertionError):
+            self.m._compute_component(component=Gaussian())
+
+@lazifyTestClass
+class TestLinearMultiFitEdgeCases:
+    def setup_method(self, method):
+        nav = Signal2D(np.random.random((2,2)))
+        s = EDS_SEM_Spectrum().isig[5.0:15.0] * nav.T
+        self.m = s.create_model()
+
+    def test_set_value_in_non_free_parameter(self):
+        self.m[1].sigma.map['values'][0,0] = 2.
+        self.m[1].sigma.map['is_set'][0,0] = True
+        with pytest.warns(UserWarning, match="model contains non-free parameters"):
+            self.m.multifit(optimizer="lstsq")
+
+class TestLinearModelTools:
+    def setup_method(self):
+        nav = Signal2D(np.random.random((2,2)))
+        s = EDS_SEM_Spectrum() * nav.T
+        self.m = s.create_model()
+
+    def test_parameter_map_values_all_identical(self):
+        para = self.m[0].a1
+        assert parameter_map_values_all_identical(para)
+        para.map['values'][0,0] = 2
+        assert not parameter_map_values_all_identical(para)
+
+
+    def test_all_set_non_free_para_have_identical_values(self):
+        assert all_set_non_free_para_have_identical_values(self.m)
+        
+        para1 = self.m[0].a1
+        
+        # Value varies, but is_set is False
+        para1.map['values'][0,0] = 2
+        is_identical, para_list =  all_set_non_free_para_have_identical_values(self.m)
+        assert is_identical is True
+        assert not para_list
+        
+        # Same, but para is not free
+        para1.free = False
+        is_identical, para_list =  all_set_non_free_para_have_identical_values(self.m)
+        assert is_identical is True
+        assert not para_list
+
+        # para is_set is now True, no longer identical
+        para1.map['is_set'][0,0] = True
+        is_identical, para_list = all_set_non_free_para_have_identical_values(self.m)
+        assert is_identical is False
+        assert para1 in para_list and len(para_list) == 1
+
+        # all is_set are True, but the values vary, no not identical either
+        para1.map['is_set'] = True
+        is_identical, para_list = all_set_non_free_para_have_identical_values(self.m)
+        assert is_identical is False
+        assert para1 in para_list and len(para_list) == 1
+
+class TestModelLinearPara:
+    def setup_method(self):
+        nav = Signal2D(np.random.random((2,2)))
+        s = EDS_SEM_Spectrum() * nav.T
+        self.m = s.create_model()
+
+    def test_linear_parameters_to_one(self):
+        for para in self.m.linear_parameters:
+            para.value = 3
+
+        self.m._set_linear_parameters_to_one()
+        for para in self.m.linear_parameters:
+            if para.free:
+                assert para.value == 1
+
+        self.m._set_linear_parameters_to_one(set_map=True)
+        for para in self.m.linear_parameters:
+            if para.free:
+                assert (para.map['values'] == 1).all()
+
+class TestTwinnedComponents:
+    def setup_method(self):
+        self.m = EDS_SEM_Spectrum().create_model()
+        self.m2 = EDS_SEM_Spectrum().isig[5.:15.].create_model()
+
+    def test_fixed_chained_twinned_components(self):
+        m = self.m
+        m.fit(optimizer="lstsq")
+        A = m.as_signal()
+
+        m[4].A.free = False
+        m.fit(optimizer="lstsq")
+        B = m.as_signal()
+        np.testing.assert_array_almost_equal(A.data, B.data)
+        
+
+    def test_fit_fixed_twinned_components_and_std(self):
+        m = self.m2
+        m[1].A.free = False
+        m.fit(optimizer='lstsq')
+        lstsq_fit = m.as_signal()
+        linear_std = [para.std for para in (self.m.linear_parameters + self.m.nonlinear_parameters) if para.std]
+
+        m.fit()
+        nonlinear_fit = m.as_signal()
+        nonlinear_std = [para.std for para in (self.m.linear_parameters + self.m.nonlinear_parameters) if para.std]
+
+        np.testing.assert_array_almost_equal(nonlinear_fit.data, lstsq_fit.data)
+        np.testing.assert_array_almost_equal(nonlinear_std, linear_std, decimal=4)
+
+class MultiLinearCustomComponent(Component):
+    def __init__(self, a0=1, a1=1):
+        Component.__init__(self, ('a0', 'a1'))
+
+        self.a0.value = a0
+        self.a1.value = a1
+        self.a0._is_linear = True
+        self.a1._is_linear = True
+
+    def function(self, x):
+        a0 = self.a0.value
+        a1 = self.a1.value
+        return a0 + x * a1
+
+class TestCustomComponent:
+    def setup_method(self):
+        self.m = EDS_SEM_Spectrum().create_model(auto_background=False)
+
+    def test_custom_comp_w_two_linear_attributes(self):
+        c = MultiLinearCustomComponent()
+        self.m.append(c)
+        with pytest.raises(AttributeError, match="has more than one free"):
+            with pytest.warns(UserWarning, match="contains custom components not based on Expression"):
+                self.m.fit(optimizer='lstsq')
+
+    def test_custom_comp_warning(self):
+        c = MultiLinearCustomComponent()
+        c.a0.free = False
+        self.m.append(c)
+        with pytest.warns(UserWarning, match="contains custom components"):
+            self.m.fit(optimizer='lstsq')
+
+    def test_compare_custom_comp(self):
+        c = MultiLinearCustomComponent()
+        c.a0.free = False
+        c.a0.value = 0
+
+        self.m.append(c)
+        with pytest.warns(UserWarning, match="contains custom components"):
+            self.m.fit(optimizer='lstsq')
+        linear = c.a1.value
+
+        self.m.fit()
+        nonlinear = c.a1.value
+
+        np.testing.assert_almost_equal(linear, nonlinear)
+
+def test_fixed_free_offset():
+    s = Signal1D(np.ones(100)*3)
+    m = s.create_model()
+    a = Offset(1.)
+    a.offset.free = False
+    b = Offset(0.)
+    m.extend((a, b))
+
+    m.fit(optimizer="lstsq")
+
+    np.testing.assert_almost_equal(a.offset.value, 1.)
+    np.testing.assert_almost_equal(b.offset.value, 2.)

--- a/hyperspy/tests/model/test_linear_model.py
+++ b/hyperspy/tests/model/test_linear_model.py
@@ -12,7 +12,6 @@ from hyperspy.components2d import Gaussian2D
 from hyperspy.datasets.example_signals import EDS_SEM_Spectrum
 from hyperspy.datasets.artificial_data import get_low_loss_eels_signal
 from hyperspy.datasets.artificial_data import get_core_loss_eels_signal
-from hyperspy.misc.model_tools import get_top_parent_twin
 from hyperspy.decorators import lazifyTestClass
 from hyperspy.misc.model_tools import (
     parameter_map_values_all_identical,
@@ -131,29 +130,30 @@ class TestMultiFitLinear:
 class TestLinearFitting:
 
     def setup_method(self, method):
-        self.s = EDS_SEM_Spectrum().isig[5.0:15.0]
-        self.m = self.s.create_model(auto_background=False)
-        self.c = Expression('a*x+b', 'line with offset')
-        self.m.append(self.c)
+        s = EDS_SEM_Spectrum().isig[5.0:15.0]
+        m = s.create_model(auto_background=False)
+        c = Expression('a*x+b', 'line with offset')
+        m.append(c)
+        self.s = s
+        self.m = m
+        self.c = c
 
     def test_linear_fitting_with_offset(self):
         m = self.m
+        c = self.c
         m.fit(optimizer='lstsq')
-        np.testing.assert_allclose(
-            m.p0,
-            np.array([933.2343071493418,
-                      47822.98004150301,
-                      -5867.611808815612,
-                      56805.518919752234])
+        expected_values = np.array(
+            [933.23065365,
+             47822.97407409,
+             -5867.61623971,
+             56805.50459484]
             )
+        np.testing.assert_allclose(m.p0, expected_values, rtol=5E-6)
 
         # Repeat test with offset fixed
-        self.c.b.free = False
+        c.b.free = False
         m.fit(optimizer='lstsq')
-        np.testing.assert_allclose(
-            m.p0,
-            np.array([933.2343071496773, 47822.98004150315, -5867.611808815624])
-            )
+        np.testing.assert_allclose(m.p0, expected_values[:3], rtol=5E-6)
 
     def test_fixed_offset_value(self):
         self.m.fit(optimizer='lstsq')
@@ -185,9 +185,9 @@ class TestFitAlgorithms:
         m = self.m
         m.fit(optimizer='lstsq')
         lstsq_fit = m.as_signal()
-        np.testing.assert_allclose(self.nonlinear_fit_res, lstsq_fit.data, rtol=2E-6)
+        np.testing.assert_allclose(self.nonlinear_fit_res, lstsq_fit.data, rtol=1E-2)
         linear_std = [para.std for para in m._free_parameters if para.std]
-        np.testing.assert_allclose(self.nonlinear_fit_std, linear_std)
+        np.testing.assert_allclose(self.nonlinear_fit_std, linear_std, rtol=5E-3)
 
     def test_nonactive_component(self):
         m = self.m
@@ -196,7 +196,7 @@ class TestFitAlgorithms:
         linear_fit = m.as_signal()
         m.fit()
         nonlinear_fit = m.as_signal()
-        np.testing.assert_allclose(nonlinear_fit.data, linear_fit.data, rtol=5E-6)
+        np.testing.assert_allclose(nonlinear_fit.data, linear_fit.data, rtol=3E-4)
 
     def test_compare_ridge(self):
         pytest.importorskip("sklearn")
@@ -208,9 +208,9 @@ class TestFitAlgorithms:
         else:
             m.fit(optimizer='ridge_regression')
         ridge_fit = m.as_signal()
-        np.testing.assert_allclose(self.nonlinear_fit_res, ridge_fit.data, rtol=2E-6)
+        np.testing.assert_allclose(self.nonlinear_fit_res, ridge_fit.data, rtol=1E-2)
         linear_std = [para.std for para in m._free_parameters if para.std]
-        np.testing.assert_allclose(self.nonlinear_fit_std, linear_std)
+        np.testing.assert_allclose(self.nonlinear_fit_std, linear_std, rtol=5E-3)
 
 
 @lazifyTestClass
@@ -256,15 +256,16 @@ class TestLinearModel2D:
         self.mesh = np.meshgrid(self.x, self.y)
 
     def test_model2D_one_component(self):
+        mesh, x, y = self.mesh, self.x, self.y
         G1 = Gaussian2D(30, 5.0, 4.0, 0, 0)
 
-        data = G1.function(*self.mesh)
+        data = G1.function(*mesh)
         s = Signal2D(data)
-        s.axes_manager[-2].offset = self.x[0]
-        s.axes_manager[-1].offset = self.y[0]
+        s.axes_manager[-2].offset = x[0]
+        s.axes_manager[-1].offset = y[0]
 
-        s.axes_manager[-2].scale = self.x[1] - self.x[0]
-        s.axes_manager[-1].scale = self.y[1] - self.y[0]
+        s.axes_manager[-2].scale = x[1] - x[0]
+        s.axes_manager[-1].scale = y[1] - y[0]
 
         m = s.create_model()
         m.append(G1)
@@ -300,13 +301,13 @@ class TestLinearModel2D:
         m = s.create_model()
         for i in np.arange(gausslow, gausshigh+1, gauss_step):
             for j in np.arange(gausslow, gausshigh+1, gauss_step):
-                g = Gaussian2D(centre_x = i, centre_y=j)
+                g = Gaussian2D(centre_x=i, centre_y=j)
                 g.set_parameters_not_free()
                 g.A.free = True
                 m.append(g)
 
         m.fit(optimizer='lstsq')
-        np.testing.assert_array_almost_equal(s.data, m.as_signal().data)
+        np.testing.assert_allclose(s.data, m.as_signal().data)
 
     def test_model2D_polyexpression(self):
         poly = "a*x**2 + b*x - c*y**2 + d*y + e"
@@ -331,8 +332,6 @@ class TestLinearModel2D:
 class TestLinearFitTwins:
 
     def setup_method(self, method):
-        from hyperspy._components.gaussian import Gaussian
-        from hyperspy._signals.signal1d import Signal1D
         g1 = Gaussian(centre=10)
         g2 = Gaussian(centre=20)
         g3 = Gaussian(centre=30)
@@ -354,26 +353,6 @@ class TestLinearFitTwins:
         m.extend(gs)
         self.s, self.m, self.gs = s, m, gs
 
-    def test_get_parent_twin(self):
-        assert get_top_parent_twin(self.gs[2].A) is self.gs[0].A
-        assert get_top_parent_twin(self.gs[1].A) is self.gs[0].A
-        assert get_top_parent_twin(self.gs[0].A) is self.gs[0].A
-
-    def test_top_parent_twins_are_active(self):
-        assert self.gs[0]._top_parent_twins_are_active
-        assert self.gs[1]._top_parent_twins_are_active
-        assert self.gs[2]._top_parent_twins_are_active
-
-        self.gs[2].active = False
-        assert self.gs[0]._top_parent_twins_are_active
-        assert self.gs[1]._top_parent_twins_are_active
-        assert not self.gs[2]._top_parent_twins_are_active
-
-        self.gs[0].active = False
-        assert not self.gs[0]._top_parent_twins_are_active
-        assert not self.gs[1]._top_parent_twins_are_active
-        assert not self.gs[2]._top_parent_twins_are_active
-
     def test_without_twins(self):
         for g in self.gs:
             g.sigma.free = False
@@ -383,10 +362,10 @@ class TestLinearFitTwins:
         self.gs[0].A.value = 1
         self.m.fit(optimizer='lstsq')
 
-        np.testing.assert_almost_equal(self.gs[0].A.value, 20)
-        np.testing.assert_almost_equal(self.gs[1].A.value, -10)
-        np.testing.assert_almost_equal(self.gs[2].A.value, 5)
-        np.testing.assert_array_almost_equal((self.s - self.m.as_signal()).data, 0)
+        np.testing.assert_allclose(self.gs[0].A.value, 20)
+        np.testing.assert_allclose(self.gs[1].A.value, -10)
+        np.testing.assert_allclose(self.gs[2].A.value, 5)
+        np.testing.assert_allclose((self.s - self.m.as_signal()).data, 0)
 
     def test_with_twins(self):
         for g in self.gs:
@@ -396,33 +375,22 @@ class TestLinearFitTwins:
         self.gs[0].A.value = 1
         self.m.fit(optimizer='lstsq')
 
-        np.testing.assert_almost_equal(self.gs[0].A.value, 20)
-        np.testing.assert_almost_equal(self.gs[1].A.value, -10)
-        np.testing.assert_almost_equal(self.gs[2].A.value, 5)
-        np.testing.assert_array_almost_equal((self.s - self.m.as_signal()).data, 0)
+        np.testing.assert_allclose(self.gs[0].A.value, 20)
+        np.testing.assert_allclose(self.gs[1].A.value, -10)
+        np.testing.assert_allclose(self.gs[2].A.value, 5)
+        np.testing.assert_allclose((self.s - self.m.as_signal()).data, 0)
 
 
-class TestCompute:
+def test_compute_constant_term():
+    s = Signal1D(np.random.random(10))
+    m = s.create_model()
+    lin = Expression("a*x + b", name='linear')
+    m.append(lin)
 
-    def setup_method(self):
-        self.s = Signal1D(np.random.random(10))
-        m = self.s.create_model()
-        self.lin = Expression("a*x + b", name='linear')
-        m.append(self.lin)
-
-    def test_compute_component_zero(self):
-        np.testing.assert_array_almost_equal(self.lin._compute_component(), 0)
-
-    def test_compute_component(self):
-        self.lin.a.value = 2
-        self.lin.b.value = 3
-        np.testing.assert_array_almost_equal(self.lin._compute_component(), 2*np.arange(self.s.axes_manager[-1].size) + 3)
-
-    def test_compute_constant(self):
-        self.lin.a.value = 2
-        self.lin.b.value = 3
-        self.lin.b.free = False
-        np.testing.assert_array_almost_equal(self.lin._compute_constant_term(), 3)
+    lin.a.value = 2
+    lin.b.value = 3
+    lin.b.free = False
+    np.testing.assert_allclose(lin._compute_constant_term(), 3)
 
 
 @lazifyTestClass
@@ -446,10 +414,6 @@ class TestLinearEdgeCases:
     def test_force_fake_linear_optimizer(self):
         with pytest.raises(ValueError, match="not supported"):
             self.m._linear_fit(optimizer="foo")
-
-    def test_append_linear_comp_not_in_model(self):
-        with pytest.raises(AssertionError):
-            self.m._compute_component(component=Gaussian())
 
 
 @lazifyTestClass
@@ -514,8 +478,10 @@ class TestLinearModelTools:
 class TestTwinnedComponents:
 
     def setup_method(self):
-        self.m = EDS_SEM_Spectrum().create_model()
-        self.m2 = EDS_SEM_Spectrum().isig[5.:15.].create_model()
+        m = EDS_SEM_Spectrum().create_model()
+        m2 = EDS_SEM_Spectrum().isig[5.:15.].create_model()
+        self.m = m
+        self.m2 = m2
 
     def test_fixed_chained_twinned_components(self):
         m = self.m
@@ -525,7 +491,7 @@ class TestTwinnedComponents:
         m[4].A.free = False
         m.fit(optimizer="lstsq")
         B = m.as_signal()
-        np.testing.assert_array_almost_equal(A.data, B.data)
+        np.testing.assert_allclose(A.data, B.data, rtol=5E-5)
 
     def test_fit_fixed_twinned_components_and_std(self):
         m = self.m2
@@ -567,15 +533,13 @@ class TestCustomComponent:
         c = MultiLinearCustomComponent()
         self.m.append(c)
         with pytest.raises(AttributeError, match="has more than one free"):
-            with pytest.warns(UserWarning, match="not based on Expression"):
-                self.m.fit(optimizer='lstsq')
+            self.m.fit(optimizer='lstsq')
 
-    def test_custom_comp_warning(self):
+    def test_custom_comp(self):
         c = MultiLinearCustomComponent()
         c.a0.free = False
         self.m.append(c)
-        with pytest.warns(UserWarning, match="contains custom components"):
-            self.m.fit(optimizer='lstsq')
+        self.m.fit(optimizer='lstsq')
 
     def test_compare_custom_comp(self):
         c = MultiLinearCustomComponent()
@@ -583,8 +547,7 @@ class TestCustomComponent:
         c.a0.value = 0
 
         self.m.append(c)
-        with pytest.warns(UserWarning, match="contains custom components"):
-            self.m.fit(optimizer='lstsq')
+        self.m.fit(optimizer='lstsq')
         linear = c.a1.value
 
         self.m.fit()

--- a/hyperspy/tests/model/test_linear_model.py
+++ b/hyperspy/tests/model/test_linear_model.py
@@ -430,7 +430,8 @@ class TestLinearModel2D:
         np.testing.assert_allclose(diff.data, 0.0, atol=1E-7)
         np.testing.assert_allclose(m.p_std[0], 0.0, atol=1E-7)
 
-    def test_model2D_linear_many_gaussians(self):
+    @pytest.mark.parametrize('nav2d', [False, True])
+    def test_model2D_linear_many_gaussians(self, nav2d):
         mesh, x, y = self.mesh, self.x, self.y
         gausslow, gausshigh = -8, 8
         gauss_step = 8
@@ -451,6 +452,10 @@ class TestLinearModel2D:
         s.axes_manager[-2].scale = x[1] - x[0]
         s.axes_manager[-1].scale = y[1] - y[0]
 
+        if nav2d:
+            s = hs.stack([s]*2)
+            s = hs.stack([s]*3)
+
         m = s.create_model()
         for i in np.arange(gausslow, gausshigh+1, gauss_step):
             for j in np.arange(gausslow, gausshigh+1, gauss_step):
@@ -462,7 +467,8 @@ class TestLinearModel2D:
         m.fit(optimizer='lstsq')
         np.testing.assert_allclose(s.data, m.as_signal().data)
 
-    def test_model2D_polyexpression(self):
+    @pytest.mark.parametrize('nav2d', [False, True])
+    def test_model2D_polyexpression(self, nav2d):
         poly = "a*x**2 + b*x - c*y**2 + d*y + e"
         P = Expression(poly, 'poly')
         P.a.value = 6
@@ -473,6 +479,10 @@ class TestLinearModel2D:
 
         data = P.function(*self.mesh)
         s = Signal2D(data)
+
+        if nav2d:
+            s = hs.stack([s]*2)
+            s = hs.stack([s]*3)
 
         m = s.create_model()
         m.append(P)

--- a/hyperspy/tests/model/test_linear_model.py
+++ b/hyperspy/tests/model/test_linear_model.py
@@ -463,11 +463,13 @@ class TestTwinnedComponents:
         m[1].A.free = False
         m.fit(optimizer='lstsq')
         lstsq_fit = m.as_signal()
-        linear_std = [para.std for para in self.m.nonlinear_parameters if para.std]
+        nonlinear_parameters = [p for c in m for p in c.parameters
+                                if not p._linear]
+        linear_std = [para.std for para in nonlinear_parameters if para.std]
 
         m.fit()
         nonlinear_fit = m.as_signal()
-        nonlinear_std = [para.std for para in self.m.nonlinear_parameters if para.std]
+        nonlinear_std = [para.std for para in nonlinear_parameters if para.std]
 
         np.testing.assert_allclose(nonlinear_fit.data, lstsq_fit.data)
         np.testing.assert_allclose(nonlinear_std, linear_std)

--- a/hyperspy/tests/model/test_linearity.py
+++ b/hyperspy/tests/model/test_linearity.py
@@ -40,26 +40,31 @@ class TestModelLinearity:
         Model is not currently linear as Gaussian sigma and centre parameters
         are free
         """
-        assert len(self.m.nonlinear_parameters) > 0
+        nonlinear_parameters = [p for c in self.m for p in c.parameters
+                                if not p._linear]
+        assert len(nonlinear_parameters) > 0
 
     def test_model_linear(self):
         self.g.sigma.free = False
         self.g.centre.free = False
-        nonlinear_parameters = self.m.nonlinear_parameters
+        nonlinear_parameters = [p for c in self.m for p in c.parameters
+                                if not p._linear]
         assert len(nonlinear_parameters) == 2
         l = [p for p in nonlinear_parameters if p in self.m._free_parameters]
         assert len(l) == 0
 
     def test_model_parameters_inactive(self):
         self.g.active = False
-        nonlinear_parameters = self.m.nonlinear_parameters
+        nonlinear_parameters = [p for c in self.m for p in c.parameters
+                                if not p._linear]
         assert len(nonlinear_parameters) == 2
         l = [p for p in nonlinear_parameters if p in self.m._free_parameters]
         assert len(l) == 0
 
     def test_model_parameters_set_inactive(self):
         self.m.set_component_active_value(False, [self.g])
-        nonlinear_parameters = self.m.nonlinear_parameters
+        nonlinear_parameters = [p for c in self.m for p in c.parameters
+                                if not p._linear]
         assert len(nonlinear_parameters) == 2
         l = [p for p in nonlinear_parameters if p in self.m._free_parameters]
         assert len(l) == 0
@@ -68,23 +73,23 @@ class TestModelLinearity:
 def test_sympy_linear_expression():
     expression = "height * exp(-(x - centre) ** 2 * 4 * log(2)/ fwhm ** 2)"
     g = Expression(expression, name="Test_function")
-    assert g.height.linear
-    assert not g.centre.linear
-    assert not g.fwhm.linear
+    assert g.height._linear
+    assert not g.centre._linear
+    assert not g.fwhm._linear
 
 
 def test_sympy_linear_expression2():
     expression = "a * x + b"
     g = Expression(expression, name="Test_function2")
-    assert g.a.linear
-    assert g.b.linear
+    assert g.a._linear
+    assert g.b._linear
 
 
 def test_gaussian_linear():
     g = Gaussian()
-    assert g.A.linear
-    assert not g.centre.linear
-    assert not g.sigma.linear
+    assert g.A._linear
+    assert not g.centre._linear
+    assert not g.sigma._linear
 
 
 def test_parameter_linearity():

--- a/hyperspy/tests/model/test_linearity.py
+++ b/hyperspy/tests/model/test_linearity.py
@@ -21,7 +21,7 @@ import pytest
 
 from hyperspy.components1d import Expression, Gaussian
 from hyperspy._signals.signal1d import Signal1D
-from hyperspy._components.expression import check_parameter_linearity
+from hyperspy._components.expression import _check_parameter_linearity
 
 
 class TestModelLinearity:
@@ -96,20 +96,20 @@ def test_gaussian_linear():
 
 def test_parameter_linearity():
     expr = "a*x**2 + b*x + c"
-    assert check_parameter_linearity(expr, 'a')
-    assert check_parameter_linearity(expr, 'b')
-    assert check_parameter_linearity(expr, 'c')
+    assert _check_parameter_linearity(expr, 'a')
+    assert _check_parameter_linearity(expr, 'b')
+    assert _check_parameter_linearity(expr, 'c')
 
     expr = "a*sin(b*x)"
-    assert check_parameter_linearity(expr, 'a')
-    assert not check_parameter_linearity(expr, 'b')
+    assert _check_parameter_linearity(expr, 'a')
+    assert not _check_parameter_linearity(expr, 'b')
 
     expr = "a*exp(-b*x)"
-    assert check_parameter_linearity(expr, 'a')
-    assert not check_parameter_linearity(expr, 'b')
+    assert _check_parameter_linearity(expr, 'a')
+    assert not _check_parameter_linearity(expr, 'b')
     
     expr = "where(x > 10, a*sin(b*x), 0)"
     with pytest.warns(UserWarning):
-        check_parameter_linearity(expr, 'a')
+        _check_parameter_linearity(expr, 'a')
     with pytest.warns(UserWarning):
-        check_parameter_linearity(expr, 'b')
+        _check_parameter_linearity(expr, 'b')

--- a/hyperspy/tests/model/test_linearity.py
+++ b/hyperspy/tests/model/test_linearity.py
@@ -17,6 +17,8 @@
 # along with  HyperSpy.  If not, see <http://www.gnu.org/licenses/>.
 
 import numpy as np
+import pytest
+
 from hyperspy.components1d import Expression, Gaussian
 from hyperspy._signals.signal1d import Signal1D
 from hyperspy._components.expression import check_parameter_linearity
@@ -105,3 +107,9 @@ def test_parameter_linearity():
     expr = "a*exp(-b*x)"
     assert check_parameter_linearity(expr, 'a')
     assert not check_parameter_linearity(expr, 'b')
+    
+    expr = "where(x > 10, a*sin(b*x), 0)"
+    with pytest.warns(UserWarning):
+        check_parameter_linearity(expr, 'a')
+    with pytest.warns(UserWarning):
+        check_parameter_linearity(expr, 'b')

--- a/hyperspy/tests/model/test_linearity.py
+++ b/hyperspy/tests/model/test_linearity.py
@@ -1,0 +1,87 @@
+# -*- coding: utf-8 -*-
+# Copyright 2007-2016 The HyperSpy developers
+#
+# This file is part of  HyperSpy.
+#
+#  HyperSpy is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+#  HyperSpy is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with  HyperSpy.  If not, see <http://www.gnu.org/licenses/>.
+
+import numpy as np
+from hyperspy.components1d import Expression, Gaussian
+from hyperspy._signals.signal1d import Signal1D
+from hyperspy._components.expression import check_parameter_linearity
+
+class TestModelLinearity:
+
+    def setup_method(self, method):
+        np.random.seed(1)
+        s = Signal1D(
+            np.random.normal(
+                scale=2,
+                size=10000)).get_histogram()
+        self.g = Gaussian()
+        m = s.create_model()
+        m.append(self.g)
+        self.m = m
+
+    def test_model_is_not_linear(self):
+        """
+        Model is not currently linear as Gaussian sigma and centre parameters
+        are free
+        """
+        assert self.m.nonlinear_parameters
+        assert self.m.linear_parameters
+
+    def test_model_is_linear(self):
+        self.g.sigma.free = False
+        self.g.centre.free = False
+        assert len(self.m.nonlinear_parameters) == 2
+        assert len(self.m.linear_parameters) == 1
+
+    def test_model_parameters_inactive(self):
+        self.g.active = False
+        assert not self.m.nonlinear_parameters
+        assert not self.m.linear_parameters
+
+def test_sympy_linear_expression():
+    expression = "height * exp(-(x - centre) ** 2 * 4 * log(2)/ fwhm ** 2)"
+    g = Expression(expression, name="Test_function")
+    assert g.height._is_linear
+    assert not g.centre._is_linear
+    assert not g.fwhm._is_linear
+
+def test_sympy_linear_expression2():
+    expression = "a * x + b"
+    g = Expression(expression, name="Test_function2")
+    assert g.a._is_linear
+    assert g.b._is_linear
+
+def test_gaussian_linear():
+    g = Gaussian()
+    assert g.A._is_linear
+    assert not g.centre._is_linear
+    assert not g.sigma._is_linear
+
+def test_parameter_linearity():
+    expr = "a*x**2 + b*x + c"
+    assert check_parameter_linearity(expr, 'a')
+    assert check_parameter_linearity(expr, 'b')
+    assert check_parameter_linearity(expr, 'c')
+    
+    expr = "a*sin(b*x)"
+    assert check_parameter_linearity(expr, 'a')
+    assert not check_parameter_linearity(expr, 'b')
+
+    expr = "a*exp(-b*x)"
+    assert check_parameter_linearity(expr, 'a')
+    assert not check_parameter_linearity(expr, 'b')

--- a/hyperspy/tests/model/test_model2d.py
+++ b/hyperspy/tests/model/test_model2d.py
@@ -102,6 +102,10 @@ class TestModel2D:
         with pytest.raises(NotImplementedError, match="is not implemented for Model2D"):
             self.m.fit(optimizer="odr")
 
+    def test_call(self):
+        with pytest.raises(ValueError):
+            self.m(component_list=0)
+
 
 def test_Model2D_NotImplementedError_range():
     im = hs.signals.Signal2D(np.ones((128, 128)))

--- a/hyperspy/tests/model/test_model_storing.py
+++ b/hyperspy/tests/model/test_model_storing.py
@@ -139,6 +139,18 @@ class TestModelStoring:
             s.models.restore('a')
 
 
+@pytest.mark.parametrize('save_std', [True, False])
+@pytest.mark.parametrize('only_free', [True, False])
+@pytest.mark.parametrize('only_active', [True, False])
+def test_model_export(tmp_path, save_std, only_free, only_active):
+    s = Signal1D(range(100))
+    m = s.create_model()
+    m.append(Gaussian())
+    m.fit()
+    m.export_results(tmp_path, save_std=save_std, only_free=only_free,
+                     only_active=only_active)
+
+
 class TestModelSaving:
 
     def setup_method(self, method):

--- a/hyperspy/tests/model/test_parameter.py
+++ b/hyperspy/tests/model/test_parameter.py
@@ -239,10 +239,12 @@ class TestParameterTwin:
         self.p1 = Parameter()
         self.p2 = Parameter()
 
-    def test_slave_fixed(self):
+    def test_free_when_twin(self):
         assert self.p2.free
         self.p2.twin = self.p1
         assert not self.p2.free
+        with pytest.raises(ValueError):
+            self.p2.free = True
 
     def test_twin_value(self):
         self.p2.twin = self.p1

--- a/hyperspy/tests/model/test_set_parameter_state.py
+++ b/hyperspy/tests/model/test_set_parameter_state.py
@@ -131,3 +131,48 @@ class TestSetParameterInModel:
         assert not g3.A.free
         assert not g3.sigma.free
         assert not g3.centre.free
+
+    def test_set_parameter_in_model_linearity(self):
+        m = self.model
+        g1 = self.g1
+        g2 = self.g2
+        g3 = self.g3
+
+        m.set_parameters_not_free(only_linear=True)
+        assert not g1.A.free
+        assert not g2.A.free
+        assert not g3.A.free
+        assert g1.sigma.free
+        assert g1.centre.free
+
+        m.set_parameters_not_free(only_nonlinear=True)
+        assert not g1.A.free
+        assert not g2.A.free
+        assert not g3.A.free
+        assert not g1.sigma.free
+        assert not g1.centre.free
+
+        m.set_parameters_free([g1], only_linear=True)
+        assert g1.A.free
+        assert not g1.sigma.free
+        assert not g1.centre.free
+        assert not g2.A.free
+        assert not g2.sigma.free
+        assert not g2.centre.free
+
+        m.set_parameters_free(only_linear=True)
+        assert g1.A.free
+        assert not g1.sigma.free
+        assert not g1.centre.free
+        assert g2.A.free
+        assert not g2.sigma.free
+        assert not g2.centre.free
+
+        m.set_parameters_not_free(only_linear=True)
+        m.set_parameters_free(only_nonlinear=True)
+        assert not g2.A.free
+        assert g2.sigma.free
+        assert g2.centre.free
+        assert not g3.A.free
+        assert g3.sigma.free
+        assert g3.centre.free

--- a/upcoming_changes/2422.new.rst
+++ b/upcoming_changes/2422.new.rst
@@ -1,0 +1,1 @@
+Add (weighted) :ref:`linear least square fitting <linear_fitting-label>`. Close `#488 <https://github.com/hyperspy/hyperspy/issues/488>`_ and `#574 <https://github.com/hyperspy/hyperspy/issues/574>`_.


### PR DESCRIPTION
### Description of the change
I've implemented unbounded linear fitting in hyperspy, by multivariate linear regression. This can fit components with free, *linear* parameters. 

Code coverage is nearly 100%.
Closes #574, partially #488.

### Too long, didn't read:
Run this and be wowed as to how fast it is:
```python
import hyperspy.api as hs
import numpy as np
nav = hs.signals.Signal2D(np.random.random((300, 300)))
s = hs.datasets.example_signals.EDS_SEM_Spectrum() * nav.T
m = s.create_model()

m.multifit(optimizer='lstsq') # ~ 5 seconds, regular multifit would take 30 minutes
```

### Linear fitting
A linear parameter is one that only stretches the component vertically, so it has no effect on the position or otherwise shape of the component. A single hyperspy component can contain several of these, which can be a bit confusing, so let me explain with some examples:

### Examples of linear and nonlinear parameters
<details>
  <summary>Click to expand!</summary>
  
- `A*x`, the simplest case, scales the function `f(x)=x` by the linear parameter `A`.

A hyperspy model contains a _linear combination_ of components. Due to the `Expression` component, a component can contain what I call "pseudo-components" which are themselves linear combinations, like the following example:
- `A*x**2 + b*x + c`. 

Here *all* parameters are considered linear. One could also have added these separately as three hyperspy components.

- In `A*sin(B*x-C)`, A is linear, B and C are not linear because they scale and shift the component horizontally
- In `A*exp(-b*x)`, A is linear, b is not linear

HyperSpy automatically recognizes linear parameters using `sympy`. The properties `Component.is_linear` and `Parameter._is_linear` are automatically set for `Expression` components. `m.linear_parameters` and `m.nonlinear_parameters` help the user understand which parameters are considered linear.

</details>

### New optimizers
- `optimizer='lstsq'`: Uses either `np.linalg.lstsq` or `dask.array.linalg.lstsq`, depending if the model is lazy. 
- `optimizer='ridge_regression`: Uses [sklearn.linear_model.Ridge](https://scikit-learn.org/stable/modules/generated/sklearn.linear_model.Ridge.html), which supports regularization but does not support lazy signals.

### How to use
The main difference between regular nonlinear fitting and linear fitting is that the components must all be made linear. `m.fit(optimizer='lstsq')` will inform the user of any *free* nonlinear parameters so that they can be set with `parameter.free=False` or `m.set_parameters_not_free(only_nonlinear=True)`.

Since linear fitting does not rely on the fit in the previous pixel, we can fit the entire dataset in one vectorised operation. This has major consequences for lazy loading - fitting a 25 GB dataset with 25 components takes 2 minutes (see lazy example).

If one requires the standard errors on parameters, then that must be specified for multifit calls because the `np.linalg.inv` operation required during error calculation may take signficantly longer than the fitting on its own. It is specified as `m.multifit(optimizer='lstsq', calculate_errors=True)`. I am open to suggestions for alternative ways of handling this.

Finally, if the nonlinear parameters are `set` and vary across the navigation space (through `para.map['values']`), then multifit will default to the regular behaviour of iterating through the navigator, rather than fitting everything at once. This is because the simultaneous fitting assumes that all nonlinear parameters are the same across the navigator.

### Progress of the PR
- [x] Change implemented (can be split into several points),
- [x] update docstring (if appropriate),
- [x] update user guide (if appropriate),
- [x] add tests,
- [x] ready for review.

### Minimal examples
#### Regular fit
Approximately as fast as `optimizer='lm'`
```python
from hyperspy.datasets.example_signals import EDS_SEM_Spectrum
s = EDS_SEM_Spectrum()
m = s.create_model()
m.fit(optimizer='lstsq')
```

#### Multifit
About 200 times faster than `optimizer='lm'` for a small example. Replace the random shape below with (320, 320) and it is 750 times faster.
```python
import hyperspy.api as hs
import numpy as np
nav = hs.signals.Signal2D(np.random.random((32, 32)))
s = hs.datasets.example_signals.EDS_SEM_Spectrum() * nav.T
m = s.create_model()
m.multifit(optimizer='lstsq')
# We would use `calculate_errors=True` if errors were required, which takes a bit longer
```

### When is linear fitting useful?
- When you only have free *linear* parameters in your model
- When you want a (hopefully decent) starting point for further nonlinear fitting
- When you have many components in your model
- You need to fit data much bigger than memory, but regular multifit takes too long

### Applications of linear fitting relevant to hyperspy
- EDS fitting (fits the entire dataset, including background)
- EELS fitting after background subtraction (Powerlaw *could* be fitted by taking log of data)
- Fitting 2D atomic columns with known positions

### More examples (convolution and large lazy example)
<details>
  <summary>Click to expand!</summary>

#### Convolution EELS example
This works great for convolved data as well
```python
s = hs.datasets.artificial_data.get_core_loss_eels_signal()
s.add_elements(['Fe'])
ll = hs.datasets.artificial_data.get_low_loss_eels_signal()

m = s.create_model(ll=ll, auto_background=False)
m[0].onset_energy.value = 690.
m.fit(optimizer='lstsq')
s_linear = m.as_signal()

m = s.create_model(ll=ll, auto_background=False)
m[0].onset_energy.value = 690.
m.fit(optimizer='lm')
s_nonlinear = m.as_signal()

np.testing.assert_array_almost_equal(s_linear.data, s_nonlinear.data)
```

#### Lazy fitting
This is a real strength of this PR: Fitting 3 million nav positions takes two minutes.
```python
import hyperspy.api as hs
from hyperspy.axes import UniformDataAxis
import dask.array as da

from hyperspy.datasets.example_signals import EDS_SEM_Spectrum
from hyperspy._signals.eds_sem import LazyEDSSEMSpectrum
from hyperspy._signals.signal2d import LazySignal2D

s = EDS_SEM_Spectrum()
data = s.data
axis = UniformDataAxis(offset = -0.1, scale = 0.01, size = 1024, units="keV")
s2 = LazyEDSSEMSpectrum(data, axes = [axis])
s2.add_elements(s.metadata.Sample.elements)
s2.set_microscope_parameters(beam_energy=10.)

nav = LazySignal2D(da.random.random((3000, 1000)))
s = s2 * nav.T

s.save("lazy.hspy", compression=None, overwrite=True, chunks = (30, 1000, 1024)) # This will take a few minutes

# Then run these: 
s = hs.load('lazy.hspy', lazy=True)
m = s.create_model(auto_add_lines=False) # False temporarily due to #2806
m.multifit(optimizer='lstsq')
# Here we would use `calculate_errors=True` if errors were required, 
# but that aspect isn't lazy, so we would use a lot of ram. 
```
</details>

