### PR TITLE
Correct warning message for signal types

### DIFF
--- a/hyperspy/io.py
+++ b/hyperspy/io.py
@@ -402,7 +402,7 @@ def load_with_reader(filename, reader, signal_type=None, convert_units=False,
 
 
 def assign_signal_subclass(dtype, signal_dimension, signal_type="", lazy=False):
-    """Given record_by and signal_type, return the matching Signal subclass.
+    """Given dtype, signal_dimension and signal_type, return the matching Signal subclass.
 
     See `hs.print_known_signal_types()` for a list of known signal_types.
 

--- a/hyperspy/io.py
+++ b/hyperspy/io.py
@@ -431,7 +431,7 @@ def assign_signal_subclass(dtype, signal_dimension, signal_type="", lazy=False):
           'object' in dtype.name):
         dtype = 'real'
     else:
-        raise ValueError('Data type "{}" not understood!'.format(dtype.name))
+        raise ValueError(f'Data type "{dtype.name}" not understood!')
     if not isinstance(signal_dimension, int) or signal_dimension < 0:
         raise ValueError("signal_dimension must be a positive interger")
 

--- a/hyperspy/io.py
+++ b/hyperspy/io.py
@@ -401,18 +401,21 @@ def load_with_reader(filename, reader, signal_type=None, convert_units=False,
     return objects
 
 
-def assign_signal_subclass(dtype,
-                           signal_dimension,
-                           signal_type="",
-                           lazy=False):
-    """Given record_by and signal_type return the matching Signal subclass.
+def assign_signal_subclass(dtype, signal_dimension, signal_type="", lazy=False):
+    """Given record_by and signal_type, return the matching Signal subclass.
+
+    See `hs.print_known_signal_types()` for a list of known signal_types.
 
     Parameters
     ----------
     dtype : :class:`~.numpy.dtype`
-    signal_dimension: int
-    signal_type : {"EELS", "EDS", "EDS_SEM", "EDS_TEM", "DielectricFunction", "", str}
-    lazy: bool
+        Signal dtype
+    signal_dimension : int
+        Signal dimension
+    signal_type : str, default ""
+        Signal type. Optional. Will log a warning if it is unknown to HyperSpy.
+    lazy : bool, default False
+        If True, returns the matching LazySignal subclass.
 
     Returns
     -------

--- a/hyperspy/io.py
+++ b/hyperspy/io.py
@@ -441,6 +441,22 @@ def assign_signal_subclass(dtype,
                               if signal_type == value["signal_type"] or
                               "signal_type_aliases" in value and
                               signal_type in value["signal_type_aliases"]}
+
+    valid_signal_types = [v["signal_type"] for v in signals.values()]
+    valid_signal_aliases = [
+        v["signal_type_aliases"]
+        for v in signals.values()
+        if "signal_type_aliases" in v
+    ]
+    valid_signal_aliases = [i for j in valid_signal_aliases for i in j]
+    valid_signal_types.extend(valid_signal_aliases)
+
+    if signal_type not in set(valid_signal_types):
+        _logger.warning(
+            f"`signal_type='{signal_type}'` not understood. "
+            f"See `hs.print_known_signal_types()` for a list of known signal types."
+        )
+
     if dtype_dim_type_matches:
         # Perfect match found
         signal_dict = dtype_dim_type_matches
@@ -470,14 +486,7 @@ def assign_signal_subclass(dtype,
     for key, value in signal_dict.items():
         signal_class = getattr(importlib.import_module(value["module"]), key)
 
-        if value["signal_type"] == "":
-            _logger.warning(
-                f"`signal_type='{signal_type}'` not understood. "
-                f"Setting signal type to `{key}`"
-            )
-
         return signal_class
-
 
 def dict2signal(signal_dict, lazy=False):
     """Create a signal (or subclass) instance defined by a dictionary

--- a/hyperspy/io.py
+++ b/hyperspy/io.py
@@ -454,16 +454,16 @@ def assign_signal_subclass(dtype, signal_dimension, signal_type="", lazy=False):
     valid_signal_aliases = [i for j in valid_signal_aliases for i in j]
     valid_signal_types.extend(valid_signal_aliases)
 
-    if signal_type not in set(valid_signal_types):
-        _logger.warning(
-            f"`signal_type='{signal_type}'` not understood. "
-            f"See `hs.print_known_signal_types()` for a list of known signal types."
-        )
-
     if dtype_dim_type_matches:
         # Perfect match found
         signal_dict = dtype_dim_type_matches
     else:
+        if signal_type not in set(valid_signal_types):
+            _logger.warning(
+                f"`signal_type='{signal_type}'` not understood. "
+                f"See `hs.print_known_signal_types()` for a list of known signal types."
+            )
+
         # If the following dict is not empty, only signal_dimension and dtype match.
         # The dict should contain a general class for the given signal
         # dimension.

--- a/hyperspy/io.py
+++ b/hyperspy/io.py
@@ -404,7 +404,8 @@ def load_with_reader(filename, reader, signal_type=None, convert_units=False,
 def assign_signal_subclass(dtype, signal_dimension, signal_type="", lazy=False):
     """Given dtype, signal_dimension and signal_type, return the matching Signal subclass.
 
-    See `hs.print_known_signal_types()` for a list of known signal_types.
+    See `hs.print_known_signal_types()` for a list of known signal_types,
+    and the developer guide for details on how to add new signal_types.
 
     Parameters
     ----------
@@ -461,7 +462,8 @@ def assign_signal_subclass(dtype, signal_dimension, signal_type="", lazy=False):
         if signal_type not in set(valid_signal_types):
             _logger.warning(
                 f"`signal_type='{signal_type}'` not understood. "
-                f"See `hs.print_known_signal_types()` for a list of known signal types."
+                f"See `hs.print_known_signal_types()` for a list of known signal types, "
+                f"and the developer guide for details on how to add new signal_types."
             )
 
         # If the following dict is not empty, only signal_dimension and dtype match.

--- a/hyperspy/signal.py
+++ b/hyperspy/signal.py
@@ -4722,7 +4722,8 @@ class BaseSignal(FancySlicing,
         HyperSpy ships with a minimal set of known signal types. External
         packages can register extra signal types. To print a list of
         registered signal types in the current installation, call
-        :py:meth:`hyperspy.utils.print_known_signal_types()`.
+        :py:meth:`hyperspy.utils.print_known_signal_types()`, and see
+        the developer guide for details on how to add new signal_types.
 
         Parameters
         ----------

--- a/hyperspy/signal.py
+++ b/hyperspy/signal.py
@@ -4705,7 +4705,7 @@ class BaseSignal(FancySlicing,
         if self._lazy:
             self._make_lazy()
 
-    def set_signal_type(self, signal_type=None):
+    def set_signal_type(self, signal_type=""):
         """Set the signal type and convert the current signal accordingly.
 
         The ``signal_type`` attribute specifies the type of data that the signal
@@ -4782,6 +4782,13 @@ class BaseSignal(FancySlicing,
         <Signal1D, title: , dimensions: (|4)>
 
         """
+        if signal_type is None:
+            warnings.warn(
+                "`s.set_signal_type(signal_type=None)` is deprecated. "
+                "Use `s.set_signal_type(signal_type='')` instead.",
+                VisibleDeprecationWarning
+            )
+
         self.metadata.Signal.signal_type = signal_type
         # _assign_subclass takes care of matching aliases with their
         # corresponding signal class

--- a/hyperspy/signal.py
+++ b/hyperspy/signal.py
@@ -4724,6 +4724,8 @@ class BaseSignal(FancySlicing,
         registered signal types in the current installation, call
         :py:meth:`hyperspy.utils.print_known_signal_types`, and see
         the developer guide for details on how to add new signal_types.
+        A non-exhaustive list of HyperSpy extensions is also maintained
+        here: https://github.com/hyperspy/hyperspy-extensions-list.
 
         Parameters
         ----------

--- a/hyperspy/signal.py
+++ b/hyperspy/signal.py
@@ -4722,7 +4722,7 @@ class BaseSignal(FancySlicing,
         HyperSpy ships with a minimal set of known signal types. External
         packages can register extra signal types. To print a list of
         registered signal types in the current installation, call
-        :py:meth:`hyperspy.utils.print_known_signal_types()`, and see
+        :py:meth:`hyperspy.utils.print_known_signal_types`, and see
         the developer guide for details on how to add new signal_types.
 
         Parameters
@@ -4739,7 +4739,7 @@ class BaseSignal(FancySlicing,
 
         See Also
         --------
-        * :py:meth:`hyperspy.utils.print_known_signal_types()`
+        * :py:meth:`hyperspy.utils.print_known_signal_types`
 
         Examples
         --------

--- a/hyperspy/signal.py
+++ b/hyperspy/signal.py
@@ -4721,9 +4721,8 @@ class BaseSignal(FancySlicing,
 
         HyperSpy ships with a minimal set of known signal types. External
         packages can register extra signal types. To print a list of
-        registered signal types in the current installation run this method
-        without arguments. Note that
-
+        registered signal types in the current installation, call
+        :py:meth:`hyperspy.utils.print_known_signal_types()`.
 
         Parameters
         ----------
@@ -4739,7 +4738,7 @@ class BaseSignal(FancySlicing,
 
         See Also
         --------
-        print_known_signal_types
+        * :py:meth:`hyperspy.utils.print_known_signal_types()`
 
         Examples
         --------

--- a/hyperspy/tests/signal/test_assign_subclass.py
+++ b/hyperspy/tests/signal/test_assign_subclass.py
@@ -29,24 +29,23 @@ from hyperspy import _lazy_signals
 
 testcase = namedtuple('testcase', ['dtype', 'sig_dim', 'sig_type', 'cls'])
 
-subclass_cases = (testcase('float', 1000, '', 'BaseSignal'),
-                  testcase('float', 1, '', 'Signal1D'),
-                  testcase('float', 2, '', 'Signal2D'),
-                  testcase('float', 1, 'EELS', 'EELSSpectrum'),
-                  testcase('float', 1, 'EDS_SEM', 'EDSSEMSpectrum'),
-                  testcase('float', 1, 'EDS_TEM', 'EDSTEMSpectrum'),
-                  testcase('complex', 1, 'DielectricFunction',
-                           'DielectricFunction'),
-                  testcase('complex', 1, 'dielectric function',
-                           'DielectricFunction'),
-                  testcase('complex', 1000, '', 'ComplexSignal'),
-                  testcase('complex', 1, '', 'ComplexSignal1D'),
-                  testcase('complex', 2, '', 'ComplexSignal2D'),
-                  testcase('float', 1000, 'weird', 'BaseSignal'),
-                  testcase('float', 1, 'weird', 'Signal1D'),
-                  testcase('complex', 1000, 'weird', 'ComplexSignal'),
-                  )
-
+subclass_cases = (
+    testcase("float", 1000, "", "BaseSignal"),
+    testcase("float", 1, "", "Signal1D"),
+    testcase("float", 2, "", "Signal2D"),
+    testcase("float", 1, "EELS", "EELSSpectrum"),
+    testcase("float", 1, "EDS_SEM", "EDSSEMSpectrum"),
+    testcase("float", 1, "EDS_TEM", "EDSTEMSpectrum"),
+    testcase("complex", 1, "DielectricFunction", "DielectricFunction"),
+    testcase("complex", 1, "dielectric function", "DielectricFunction"),
+    testcase("complex", 1000, "", "ComplexSignal"),
+    testcase("complex", 1, "", "ComplexSignal1D"),
+    testcase("complex", 2, "", "ComplexSignal2D"),
+    testcase("float", 1000, "DefinitelyNotAHyperSpySignal", "BaseSignal"),
+    testcase("float", 1, "DefinitelyNotAHyperSpySignal", "Signal1D"),
+    testcase("complex", 1000, "DefinitelyNotAHyperSpySignal", "ComplexSignal"),
+    testcase("float", 1, "DefinitelyNotAHyperSpySignal", "Signal1D"),
+)
 
 def test_assignment_class(caplog):
     for case in subclass_cases:
@@ -60,8 +59,11 @@ def test_assignment_class(caplog):
 
         assert new_subclass is getattr(hs.signals, case.cls)
 
-        if case.sig_type == "weird":
-            assert "not understood. Setting signal type to" in caplog.text
+        warn_msg = "not understood. See `hs.print_known_signal_types()` for a list of known signal types"
+        if case.sig_type == "DefinitelyNotAHyperSpySignal":
+            assert warn_msg in caplog.text
+        else:
+            assert warn_msg not in caplog.text
 
         lazyclass = 'Lazy' + case.cls if case.cls != 'BaseSignal' else 'LazySignal'
         new_subclass = assign_signal_subclass(

--- a/hyperspy/tests/signal/test_assign_subclass.py
+++ b/hyperspy/tests/signal/test_assign_subclass.py
@@ -25,6 +25,7 @@ import logging
 import hyperspy.api as hs
 from hyperspy.io import assign_signal_subclass
 from hyperspy import _lazy_signals
+from hyperspy.exceptions import VisibleDeprecationWarning
 
 
 testcase = namedtuple('testcase', ['dtype', 'sig_dim', 'sig_type', 'cls'])
@@ -137,6 +138,13 @@ class TestConvertSignal1D:
         assert isinstance(self.s, hs.signals.EDSSEMSpectrum)
         self.s.set_signal_type("")
         assert isinstance(self.s, hs.signals.Signal1D)
+
+    def test_deprecated(self):
+        with pytest.warns(
+            VisibleDeprecationWarning,
+            match=r"is deprecated. Use ",
+        ):
+            self.s.set_signal_type(None)
 
 
 class TestConvertComplexSignal:


### PR DESCRIPTION
### Description of the change
Fixes #2433.

```python
>>> import hyperspy.api as hs
>>> s = hs.signals.Signal1D([1,2,3])
>>> m = s.create_model() # Prints no warning, as per example in #2433

>>> s.set_signal_type("EELS") # Prints no warning
>>> s.metadata
├── General
│   └── title = 
└── Signal
    ├── binned = True
    └── signal_type = EELS

>>> s.set_signal_type()
WARNING:hyperspy.io:`signal_type='None'` not understood. See `hs.print_known_signal_types()` for a list of known signal types.
>>> s.metadata
├── General
│   └── title = 
└── Signal
    ├── binned = False
    └── signal_type = None

>>> s.set_signal_type("LIGO")
WARNING:hyperspy.io:`signal_type='LIGO'` not understood. See `hs.print_known_signal_types()` for a list of known signal types.
>>> s.metadata
├── General
│   └── title = 
└── Signal
    ├── binned = False
    └── signal_type = LIGO
```
### Progress of the PR
- [x] Change implemented (can be split into several points),
- [x] update docstring (if appropriate),
- [x] update user guide (if appropriate),
- [x] add tests,
- [x] ready for review.

@thomasaarholt & @francisco-dlp  is this the correct behaviour now?

