### PR TITLE
Use a simpler dataset for BSS testing

### DIFF
--- a/hyperspy/misc/machine_learning/tools.py
+++ b/hyperspy/misc/machine_learning/tools.py
@@ -59,11 +59,3 @@ def amari(W, A):
     P_sr_1 = np.sum(P_sq_sum_1 / P_sq_max_1 - 1)
 
     return (P_sr_0 + P_sr_1) / (2 * m)
-
-
-def _ntu(C):
-    m, n = C.shape
-    CN = C.copy() * 0
-    for t in range(n):
-        CN[:, t] = C[:, t] / np.max(np.abs(C[:, t]))
-    return CN

--- a/hyperspy/misc/machine_learning/tools.py
+++ b/hyperspy/misc/machine_learning/tools.py
@@ -19,25 +19,46 @@
 import numpy as np
 
 
-def amari(C, A):
-    """Amari test for ICA
-    Adapted from the MILCA package http://www.klab.caltech.edu/~kraskov/MILCA/
+def amari(W, A):
+    """Calculate the Amari distance between two non-singular matrices.
+
+    Convenient for checking convergence in ICA algorithms
+    (See [Moreau1998]_ and [Bach2002]_).
 
     Parameters
     ----------
-    C : numpy array
-    A : numpy array
+    W, A : array-like
+        The two matrices to measure.
+
+    Returns
+    -------
+    float
+        Amari distance between W and A.
+
+    References
+    ----------
+    .. [Moreau1998] E. Moreau and O. Macchi, "Self-adaptive source separation.
+        ii. comparison of the direct, feedback, and mixed linear network",
+        IEEE Trans. on Signal Processing, vol. 46(1), pp. 39-50, 1998.
+    .. [Bach2002] F. Bach and M. Jordan, "Kernel independent component analysis",
+        Journal of Machine Learning Research, vol. 3, pp. 1-48, 2002.
+
     """
-    b, a = C.shape
+    P = W @ A
+    m, _ = P.shape
 
-    dummy = np.dot(np.linalg.pinv(A), C)
-    dummy = np.sum(_ntu(np.abs(dummy)), 0) - 1
+    P_sq = P ** 2
 
-    dummy2 = np.dot(np.linalg.pinv(C), A)
-    dummy2 = np.sum(_ntu(np.abs(dummy2)), 0) - 1
+    P_sq_sum_0 = np.sum(P_sq, axis=0)
+    P_sq_max_0 = np.max(P_sq, axis=0)
 
-    out = (np.sum(dummy) + np.sum(dummy2)) / (2 * a * (a - 1))
-    return out
+    P_sq_sum_1 = np.sum(P_sq, axis=1)
+    P_sq_max_1 = np.max(P_sq, axis=1)
+
+    P_sr_0 = np.sum(P_sq_sum_0 / P_sq_max_0 - 1)
+    P_sr_1 = np.sum(P_sq_sum_1 / P_sq_max_1 - 1)
+
+    return (P_sr_0 + P_sr_1) / (2 * m)
 
 
 def _ntu(C):

--- a/hyperspy/tests/mva/test_bss.py
+++ b/hyperspy/tests/mva/test_bss.py
@@ -113,7 +113,6 @@ def test_bss_pipeline():
 def test_orthomax(whiten_method):
     rng = np.random.RandomState(123)
     S = rng.laplace(size=(3, 500))
-    S -= 2 * S.min()  # Required to give us a positive dataset
     A = rng.random((3, 3))
     s = Signal1D(A @ S)
     s.decomposition()

--- a/hyperspy/tests/mva/test_bss.py
+++ b/hyperspy/tests/mva/test_bss.py
@@ -24,6 +24,7 @@ from hyperspy._signals.signal2d import Signal2D
 from hyperspy.datasets import artificial_data
 from hyperspy.decorators import lazifyTestClass
 from hyperspy.misc.machine_learning.import_sklearn import sklearn_installed
+from hyperspy.misc.machine_learning.tools import amari
 from hyperspy.signals import BaseSignal
 
 
@@ -53,6 +54,19 @@ def are_bss_components_equivalent(c1_list, c2_list, atol=1e-4):
             ):
                 matches += 1
     return matches == len(c1_list)
+
+
+def test_amari_distance(n=16, tol=1e-6):
+    """Amari distance between matrix and its inverse should be 0."""
+    rng = np.random.RandomState(123)
+
+    A = rng.randn(n, n)
+    W = np.linalg.inv(A)
+    X = np.linalg.pinv(A)
+
+    np.testing.assert_allclose(amari(W, A), 0.0, rtol=tol)
+    np.testing.assert_allclose(amari(A, A), 2.912362, rtol=tol)
+    np.testing.assert_allclose(amari(X, A), 0.0, rtol=tol)
 
 
 @pytest.mark.skipif(not sklearn_installed, reason="sklearn not installed")
@@ -97,16 +111,16 @@ def test_bss_pipeline():
 
 @pytest.mark.parametrize("whiten_method", ["pca", "zca"])
 def test_orthomax(whiten_method):
-    s = artificial_data.get_core_loss_eels_line_scan_signal()
+    rng = np.random.RandomState(123)
+    S = rng.laplace(size=(3, 500))
+    S -= 2 * S.min()  # Required to give us a positive dataset
+    A = rng.random((3, 3))
+    s = Signal1D(A @ S)
     s.decomposition()
-    s.blind_source_separation(2, algorithm="orthomax", whiten_method=whiten_method)
+    s.blind_source_separation(3, algorithm="orthomax", whiten_method=whiten_method)
 
-    s.learning_results.bss_factors[:, 0] *= -1
-    s._auto_reverse_bss_component("loadings")
-    np.testing.assert_array_less(s.learning_results.bss_factors[:, 0], 0)
-    np.testing.assert_array_less(0, s.learning_results.bss_factors[:, 1])
-    s._auto_reverse_bss_component("factors")
-    np.testing.assert_array_less(0, s.learning_results.bss_factors)
+    W = s.learning_results.unmixing_matrix
+    assert amari(W, A) < 0.5
 
     # Verify that we can change gamma for orthomax method
     s = artificial_data.get_core_loss_eels_line_scan_signal()
@@ -226,7 +240,11 @@ def test_fastica_whiten_method(whiten_method):
 @lazifyTestClass
 class TestReverseBSS:
     def setup_method(self, method):
-        s = artificial_data.get_core_loss_eels_line_scan_signal()
+        rng = np.random.RandomState(123)
+        S = rng.laplace(size=(3, 500))
+        S -= 2 * S.min()  # Required to give us a positive dataset
+        A = rng.random((3, 3))
+        s = Signal1D(A @ S)
         s.decomposition()
         s.blind_source_separation(2)
         self.s = s
@@ -276,7 +294,6 @@ class TestBSS1D:
         assert are_bss_components_equivalent(
             self.s.get_bss_factors(), s2.get_bss_loadings()
         )
-
 
     @pytest.mark.filterwarnings("ignore:FastICA did not converge")
     @pytest.mark.parametrize("on_loadings", [True, False])


### PR DESCRIPTION
* #2395 encountered an unclear test failure, in that the BSS tests relied on the artificial dataset generation to test an unrelated piece of functionality (i.e. the ability to reverse components). This PR replaces the dataset with a random one that is easier to see how it works!
* Also correct Amari distance function and add test for Amari distance

### Progress of the PR
- [x] Change implemented (can be split into several points),
- [x] update docstring (if appropriate),
- [x] update user guide (if appropriate),
- [x] add tests,
- [x] ready for review.

