### PR TITLE
Update pytest manually.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,6 +29,9 @@ before_install:
   - source ci-scripts/travis/setup_travis.sh
 
 install:
+  # Because of https://github.com/pypa/pip/issues/4391, we need to update pytest
+  # manually
+  - pip install -U pytest
   # Install the package
   - pip install --upgrade -e .["${PIP_SELECTOR}"]
 


### PR DESCRIPTION
Workaround to fix #2421, which is due to a pip bug (https://github.com/pypa/pip/issues/4391).

The issue is that pytest version requirement of pytest-cov is not honoured by pip because pytest requirement is already defined elsewhere (in the "tests" extras_require)

