### PR TITLE
type check for xray_lines in get_lines_intensity()

### DIFF
--- a/hyperspy/_signals/eds.py
+++ b/hyperspy/_signals/eds.py
@@ -20,6 +20,7 @@ import logging
 
 import numpy as np
 import warnings
+from collections.abc import Iterable
 from matplotlib import pyplot as plt
 
 from hyperspy import utils
@@ -550,7 +551,7 @@ class EDS_mixin:
 
         Parameters
         ----------
-        xray_lines: {None, list of string}
+        xray_lines: {None, Iterable* of strings}
             If None,
             if `metadata.Sample.elements.xray_lines` contains a
             list of lines use those.
@@ -560,6 +561,8 @@ class EDS_mixin:
             for the operation.
             Alternatively, provide an iterable containing
             a list of valid X-ray lines symbols.
+            * Note that while dictionaries and strings are iterable,
+            their use is ambiguous and specifically not allowed.
         integration_windows: Float or array
             If float, the width of the integration windows is the
             'integration_windows_width' times the calculated FWHM of the line.
@@ -616,6 +619,13 @@ class EDS_mixin:
         plot
 
         """
+        if xray_lines is not None and \
+            (not isinstance(xray_lines, Iterable) or \
+            isinstance(xray_lines, str) or isinstance(xray_lines, dict)):
+
+            raise TypeError(
+                "xray_lines must be a compatible iterable, but was "
+                "mistakenly provided as a %s." % type(xray_lines))
 
         xray_lines = self._parse_xray_lines(xray_lines, only_one, only_lines)
         if hasattr(integration_windows, '__iter__') is False:

--- a/hyperspy/_signals/eds.py
+++ b/hyperspy/_signals/eds.py
@@ -621,7 +621,7 @@ class EDS_mixin:
         """
         if xray_lines is not None and \
             (not isinstance(xray_lines, Iterable) or \
-            isinstance(xray_lines, str) or isinstance(xray_lines, dict)):
+            isinstance(xray_lines, (str, dict))):
 
             raise TypeError(
                 "xray_lines must be a compatible iterable, but was "

--- a/hyperspy/io_plugins/sur.py
+++ b/hyperspy/io_plugins/sur.py
@@ -1224,7 +1224,7 @@ class DigitalSurfHandler(object):
             #set to 0 instead of 1 in non-spectral data to compute the
             #space occupied by data in the file
             readsize = Npts_tot*Psize
-            if Wsize is not 0:
+            if Wsize != 0:
                 readsize*=Wsize
             #if Npts_channel is not 0:
             #    readsize*=Npts_channel

--- a/hyperspy/tests/signal/test_eds_sem.py
+++ b/hyperspy/tests/signal/test_eds_sem.py
@@ -19,7 +19,7 @@ import sys
 
 import numpy as np
 
-from numpy.testing import assert_allclose
+from numpy.testing import assert_allclose, assert_raises
 
 from hyperspy.signals import EDSSEMSpectrum
 from hyperspy.defaults_parser import preferences
@@ -192,7 +192,7 @@ class Test_metadata:
 
 
 @lazifyTestClass
-class Test_get_lines_intentisity:
+class Test_get_lines_intensity:
 
     def setup_method(self, method):
         # Create an empty spectrum
@@ -211,6 +211,26 @@ class Test_get_lines_intentisity:
 
     def test(self):
         s = self.signal
+
+        # get_lines_intensity() should raise TypeError when
+        # xray_lines is a string or a dictionary
+        for bad_iter in ["Al_Kb", {"A" : "Al_Kb", "B" : "Ca_Ka"}]:
+                assert_raises(TypeError,
+                        s.get_lines_intensity,
+                        xray_lines=bad_iter,
+                        plot_result=False)
+
+        # get_lines_intensity() should succeed and return a list
+        # when xray_lines is an iterable (other than a str or dict)
+        good_iter = {"tuple" : ("Al_Kb", "Ca_Ka"),
+                      "list" : ["Al_Kb", "Ca_Ka"],
+                      "set" : set(["Al_Kb", "Ca_Ka"])}
+        for itr in good_iter:
+                assert isinstance(s.get_lines_intensity(
+                                xray_lines=good_iter[itr],
+                                plot_result=False), list), \
+                                "get_lines_intensity() trouble with {}".format( itr )
+
         sAl = s.get_lines_intensity(["Al_Ka"],
                                     plot_result=False,
                                     integration_windows=5)[0]


### PR DESCRIPTION
Addresses issue #2448 where xray_lines argument type was not checked.

## Description of the change
- Change to get_lines_intensity()
Check type of xray_lines arguement and raise a TypeError if xray_lines is not None and not a list.
- Corrected typo in EDS test class Test_get_lines_intensity
- Added tests to Test_get_lines_intensity.test()
Function now checks type of xray_lines.
**Note** !!! Most arguments to get_lines_intensity() remain un-validated at runtime !!!
- Change to _unpack_data()
Fix syntax error in _unpack_data() where numerical comparison was performed incorrectly.
Bug turned up while testing get_lines_intensity() fix.

### Progress of the PR
- [x] Change implemented (can be split into several points),
- [x] update docstring (if appropriate),
- [ ] update user guide (if appropriate),
- [x] add tests,
- [x] ready for review.

### Minimal example of the bug fix or the new feature
The following code shows that the new type check works as expected, but it is not a full test of get_lines_intensity().
```
import numpy as np
import hyperspy.api as hs

s = hs.signals.Signal1D(np.random.random((10,100)))
s.set_signal_type("EDS_SEM")

#should fail and raise KeyError
s.get_lines_intensity(xray_lines="Ca_Ka")
```
