### PR TITLE
Fix bug in `signal.split`

### DIFF
--- a/hyperspy/signal.py
+++ b/hyperspy/signal.py
@@ -2577,6 +2577,10 @@ class BaseSignal(FancySlicing,
             A list of the split signals
 
         """
+        if number_of_parts != 'auto' and step_sizes != 'auto':
+            raise ValueError(
+                "You can define step_sizes or number_of_parts but not both."
+            )
 
         shape = self.data.shape
         signal_dict = self._to_dictionary(add_learning_results=False)
@@ -2600,18 +2604,13 @@ class BaseSignal(FancySlicing,
         if number_of_parts == 'auto' and step_sizes == 'auto':
             step_sizes = 1
             number_of_parts = len_axis
-        elif number_of_parts != 'auto' and step_sizes != 'auto':
-            raise ValueError(
-                "You can define step_sizes or number_of_parts "
-                "but not both.")
         elif step_sizes == 'auto':
             if number_of_parts > shape[axis]:
                 raise ValueError(
-                    "The number of parts is greater than "
-                    "the axis size.")
-            else:
-                step_sizes = ([shape[axis] // number_of_parts, ] *
-                              number_of_parts)
+                    "The number of parts is greater than the axis size."
+                )
+
+            step_sizes = ([shape[axis] // number_of_parts, ] * number_of_parts)
 
         if isinstance(step_sizes, numbers.Integral):
             step_sizes = [step_sizes] * int(len_axis / step_sizes)

--- a/hyperspy/tests/signal/test_tools.py
+++ b/hyperspy/tests/signal/test_tools.py
@@ -279,6 +279,25 @@ class Test2D:
         assert len(result) == 5
         nt.assert_array_almost_equal(result[0].data, self.data[0])
 
+    def test_split_step_size_list(self):
+        result = self.signal.split(step_sizes=[1, 2])
+        assert len(result) == 2
+        nt.assert_array_almost_equal(result[0].data, self.data[:1, :10])
+        nt.assert_array_almost_equal(result[1].data, self.data[1:3, :10])
+
+    def test_split_error(self):
+        with pytest.raises(
+            ValueError,
+            match="You can define step_sizes or number_of_parts but not both",
+        ):
+            _ = self.signal.split(number_of_parts=2, step_sizes=2)
+
+        with pytest.raises(
+            ValueError,
+            match="The number of parts is greater than the axis size.",
+        ):
+            _ = self.signal.split(number_of_parts=1e9)
+
     def test_histogram(self):
         result = self.signal.get_histogram(3)
         assert isinstance(result, signals.Signal1D)

--- a/hyperspy/tests/utils/test_stack.py
+++ b/hyperspy/tests/utils/test_stack.py
@@ -1,4 +1,3 @@
-import pytest
 import numpy as np
 
 from hyperspy.signal import BaseSignal

--- a/hyperspy/tests/utils/test_stack.py
+++ b/hyperspy/tests/utils/test_stack.py
@@ -1,4 +1,4 @@
-
+import pytest
 import numpy as np
 
 from hyperspy.signal import BaseSignal
@@ -24,6 +24,18 @@ class TestUtilsStack:
         test_axis = s.axes_manager[0].index_in_array
         result_signal = utils.stack([s, s1, s2])
         result_list = result_signal.split()
+        assert test_axis == s.axes_manager[0].index_in_array
+        assert len(result_list) == 3
+        np.testing.assert_array_almost_equal(
+            result_list[0].data, result_signal.inav[:, :, 0].data)
+
+    def test_stack_number_of_parts(self):
+        s = self.signal
+        s1 = s.deepcopy() + 1
+        s2 = s.deepcopy() * 4
+        test_axis = s.axes_manager[0].index_in_array
+        result_signal = utils.stack([s, s1, s2])
+        result_list = result_signal.split(number_of_parts=3)
         assert test_axis == s.axes_manager[0].index_in_array
         assert len(result_list) == 3
         np.testing.assert_array_almost_equal(


### PR DESCRIPTION
### Description of the change
Closes #1298. Pretty certain `codecov` can be ignored here

### Progress of the PR
- [x] Change implemented (can be split into several points),
- [x] update docstring (if appropriate),
- [x] update user guide (if appropriate),
- [x] add tests,
- [x] ready for review.
