### PR TITLE
Add random_state argument to functions that return stochastic output

### DIFF
--- a/hyperspy/datasets/artificial_data.py
+++ b/hyperspy/datasets/artificial_data.py
@@ -6,11 +6,18 @@ For use in things like docstrings or to test HyperSpy functionalities.
 
 import numpy as np
 
+from hyperspy.misc.math_tools import check_random_state
 
-def get_low_loss_eels_signal():
+
+def get_low_loss_eels_signal(random_state=None):
     """Get an artificial low loss electron energy loss spectrum.
 
     The zero loss peak is offset by 4.1 eV.
+
+    Parameters
+    ----------
+    random_state : None or int or RandomState instance, default None
+        Random seed used to generate the data.
 
     Returns
     -------
@@ -31,13 +38,15 @@ def get_low_loss_eels_signal():
     from hyperspy.signals import EELSSpectrum
     from hyperspy import components1d
 
+    random_state = check_random_state(random_state)
+
     x = np.arange(-100, 400, 0.5)
     zero_loss = components1d.Gaussian(A=100, centre=4.1, sigma=1)
     plasmon = components1d.Gaussian(A=100, centre=60, sigma=20)
 
     data = zero_loss.function(x)
     data += plasmon.function(x)
-    data += np.random.random(size=len(x)) * 0.7
+    data += random_state.random(size=len(x)) * 0.7
 
     s = EELSSpectrum(data)
     s.axes_manager[0].offset = x[0]
@@ -50,7 +59,7 @@ def get_low_loss_eels_signal():
     return s
 
 
-def get_core_loss_eels_signal(add_powerlaw=False):
+def get_core_loss_eels_signal(add_powerlaw=False, random_state=None):
     """Get an artificial core loss electron energy loss spectrum.
 
     Similar to a Mn-L32 edge from a perovskite oxide.
@@ -60,9 +69,10 @@ def get_core_loss_eels_signal(add_powerlaw=False):
 
     Parameters
     ----------
-    add_powerlaw : bool
+    add_powerlaw : bool, default False
         If True, adds a powerlaw background to the spectrum.
-        Default False.
+    random_state : None or int or RandomState instance, default None
+        Random seed used to generate the data.
 
     Returns
     -------
@@ -82,10 +92,8 @@ def get_core_loss_eels_signal(add_powerlaw=False):
     To make the noise the same for multiple spectra, which can
     be useful for testing fitting routines
 
-    >>> np.random.seed(seed=10)
-    >>> s1 = ad.get_core_loss_eels_signal()
-    >>> np.random.seed(seed=10)
-    >>> s2 = ad.get_core_loss_eels_signal()
+    >>> s1 = ad.get_core_loss_eels_signal(random_state=10)
+    >>> s2 = ad.get_core_loss_eels_signal(random_state=10)
     >>> (s1.data == s2.data).all()
     True
 
@@ -99,6 +107,8 @@ def get_core_loss_eels_signal(add_powerlaw=False):
     from hyperspy.signals import EELSSpectrum
     from hyperspy import components1d
 
+    random_state = check_random_state(random_state)
+
     x = np.arange(400, 800, 1)
     arctan = components1d.EELSArctan(A=1, k=0.2, x0=688)
     mn_l3_g = components1d.Gaussian(A=100, centre=695, sigma=4)
@@ -107,7 +117,7 @@ def get_core_loss_eels_signal(add_powerlaw=False):
     data = arctan.function(x)
     data += mn_l3_g.function(x)
     data += mn_l2_g.function(x)
-    data += np.random.random(size=len(x)) * 0.7
+    data += random_state.random(size=len(x)) * 0.7
 
     if add_powerlaw:
         powerlaw = components1d.PowerLaw(A=10e8, r=3, origin=0)
@@ -123,10 +133,15 @@ def get_core_loss_eels_signal(add_powerlaw=False):
     return s
 
 
-def get_low_loss_eels_line_scan_signal():
+def get_low_loss_eels_line_scan_signal(random_state=None):
     """Get an artificial low loss electron energy loss line scan spectrum.
 
     The zero loss peak is offset by 4.1 eV.
+
+    Parameters
+    ----------
+    random_state : None or int or RandomState instance, default None
+        Random seed used to generate the data.
 
     Returns
     -------
@@ -147,6 +162,8 @@ def get_low_loss_eels_line_scan_signal():
     from hyperspy.signals import EELSSpectrum
     from hyperspy import components1d
 
+    random_state = check_random_state(random_state)
+
     x = np.arange(-100, 400, 0.5)
     zero_loss = components1d.Gaussian(A=100, centre=4.1, sigma=1)
     plasmon = components1d.Gaussian(A=100, centre=60, sigma=20)
@@ -156,7 +173,7 @@ def get_low_loss_eels_line_scan_signal():
     data = np.zeros((12, len(x)))
     for i in range(12):
         data[i] += data_signal
-        data[i] += np.random.random(size=len(x)) * 0.7
+        data[i] += random_state.random(size=len(x)) * 0.7
 
     s = EELSSpectrum(data)
     s.axes_manager.signal_axes[0].offset = x[0]
@@ -171,16 +188,17 @@ def get_low_loss_eels_line_scan_signal():
     return s
 
 
-def get_core_loss_eels_line_scan_signal(add_powerlaw=False):
+def get_core_loss_eels_line_scan_signal(add_powerlaw=False, random_state=None):
     """Get an artificial core loss electron energy loss line scan spectrum.
 
     Similar to a Mn-L32 and Fe-L32 edge from a perovskite oxide.
 
     Parameters
     ----------
-    add_powerlaw : bool
+    add_powerlaw : bool, default False
         If True, adds a powerlaw background to the spectrum.
-        Default False.
+    random_state : None or int or RandomState instance, default None
+        Random seed used to generate the data.
 
     Returns
     -------
@@ -200,6 +218,8 @@ def get_core_loss_eels_line_scan_signal(add_powerlaw=False):
     from hyperspy.signals import EELSSpectrum
     from hyperspy import components1d
 
+    random_state = check_random_state(random_state)
+
     x = np.arange(400, 800, 1)
     arctan_mn = components1d.EELSArctan(A=1, k=0.2, x0=688)
     arctan_fe = components1d.EELSArctan(A=1, k=0.2, x0=612)
@@ -218,7 +238,7 @@ def get_core_loss_eels_line_scan_signal(add_powerlaw=False):
         data[i] += arctan_fe.function(x) * fe_intensity[i]
         data[i] += fe_l3_g.function(x) * fe_intensity[i]
         data[i] += fe_l2_g.function(x) * fe_intensity[i]
-        data[i] += np.random.random(size=len(x)) * 0.7
+        data[i] += random_state.random(size=len(x)) * 0.7
 
     if add_powerlaw:
         powerlaw = components1d.PowerLaw(A=10e8, r=3, origin=0)
@@ -236,16 +256,17 @@ def get_core_loss_eels_line_scan_signal(add_powerlaw=False):
     return s
 
 
-def get_core_loss_eels_model(add_powerlaw=False):
+def get_core_loss_eels_model(add_powerlaw=False, random_state=None):
     """Get an artificial core loss electron energy loss model.
 
     Similar to a Mn-L32 edge from a perovskite oxide.
 
     Parameters
     ----------
-    add_powerlaw : bool
+    add_powerlaw : bool, default False
         If True, adds a powerlaw background to the spectrum.
-        Default False.
+    random_state : None or int or RandomState instance, default None
+        Random seed used to generate the data.
 
     Returns
     -------
@@ -267,7 +288,7 @@ def get_core_loss_eels_model(add_powerlaw=False):
     get_core_loss_eels_signal
 
     """
-    s = get_core_loss_eels_signal(add_powerlaw=add_powerlaw)
+    s = get_core_loss_eels_signal(add_powerlaw=add_powerlaw, random_state=random_state)
     m = s.create_model(auto_background=False, GOS='hydrogenic')
     return m
 

--- a/hyperspy/misc/math_tools.py
+++ b/hyperspy/misc/math_tools.py
@@ -201,7 +201,7 @@ def check_random_state(seed, lazy=False):
         return da.random._state if lazy else np.random.mtrand._rand
 
     if isinstance(seed, numbers.Integral):
-        return da.random.RandomState() if lazy else np.random.RandomState(seed)
+        return da.random.RandomState(seed) if lazy else np.random.RandomState(seed)
 
     if isinstance(seed, (da.random.RandomState, np.random.RandomState)):
         return seed

--- a/hyperspy/misc/math_tools.py
+++ b/hyperspy/misc/math_tools.py
@@ -17,7 +17,10 @@
 # along with  HyperSpy.  If not, see <http://www.gnu.org/licenses/>.
 
 import math
+import numbers
 import numpy as np
+import dask.array as da
+
 from functools import reduce
 
 
@@ -168,3 +171,39 @@ def optimal_fft_size(target, real=False):
         return next_fast_len(target, real)
     else:
         return next_fast_len(target)
+
+
+def check_random_state(seed, lazy=False):
+    """Turn a random seed into a np.random.RandomState instance.
+
+    Parameters
+    ----------
+    seed : None or int or np.random.RandomState or dask.array.random.RandomState
+        If None:
+            Return the RandomState singleton used by
+            np.random or dask.array.random
+        If int:
+            Return a new RandomState instance seeded with ``seed``.
+        If np.random.RandomState:
+            Return it.
+        If dask.array.random.RandomState:
+            Return it.
+    lazy : bool, default False
+        If True, and seed is ``None`` or ``int``, return
+        a dask.array.random.RandomState instance instead.
+
+    """
+    # Derived from `sklearn.utils.check_random_state`.
+    # Copyright (c) 2007-2020 The scikit-learn developers.
+    # All rights reserved.
+
+    if seed is None or seed is np.random:
+        return da.random._state if lazy else np.random.mtrand._rand
+
+    if isinstance(seed, numbers.Integral):
+        return da.random.RandomState() if lazy else np.random.RandomState(seed)
+
+    if isinstance(seed, (da.random.RandomState, np.random.RandomState)):
+        return seed
+
+    raise ValueError(f"{seed} cannot be used to seed a RandomState instance")

--- a/hyperspy/samfire.py
+++ b/hyperspy/samfire.py
@@ -24,6 +24,7 @@ import numpy as np
 
 from hyperspy.misc.utils import DictionaryTreeBrowser
 from hyperspy.misc.utils import slugify
+from hyperspy.misc.math_tools import check_random_state
 from hyperspy.external.progressbar import progressbar
 from hyperspy.signal import BaseSignal
 from hyperspy.samfire_utils.strategy import (LocalStrategy,
@@ -115,6 +116,8 @@ class Samfire:
     save_every : int
         When running, samfire saves results every time save_every good fits are
         found.
+    random_state : None or int or RandomState instance, default None
+        Random seed used to select the next pixels.
 
     Methods
     -------
@@ -158,7 +161,7 @@ class Samfire:
     _args = None
     count = 0
 
-    def __init__(self, model, workers=None, setup=True, **kwargs):
+    def __init__(self, model, workers=None, setup=True, random_state=None, **kwargs):
         # constants:
         if workers is None:
             workers = max(1, cpu_count() - 1)
@@ -192,6 +195,7 @@ class Samfire:
         if len(kwargs) or setup:
             self._setup(**kwargs)
         self.refresh_database()
+        self.random_state = check_random_state(random_state)
 
     @property
     def active_strategy(self):
@@ -495,7 +499,7 @@ class Samfire:
         if best > 0.0:
             ind_list = np.where(self.metadata.marker == best)
             while number and ind_list[0].size > 0:
-                i = np.random.randint(len(ind_list[0]))
+                i = self.random_state.randint(len(ind_list[0]))
                 ind = tuple([lst[i] for lst in ind_list])
                 if ind not in self.running_pixels:
                     inds.append(ind)

--- a/hyperspy/tests/misc/test_math_tools.py
+++ b/hyperspy/tests/misc/test_math_tools.py
@@ -16,7 +16,9 @@
 # You should have received a copy of the GNU General Public License
 # along with  HyperSpy.  If not, see <http://www.gnu.org/licenses/>.
 
+import pytest
 import numpy as np
+import dask.array as da
 
 from hyperspy.misc import math_tools
 
@@ -35,3 +37,18 @@ def test_isfloat_npfloat():
 
 def test_isfloat_npint():
     assert not math_tools.isfloat(np.int16(3))
+
+
+@pytest.mark.parametrize("seed", [None, 123, np.random.RandomState(123)])
+def test_random_state(seed):
+    assert isinstance(math_tools.check_random_state(seed), np.random.RandomState)
+
+
+@pytest.mark.parametrize("seed", [None, 123, da.random.RandomState(123)])
+def test_random_state_lazy(seed):
+    assert isinstance(math_tools.check_random_state(seed, lazy=True), da.random.RandomState)
+
+
+def test_random_state_error():
+    with pytest.raises(ValueError, match="RandomState"):
+        math_tools.check_random_state("string")

--- a/hyperspy/tests/signal/test_tools.py
+++ b/hyperspy/tests/signal/test_tools.py
@@ -17,6 +17,8 @@
 # along with  HyperSpy.  If not, see <http://www.gnu.org/licenses/>.
 
 import sys
+import logging
+
 from unittest import mock
 
 import dask.array as da
@@ -436,6 +438,35 @@ class Test2D:
         np.testing.assert_array_almost_equal(
             s.data - data, normal(scale=1.0, size=data.shape, **kwargs))
 
+    def test_add_gaussian_noise_seed(self):
+        s = self.signal
+        s.change_dtype("float64")
+        kwargs = {}
+        if s._lazy:
+            data = s.data.compute()
+            from dask.array.random import RandomState
+            kwargs["chunks"] = s.data.chunks
+            rng1 = RandomState(123)
+            rng2 = RandomState(123)
+        else:
+            data = s.data.copy()
+            rng1 = np.random.RandomState(123)
+            rng2 = np.random.RandomState(123)
+
+        s.add_gaussian_noise(std=1.0, random_state=rng1)
+        if s._lazy:
+            s.compute()
+
+        np.testing.assert_array_almost_equal(
+            s.data - data, rng2.normal(scale=1.0, size=data.shape, **kwargs))
+
+    def test_gaussian_noise_error(self):
+        s = self.signal
+        s.change_dtype("int64")
+        with pytest.raises(TypeError, match="float datatype"):
+            s.add_gaussian_noise(std=1.0)
+
+
     def test_add_poisson_noise(self):
         s = self.signal
         kwargs = {}
@@ -447,7 +478,9 @@ class Test2D:
             data = s.data.copy()
             from numpy.random import seed, poisson
         seed(1)
+
         s.add_poissonian_noise(keep_dtype=False)
+
         if s._lazy:
             s.compute()
         seed(1)
@@ -455,10 +488,54 @@ class Test2D:
             s.data, poisson(lam=data, **kwargs))
         s.change_dtype("float64")
         seed(1)
+
         s.add_poissonian_noise(keep_dtype=True)
         if s._lazy:
             s.compute()
         assert s.data.dtype == np.dtype("float64")
+
+    def test_add_poisson_noise_seed(self):
+        s = self.signal
+        kwargs = {}
+        if s._lazy:
+            data = s.data.compute()
+            from dask.array.random import RandomState
+            kwargs["chunks"] = s.data.chunks
+            rng1 = RandomState(123)
+            rng2 = RandomState(123)
+        else:
+            data = s.data.copy()
+            rng1 = np.random.RandomState(123)
+            rng2 = np.random.RandomState(123)
+
+        s.add_poissonian_noise(keep_dtype=False, random_state=rng1)
+
+        if s._lazy:
+            s.compute()
+
+        np.testing.assert_array_almost_equal(
+            s.data, rng2.poisson(lam=data, **kwargs))
+        s.change_dtype("float64")
+
+        s.add_poissonian_noise(keep_dtype=True, random_state=rng1)
+        if s._lazy:
+            s.compute()
+
+        assert s.data.dtype == np.dtype("float64")
+
+    def test_add_poisson_noise_warning(self, caplog):
+        s = self.signal
+        s.change_dtype("float64")
+
+        with caplog.at_level(logging.WARNING):
+            s.add_poissonian_noise(keep_dtype=True)
+
+        assert "Changing data type from" in caplog.text
+
+        with caplog.at_level(logging.WARNING):
+            s.add_poissonian_noise(keep_dtype=False)
+
+        assert "The data type changed from" in caplog.text
 
 
 def _test_default_navigation_signal_operations_over_many_axes(self, op):


### PR DESCRIPTION
### Description of the change
- Add a `random_state` argument to functions that previously required `np.random.seed()` to be set externally. 
- Also works for lazy arrays with `dask.array.random.RandomState()`. 
- Inspired by sklearn's `check_random_state()` function.
- The old way using `np.random.seed()` is unaffected.
- This is a step towards replacing `np.random.RandomState` with [Generators](https://numpy.org/doc/stable/reference/random/generator.html) in future if desired.

```python
>>> import numpy as np
>>> import hyperspy.api as hs
>>> s = hs.signals.Signal1D(np.arange(10, dtype=float))

>>> # Old way
>>> np.random.seed(1)
>>> s.add_gaussian_noise(std=1.0)

>>> # New way (no need to set seed beforehand)
>>> s.add_gaussian_noise(std=1.0, random_state=1)
>>> rng = np.random.RandomState(123)
>>> s.add_gaussian_noise(std=1.0, random_state=rng)
```

### Progress of the PR
- [x] Change implemented (can be split into several points),
- [x] update docstring (if appropriate),
- [x] update user guide (if appropriate),
- [x] add tests,
- [x] ready for review.

