### PR TITLE
Fix duplicate and unused imports

### DIFF
--- a/hyperspy/drawing/_widgets/label.py
+++ b/hyperspy/drawing/_widgets/label.py
@@ -20,7 +20,6 @@ import numpy as np
 import matplotlib.transforms as transforms
 
 from hyperspy.drawing.widgets import Widget1DBase
-from hyperspy.drawing.utils import picker_kwargs
 
 
 class LabelWidget(Widget1DBase):

--- a/hyperspy/drawing/image.py
+++ b/hyperspy/drawing/image.py
@@ -27,7 +27,6 @@ from traits.api import Undefined
 import logging
 import inspect
 import copy
-from distutils.version import LooseVersion
 
 from hyperspy.drawing import widgets
 from hyperspy.drawing import utils

--- a/hyperspy/drawing/tiles.py
+++ b/hyperspy/drawing/tiles.py
@@ -23,7 +23,6 @@ import numpy as np
 import matplotlib.pyplot as plt
 
 from hyperspy.drawing.figure import BlittedFigure
-from hyperspy.drawing import utils
 
 
 class HistogramTilePlot(BlittedFigure):

--- a/hyperspy/io_plugins/msa.py
+++ b/hyperspy/io_plugins/msa.py
@@ -17,7 +17,6 @@
 # along with  HyperSpy.  If not, see <http://www.gnu.org/licenses/>.
 
 from datetime import datetime as dt
-import warnings
 import codecs
 import os
 import logging
@@ -25,7 +24,6 @@ import logging
 import numpy as np
 from traits.api import Undefined
 
-from hyperspy.misc.config_dir import os_name
 from hyperspy import Release
 from hyperspy.misc.utils import DictionaryTreeBrowser
 

--- a/hyperspy/io_plugins/sur.py
+++ b/hyperspy/io_plugins/sur.py
@@ -36,7 +36,6 @@ import sys
 import zlib
 import os
 import warnings
-import re
 
 #Maybe later we can implement reading the class with the io utils tools instead
 #of re-defining read functions in the class
@@ -47,7 +46,6 @@ import re
 
 #DictionaryTreeBrowser class handles the fancy metadata dictionnaries
 #from hyperspy.misc.utils import DictionaryTreeBrowser
-from hyperspy.docstrings.signal import OPTIMIZE_ARG
 from hyperspy.exceptions import MountainsMapFileError
 
 _logger = logging.getLogger(__name__)

--- a/hyperspy/misc/holography/tools.py
+++ b/hyperspy/misc/holography/tools.py
@@ -17,8 +17,7 @@
 # along with  HyperSpy.  If not, see <http://www.gnu.org/licenses/>.
 
 import numpy as np
-import matplotlib.pyplot as plt
-from scipy.fftpack import fft2, fftshift
+from scipy.fftpack import fft2
 import logging
 
 _logger = logging.getLogger(__name__)

--- a/hyperspy/tests/io/test_mrcz.py
+++ b/hyperspy/tests/io/test_mrcz.py
@@ -28,21 +28,8 @@ from hyperspy import signals
 from hyperspy.io import load, save
 from hyperspy.misc.test_utils import assert_deep_almost_equal
 
-try:
-    import blosc
-    blosc_installed = True
-except BaseException:
-    blosc_installed = False
-try:
-    import mrcz
-    mrcz_installed = True
-except BaseException:
-    mrcz_installed = False
 
-
-
-pytestmark = pytest.mark.skipif(
-    not mrcz_installed, reason="mrcz not installed")
+mrcz = pytest.importorskip("mrcz", reason="skipping test_mrcz tests, requires mrcz")
 
 
 #==============================================================================
@@ -168,6 +155,14 @@ class TestPythonMrcz:
                              _generate_parameters())
     def test_MRC(self, dtype, compressor, clevel, lazy):
         t_start = perf_counter()
+
+        try:
+            import blosc
+
+            blosc_installed = True
+        except BaseException:
+            blosc_installed = False
+
         if not blosc_installed and compressor is not None:
             with pytest.raises(ImportError):
                 return self.compareSaveLoad([2, 64, 32], dtype=dtype,
@@ -182,7 +177,7 @@ class TestPythonMrcz:
 
     @pytest.mark.parametrize("dtype", dtype_list)
     def test_Async(self, dtype):
-        pytest.importorskip('blosc')
+        blosc = pytest.importorskip('blosc', reason="skipping test_async, requires blosc")
         t_start = perf_counter()
         self.compareSaveLoad([2, 64, 32], dtype=dtype, compressor='zstd',
                              clevel=1, do_async=True)

--- a/hyperspy/tests/io/test_phenom.py
+++ b/hyperspy/tests/io/test_phenom.py
@@ -23,11 +23,7 @@ import pytest
 
 import hyperspy.api as hs
 
-try:
-    import imagecodecs
-except ImportError:
-    pytest.skip("skipping test_phenom tests, failed to import imagecodecs", allow_module_level=True)
-
+imagecodecs = pytest.importorskip("imagecodecs", reason="skipping test_phenom tests, requires imagecodecs")
 
 DIRPATH = os.path.dirname(__file__)
 ELID2VERSION0 = os.path.join(DIRPATH, 'phenom_data', 'Elid2Version0.elid')

--- a/hyperspy/utils/__init__.py
+++ b/hyperspy/utils/__init__.py
@@ -36,15 +36,15 @@ Subpackages:
 
 
 """
-import hyperspy.utils.material
-import hyperspy.utils.eds
-import hyperspy.utils.plot
 import hyperspy.datasets.example_signals
+import hyperspy.utils.eds
+import hyperspy.utils.material
 import hyperspy.utils.model
-from hyperspy.misc.utils import (stack, transpose)
-from hyperspy.interactive import interactive
+import hyperspy.utils.plot
 import hyperspy.utils.roi
 import hyperspy.utils.samfire
+from hyperspy.interactive import interactive
+from hyperspy.misc.utils import stack, transpose
 
 
 def print_known_signal_types():

--- a/hyperspy/utils/eds.py
+++ b/hyperspy/utils/eds.py
@@ -16,8 +16,7 @@
 # You should have received a copy of the GNU General Public License
 # along with  HyperSpy.  If not, see <http://www.gnu.org/licenses/>.
 
-from hyperspy.misc.eds.utils import xray_range
-from hyperspy.misc.eds.utils import electron_range
-from hyperspy.misc.eds.utils import take_off_angle
-from hyperspy.misc.eds.utils import get_xray_lines_near_energy
-from hyperspy.misc.eds.utils import edx_cross_section_to_zeta, zeta_to_edx_cross_section
+from hyperspy.misc.eds.utils import (edx_cross_section_to_zeta, electron_range,
+                                     get_xray_lines_near_energy,
+                                     take_off_angle, xray_range,
+                                     zeta_to_edx_cross_section)

--- a/hyperspy/utils/markers.py
+++ b/hyperspy/utils/markers.py
@@ -28,15 +28,15 @@ Example
 
 """
 
-from hyperspy.drawing._markers.horizontal_line \
-    import HorizontalLine as horizontal_line
-from hyperspy.drawing._markers.vertical_line \
-    import VerticalLine as vertical_line
-from hyperspy.drawing._markers.vertical_line_segment \
-    import VerticalLineSegment as vertical_line_segment
+from hyperspy.drawing._markers.horizontal_line import \
+    HorizontalLine as horizontal_line
+from hyperspy.drawing._markers.horizontal_line_segment import \
+    HorizontalLineSegment as horizontal_line_segment
 from hyperspy.drawing._markers.line_segment import LineSegment as line_segment
-from hyperspy.drawing._markers.horizontal_line_segment \
-    import HorizontalLineSegment as horizontal_line_segment
-from hyperspy.drawing._markers.rectangle import Rectangle as rectangle
 from hyperspy.drawing._markers.point import Point as point
+from hyperspy.drawing._markers.rectangle import Rectangle as rectangle
 from hyperspy.drawing._markers.text import Text as text
+from hyperspy.drawing._markers.vertical_line import \
+    VerticalLine as vertical_line
+from hyperspy.drawing._markers.vertical_line_segment import \
+    VerticalLineSegment as vertical_line_segment

--- a/hyperspy/utils/material.py
+++ b/hyperspy/utils/material.py
@@ -16,9 +16,7 @@
 # You should have received a copy of the GNU General Public License
 # along with  HyperSpy.  If not, see <http://www.gnu.org/licenses/>.
 
-from hyperspy.misc.material import weight_to_atomic
-from hyperspy.misc.material import atomic_to_weight
-from hyperspy.misc.material import density_of_mixture
-from hyperspy.misc.material import mass_absorption_coefficient
-from hyperspy.misc.material import mass_absorption_mixture
 from hyperspy.misc.elements import elements_db as elements
+from hyperspy.misc.material import (atomic_to_weight, density_of_mixture,
+                                    mass_absorption_coefficient,
+                                    mass_absorption_mixture, weight_to_atomic)

--- a/hyperspy/utils/model_selection.py
+++ b/hyperspy/utils/model_selection.py
@@ -17,6 +17,7 @@
 # along with  HyperSpy.  If not, see <http://www.gnu.org/licenses/>.
 
 import numpy as np
+
 from hyperspy import model
 from hyperspy.exceptions import NavigationSizeError
 

--- a/hyperspy/utils/parallel_pool.py
+++ b/hyperspy/utils/parallel_pool.py
@@ -17,10 +17,11 @@
 # along with  HyperSpy.  If not, see <http://www.gnu.org/licenses/>.
 
 
-import time
 import logging
-from multiprocessing import (cpu_count, Pool)
+import time
+from multiprocessing import Pool, cpu_count
 from multiprocessing.pool import Pool as Pool_type
+
 import numpy as np
 
 _logger = logging.getLogger(__name__)

--- a/hyperspy/utils/plot.py
+++ b/hyperspy/utils/plot.py
@@ -34,8 +34,6 @@ The :mod:`~hyperspy.api.plot` module contains the following submodules:
 
 """
 
-from hyperspy.drawing.utils import plot_spectra
-from hyperspy.drawing.utils import plot_images
-from hyperspy.drawing.utils import plot_signals
-from hyperspy.drawing.utils import plot_histograms
+from hyperspy.drawing.utils import (plot_histograms, plot_images, plot_signals,
+                                    plot_spectra)
 from hyperspy.utils import markers

--- a/hyperspy/utils/roi.py
+++ b/hyperspy/utils/roi.py
@@ -16,10 +16,7 @@
 # You should have received a copy of the GNU General Public License
 # along with HyperSpy.  If not, see <http://www.gnu.org/licenses/>.
 import hyperspy.roi
+from hyperspy.roi import (CircleROI, Line2DROI, Point1DROI, Point2DROI,
+                          RectangularROI, SpanROI)
+
 __doc__ = hyperspy.roi.__doc__
-from hyperspy.roi import (Point1DROI,
-                          Point2DROI,
-                          SpanROI,
-                          RectangularROI,
-                          CircleROI,
-                          Line2DROI)

--- a/hyperspy/utils/samfire.py
+++ b/hyperspy/utils/samfire.py
@@ -34,6 +34,5 @@ SamfirePool
     The parallel pool, customized to run SAMFire.
 
 """
-from hyperspy.samfire_utils import fit_tests
-from hyperspy.samfire_utils import global_strategies
-from hyperspy.samfire_utils import local_strategies
+from hyperspy.samfire_utils import (fit_tests, global_strategies,
+                                    local_strategies)

--- a/setup.cfg
+++ b/setup.cfg
@@ -25,19 +25,31 @@ precision = 2
 
 
 [flake8]
+docstring-convention = numpy
 # See https://www.flake8rules.com/rules/
 # and http://www.pydocstyle.org/en/5.0.2/error_codes.html
 ignore =
-    E203 # Whitespace before ':'
-    E501 # Line too long
-    W503 # Line break occurred before a binary operator
-    C901 # Function is too complex
-    D100 # Missing docstring in public module
-    D104 # Missing docstring in public package
-    D202 # No blank lines allowed after function docstring
-    D401 # First line should be in imperative mood; try rephrasing
+    E203  # Whitespace before ':'
+    E501  # Line too long
+    W503  # Line break occurred before a binary operator
+    C901  # Function is too complex
+    D100  # Missing docstring in public module
+    D104  # Missing docstring in public package
+    D202  # No blank lines allowed after function docstring
+    D401  # First line should be in imperative mood; try rephrasing
 exclude =
     hyperspy/external/*
     setup.py
     examples/*
-docstring-convention = numpy
+# Avoid F401 warnings about unused imports
+# that are actually part of the API
+per-file-ignores =
+    hyperspy/_lazy_signals.py:F401
+    hyperspy/api.py:F401
+    hyperspy/api_nogui.py:F401
+    hyperspy/datasets/*:F401
+    hyperspy/drawing/widgets.py:F401
+    hyperspy/extensions.py:F401
+    hyperspy/misc/machine_learning/import_sklearn.py:F401
+    hyperspy/samfire_utils/*:F401
+    hyperspy/utils/*:F401

--- a/setup.cfg
+++ b/setup.cfg
@@ -47,8 +47,10 @@ per-file-ignores =
     hyperspy/_lazy_signals.py:F401
     hyperspy/api.py:F401
     hyperspy/api_nogui.py:F401
+    hyperspy/conftest.py:F401
     hyperspy/datasets/*:F401
     hyperspy/drawing/widgets.py:F401
+    hyperspy/events.py:F401
     hyperspy/extensions.py:F401
     hyperspy/misc/machine_learning/import_sklearn.py:F401
     hyperspy/samfire_utils/*:F401


### PR DESCRIPTION
### Description of the change
Follows on from #2451, removing unused and/or duplicate imports from `hyperspy/*`. These are found with the command: `flake8 hyperspy/ | egrep "F401|F811"`

Crucially, it also updates the `flake8` rules in `setup.cfg` to ignore any F401 warnings raised in files where the imports _appear_ unused, but are actually a part of the API, so that anyone who runs a similar command in future isn't caught out. There may well be unused imports in the ignored files, particularly in files like `api_nogui.py` (cf. #1480), but they ought to be handled more carefully.

### Progress of the PR
- [x] Change implemented (can be split into several points),
- [x] update docstring (if appropriate),
- [x] update user guide (if appropriate),
- [x] add tests,
- [x] ready for review.

