### PR TITLE
Tidy up imports in hyperspy/tests/*

### DIFF
--- a/hyperspy/tests/__init__.py
+++ b/hyperspy/tests/__init__.py
@@ -20,6 +20,7 @@ import os
 import warnings
 
 from hyperspy.defaults_parser import preferences
+
 preferences.General.show_progressbar = True
 
 # Check if we should fail on external deprecation messages

--- a/hyperspy/tests/axes/test_axes_manager.py
+++ b/hyperspy/tests/axes/test_axes_manager.py
@@ -18,10 +18,11 @@
 
 from unittest import mock
 
-from hyperspy.axes import AxesManager, serpentine_iter
-from hyperspy.signals import BaseSignal, Signal1D, Signal2D
-from hyperspy.defaults_parser import preferences
 from numpy import arange, zeros
+
+from hyperspy.axes import AxesManager
+from hyperspy.defaults_parser import preferences
+from hyperspy.signals import BaseSignal, Signal1D, Signal2D
 
 
 class TestAxesManager:

--- a/hyperspy/tests/axes/test_conversion_units.py
+++ b/hyperspy/tests/axes/test_conversion_units.py
@@ -17,11 +17,11 @@
 # along with  HyperSpy.  If not, see <http://www.gnu.org/licenses/>.
 
 import numpy.testing as nt
-import traits.api as t
 import pytest
+import traits.api as t
 
-from hyperspy.axes import DataAxis, AxesManager, UnitConversion, _ureg
-from hyperspy.misc.test_utils import assert_warns, assert_deep_almost_equal
+from hyperspy.axes import AxesManager, DataAxis, UnitConversion, _ureg
+from hyperspy.misc.test_utils import assert_deep_almost_equal, assert_warns
 
 
 class TestUnitConversion:

--- a/hyperspy/tests/component/test_EELSarctan.py
+++ b/hyperspy/tests/component/test_EELSarctan.py
@@ -18,10 +18,8 @@
 
 import numpy as np
 from numpy.testing import assert_allclose
-import pytest
 
 from hyperspy.components1d import EELSArctan
-from hyperspy.signals import Signal1D
 
 
 def test_function2():

--- a/hyperspy/tests/component/test_arctan.py
+++ b/hyperspy/tests/component/test_arctan.py
@@ -18,10 +18,8 @@
 
 import numpy as np
 from numpy.testing import assert_allclose
-import pytest
 
 from hyperspy.components1d import Arctan
-from hyperspy.signals import Signal1D
 
 
 def test_function():

--- a/hyperspy/tests/component/test_bleasdale.py
+++ b/hyperspy/tests/component/test_bleasdale.py
@@ -17,10 +17,10 @@
 # along with  HyperSpy.  If not, see <http://www.gnu.org/licenses/>.
 
 
-import numpy as np
 from numpy.testing import assert_allclose
 
 from hyperspy.components1d import Bleasdale
+
 
 def test_function():
     g = Bleasdale()

--- a/hyperspy/tests/component/test_component.py
+++ b/hyperspy/tests/component/test_component.py
@@ -16,11 +16,12 @@
 # You should have received a copy of the GNU General Public License
 # along with  HyperSpy.  If not, see <http://www.gnu.org/licenses/>.
 
+from unittest import mock
+
 import numpy as np
 
-from hyperspy.component import Component
 from hyperspy.axes import AxesManager
-from unittest import mock
+from hyperspy.component import Component
 
 
 class TestMultidimensionalActive:

--- a/hyperspy/tests/component/test_component_active_array.py
+++ b/hyperspy/tests/component/test_component_active_array.py
@@ -17,9 +17,10 @@
 
 
 import numpy as np
+
 from hyperspy.components1d import Gaussian
-from hyperspy.signals import Signal1D
 from hyperspy.misc.utils import stash_active_state
+from hyperspy.signals import Signal1D
 
 
 class TestParametersAsSignals:

--- a/hyperspy/tests/component/test_component_print_current.py
+++ b/hyperspy/tests/component/test_component_print_current.py
@@ -18,7 +18,10 @@
 import pytest
 
 from hyperspy.datasets.example_signals import EDS_SEM_Spectrum
-from hyperspy.misc.model_tools import current_component_values, current_model_values, _is_iter, _iter_join, _non_iter
+from hyperspy.misc.model_tools import (_is_iter, _iter_join, _non_iter,
+                                       current_component_values,
+                                       current_model_values)
+
 
 class TestSetParameters:
 

--- a/hyperspy/tests/component/test_components.py
+++ b/hyperspy/tests/component/test_components.py
@@ -16,18 +16,18 @@
 # You should have received a copy of the GNU General Public License
 # along with  HyperSpy.  If not, see <http://www.gnu.org/licenses/>.
 
-import itertools
-import numpy as np
-from numpy.testing import assert_allclose
-import pytest
 import inspect
+import itertools
+
+import numpy as np
+import pytest
+from numpy.testing import assert_allclose
 
 import hyperspy.api as hs
-from hyperspy.models.model1d import Model1D
-from hyperspy.misc.test_utils import ignore_warning
 from hyperspy import components1d
 from hyperspy.component import Component
-
+from hyperspy.misc.test_utils import ignore_warning
+from hyperspy.models.model1d import Model1D
 
 TRUE_FALSE_2_TUPLE = [p for p in itertools.product((True, False), repeat=2)]
 

--- a/hyperspy/tests/component/test_components2D.py
+++ b/hyperspy/tests/component/test_components2D.py
@@ -17,7 +17,6 @@
 # along with  HyperSpy.  If not, see <http://www.gnu.org/licenses/>.
 
 import numpy as np
-
 from numpy.testing import assert_allclose
 
 import hyperspy.api as hs

--- a/hyperspy/tests/component/test_doniach.py
+++ b/hyperspy/tests/component/test_doniach.py
@@ -18,6 +18,7 @@
 
 import numpy as np
 from numpy.testing import assert_allclose
+
 from hyperspy.components1d import Doniach
 
 sqrt2pi = np.sqrt(2 * np.pi)
@@ -32,5 +33,3 @@ def test_function():
     g.alpha.value = 1.0e-7
     assert_allclose(g.function(2), 3.151281311482424)
     assert_allclose(g.function(1), 7.519884823893001)
-
-

--- a/hyperspy/tests/component/test_double_power_law.py
+++ b/hyperspy/tests/component/test_double_power_law.py
@@ -40,5 +40,3 @@ def test_function():
     assert g.grad_origin(2)  == -6
     assert g.grad_shift(2)  == -12
     assert g.grad_ratio(2)  == 3
-    
-    

--- a/hyperspy/tests/component/test_erf.py
+++ b/hyperspy/tests/component/test_erf.py
@@ -17,11 +17,11 @@
 # along with  HyperSpy.  If not, see <http://www.gnu.org/licenses/>.
 
 
-import numpy as np
-from numpy.testing import assert_allclose
-import pytest
 from distutils.version import LooseVersion
+
+import pytest
 import sympy
+from numpy.testing import assert_allclose
 
 from hyperspy.components1d import Erf
 
@@ -37,4 +37,3 @@ def test_function():
     assert g.function(3) == 0.
     assert_allclose(g.function(15),0.5)
     assert_allclose(g.function(1.951198),-0.2,rtol=1e-6)
-

--- a/hyperspy/tests/component/test_exponential.py
+++ b/hyperspy/tests/component/test_exponential.py
@@ -17,10 +17,10 @@
 # along with  HyperSpy.  If not, see <http://www.gnu.org/licenses/>.
 
 import itertools
+
 import numpy as np
-from numpy.testing import assert_allclose
 import pytest
-import matplotlib.pyplot as plt
+from numpy.testing import assert_allclose
 
 from hyperspy.components1d import Exponential
 from hyperspy.signals import Signal1D

--- a/hyperspy/tests/component/test_gaussian.py
+++ b/hyperspy/tests/component/test_gaussian.py
@@ -17,9 +17,10 @@
 # along with  HyperSpy.  If not, see <http://www.gnu.org/licenses/>.
 
 import itertools
+
 import numpy as np
-from numpy.testing import assert_allclose
 import pytest
+from numpy.testing import assert_allclose
 
 from hyperspy.components1d import Gaussian
 from hyperspy.signals import Signal1D

--- a/hyperspy/tests/component/test_gaussian2d.py
+++ b/hyperspy/tests/component/test_gaussian2d.py
@@ -17,10 +17,12 @@
 # along with  HyperSpy.  If not, see <http://www.gnu.org/licenses/>.
 
 import math
+
 import numpy as np
 from numpy.testing import assert_allclose
 
 from hyperspy.components2d import Gaussian2D
+
 sigma2fwhm = 2 * np.sqrt(2 * np.log(2))
 
 

--- a/hyperspy/tests/component/test_gaussianhf.py
+++ b/hyperspy/tests/component/test_gaussianhf.py
@@ -17,9 +17,10 @@
 # along with  HyperSpy.  If not, see <http://www.gnu.org/licenses/>.
 
 import itertools
+
 import numpy as np
-from numpy.testing import assert_allclose
 import pytest
+from numpy.testing import assert_allclose
 
 from hyperspy.components1d import GaussianHF
 from hyperspy.signals import Signal1D

--- a/hyperspy/tests/component/test_heaviside.py
+++ b/hyperspy/tests/component/test_heaviside.py
@@ -17,8 +17,6 @@
 # along with  HyperSpy.  If not, see <http://www.gnu.org/licenses/>.
 
 
-import numpy as np
-
 from hyperspy.components1d import HeavisideStep
 
 

--- a/hyperspy/tests/component/test_logistic.py
+++ b/hyperspy/tests/component/test_logistic.py
@@ -16,7 +16,6 @@
 # You should have received a copy of the GNU General Public License
 # along with  HyperSpy.  If not, see <http://www.gnu.org/licenses/>.
 
-import numpy as np
 from numpy.testing import assert_allclose
 
 from hyperspy.components1d import Logistic

--- a/hyperspy/tests/component/test_lorentzian.py
+++ b/hyperspy/tests/component/test_lorentzian.py
@@ -17,12 +17,13 @@
 # along with  HyperSpy.  If not, see <http://www.gnu.org/licenses/>.
 
 import itertools
-import numpy as np
-from numpy.testing import assert_allclose
-import pytest
 
-from hyperspy.signals import Signal1D
+import numpy as np
+import pytest
+from numpy.testing import assert_allclose
+
 from hyperspy.components1d import Lorentzian
+from hyperspy.signals import Signal1D
 from hyperspy.utils import stack
 
 TRUE_FALSE_2_TUPLE = [p for p in itertools.product((True, False), repeat=2)]

--- a/hyperspy/tests/component/test_pesvoigt.py
+++ b/hyperspy/tests/component/test_pesvoigt.py
@@ -11,24 +11,22 @@
 #  HyperSpy is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.from hyperspy.utils import stack
+# GNU General Public License for more details.
 
 #
 # You should have received a copy of the GNU General Public License
 # along with  HyperSpy.  If not, see <http://www.gnu.org/licenses/>.
 
 import itertools
-import numpy as np
-from numpy.testing import assert_allclose
-import pytest
 
-from hyperspy.signals import Signal1D
-from hyperspy.components1d import PESVoigt
-from hyperspy.utils import stack
-from hyperspy.exceptions import VisibleDeprecationWarning
+import numpy as np
+import pytest
+from numpy.testing import assert_allclose
 
 #Legacy test, to be removed in v2.0
-from hyperspy.components1d import Voigt
+from hyperspy.components1d import PESVoigt, Voigt
+from hyperspy.exceptions import VisibleDeprecationWarning
+from hyperspy.signals import Signal1D
 
 TRUE_FALSE_2_TUPLE = [p for p in itertools.product((True, False), repeat=2)]
 
@@ -82,4 +80,3 @@ def test_legacy():
         g.centre.value = 1
         assert_allclose(g.function(0), 0.35380168)
         assert_allclose(g.function(1), 5.06863535)
-

--- a/hyperspy/tests/component/test_powerlaw.py
+++ b/hyperspy/tests/component/test_powerlaw.py
@@ -17,9 +17,10 @@
 # along with  HyperSpy.  If not, see <http://www.gnu.org/licenses/>.
 
 import itertools
+
 import numpy as np
-from numpy.testing import assert_allclose
 import pytest
+from numpy.testing import assert_allclose
 
 from hyperspy.components1d import PowerLaw
 from hyperspy.signals import Signal1D

--- a/hyperspy/tests/component/test_skewnormal.py
+++ b/hyperspy/tests/component/test_skewnormal.py
@@ -18,11 +18,12 @@
 
 
 import itertools
-import numpy as np
-from numpy.testing import assert_allclose
-import pytest
 from distutils.version import LooseVersion
+
+import numpy as np
+import pytest
 import sympy
+from numpy.testing import assert_allclose
 
 from hyperspy.components1d import SkewNormal
 from hyperspy.signals import Signal1D

--- a/hyperspy/tests/component/test_splitvoigt.py
+++ b/hyperspy/tests/component/test_splitvoigt.py
@@ -18,13 +18,13 @@
 
 
 import itertools
+
 import numpy as np
-from numpy.testing import assert_allclose
 import pytest
+from numpy.testing import assert_allclose
 
 from hyperspy.components1d import SplitVoigt
 from hyperspy.signals import Signal1D
-from hyperspy.utils import stack
 
 TRUE_FALSE_2_TUPLE = [p for p in itertools.product((True, False), repeat=2)]
 
@@ -59,4 +59,3 @@ def test_estimate_parameters_binned(only_current, binned, lazy):
     assert abs(g2.centre.value - g1.centre.value) <= 0.1
     assert abs(g2.sigma1.value - g1.sigma1.value) <= 0.1
     assert abs(g2.sigma2.value - g1.sigma2.value) <= 0.1
-

--- a/hyperspy/tests/component/test_voigt.py
+++ b/hyperspy/tests/component/test_voigt.py
@@ -18,12 +18,13 @@
 # along with  HyperSpy.  If not, see <http://www.gnu.org/licenses/>.
 
 import itertools
-import numpy as np
-from numpy.testing import assert_allclose
-import pytest
 
-from hyperspy.signals import Signal1D
+import numpy as np
+import pytest
+from numpy.testing import assert_allclose
+
 from hyperspy.components1d import Voigt
+from hyperspy.signals import Signal1D
 from hyperspy.utils import stack
 
 TRUE_FALSE_2_TUPLE = [p for p in itertools.product((True, False), repeat=2)]

--- a/hyperspy/tests/component/test_volume_plasmon_drude.py
+++ b/hyperspy/tests/component/test_volume_plasmon_drude.py
@@ -16,7 +16,6 @@
 # You should have received a copy of the GNU General Public License
 # along with  HyperSpy.  If not, see <http://www.gnu.org/licenses/>.
 
-import numpy as np
 from numpy.testing import assert_allclose
 
 from hyperspy.components1d import VolumePlasmonDrude

--- a/hyperspy/tests/datasets/test_artificial_data.py
+++ b/hyperspy/tests/datasets/test_artificial_data.py
@@ -17,6 +17,7 @@
 # along with  HyperSpy.  If not, see <http://www.gnu.org/licenses/>.
 
 import numpy as np
+
 import hyperspy.datasets.artificial_data as ad
 
 

--- a/hyperspy/tests/datasets/test_eelsdb.py
+++ b/hyperspy/tests/datasets/test_eelsdb.py
@@ -16,11 +16,13 @@
 # You should have received a copy of the GNU General Public License
 # along with  HyperSpy.  If not, see <http://www.gnu.org/licenses/>.
 
+import warnings
+
 import pytest
 import requests
-from hyperspy.misc.eels.eelsdb import eelsdb
 from requests.exceptions import SSLError
-import warnings
+
+from hyperspy.misc.eels.eelsdb import eelsdb
 
 
 def eelsdb_down():

--- a/hyperspy/tests/drawing/test_figure.py
+++ b/hyperspy/tests/drawing/test_figure.py
@@ -18,10 +18,10 @@
 import numpy as np
 import pytest
 
-from hyperspy.drawing.figure import BlittedFigure
-from hyperspy.datasets.example_signals import EDS_TEM_Spectrum
-from hyperspy.signals import Signal1D, Signal2D
 from hyperspy._components.polynomial import Polynomial
+from hyperspy.datasets.example_signals import EDS_TEM_Spectrum
+from hyperspy.drawing.figure import BlittedFigure
+from hyperspy.signals import Signal1D, Signal2D
 
 
 def test_figure_title_length():

--- a/hyperspy/tests/drawing/test_mpl_testing_setup.py
+++ b/hyperspy/tests/drawing/test_mpl_testing_setup.py
@@ -15,8 +15,9 @@
 # You should have received a copy of the GNU General Public License
 # along with  HyperSpy.  If not, see <http://www.gnu.org/licenses/>.
 
-import matplotlib
 from distutils.version import LooseVersion
+
+import matplotlib
 import pytest
 
 from hyperspy.misc.test_utils import check_running_tests_in_CI

--- a/hyperspy/tests/drawing/test_plot_markers.py
+++ b/hyperspy/tests/drawing/test_plot_markers.py
@@ -18,12 +18,11 @@
 import numpy as np
 import pytest
 
-from hyperspy.misc.test_utils import update_close_figure, sanitize_dict
-from hyperspy.signals import Signal2D, Signal1D, BaseSignal
-from hyperspy.utils import markers, stack
-from hyperspy.drawing.marker import dict2marker
 from hyperspy.datasets.example_signals import EDS_TEM_Spectrum
-
+from hyperspy.drawing.marker import dict2marker
+from hyperspy.misc.test_utils import sanitize_dict, update_close_figure
+from hyperspy.signals import BaseSignal, Signal1D, Signal2D
+from hyperspy.utils import markers, stack
 
 default_tol = 2.0
 baseline_dir = 'plot_markers'

--- a/hyperspy/tests/drawing/test_plot_model.py
+++ b/hyperspy/tests/drawing/test_plot_model.py
@@ -17,14 +17,14 @@
 # along with  HyperSpy.  If not, see <http://www.gnu.org/licenses/>.
 
 import os
+
 import numpy as np
-import pytest
 import numpy.testing as nt
+import pytest
 
 import hyperspy.api as hs
-from hyperspy.signals import Signal1D, EELSSpectrum
 from hyperspy.components1d import Gaussian
-
+from hyperspy.signals import EELSSpectrum, Signal1D
 
 my_path = os.path.dirname(__file__)
 baseline_dir = 'plot_model'

--- a/hyperspy/tests/drawing/test_plot_model1d.py
+++ b/hyperspy/tests/drawing/test_plot_model1d.py
@@ -19,8 +19,8 @@
 import numpy as np
 import pytest
 
-from hyperspy.signals import Signal1D
 from hyperspy.components1d import Expression
+from hyperspy.signals import Signal1D
 
 DEFAULT_TOL = 2.0
 BASELINE_DIR = 'plot_model1d'

--- a/hyperspy/tests/drawing/test_plot_mva.py
+++ b/hyperspy/tests/drawing/test_plot_mva.py
@@ -21,7 +21,6 @@ import pytest
 
 from hyperspy import signals
 
-
 baseline_dir = 'plot_mva'
 default_tol = 2.0
 

--- a/hyperspy/tests/drawing/test_plot_roi_widgets.py
+++ b/hyperspy/tests/drawing/test_plot_roi_widgets.py
@@ -22,7 +22,6 @@ import pytest
 from hyperspy.signals import Signal2D
 from hyperspy.utils import roi
 
-
 BASELINE_DIR = 'plot_roi'
 DEFAULT_TOL = 2.0
 STYLE_PYTEST_MPL = 'default'

--- a/hyperspy/tests/drawing/test_plot_signal.py
+++ b/hyperspy/tests/drawing/test_plot_signal.py
@@ -15,14 +15,13 @@
 # You should have received a copy of the GNU General Public License
 # along with  HyperSpy.  If not, see <http://www.gnu.org/licenses/>.
 
-import numpy as np
-import traits.api as t
-import pytest
 import matplotlib.pyplot as plt
+import numpy as np
+import pytest
+import traits.api as t
 
-from hyperspy.misc.test_utils import update_close_figure
 import hyperspy.api as hs
-
+from hyperspy.misc.test_utils import update_close_figure
 
 scalebar_color = 'blue'
 default_tol = 2.0

--- a/hyperspy/tests/drawing/test_plot_signal1d.py
+++ b/hyperspy/tests/drawing/test_plot_signal1d.py
@@ -15,19 +15,18 @@
 # You should have received a copy of the GNU General Public License
 # along with  HyperSpy.  If not, see <http://www.gnu.org/licenses/>.
 
-import numpy as np
-import scipy.misc
-import pytest
-import matplotlib.pyplot as plt
 import os
 from shutil import copyfile
+
+import matplotlib.pyplot as plt
 import numpy as np
+import pytest
+import scipy.misc
 
 import hyperspy.api as hs
 from hyperspy.misc.test_utils import update_close_figure
 from hyperspy.signals import Signal1D
 from hyperspy.tests.drawing.test_plot_signal import _TestPlot
-
 
 scalebar_color = 'blue'
 default_tol = 2.0

--- a/hyperspy/tests/drawing/test_plot_signal2d.py
+++ b/hyperspy/tests/drawing/test_plot_signal2d.py
@@ -15,16 +15,15 @@
 # You should have received a copy of the GNU General Public License
 # along with  HyperSpy.  If not, see <http://www.gnu.org/licenses/>.
 
+import matplotlib.pyplot as plt
 import numpy as np
+import pytest
 import scipy.ndimage
 import traits.api as t
-import pytest
-import matplotlib.pyplot as plt
 
 import hyperspy.api as hs
-from hyperspy.drawing.utils import plot_RGB_map
+from hyperspy.drawing.utils import make_cmap, plot_RGB_map
 from hyperspy.tests.drawing.test_plot_signal import _TestPlot
-from hyperspy.drawing.utils import make_cmap
 
 scalebar_color = 'blue'
 default_tol = 2.0

--- a/hyperspy/tests/drawing/test_plot_signal_tools.py
+++ b/hyperspy/tests/drawing/test_plot_signal_tools.py
@@ -15,14 +15,13 @@
 # You should have received a copy of the GNU General Public License
 # along with  HyperSpy.  If not, see <http://www.gnu.org/licenses/>.
 
+import matplotlib.pyplot as plt
 import numpy as np
 import pytest
-import matplotlib.pyplot as plt
 
-from hyperspy import signals, components1d
+from hyperspy import components1d, signals
 from hyperspy._signals.signal1d import BackgroundRemoval
 from hyperspy.signal_tools import ImageContrastEditor
-
 
 BASELINE_DIR = "plot_signal_tools"
 DEFAULT_TOL = 2.0
@@ -80,4 +79,3 @@ def test_plot_contrast_editor_norm(norm):
         s2.plot(norm=norm)
         ceditor2 = ImageContrastEditor(s._plot.signal_plot)
     assert ceditor.norm == norm.capitalize()
-

--- a/hyperspy/tests/drawing/test_plot_widgets.py
+++ b/hyperspy/tests/drawing/test_plot_widgets.py
@@ -16,14 +16,13 @@
 # You should have received a copy of the GNU General Public License
 # along with  HyperSpy.  If not, see <http://www.gnu.org/licenses/>.
 
+import matplotlib
 import numpy as np
 import numpy.testing as nt
 import pytest
-import matplotlib
 
-from hyperspy.signals import Signal2D, Signal1D
 from hyperspy.drawing import widgets
-
+from hyperspy.signals import Signal1D, Signal2D
 
 baseline_dir = 'plot_widgets'
 default_tol = 2.0

--- a/hyperspy/tests/external/test_mpfit.py
+++ b/hyperspy/tests/external/test_mpfit.py
@@ -1,5 +1,6 @@
-import numpy as N
 import copy
+
+import numpy as N
 
 from hyperspy.external.mpfit.mpfit import mpfit
 
@@ -75,6 +76,3 @@ def test_rosenbrock():
     assert N.allclose(m.params, pactual)
     assert N.allclose(m.fnorm, 0)
     return
-
-if __name__ == "__main__":
-    run_module_suite()

--- a/hyperspy/tests/io/test_blockfile.py
+++ b/hyperspy/tests/io/test_blockfile.py
@@ -17,21 +17,20 @@
 # along with  HyperSpy.  If not, see <http://www.gnu.org/licenses/>.
 
 
-import warnings
-import os
 import gc
+import os
 import tempfile
+import warnings
 
 import numpy as np
-from numpy.testing import assert_allclose
 import pytest
+from numpy.testing import assert_allclose
 
+import hyperspy.api as hs
 from hyperspy.io_plugins.blockfile import get_default_header
 from hyperspy.misc.array_tools import sarray2dict
-import hyperspy.api as hs
-from hyperspy.misc.test_utils import assert_deep_almost_equal
 from hyperspy.misc.date_time_tools import serial_date_to_ISO_format
-
+from hyperspy.misc.test_utils import assert_deep_almost_equal
 
 try:
     WindowsError

--- a/hyperspy/tests/io/test_bruker.py
+++ b/hyperspy/tests/io/test_bruker.py
@@ -1,13 +1,12 @@
-import os
-
 import json
+import os
 
 import numpy as np
 import pytest
 from numpy.testing import assert_allclose
 
-from hyperspy.io import load
 from hyperspy import signals
+from hyperspy.io import load
 from hyperspy.misc.test_utils import assert_deep_almost_equal
 
 test_files = ['30x30_instructively_packed_16bit_compressed.bcf',

--- a/hyperspy/tests/io/test_dens.py
+++ b/hyperspy/tests/io/test_dens.py
@@ -20,12 +20,10 @@
 import os
 
 import numpy as np
-from numpy.testing import assert_allclose
 import pytest
-
+from numpy.testing import assert_allclose
 
 import hyperspy.api as hs
-
 
 dirpath = os.path.dirname(__file__)
 

--- a/hyperspy/tests/io/test_dm3.py
+++ b/hyperspy/tests/io/test_dm3.py
@@ -17,18 +17,19 @@
 # along with  HyperSpy.  If not, see <http://www.gnu.org/licenses/>.
 
 
+import json
 import os
 
 import numpy as np
-from numpy.testing import assert_allclose
 import pytest
+from numpy.testing import assert_allclose
 
+from hyperspy.io import load
+from hyperspy.io_plugins.digital_micrograph import (DigitalMicrographReader,
+                                                    ImageObject)
+from hyperspy.signals import Signal1D, Signal2D
 from hyperspy.tests.io.generate_dm_testing_files import (dm3_data_types,
                                                          dm4_data_types)
-from hyperspy.io import load
-from hyperspy.io_plugins.digital_micrograph import DigitalMicrographReader, ImageObject
-from hyperspy.signals import Signal1D, Signal2D
-import json
 
 MY_PATH = os.path.dirname(__file__)
 

--- a/hyperspy/tests/io/test_dm_stackbuilder_plugin.py
+++ b/hyperspy/tests/io/test_dm_stackbuilder_plugin.py
@@ -19,9 +19,9 @@
 
 import os
 
-from hyperspy.io import load
 from numpy.testing import assert_allclose
 
+from hyperspy.io import load
 
 my_path = os.path.dirname(__file__)
 

--- a/hyperspy/tests/io/test_edax.py
+++ b/hyperspy/tests/io/test_edax.py
@@ -1,18 +1,17 @@
-import os.path
-import os
-import tempfile
 import gc
-import zipfile
 import hashlib
+import os
+import os.path
+import tempfile
+import zipfile
 
 import numpy as np
-from numpy.testing import assert_allclose, assert_equal
 import pytest
 import requests
+from numpy.testing import assert_allclose, assert_equal
 
-from hyperspy.io import load
 from hyperspy import signals
-
+from hyperspy.io import load
 
 MY_PATH = os.path.dirname(__file__)
 ZIPF = os.path.join(MY_PATH, "edax_files.zip")

--- a/hyperspy/tests/io/test_emd.py
+++ b/hyperspy/tests/io/test_emd.py
@@ -21,23 +21,22 @@
 # NOT to be confused with the FEI EMD format which was developed later.
 
 
+import gc
 import os.path
-from os import remove
 import shutil
 import tempfile
-import gc
-
-from numpy.testing import assert_allclose
-import numpy as np
-import h5py
-from dateutil import tz
 from datetime import datetime
+from os import remove
+
+import h5py
+import numpy as np
 import pytest
+from dateutil import tz
+from numpy.testing import assert_allclose
 
 from hyperspy.io import load
-from hyperspy.signals import BaseSignal, Signal2D, Signal1D, EDSTEMSpectrum
 from hyperspy.misc.test_utils import assert_deep_almost_equal
-
+from hyperspy.signals import BaseSignal, EDSTEMSpectrum, Signal1D, Signal2D
 
 my_path = os.path.dirname(__file__)
 

--- a/hyperspy/tests/io/test_emd_prismatic.py
+++ b/hyperspy/tests/io/test_emd_prismatic.py
@@ -17,9 +17,10 @@
 # along with  HyperSpy.  If not, see <http://www.gnu.org/licenses/>.
 
 import os
+
 import numpy as np
-import traits.api as t
 import pytest
+import traits.api as t
 
 import hyperspy.api as hs
 

--- a/hyperspy/tests/io/test_empad.py
+++ b/hyperspy/tests/io/test_empad.py
@@ -1,13 +1,13 @@
 
 import os
-import traits.api as t
+import struct
+
 import numpy as np
 import numpy.testing as nt
 import pytest
-import struct
+import traits.api as t
 
 import hyperspy.api as hs
-
 
 DATA_DIR = os.path.join(os.path.dirname(__file__), 'empad_data')
 FILENAME_STACK_RAW = os.path.join(DATA_DIR, 'series_x10.raw')

--- a/hyperspy/tests/io/test_fei.py
+++ b/hyperspy/tests/io/test_fei.py
@@ -18,11 +18,10 @@
 
 import os
 
-import pytest
 import numpy as np
-from numpy.testing import assert_allclose
+import pytest
 import traits.api as t
-
+from numpy.testing import assert_allclose
 
 from hyperspy.io import load
 from hyperspy.io_plugins.fei import load_ser_file

--- a/hyperspy/tests/io/test_hdf5.py
+++ b/hyperspy/tests/io/test_hdf5.py
@@ -16,30 +16,27 @@
 # You should have received a copy of the GNU General Public License
 # along with  HyperSpy.  If not, see <http://www.gnu.org/licenses/>.
 
-import os.path
-from os import remove
-import sys
 import gc
-import time
+import os.path
+import sys
 import tempfile
+import time
+from os import remove
 
+import dask.array as da
 import h5py
 import numpy as np
-import dask
-import dask.array as da
 import pytest
-from distutils.version import LooseVersion
 
-from hyperspy.io import load
-from hyperspy.signal import BaseSignal
 from hyperspy._signals.signal1d import Signal1D
 from hyperspy._signals.signal2d import Signal2D
-from hyperspy.roi import Point2DROI
 from hyperspy.datasets.example_signals import EDS_TEM_Spectrum
-from hyperspy.utils import markers
-from hyperspy.misc.test_utils import sanitize_dict as san_dict
+from hyperspy.io import load
 from hyperspy.misc.test_utils import assert_deep_almost_equal
-
+from hyperspy.misc.test_utils import sanitize_dict as san_dict
+from hyperspy.roi import Point2DROI
+from hyperspy.signal import BaseSignal
+from hyperspy.utils import markers
 
 my_path = os.path.dirname(__file__)
 

--- a/hyperspy/tests/io/test_image.py
+++ b/hyperspy/tests/io/test_image.py
@@ -17,8 +17,9 @@
 # along with  HyperSpy.  If not, see <http://www.gnu.org/licenses/>.
 
 import os
-import numpy as np
 import tempfile
+
+import numpy as np
 import pytest
 
 import hyperspy.api as hs
@@ -51,4 +52,3 @@ def test_save_load_cycle_color(color, ext):
         filename = os.path.join(tmpdir, 'test_image.'+ext)
         s.save(filename)
         hs.load(filename)
-

--- a/hyperspy/tests/io/test_io.py
+++ b/hyperspy/tests/io/test_io.py
@@ -16,16 +16,16 @@
 # You should have received a copy of the GNU General Public License
 # along with  HyperSpy.  If not, see <http://www.gnu.org/licenses/>.
 
-import os
 import hashlib
+import os
+import tempfile
+from unittest.mock import patch
+
 import numpy as np
 import pytest
-import tempfile
+
 import hyperspy.api as hs
-
-from unittest.mock import patch
 from hyperspy.signals import Signal1D
-
 
 DIRPATH = os.path.dirname(__file__)
 FILENAME = 'test_io_overwriting.hspy'

--- a/hyperspy/tests/io/test_mrcz.py
+++ b/hyperspy/tests/io/test_mrcz.py
@@ -16,13 +16,18 @@
 # You should have received a copy of the GNU General Public License
 # along with  HyperSpy.  If not, see <http://www.gnu.org/licenses/>.
 
+import os
+import tempfile
+from time import perf_counter, sleep
+
 import numpy as np
 import numpy.testing as npt
-import os
-import sys
-import tempfile
 import pytest
-from time import perf_counter, sleep
+
+from hyperspy import signals
+from hyperspy.io import load, save
+from hyperspy.misc.test_utils import assert_deep_almost_equal
+
 try:
     import blosc
     blosc_installed = True
@@ -34,9 +39,6 @@ try:
 except BaseException:
     mrcz_installed = False
 
-from hyperspy.io import load, save
-from hyperspy import signals
-from hyperspy.misc.test_utils import assert_deep_almost_equal
 
 
 pytestmark = pytest.mark.skipif(
@@ -186,11 +188,3 @@ class TestPythonMrcz:
                              clevel=1, do_async=True)
         print("MRCZ Asychronous test finished in {} s".format(
             perf_counter() - t_start))
-
-
-if __name__ == '__main__':
-    theSuite = TestPythonMrcz()
-    parameters = _generate_parameters()
-    for parameter in parameters:
-        theSuite.test_MRC(*parameter)
-    theSuite.test_Async(parameter[0])

--- a/hyperspy/tests/io/test_msa.py
+++ b/hyperspy/tests/io/test_msa.py
@@ -1,6 +1,6 @@
+import copy
 import os.path
 import tempfile
-import copy
 
 from hyperspy.io import load
 from hyperspy.misc.test_utils import assert_deep_almost_equal

--- a/hyperspy/tests/io/test_nexus_hdf.py
+++ b/hyperspy/tests/io/test_nexus_hdf.py
@@ -16,21 +16,23 @@
 # You should have received a copy of the GNU General Public License
 # along with  HyperSpy.  If not, see <http://www.gnu.org/licenses/>.
 
-import os.path
 import gc
+import os.path
 import tempfile
+
 import numpy as np
 import pytest
-from hyperspy.io import load
-from hyperspy.io_plugins.nexus import read_metadata_from_file,\
-    list_datasets_in_file, file_writer, _is_int, _is_numeric_data,\
-    _fix_exclusion_keys, _byte_to_string
-import hyperspy.api as hs
-from hyperspy.signal import BaseSignal
-from hyperspy._signals.signal1d import Signal1D
-from hyperspy._signals.signal2d import Signal2D
 import traits.api as t
 
+import hyperspy.api as hs
+from hyperspy._signals.signal1d import Signal1D
+from hyperspy._signals.signal2d import Signal2D
+from hyperspy.io import load
+from hyperspy.io_plugins.nexus import (_byte_to_string, _fix_exclusion_keys,
+                                       _is_int, _is_numeric_data, file_writer,
+                                       list_datasets_in_file,
+                                       read_metadata_from_file)
+from hyperspy.signal import BaseSignal
 
 dirpath = os.path.dirname(__file__)
 

--- a/hyperspy/tests/io/test_phenom.py
+++ b/hyperspy/tests/io/test_phenom.py
@@ -18,7 +18,9 @@
 
 
 import os
+
 import pytest
+
 import hyperspy.api as hs
 
 try:

--- a/hyperspy/tests/io/test_protochips.py
+++ b/hyperspy/tests/io/test_protochips.py
@@ -20,7 +20,6 @@ import os
 
 import numpy as np
 import pytest
-
 from numpy.testing import assert_allclose
 
 import hyperspy.api as hs

--- a/hyperspy/tests/io/test_ripple.py
+++ b/hyperspy/tests/io/test_ripple.py
@@ -1,16 +1,14 @@
-import tempfile
-import os.path
 import gc
+import os.path
+import tempfile
 
 import numpy as np
-
-import pytest
 import numpy.testing as npt
+import pytest
 
-from hyperspy.io import load
 import hyperspy.signals as signals
+from hyperspy.io import load
 from hyperspy.io_plugins import ripple
-
 
 # Tuple of tuples (data shape, signal_dimensions)
 SHAPES_SDIM = (((3,), (1, )),

--- a/hyperspy/tests/io/test_semper_unf.py
+++ b/hyperspy/tests/io/test_semper_unf.py
@@ -17,16 +17,14 @@
 # along with  HyperSpy.  If not, see <http://www.gnu.org/licenses/>.
 
 import os.path
-from os import remove
 import tempfile
-
+from os import remove
 
 import numpy as np
 import pytest
 
 from hyperspy.io import load
-from hyperspy.signals import BaseSignal, Signal2D, Signal1D, ComplexSignal
-
+from hyperspy.signals import BaseSignal, ComplexSignal, Signal1D, Signal2D
 
 my_path = os.path.dirname(__file__)
 
@@ -182,9 +180,3 @@ class TestCaseSaveAndReadByte():
 
     def teardown_method(self, method):
         remove(os.path.join(my_path, 'unf_files', 'example_temp.unf'))
-
-
-if __name__ == '__main__':
-
-    import pytest
-    pytest.main(__name__)

--- a/hyperspy/tests/io/test_sur.py
+++ b/hyperspy/tests/io/test_sur.py
@@ -20,7 +20,6 @@ import os
 
 from numpy import dtype
 from numpy.testing import assert_allclose
-import pytest
 
 from hyperspy.io import load
 

--- a/hyperspy/tests/io/test_tiff.py
+++ b/hyperspy/tests/io/test_tiff.py
@@ -2,9 +2,9 @@ import os
 import tempfile
 
 import numpy as np
-from numpy.testing import assert_allclose
 import pytest
 import traits.api as t
+from numpy.testing import assert_allclose
 
 import hyperspy.api as hs
 from hyperspy.misc.test_utils import assert_deep_almost_equal

--- a/hyperspy/tests/io/test_usid.py
+++ b/hyperspy/tests/io/test_usid.py
@@ -1,9 +1,12 @@
 import tempfile
-import pytest
-import numpy as np
+
 import dask.array as da
 import h5py
+import numpy as np
+import pytest
+
 from hyperspy import api as hs
+
 try:
     import pyUSID as usid
     pyusid_installed = True

--- a/hyperspy/tests/learn/test_lazy_decomposition.py
+++ b/hyperspy/tests/learn/test_lazy_decomposition.py
@@ -19,9 +19,9 @@
 import numpy as np
 import pytest
 
-from hyperspy.signals import Signal1D
 from hyperspy.exceptions import VisibleDeprecationWarning
 from hyperspy.misc.machine_learning.import_sklearn import sklearn_installed
+from hyperspy.signals import Signal1D
 
 
 class TestLazyDecomposition:

--- a/hyperspy/tests/learn/test_learning_results.py
+++ b/hyperspy/tests/learn/test_learning_results.py
@@ -20,8 +20,8 @@
 import numpy as np
 import pytest
 
-from hyperspy.signals import Signal1D
 from hyperspy.misc.machine_learning.import_sklearn import sklearn_installed
+from hyperspy.signals import Signal1D
 
 
 def test_learning_results_decom():

--- a/hyperspy/tests/learn/test_svd_pca.py
+++ b/hyperspy/tests/learn/test_svd_pca.py
@@ -19,8 +19,8 @@
 import numpy as np
 import pytest
 
-from hyperspy.misc.machine_learning.import_sklearn import sklearn_installed
 from hyperspy.learn.svd_pca import svd_pca
+from hyperspy.misc.machine_learning.import_sklearn import sklearn_installed
 
 
 class TestSVDPCA:

--- a/hyperspy/tests/misc/test_arraytools.py
+++ b/hyperspy/tests/misc/test_arraytools.py
@@ -17,11 +17,10 @@
 # along with  HyperSpy.  If not, see <http://www.gnu.org/licenses/>.
 
 
-import pytest
 import numpy as np
+import pytest
 
 from hyperspy.misc.array_tools import dict2sarray
-
 
 dt = [('x', np.uint8), ('y', np.uint16), ('text', (bytes, 6))]
 

--- a/hyperspy/tests/misc/test_date_time_tools.py
+++ b/hyperspy/tests/misc/test_date_time_tools.py
@@ -17,13 +17,12 @@
 # along with  HyperSpy.  If not, see <http://www.gnu.org/licenses/>.
 
 import numpy as np
-from dateutil import tz, parser
-
+from dateutil import parser, tz
 from numpy.testing import assert_allclose
 
 import hyperspy.misc.date_time_tools as dtt
-from hyperspy.misc.utils import DictionaryTreeBrowser
 from hyperspy.misc.test_utils import assert_deep_almost_equal
+from hyperspy.misc.utils import DictionaryTreeBrowser
 
 
 def _get_example(date, time, time_zone=None):

--- a/hyperspy/tests/misc/test_fei_stream_readers.py
+++ b/hyperspy/tests/misc/test_fei_stream_readers.py
@@ -25,11 +25,11 @@ in order to mimic the usage in the FEI EMD reader.
 
 """
 import numpy as np
-import dask.array as da
 import pytest
 
-from hyperspy.misc.io.fei_stream_readers import (
-    array_to_stream, stream_to_array, stream_to_sparse_COO_array)
+from hyperspy.misc.io.fei_stream_readers import (array_to_stream,
+                                                 stream_to_array,
+                                                 stream_to_sparse_COO_array)
 
 
 @pytest.mark.parametrize("lazy", (True, False))

--- a/hyperspy/tests/misc/test_image_tools.py
+++ b/hyperspy/tests/misc/test_image_tools.py
@@ -16,8 +16,8 @@
 # You should have received a copy of the GNU General Public License
 # along with  HyperSpy.  If not, see <http://www.gnu.org/licenses/>.
 
-import pytest
 import numpy as np
+import pytest
 
 from hyperspy.drawing.utils import contrast_stretching
 

--- a/hyperspy/tests/misc/test_rgbtools.py
+++ b/hyperspy/tests/misc/test_rgbtools.py
@@ -18,6 +18,7 @@
 
 
 import numpy as np
+
 import hyperspy.misc.rgb_tools as rt
 
 

--- a/hyperspy/tests/misc/test_test_utils.py
+++ b/hyperspy/tests/misc/test_test_utils.py
@@ -19,7 +19,7 @@
 
 import warnings
 
-from hyperspy.misc.test_utils import ignore_warning, assert_warns, all_warnings
+from hyperspy.misc.test_utils import all_warnings, assert_warns, ignore_warning
 
 
 def warnsA():

--- a/hyperspy/tests/misc/test_utils.py
+++ b/hyperspy/tests/misc/test_utils.py
@@ -16,8 +16,7 @@
 # You should have received a copy of the GNU General Public License
 # along with  HyperSpy.  If not, see <http://www.gnu.org/licenses/>.
 
-from hyperspy.misc.utils import slugify, parse_quantity
-from hyperspy import roi
+from hyperspy.misc.utils import parse_quantity, slugify
 
 
 def test_slugify():

--- a/hyperspy/tests/model/test_edsmodel.py
+++ b/hyperspy/tests/model/test_edsmodel.py
@@ -18,12 +18,12 @@
 
 import numpy as np
 
-from hyperspy.misc.test_utils import assert_warns
+from hyperspy.datasets.example_signals import EDS_TEM_Spectrum
+from hyperspy.decorators import lazifyTestClass
 from hyperspy.misc import utils
 from hyperspy.misc.eds import utils as utils_eds
 from hyperspy.misc.elements import elements as elements_db
-from hyperspy.decorators import lazifyTestClass
-from hyperspy.datasets.example_signals import EDS_TEM_Spectrum
+from hyperspy.misc.test_utils import assert_warns
 
 
 @lazifyTestClass

--- a/hyperspy/tests/model/test_eelsmodel.py
+++ b/hyperspy/tests/model/test_eelsmodel.py
@@ -17,7 +17,6 @@
 # along with  HyperSpy.  If not, see <http://www.gnu.org/licenses/>.
 
 import numpy as np
-
 import pytest
 from numpy.testing import assert_allclose
 

--- a/hyperspy/tests/model/test_fancy_indexing.py
+++ b/hyperspy/tests/model/test_fancy_indexing.py
@@ -18,10 +18,8 @@
 
 import numpy as np
 
-import time
-
-from hyperspy._signals.signal1d import Signal1D
 from hyperspy._signals.eels import EELSSpectrum
+from hyperspy._signals.signal1d import Signal1D
 from hyperspy.components1d import Gaussian
 from hyperspy.decorators import lazifyTestClass
 

--- a/hyperspy/tests/model/test_model.py
+++ b/hyperspy/tests/model/test_model.py
@@ -20,13 +20,12 @@ from unittest import mock
 
 import numpy as np
 import pytest
-import logging
 
 import hyperspy.api as hs
-from hyperspy.misc.utils import slugify
 from hyperspy.decorators import lazifyTestClass
-from hyperspy.misc.test_utils import ignore_warning
 from hyperspy.exceptions import VisibleDeprecationWarning
+from hyperspy.misc.test_utils import ignore_warning
+from hyperspy.misc.utils import slugify
 
 RTOL = 1E-6
 

--- a/hyperspy/tests/model/test_model_as_dictionary.py
+++ b/hyperspy/tests/model/test_model_as_dictionary.py
@@ -18,11 +18,10 @@
 
 
 import numpy as np
-
 import pytest
 
 from hyperspy._signals.signal1d import Signal1D
-from hyperspy.component import Parameter, Component
+from hyperspy.component import Component, Parameter
 from hyperspy.components1d import Gaussian, Lorentzian, ScalableFixedPattern
 
 

--- a/hyperspy/tests/model/test_model_selection_criteria.py
+++ b/hyperspy/tests/model/test_model_selection_criteria.py
@@ -18,11 +18,9 @@
 
 import numpy as np
 
-from numpy.testing import assert_allclose
-
-from hyperspy.utils.model_selection import AIC, AICc, BIC
-from hyperspy.signals import Signal1D
 from hyperspy.components1d import Gaussian, Lorentzian
+from hyperspy.signals import Signal1D
+from hyperspy.utils.model_selection import AIC, BIC, AICc
 
 
 class TestModelSelection:
@@ -41,17 +39,17 @@ class TestModelSelection:
     def test_AIC(self):
         _aic1 = AIC(self.m1)
         _aic2 = AIC(self.m2)
-        assert_allclose(_aic1, 74.477061729373233)
-        assert_allclose(_aic2, 72.749265802224159)
+        np.testing.assert_allclose(_aic1, 74.477061729373233)
+        np.testing.assert_allclose(_aic2, 72.749265802224159)
 
     def test_AICc(self):
         _aicc1 = AICc(self.m1)
         _aicc2 = AICc(self.m2)
-        assert_allclose(_aicc1, 82.477061729373233)
-        assert_allclose(_aicc2, 80.749265802224159)
+        np.testing.assert_allclose(_aicc1, 82.477061729373233)
+        np.testing.assert_allclose(_aicc2, 80.749265802224159)
 
     def test_BIC(self):
         _bic1 = BIC(self.m1)
         _bic2 = BIC(self.m2)
-        assert_allclose(_bic1, 75.68740210134942)
-        assert_allclose(_bic2, 73.959606174200346)
+        np.testing.assert_allclose(_bic1, 75.68740210134942)
+        np.testing.assert_allclose(_bic2, 73.959606174200346)

--- a/hyperspy/tests/model/test_model_storing.py
+++ b/hyperspy/tests/model/test_model_storing.py
@@ -17,17 +17,16 @@
 # along with  HyperSpy.  If not, see <http://www.gnu.org/licenses/>.
 
 
+import gc
 from os import remove
 from unittest import mock
-import gc
 
 import numpy as np
-
 import pytest
 
 from hyperspy._signals.signal1d import Signal1D
+from hyperspy.components1d import Expression, Gaussian, GaussianHF
 from hyperspy.io import load
-from hyperspy.components1d import Gaussian, Expression, GaussianHF
 
 
 def clean_model_dictionary(d):

--- a/hyperspy/tests/model/test_parameter.py
+++ b/hyperspy/tests/model/test_parameter.py
@@ -23,7 +23,6 @@ import numpy as np
 import pytest
 
 from hyperspy.component import Parameter
-from hyperspy.exceptions import NavigationDimensionError
 
 
 class Dummy:

--- a/hyperspy/tests/samfire/test_goodness_of_fit_tests.py
+++ b/hyperspy/tests/samfire/test_goodness_of_fit_tests.py
@@ -17,9 +17,9 @@
 
 import numpy as np
 
+from hyperspy.components1d import Lorentzian
 from hyperspy.misc.utils import DictionaryTreeBrowser
 from hyperspy.signals import Signal1D
-from hyperspy.components1d import Lorentzian
 
 
 class TestRedChisq:

--- a/hyperspy/tests/samfire/test_histogram_segmenter.py
+++ b/hyperspy/tests/samfire/test_histogram_segmenter.py
@@ -17,10 +17,8 @@
 
 import numpy as np
 
-
-from hyperspy.samfire_utils.segmenters.histogram import HistogramSegmenter
-from hyperspy.misc.utils import DictionaryTreeBrowser
 from hyperspy.external.astroML.histtools import histogram
+from hyperspy.samfire_utils.segmenters.histogram import HistogramSegmenter
 
 
 def compare_two_value_dicts(ans_r, ans):

--- a/hyperspy/tests/samfire/test_red_chisq_weight.py
+++ b/hyperspy/tests/samfire/test_red_chisq_weight.py
@@ -17,9 +17,8 @@
 
 import numpy as np
 
-
-from hyperspy.samfire_utils.weights.red_chisq import ReducedChiSquaredWeight
 from hyperspy.misc.utils import DictionaryTreeBrowser
+from hyperspy.samfire_utils.weights.red_chisq import ReducedChiSquaredWeight
 
 
 class Test_Red_chisq_weight:

--- a/hyperspy/tests/samfire/test_samfire.py
+++ b/hyperspy/tests/samfire/test_samfire.py
@@ -16,18 +16,16 @@
 # You should have received a copy of the GNU General Public License
 # along with  HyperSpy.  If not, see <http://www.gnu.org/licenses/>.
 
+import copy
 import gc
+
+import dill
 import numpy as np
 import pytest
 
-import dill
-import copy
-
 import hyperspy.api as hs
-from hyperspy.samfire_utils.samfire_kernel import multi_kernel
 from hyperspy.misc.utils import DictionaryTreeBrowser
 from hyperspy.samfire_utils.samfire_worker import create_worker
-
 
 N_WORKERS = 1
 

--- a/hyperspy/tests/samfire/test_strategy.py
+++ b/hyperspy/tests/samfire/test_strategy.py
@@ -18,13 +18,12 @@
 
 
 import numpy as np
-
 from numpy.testing import assert_allclose
-from hyperspy.samfire_utils.strategy import (LocalStrategy,
-                                             GlobalStrategy)
-from hyperspy.misc.utils import DictionaryTreeBrowser
-from hyperspy.signals import Signal1D
+
 from hyperspy.components1d import Gaussian
+from hyperspy.misc.utils import DictionaryTreeBrowser
+from hyperspy.samfire_utils.strategy import GlobalStrategy, LocalStrategy
+from hyperspy.signals import Signal1D
 
 
 class someweight(object):

--- a/hyperspy/tests/samfire/test_strategy_list.py
+++ b/hyperspy/tests/samfire/test_strategy_list.py
@@ -16,8 +16,8 @@
 # You should have received a copy of the GNU General Public License
 # along with  HyperSpy.  If not, see <http://www.gnu.org/licenses/>.
 
-from hyperspy.samfire import (Samfire, StrategyList)
 from hyperspy.misc.utils import DictionaryTreeBrowser
+from hyperspy.samfire import StrategyList
 
 
 class TestStrategyList:

--- a/hyperspy/tests/samfire/test_utils.py
+++ b/hyperspy/tests/samfire/test_utils.py
@@ -16,8 +16,6 @@
 # You should have received a copy of the GNU General Public License
 # along with  HyperSpy.  If not, see <http://www.gnu.org/licenses/>.
 
-import numpy as np
-
 
 from hyperspy.samfire_utils.strategy import nearest_indices
 

--- a/hyperspy/tests/signal/test_1D_tools.py
+++ b/hyperspy/tests/signal/test_1D_tools.py
@@ -18,14 +18,14 @@
 
 from unittest import mock
 
-import numpy as np
-from scipy.signal import savgol_filter
-import pytest
 import dask.array as da
+import numpy as np
+import pytest
+from scipy.signal import savgol_filter
 
-from hyperspy.misc.tv_denoise import _tv_denoise_1d
-from hyperspy.decorators import lazifyTestClass
 import hyperspy.api as hs
+from hyperspy.decorators import lazifyTestClass
+from hyperspy.misc.tv_denoise import _tv_denoise_1d
 
 
 @lazifyTestClass

--- a/hyperspy/tests/signal/test_2D_tools.py
+++ b/hyperspy/tests/signal/test_2D_tools.py
@@ -17,11 +17,11 @@
 
 from unittest import mock
 
-import numpy.testing as npt
 import numpy as np
-from scipy.misc import face, ascent
-from scipy.ndimage import fourier_shift
+import numpy.testing as npt
 import pytest
+from scipy.misc import ascent, face
+from scipy.ndimage import fourier_shift
 
 import hyperspy.api as hs
 from hyperspy.decorators import lazifyTestClass
@@ -187,8 +187,3 @@ def test_add_ramp_lazy():
     s = hs.signals.Signal2D(np.indices((3, 3)).sum(axis=0) + 4).as_lazy()
     s.add_ramp(-1, -1, -4)
     npt.assert_almost_equal(s.data.compute(), 0)
-
-
-if __name__ == '__main__':
-    import pytest
-    pytest.main(__name__)

--- a/hyperspy/tests/signal/test_apodization.py
+++ b/hyperspy/tests/signal/test_apodization.py
@@ -16,12 +16,12 @@
 # You should have received a copy of the GNU General Public License
 # along with  HyperSpy.  If not, see <http://www.gnu.org/licenses/>.
 
-import pytest
 import numpy as np
+import pytest
 from scipy.signal import tukey
-from hyperspy.misc.math_tools import hann_window_nth_order, outer_nd
 
-from hyperspy.signals import Signal1D, Signal2D, ComplexSignal1D, ComplexSignal2D, BaseSignal
+from hyperspy.misc.math_tools import hann_window_nth_order, outer_nd
+from hyperspy.signals import BaseSignal, Signal1D, Signal2D
 
 
 def test_hann_nth_order():

--- a/hyperspy/tests/signal/test_assign_subclass.py
+++ b/hyperspy/tests/signal/test_assign_subclass.py
@@ -16,17 +16,16 @@
 # You should have received a copy of the GNU General Public License
 # along with  HyperSpy.  If not, see <http://www.gnu.org/licenses/>.
 
+import logging
 from collections import namedtuple
 
-import pytest
 import numpy as np
-import logging
+import pytest
 
 import hyperspy.api as hs
-from hyperspy.io import assign_signal_subclass
 from hyperspy import _lazy_signals
 from hyperspy.exceptions import VisibleDeprecationWarning
-
+from hyperspy.io import assign_signal_subclass
 
 testcase = namedtuple('testcase', ['dtype', 'sig_dim', 'sig_type', 'cls'])
 
@@ -173,9 +172,3 @@ class TestConvertComplexSignal1D:
         assert isinstance(self.s, hs.signals.DielectricFunction)
         self.s.set_signal_type("")
         assert isinstance(self.s, hs.signals.ComplexSignal1D)
-
-
-if __name__ == '__main__':
-
-    import pytest
-    pytest.main(__name__)

--- a/hyperspy/tests/signal/test_binned.py
+++ b/hyperspy/tests/signal/test_binned.py
@@ -18,7 +18,6 @@
 
 import numpy as np
 
-
 import hyperspy.api as hs
 
 

--- a/hyperspy/tests/signal/test_complex_signal.py
+++ b/hyperspy/tests/signal/test_complex_signal.py
@@ -18,9 +18,8 @@
 
 
 import numpy as np
-import numpy.testing as nt
-from numpy.testing import assert_allclose
 import pytest
+from numpy.testing import assert_allclose
 
 import hyperspy.api as hs
 from hyperspy.decorators import lazifyTestClass
@@ -173,9 +172,3 @@ def test_argand_diagram():
     with pytest.raises(NotImplementedError):
         s1d = s1d.as_lazy()
         s1d.argand_diagram()
-
-
-if __name__ == '__main__':
-
-    import pytest
-    pytest.main(__name__)

--- a/hyperspy/tests/signal/test_complex_signal2d.py
+++ b/hyperspy/tests/signal/test_complex_signal2d.py
@@ -37,8 +37,3 @@ def test_lazy_add_phase_ramp():
         np.exp(1j * (np.indices((3, 3)).sum(axis=0) + 4))).as_lazy()
     s.add_phase_ramp(-1, -1, -4)
     nt.assert_almost_equal(s.phase.data.compute(), 0)
-
-if __name__ == '__main__':
-
-    import pytest
-    pytest.main(__name__)

--- a/hyperspy/tests/signal/test_eds_sem.py
+++ b/hyperspy/tests/signal/test_eds_sem.py
@@ -18,15 +18,14 @@
 import sys
 
 import numpy as np
-
 from numpy.testing import assert_allclose, assert_raises
 
-from hyperspy.signals import EDSSEMSpectrum
-from hyperspy.defaults_parser import preferences
-from hyperspy.components1d import Gaussian
 from hyperspy import utils
-from hyperspy.misc.test_utils import assert_warns
+from hyperspy.components1d import Gaussian
 from hyperspy.decorators import lazifyTestClass
+from hyperspy.defaults_parser import preferences
+from hyperspy.misc.test_utils import assert_warns
+from hyperspy.signals import EDSSEMSpectrum
 
 
 @lazifyTestClass

--- a/hyperspy/tests/signal/test_eds_tem.py
+++ b/hyperspy/tests/signal/test_eds_tem.py
@@ -19,12 +19,12 @@
 import numpy as np
 import pytest
 
-from hyperspy.signals import EDSTEMSpectrum
-from hyperspy.defaults_parser import preferences
 from hyperspy.components1d import Gaussian
+from hyperspy.decorators import lazifyTestClass
+from hyperspy.defaults_parser import preferences
 from hyperspy.misc.eds import utils as utils_eds
 from hyperspy.misc.test_utils import ignore_warning
-from hyperspy.decorators import lazifyTestClass
+from hyperspy.signals import EDSTEMSpectrum
 
 
 @lazifyTestClass

--- a/hyperspy/tests/signal/test_eels.py
+++ b/hyperspy/tests/signal/test_eels.py
@@ -20,7 +20,7 @@ import os
 import numpy as np
 import pytest
 
-from hyperspy import signals, model
+from hyperspy import signals
 from hyperspy._components.gaussian import Gaussian
 from hyperspy.decorators import lazifyTestClass
 from hyperspy.io import load

--- a/hyperspy/tests/signal/test_fancy_indexing.py
+++ b/hyperspy/tests/signal/test_fancy_indexing.py
@@ -17,11 +17,10 @@
 
 
 import numpy as np
-from numpy.testing import assert_array_equal
 import pytest
+from numpy.testing import assert_array_equal
 
-from hyperspy import signals
-from hyperspy import roi
+from hyperspy import roi, signals
 
 
 class Test1D:

--- a/hyperspy/tests/signal/test_find_peaks1D_ohaver.py
+++ b/hyperspy/tests/signal/test_find_peaks1D_ohaver.py
@@ -17,6 +17,7 @@
 # along with  HyperSpy.  If not, see <http://www.gnu.org/licenses/>.
 
 import os
+
 from hyperspy.api import load
 from hyperspy.decorators import lazifyTestClass
 

--- a/hyperspy/tests/signal/test_folding.py
+++ b/hyperspy/tests/signal/test_folding.py
@@ -1,8 +1,8 @@
 
 import numpy as np
 
-from hyperspy.signal import BaseSignal
 from hyperspy.decorators import lazifyTestClass
+from hyperspy.signal import BaseSignal
 
 
 @lazifyTestClass

--- a/hyperspy/tests/signal/test_fourier_transform.py
+++ b/hyperspy/tests/signal/test_fourier_transform.py
@@ -16,11 +16,12 @@
 # You should have received a copy of the GNU General Public License
 # along with  HyperSpy.  If not, see <http://www.gnu.org/licenses/>.
 
-import pytest
 import numpy as np
+import pytest
 from numpy.testing import assert_allclose
 
-from hyperspy.signals import Signal1D, Signal2D, ComplexSignal1D, ComplexSignal2D, BaseSignal
+from hyperspy.signals import (BaseSignal, ComplexSignal1D, ComplexSignal2D,
+                              Signal1D, Signal2D)
 
 
 @pytest.mark.parametrize('lazy', [True, False])

--- a/hyperspy/tests/signal/test_hologram_image.py
+++ b/hyperspy/tests/signal/test_hologram_image.py
@@ -19,14 +19,12 @@
 import gc
 
 import numpy as np
-import numpy.testing as nt
-from numpy.testing import assert_allclose
 import pytest
 import scipy.constants as constants
+from numpy.testing import assert_allclose
+from scipy.interpolate import interp2d
 
 import hyperspy.api as hs
-from hyperspy.decorators import lazifyTestClass
-from scipy.interpolate import interp2d
 from hyperspy.datasets.example_signals import reference_hologram
 
 
@@ -435,9 +433,3 @@ def test_statistics(parallel, lazy, single_values, fringe_contrast_algorithm):
                 1,
                 1),
             fringe_contrast_algorithm='pure_guess')
-
-
-if __name__ == '__main__':
-
-    import pytest
-    pytest.main(__name__)

--- a/hyperspy/tests/signal/test_inheritance.py
+++ b/hyperspy/tests/signal/test_inheritance.py
@@ -19,9 +19,9 @@
 import numpy as np
 import pytest
 
+import hyperspy.signals
 from hyperspy.misc.utils import find_subclasses
 from hyperspy.signal import BaseSignal
-import hyperspy.signals
 
 
 @pytest.mark.parametrize("signal",

--- a/hyperspy/tests/signal/test_kramers_kronig_transform.py
+++ b/hyperspy/tests/signal/test_kramers_kronig_transform.py
@@ -17,12 +17,11 @@
 
 
 import numpy as np
-
 import pytest
 
-from hyperspy.components1d import VolumePlasmonDrude, Lorentzian
-from hyperspy.misc.eels.tools import eels_constant
 import hyperspy.api as hs
+from hyperspy.components1d import Lorentzian, VolumePlasmonDrude
+from hyperspy.misc.eels.tools import eels_constant
 
 
 class Test2D:

--- a/hyperspy/tests/signal/test_lazy.py
+++ b/hyperspy/tests/signal/test_lazy.py
@@ -16,15 +16,14 @@
 # You should have received a copy of the GNU General Public License
 # along with  HyperSpy.  If not, see <http://www.gnu.org/licenses/>.
 
-import pytest
-import numpy as np
 import dask.array as da
+import numpy as np
+import pytest
 from dask.threaded import get
 
 import hyperspy.api as hs
-from hyperspy._signals.lazy import (_reshuffle_mixed_blocks,
-                                    to_array)
 from hyperspy import _lazy_signals
+from hyperspy._signals.lazy import _reshuffle_mixed_blocks, to_array
 
 
 def _signal():

--- a/hyperspy/tests/signal/test_map_method.py
+++ b/hyperspy/tests/signal/test_map_method.py
@@ -20,10 +20,10 @@ from unittest import mock
 
 import numpy as np
 import pytest
-from scipy.ndimage import rotate, gaussian_filter, gaussian_filter1d
-from hyperspy.decorators import lazifyTestClass
+from scipy.ndimage import gaussian_filter, gaussian_filter1d, rotate
 
 import hyperspy.api as hs
+from hyperspy.decorators import lazifyTestClass
 
 
 @lazifyTestClass(ragged=False)

--- a/hyperspy/tests/signal/test_remove_background.py
+++ b/hyperspy/tests/signal/test_remove_background.py
@@ -17,11 +17,11 @@
 # along with  HyperSpy.  If not, see <http://www.gnu.org/licenses/>.
 
 import gc
+
 import numpy as np
 import pytest
 
-from hyperspy import signals
-from hyperspy import components1d
+from hyperspy import components1d, signals
 from hyperspy.decorators import lazifyTestClass
 
 

--- a/hyperspy/tests/signal/test_rgb.py
+++ b/hyperspy/tests/signal/test_rgb.py
@@ -17,11 +17,10 @@
 # along with  HyperSpy.  If not, see <http://www.gnu.org/licenses/>.
 
 import numpy as np
-
 import pytest
 
-from hyperspy.misc import rgb_tools
 import hyperspy.api as hs
+from hyperspy.misc import rgb_tools
 
 
 class TestRGBA8:

--- a/hyperspy/tests/signal/test_signal_operators.py
+++ b/hyperspy/tests/signal/test_signal_operators.py
@@ -18,9 +18,8 @@
 
 
 import numpy as np
-from numpy.testing import assert_array_equal
-
 import pytest
+from numpy.testing import assert_array_equal
 
 from hyperspy import signals
 from hyperspy.decorators import lazifyTestClass

--- a/hyperspy/tests/signal/test_signal_subclass_conversion.py
+++ b/hyperspy/tests/signal/test_signal_subclass_conversion.py
@@ -19,11 +19,10 @@
 import numpy as np
 import pytest
 
-from hyperspy.signals import BaseSignal
-from hyperspy import signals
-from hyperspy import _lazy_signals
-from hyperspy.exceptions import DataDimensionError
+from hyperspy import _lazy_signals, signals
 from hyperspy.decorators import lazifyTestClass
+from hyperspy.exceptions import DataDimensionError
+from hyperspy.signals import BaseSignal
 
 
 @lazifyTestClass

--- a/hyperspy/tests/signal/test_tools.py
+++ b/hyperspy/tests/signal/test_tools.py
@@ -16,19 +16,19 @@
 # You should have received a copy of the GNU General Public License
 # along with  HyperSpy.  If not, see <http://www.gnu.org/licenses/>.
 
-from unittest import mock
 import sys
+from unittest import mock
 
-import numpy as np
 import dask.array as da
-from numpy.testing import assert_array_equal, assert_almost_equal
-import pytest
+import numpy as np
 import numpy.testing as nt
+import pytest
+from numpy.testing import assert_almost_equal, assert_array_equal
 
 from hyperspy import signals
+from hyperspy.components1d import Gaussian
 from hyperspy.decorators import lazifyTestClass
 from hyperspy.signal_tools import SpikesRemoval
-from hyperspy.components1d import Gaussian
 
 
 def _verify_test_sum_x_E(self, s):

--- a/hyperspy/tests/test_dictionary_tree_browser.py
+++ b/hyperspy/tests/test_dictionary_tree_browser.py
@@ -18,7 +18,8 @@
 
 import numpy as np
 
-from hyperspy.misc.utils import DictionaryTreeBrowser, check_long_string, replace_html_symbols, add_key_value
+from hyperspy.misc.utils import (DictionaryTreeBrowser, check_long_string,
+                                 replace_html_symbols)
 from hyperspy.signal import BaseSignal
 
 

--- a/hyperspy/tests/test_events.py
+++ b/hyperspy/tests/test_events.py
@@ -17,6 +17,7 @@
 # along with  HyperSpy.  If not, see <http://www.gnu.org/licenses/>.
 
 import copy
+
 import pytest
 
 import hyperspy.events as he

--- a/hyperspy/tests/test_interactive.py
+++ b/hyperspy/tests/test_interactive.py
@@ -17,6 +17,7 @@
 # along with  HyperSpy.  If not, see <http://www.gnu.org/licenses/>.
 
 from __future__ import print_function
+
 from unittest import mock
 
 import numpy as np

--- a/hyperspy/tests/utils/test_attrsetter.py
+++ b/hyperspy/tests/utils/test_attrsetter.py
@@ -17,8 +17,7 @@
 
 import pytest
 
-from hyperspy.misc.utils import attrsetter
-from hyperspy.misc.utils import DictionaryTreeBrowser
+from hyperspy.misc.utils import DictionaryTreeBrowser, attrsetter
 
 
 class DummyThing(object):

--- a/hyperspy/tests/utils/test_eds.py
+++ b/hyperspy/tests/utils/test_eds.py
@@ -16,8 +16,10 @@
 # You should have received a copy of the GNU General Public License
 # along with  HyperSpy.  If not, see <http://www.gnu.org/licenses/>.
 
-from hyperspy.misc.eds.utils import get_xray_lines_near_energy, take_off_angle
 import numpy as np
+
+from hyperspy.misc.eds.utils import get_xray_lines_near_energy, take_off_angle
+
 
 def test_xray_lines_near_energy():
     E = 1.36

--- a/hyperspy/tests/utils/test_eels.py
+++ b/hyperspy/tests/utils/test_eels.py
@@ -15,10 +15,10 @@
 # You should have received a copy of the GNU General Public License
 # along with  HyperSpy.  If not, see <http://www.gnu.org/licenses/>.
 
-import numpy as np
 import pytest
 
 from hyperspy.misc.eels.tools import get_edges_near_energy
+
 
 def test_single_edge():
     edges = get_edges_near_energy(532, width=0)
@@ -34,4 +34,3 @@ def test_multiple_edges():
 def test_negative_energy_width():
     with pytest.raises(Exception):
         get_edges_near_energy(849, width=-5)
-        

--- a/hyperspy/tests/utils/test_material.py
+++ b/hyperspy/tests/utils/test_material.py
@@ -17,7 +17,6 @@
 # along with  HyperSpy.  If not, see <http://www.gnu.org/licenses/>.
 
 import numpy as np
-
 from numpy.testing import assert_allclose
 
 import hyperspy.api as hs

--- a/hyperspy/tests/utils/test_roi.py
+++ b/hyperspy/tests/utils/test_roi.py
@@ -19,9 +19,9 @@
 import numpy as np
 import pytest
 
-from hyperspy.signals import Signal2D, Signal1D
-from hyperspy.roi import (Point1DROI, Point2DROI, SpanROI, RectangularROI,
-                          Line2DROI, CircleROI)
+from hyperspy.roi import (CircleROI, Line2DROI, Point1DROI, Point2DROI,
+                          RectangularROI, SpanROI)
+from hyperspy.signals import Signal1D, Signal2D
 
 
 class TestROIs():

--- a/hyperspy/tests/utils/test_stack.py
+++ b/hyperspy/tests/utils/test_stack.py
@@ -18,8 +18,8 @@
 
 import numpy as np
 
-from hyperspy.signal import BaseSignal
 from hyperspy import utils
+from hyperspy.signal import BaseSignal
 
 
 class TestUtilsStack:

--- a/setup.cfg
+++ b/setup.cfg
@@ -38,7 +38,6 @@ ignore =
     D401 # First line should be in imperative mood; try rephrasing
 exclude =
     hyperspy/external/*
-    hyperspy/tests/*
     setup.py
     examples/*
 docstring-convention = numpy


### PR DESCRIPTION
Housekeeping of the `hyperspy/tests/*` directories - removing unused and duplicate imports (there were quite a few), along with unnecessary uses of `if name == "__main__"`. With `flake8`, unused and duplicate imports can be detected with the command `flake8 . | egrep "F811|F401"`. I've also applied [`isort`](https://pypi.org/project/isort/) to the folder. I can undo this last step if preferred @francisco-dlp and @ericpre, but it seemed like a good opportunity. One of the nice things about it is that it separates the import sections out such that `import hyperspy ...` always comes as a group at the end.

#### Changes:
- Remove unused imports from  `hyperspy/tests/*`
- Apply `isort` to imports in `hyperspy/tests/*`
- Remove duplicate imports from `hyperspy/tests/*`
- Remove instances of `if name == "__main__"` from `hyperspy/tests/*`
- Include `hyperspy/tests/*` in `flake8` config

### Progress of the PR
- [x] Change implemented (can be split into several points),
- [x] update docstring (if appropriate),
- [x] update user guide (if appropriate),
- [x] add tests,
- [x] ready for review.