### PR TITLE
Background removal: Spelling of component names and CLI aliases, documentation

### DIFF
--- a/doc/user_guide/signal1d.rst
+++ b/doc/user_guide/signal1d.rst
@@ -56,11 +56,14 @@ Background removal
 The :py:meth:`~._signals.signal1d.Signal1D.remove_background` method provides
 background removal capabilities through both a CLI and a GUI. The GUI displays
 an interactive preview of the remainder after background subtraction. Currently,
-the following background types are supported: power law, offset, polynomial, 
-Gaussian, Lorentzian and skew normal. By default, the background parameters are
-estimated using analytical approximations (keyword argument ``fast=True``). For 
-better accuracy, but higher processing time, the parameters can be estimated 
-using curve fitting by setting ``fast=False``.
+the following background types are supported: Doniach, Exponential, Gaussian,
+Lorentzian, Polynomial, Power law (default), Offset, Skew normal, Split Voigt 
+and Voigt. By default, the background parameters are estimated using analytical
+approximations (keyword argument ``fast=True``). The fast option is not accurate
+for most background types - except Gaussian, Lorentzian, Offset and Power law -
+but it is useful to estimate the initial fitting parameters before performing a
+full fit. For better accuracy, but higher processing time, the parameters can
+be estimated using curve fitting by setting ``fast=False``.
 
 Example of usage:
 

--- a/doc/user_guide/signal1d.rst
+++ b/doc/user_guide/signal1d.rst
@@ -60,7 +60,7 @@ the following background types are supported: Doniach, Exponential, Gaussian,
 Lorentzian, Polynomial, Power law (default), Offset, Skew normal, Split Voigt 
 and Voigt. By default, the background parameters are estimated using analytical
 approximations (keyword argument ``fast=True``). The fast option is not accurate
-for most background types - except Gaussian, Lorentzian, Offset and Power law -
+for most background types - except Gaussian, Offset and Power law -
 but it is useful to estimate the initial fitting parameters before performing a
 full fit. For better accuracy, but higher processing time, the parameters can
 be estimated using curve fitting by setting ``fast=False``.

--- a/hyperspy/_signals/signal1d.py
+++ b/hyperspy/_signals/signal1d.py
@@ -1138,11 +1138,11 @@ class Signal1D(BaseSignal, CommonSignal1D):
             display=True,
             toolkit=None):
         """
-        Remove the background, either in place using a gui or returned as a new
+        Remove the background, either in place using a GUI or returned as a new
         spectrum using the command line. The fast option is not accurate for
-        most background type - except Gaussian, Offset and Power law - but it
-        is useful to estimate the initial fitting parameters before performing
-        a full fit.
+        most background types - except Gaussian, Lorentzian, Offset and
+        Power law - but it is useful to estimate the initial fitting parameters
+        before performing a full fit.
 
         Parameters
         ----------
@@ -1152,16 +1152,16 @@ class Signal1D(BaseSignal, CommonSignal1D):
             If tuple is given, the a spectrum will be returned.
         background_type : str
             The type of component which should be used to fit the background.
-            Possible components: Doniach, Gaussian, Lorentzian, Offset, Polynomial,
-            PowerLaw, Exponential, SkewNormal, SplitVoigt, Voigt.
+            Possible components: Doniach, Gaussian, Lorentzian, Offset,
+            Polynomial, PowerLaw, Exponential, SkewNormal, SplitVoigt, Voigt.
             If Polynomial is used, the polynomial order can be specified
         polynomial_order : int, default 2
             Specify the polynomial order if a Polynomial background is used.
         fast : bool
             If True, perform an approximative estimation of the parameters.
             If False, the signal is fitted using non-linear least squares
-            afterwards.This is slower compared to the estimation but
-            possibly more accurate.
+            afterwards. This is slower compared to the estimation but
+            often more accurate.
         zero_fill : bool
             If True, all spectral channels lower than the lower bound of the
             fitting range will be set to zero (this is the default behavior
@@ -1184,14 +1184,14 @@ class Signal1D(BaseSignal, CommonSignal1D):
         Returns
         -------
         {None, signal, background_model or (signal, background_model)}
-            If signal_range is not 'interactive', the background substracted
-            signal is returned. If return_model is True, returns the background
-            model, otherwise, the GUI widget dictionary is returned if
-            `display=False` - see the display parameter documentation.
+            If signal_range is not 'interactive', the signal with background
+            substracted is returned. If return_model is True, returns the
+            background model, otherwise, the GUI widget dictionary is returned
+            if `display=False` - see the display parameter documentation.
 
         Examples
         --------
-        Using gui, replaces spectrum s
+        Using GUI, replaces spectrum s
 
         >>> s = hs.signals.Signal1D(range(1000))
         >>> s.remove_background() #doctest: +SKIP

--- a/hyperspy/_signals/signal1d.py
+++ b/hyperspy/_signals/signal1d.py
@@ -1140,7 +1140,7 @@ class Signal1D(BaseSignal, CommonSignal1D):
         """
         Remove the background, either in place using a GUI or returned as a new
         spectrum using the command line. The fast option is not accurate for
-        most background types - except Gaussian, Lorentzian, Offset and
+        most background types - except Gaussian, Offset and
         Power law - but it is useful to estimate the initial fitting parameters
         before performing a full fit.
 

--- a/hyperspy/_signals/signal1d.py
+++ b/hyperspy/_signals/signal1d.py
@@ -1128,7 +1128,7 @@ class Signal1D(BaseSignal, CommonSignal1D):
     def remove_background(
             self,
             signal_range='interactive',
-            background_type='Power Law',
+            background_type='Power law',
             polynomial_order=2,
             fast=True,
             zero_fill=False,

--- a/hyperspy/signal_tools.py
+++ b/hyperspy/signal_tools.py
@@ -1007,12 +1007,12 @@ class IntegrateArea(SpanSelectorInSignal1D):
 class BackgroundRemoval(SpanSelectorInSignal1D):
     background_type = t.Enum(
         'Doniach',
+        'Exponential',
         'Gaussian',
         'Lorentzian',
         'Offset',
         'Polynomial',
         'Power law',
-        'Exponential',
         'Skew normal',
         'Split Voigt',
         'Voigt',

--- a/hyperspy/signal_tools.py
+++ b/hyperspy/signal_tools.py
@@ -1011,12 +1011,12 @@ class BackgroundRemoval(SpanSelectorInSignal1D):
         'Lorentzian',
         'Offset',
         'Polynomial',
-        'Power Law',
+        'Power law',
         'Exponential',
-        'SkewNormal',
-        'SplitVoigt',
+        'Skew normal',
+        'Split Voigt',
         'Voigt',
-        default='Power Law')
+        default='Power law')
     polynomial_order = t.Range(1, 10)
     fast = t.Bool(True,
                   desc=("Perform a fast (analytic, but possibly less accurate)"
@@ -1036,7 +1036,7 @@ class BackgroundRemoval(SpanSelectorInSignal1D):
                            default='full')
     red_chisq = t.Float(np.nan)
 
-    def __init__(self, signal, background_type='Power Law', polynomial_order=2,
+    def __init__(self, signal, background_type='Power law', polynomial_order=2,
                  fast=True, plot_remainder=True, zero_fill=False,
                  show_progressbar=None, model=None):
         super(BackgroundRemoval, self).__init__(signal)
@@ -1052,6 +1052,12 @@ class BackgroundRemoval(SpanSelectorInSignal1D):
             model = Model1D(signal)
         self.model = model
         self.polynomial_order = polynomial_order
+        if background_type in ['Power Law', 'PowerLaw']:
+            background_type = 'Power law'
+        if background_type in ['Skew Normal', 'SkewNormal']:
+            background_type = 'Skew normal'
+        if background_type in ['Split voigt', 'SplitVoigt']:
+            background_type = 'Split Voigt'
         self.background_type = background_type
         self.zero_fill = zero_fill
         self.show_progressbar = show_progressbar

--- a/hyperspy/tests/signal/test_remove_background.py
+++ b/hyperspy/tests/signal/test_remove_background.py
@@ -268,7 +268,7 @@ def compare_axes_manager_metadata(s0, s1):
                           'Voigt'])
 def test_remove_backgound_type(background_type):
     s = hs.signals.Signal1D(np.arange(100))
-    s.remove_background(background_type=background_type)
+    s.remove_background(background_type=background_type,signal_range=(2,98))
 
 
 @pytest.mark.parametrize('nav_dim', [0, 1])

--- a/hyperspy/tests/signal/test_remove_background.py
+++ b/hyperspy/tests/signal/test_remove_background.py
@@ -266,9 +266,9 @@ def compare_axes_manager_metadata(s0, s1):
 @pytest.mark.parametrize('show_progressbar', [True, False])
 @pytest.mark.parametrize('plot_remainder', [True, False])
 @pytest.mark.parametrize('background_type',
-                         ['Doniach', 'Gaussian', 'Lorentzian', 'Polynomial',
-                          'Power law', 'Power Law', 'PowerLaw', 'Offset', 
-                          'Skew normal', 'Skew Normal', 'SkewNormal', 
+                         ['Doniach', 'Exponential', 'Gaussian', 'Lorentzian', 
+                          'Polynomial', 'Power law', 'Power Law', 'PowerLaw', 
+                          'Offset', 'Skew normal', 'Skew Normal', 'SkewNormal', 
                           'Split Voigt', 'Split voigt', 'SplitVoigt',
                           'Voigt'])
 def test_remove_background_metadata_axes_manager_copy(nav_dim,

--- a/hyperspy/tests/signal/test_remove_background.py
+++ b/hyperspy/tests/signal/test_remove_background.py
@@ -260,35 +260,32 @@ def compare_axes_manager_metadata(s0, s1):
     assert s0.metadata.General.title == s1.metadata.General.title
 
 
+@pytest.mark.parametrize('background_type',
+                         ['Doniach', 'Exponential', 'Gaussian', 'Lorentzian',
+                          'Polynomial', 'Power law', 'Power Law', 'PowerLaw',
+                          'Offset', 'Skew normal', 'Skew Normal', 'SkewNormal',
+                          'Split Voigt', 'Split voigt', 'SplitVoigt',
+                          'Voigt'])
+def test_remove_backgound_type(background_type):
+    s = hs.signals.Signal1D(np.arange(100))
+    s.remove_background(background_type=background_type)
+
+
 @pytest.mark.parametrize('nav_dim', [0, 1])
 @pytest.mark.parametrize('fast', [True, False])
 @pytest.mark.parametrize('zero_fill', [True, False])
 @pytest.mark.parametrize('show_progressbar', [True, False])
 @pytest.mark.parametrize('plot_remainder', [True, False])
-@pytest.mark.parametrize('background_type',
-                         ['Doniach', 'Exponential', 'Gaussian', 'Lorentzian', 
-                          'Polynomial', 'Power law', 'Power Law', 'PowerLaw', 
-                          'Offset', 'Skew normal', 'Skew Normal', 'SkewNormal', 
-                          'Split Voigt', 'Split voigt', 'SplitVoigt',
-                          'Voigt'])
 def test_remove_background_metadata_axes_manager_copy(nav_dim,
                                                       fast,
                                                       zero_fill,
                                                       show_progressbar,
-                                                      plot_remainder,
-                                                      background_type):
+                                                      plot_remainder):
     if nav_dim == 0:
-        if background_type == ('Voigt'):  # speeds up the test
-            s = hs.signals.Signal1D(np.hstack((np.arange(10, 50),
-                                               np.arange(10, 50)[::-1])))
-        else:
-            s = hs.signals.Signal1D(np.arange(10, 100)[::-1])
+        data = np.arange(10, 100)[::-1]
     else:
-        if background_type == ('Voigt'):  # avoids warning
-            s = hs.signals.Signal1D(
-                np.tile(np.exp(np.arange(0, 100)[::-1]), (2, 1)))
-        else:
-            s = hs.signals.Signal1D(np.arange(10, 210)[::-1].reshape(2, 100))
+        data = np.arange(10, 210)[::-1].reshape(2, 100)
+    s = hs.signals.Signal1D(data)
     s.axes_manager[0].name = 'axis0'
     s.axes_manager[0].units = 'units0'
     s.axes_manager[0].scale = 0.9
@@ -299,7 +296,6 @@ def test_remove_background_metadata_axes_manager_copy(nav_dim,
                               fast=fast,
                               zero_fill=zero_fill,
                               show_progressbar=show_progressbar,
-                              plot_remainder=plot_remainder,
-                              background_type=background_type)
+                              plot_remainder=plot_remainder)
     compare_axes_manager_metadata(s, s_r)
     assert s_r.data.shape == s.data.shape

--- a/hyperspy/tests/signal/test_remove_background.py
+++ b/hyperspy/tests/signal/test_remove_background.py
@@ -267,7 +267,9 @@ def compare_axes_manager_metadata(s0, s1):
 @pytest.mark.parametrize('plot_remainder', [True, False])
 @pytest.mark.parametrize('background_type',
                          ['Doniach', 'Gaussian', 'Lorentzian', 'Polynomial',
-                          'Power Law', 'Offset', 'SkewNormal', 'SplitVoigt',
+                          'Power law', 'Power Law', 'PowerLaw', 'Offset', 
+                          'Skew normal', 'Skew Normal', 'SkewNormal', 
+                          'Split Voigt', 'Split voigt', 'SplitVoigt',
                           'Voigt'])
 def test_remove_background_metadata_axes_manager_copy(nav_dim,
                                                       fast,


### PR DESCRIPTION
This PR is based on #2184 and resolves the original issue #2176.

The solution in #2176 differed/went beyond #2307 in three aspects:
1. 'Power law' would be the correct spelling in the GUI not 'Power Law'
2. The naming should be consistent also for the new components SkewNormal and SplitVoigt (here of course 'Split Voigt' and not 'Split voigt')
3. This implementation accepted the three aliases 'Power law', 'Power Law' and 'PowerLaw' in the CLI call of the `remove_background` function (same for the other two components).

With #2307 this is much cleaner than the original.

Also the tests and documentation have been updated to include missing components that have in the meantime been added to the background_removal method.

### Progress of the PR
- [X] Change implemented (can be split into several points),
- [X] update docstring (if appropriate),
- [X] update user guide (if appropriate),
- [X] add tests,
- [X] ready for review.

