### PR TITLE
Fix numpy1.19

### DIFF
--- a/hyperspy/_signals/complex_signal.py
+++ b/hyperspy/_signals/complex_signal.py
@@ -100,7 +100,7 @@ class ComplexSignal_mixin:
         # original plot
         self._plot_kwargs = {}
         if not np.issubdtype(self.data.dtype, np.complexfloating):
-            self.data = self.data.astype(np.complexfloating)
+            self.data = self.data.astype(np.complex128)
 
     def change_dtype(self, dtype):
         """Change the data type.

--- a/hyperspy/axes.py
+++ b/hyperspy/axes.py
@@ -49,7 +49,7 @@ FACTOR_DOCSTRING = \
 class ndindex_nat(np.ndindex):
 
     def __next__(self):
-        return super(ndindex_nat, self).next()[::-1]
+        return super(ndindex_nat, self).__next__()[::-1]
 
 
 def generate_axis(offset, scale, size, offset_index=0):

--- a/hyperspy/io_plugins/bruker.py
+++ b/hyperspy/io_plugins/bruker.py
@@ -1095,7 +1095,7 @@ def py_parse_hypermap(virtual_file, shape, dtype, downsample=1):
                 switched_i2 = np.frombuffer(data1,
                                             dtype='<u2'
                                             ).copy().byteswap(True)
-                data2 = np.frombuffer(switched_i2.tostring(),
+                data2 = np.frombuffer(switched_i2.tobytes(),
                                       dtype=np.uint8
                                       ).copy().repeat(2)
                 mask = np.ones_like(data2, dtype=bool)
@@ -1103,7 +1103,7 @@ def py_parse_hypermap(virtual_file, shape, dtype, downsample=1):
                 # Reinterpret expanded as 16-bit:
                 # string representation of array after switch will have
                 # always BE independently from endianess of machine
-                exp16 = np.frombuffer(data2[mask].tostring(),
+                exp16 = np.frombuffer(data2[mask].tobytes(),
                                       dtype='>u2', count=n_of_pulses).copy()
                 exp16[0::2] >>= 4           # Shift every second short by 4
                 exp16 &= np.uint16(0x0FFF)  # Mask all shorts to 12bit

--- a/hyperspy/io_plugins/emd.py
+++ b/hyperspy/io_plugins/emd.py
@@ -512,7 +512,7 @@ def _get_keys_from_group(group):
 
 def _parse_sub_data_group_metadata(sub_data_group):
     metadata_array = sub_data_group['Metadata'][:, 0].T
-    mdata_string = metadata_array.tostring().decode("utf-8")
+    mdata_string = metadata_array.tobytes().decode("utf-8")
     return json.loads(mdata_string.rstrip('\x00'))
 
 

--- a/hyperspy/io_plugins/hspy.py
+++ b/hyperspy/io_plugins/hspy.py
@@ -611,7 +611,7 @@ def hdfgroup2dict(group, dictionary=None, lazy=False):
         elif key.startswith('_tuple_empty_'):
             dictionary[key[len('_tuple_empty_'):]] = ()
         elif key.startswith('_bs_'):
-            dictionary[key[len('_bs_'):]] = value.tostring()
+            dictionary[key[len('_bs_'):]] = value.tobytes()
         # The following two elif stataments enable reading date and time from
         # v < 2 of HyperSpy's metadata specifications
         elif key.startswith('_datetime_date'):

--- a/hyperspy/tests/io/test_hdf5.py
+++ b/hyperspy/tests/io/test_hdf5.py
@@ -676,7 +676,7 @@ def test_lazy_metadata_arrays(tmpfilepath):
 def test_save_ragged_array(tmpfilepath):
     a = np.array([0, 1])
     b = np.array([0, 1, 2])
-    s = BaseSignal(np.array([a, b])).T
+    s = BaseSignal(np.array([a, b], dtype=object)).T
     filename = os.path.join(tmpfilepath, "test_save_ragged_array.hspy")
     s.save(filename)
     s1 = load(filename)
@@ -689,4 +689,4 @@ def test_load_missing_extension(caplog):
     s = load(path)
     assert "This file contains a signal provided by the hspy_ext_missing" in caplog.text
     with pytest.raises(ImportError):
-       m = s.models.restore("a") 
+       _ = s.models.restore("a")


### PR DESCRIPTION
Fix travis failure mentioned in #2430 due to the last version of numpy: https://github.com/numpy/numpy/releases/tag/v1.19.0

### Progress of the PR
- [x] fix axes_manager `next` (https://github.com/numpy/numpy/pull/15887),
- [x] fix `tostring` deprecation warning,
- [x] fix numpy ragged array deprecation warning,
- [x] fix complex change dtype deprecation warning,
- [x] ready for review.

