### PR TITLE
Tidy up long-running and duplicated tests

### DIFF
--- a/hyperspy/tests/learn/test_cluster.py
+++ b/hyperspy/tests/learn/test_cluster.py
@@ -39,16 +39,10 @@ class TestCluster1d:
         self.signal_mask = np.zeros((7,), dtype=bool)
         self.signal_mask[2:6] = True
 
-    @pytest.mark.parametrize("algorithm",
-                             (None, "kmeans", "agglomerative",
-                              "spectralclustering",
-                              "minibatchkmeans"))
-    @pytest.mark.parametrize("cluster_source",
-                             ("signal", "bss", "decomposition"))
-    @pytest.mark.parametrize("source_for_centers",
-                             (None, "signal", "bss", "decomposition"))
-    @pytest.mark.parametrize("preprocessing",
-                             (None, "standard", "norm", "minmax", None))
+    @pytest.mark.parametrize("algorithm", (None, "agglomerative", "spectralclustering"))
+    @pytest.mark.parametrize("cluster_source", ("signal", "bss", "decomposition"))
+    @pytest.mark.parametrize("source_for_centers", (None, "signal", "bss", "decomposition"))
+    @pytest.mark.parametrize("preprocessing", (None, "standard", "norm", "minmax"))
     @pytest.mark.parametrize("use_masks", (True, False))
     def test_combinations(self, algorithm,
                           cluster_source,

--- a/hyperspy/tests/signal/test_1D.py
+++ b/hyperspy/tests/signal/test_1D.py
@@ -1,0 +1,38 @@
+# -*- coding: utf-8 -*-
+# Copyright 2007-2020 The HyperSpy developers
+#
+# This file is part of  HyperSpy.
+#
+#  HyperSpy is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+#  HyperSpy is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with  HyperSpy.  If not, see <http://www.gnu.org/licenses/>.
+
+import numpy as np
+
+from hyperspy.components1d import Gaussian
+from hyperspy.decorators import lazifyTestClass
+from hyperspy.signals import Signal1D
+
+
+@lazifyTestClass
+class Test1D:
+    def setup_method(self, method):
+        gaussian = Gaussian()
+        gaussian.A.value = 20
+        gaussian.sigma.value = 10
+        gaussian.centre.value = 50
+        self.signal = Signal1D(gaussian.function(np.arange(0, 100, 0.01)))
+        self.signal.axes_manager[0].scale = 0.01
+
+    def test_integrate1D(self):
+        integrated_signal = self.signal.integrate1D(axis=0)
+        np.testing.assert_allclose(integrated_signal.data, 20, rtol=1e-6)

--- a/hyperspy/tests/signal/test_2D.py
+++ b/hyperspy/tests/signal/test_2D.py
@@ -1,0 +1,510 @@
+# -*- coding: utf-8 -*-
+# Copyright 2007-2020 The HyperSpy developers
+#
+# This file is part of  HyperSpy.
+#
+#  HyperSpy is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+#  HyperSpy is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with  HyperSpy.  If not, see <http://www.gnu.org/licenses/>.
+
+import logging
+from unittest import mock
+
+import numpy as np
+import pytest
+
+from hyperspy.decorators import lazifyTestClass
+from hyperspy.signals import Signal1D, Signal2D
+
+
+def _verify_test_sum_x_E(self, s):
+    np.testing.assert_array_equal(self.signal.data.sum(), s.data)
+    assert s.data.ndim == 1
+    # Check that there is still one signal axis.
+    assert s.axes_manager.signal_dimension == 1
+
+
+@lazifyTestClass
+class Test2D:
+    def setup_method(self, method):
+        self.signal = Signal1D(np.arange(5 * 10).reshape(5, 10))  # dtype int
+        self.signal.axes_manager[0].name = "x"
+        self.signal.axes_manager[1].name = "E"
+        self.signal.axes_manager[0].scale = 0.5
+        self.data = self.signal.data.copy()
+
+    def test_sum_x(self):
+        s = self.signal.sum("x")
+        np.testing.assert_array_equal(self.signal.data.sum(0), s.data)
+        assert s.data.ndim == 1
+        assert s.axes_manager.navigation_dimension == 0
+
+    def test_sum_x_E(self):
+        s = self.signal.sum(("x", "E"))
+        _verify_test_sum_x_E(self, s)
+        s = self.signal.sum((0, "E"))
+        _verify_test_sum_x_E(self, s)
+        s = self.signal.sum((self.signal.axes_manager[0], "E"))
+        _verify_test_sum_x_E(self, s)
+        s = self.signal.sum("x").sum("E")
+        _verify_test_sum_x_E(self, s)
+
+    def test_axis_by_str(self):
+        m = mock.Mock()
+        s1 = self.signal.deepcopy()
+        s1.events.data_changed.connect(m.data_changed)
+        s2 = self.signal.deepcopy()
+        s1.crop(0, 2, 4)
+        assert m.data_changed.called
+        s2.crop("x", 2, 4)
+        np.testing.assert_array_almost_equal(s1.data, s2.data)
+
+    def test_crop_int(self):
+        s = self.signal
+        d = self.data
+        s.crop(0, 2, 4)
+        np.testing.assert_array_almost_equal(s.data, d[2:4, :])
+
+    def test_crop_float(self):
+        s = self.signal
+        d = self.data
+        s.crop(0, 2, 2.0)
+        np.testing.assert_array_almost_equal(s.data, d[2:4, :])
+
+    def test_crop_start_end_equal(self):
+        s = self.signal
+        with pytest.raises(ValueError):
+            s.crop(0, 2, 2)
+        with pytest.raises(ValueError):
+            s.crop(0, 2.0, 2.0)
+
+    def test_crop_float_no_unit_convertion_signal1D(self):
+        # Should convert the unit to eV
+        d = np.arange(5 * 10 * 2000).reshape(5, 10, 2000)
+        s = Signal1D(d)
+        s.axes_manager.signal_axes[0].name = "E"
+        s.axes_manager.signal_axes[0].scale = 0.05
+        s.axes_manager.signal_axes[0].units = "keV"
+        s.crop("E", 0.0, 1.0, convert_units=False)
+        np.testing.assert_almost_equal(s.axes_manager.signal_axes[0].scale, 0.05)
+        assert s.axes_manager.signal_axes[0].units == "keV"
+        np.testing.assert_allclose(s.data, d[:, :, :20])
+
+        # Should keep the unit to keV
+        s = Signal1D(d)
+        s.axes_manager.signal_axes[0].name = "E"
+        s.axes_manager.signal_axes[0].scale = 0.05
+        s.axes_manager.signal_axes[0].units = "keV"
+        s.crop("E", 0.0, 50.0, convert_units=False)
+        np.testing.assert_almost_equal(s.axes_manager.signal_axes[0].scale, 0.05)
+        assert s.axes_manager.signal_axes[0].units == "keV"
+        np.testing.assert_allclose(s.data, d[:, :, :1000])
+
+    def test_crop_float_unit_convertion_signal1D(self):
+        # Should convert the unit to eV
+        d = np.arange(5 * 10 * 2000).reshape(5, 10, 2000)
+        s = Signal1D(d)
+        s.axes_manager.signal_axes[0].name = "E"
+        s.axes_manager.signal_axes[0].scale = 0.05
+        s.axes_manager.signal_axes[0].units = "keV"
+        s.crop("E", 0.0, 1.0, convert_units=True)
+        np.testing.assert_almost_equal(s.axes_manager.signal_axes[0].scale, 50.0)
+        assert s.axes_manager.signal_axes[0].units == "eV"
+        np.testing.assert_allclose(s.data, d[:, :, :20])
+
+        # Should keep the unit to keV
+        s = Signal1D(d)
+        s.axes_manager.signal_axes[0].name = "E"
+        s.axes_manager.signal_axes[0].scale = 0.05
+        s.axes_manager.signal_axes[0].units = "keV"
+        s.crop("E", 0.0, 50.0, convert_units=True)
+        np.testing.assert_almost_equal(s.axes_manager.signal_axes[0].scale, 0.05)
+        assert s.axes_manager.signal_axes[0].units == "keV"
+        np.testing.assert_allclose(s.data, d[:, :, :1000])
+
+    def test_crop_float_no_unit_convertion_signal2D(self):
+        # Should convert the unit to nm
+        d = np.arange(512 * 512).reshape(512, 512)
+        s = Signal2D(d)
+        s.axes_manager[0].name = "x"
+        s.axes_manager[0].scale = 0.01
+        s.axes_manager[0].units = "µm"
+        s.axes_manager[1].name = "y"
+        s.axes_manager[1].scale = 0.01
+        s.axes_manager[1].units = "µm"
+        s.crop(0, 0.0, 0.5, convert_units=False)
+        s.crop(1, 0.0, 0.5, convert_units=False)
+        np.testing.assert_almost_equal(s.axes_manager[0].scale, 0.01)
+        assert s.axes_manager[0].units == "µm"
+        np.testing.assert_allclose(s.data, d[:50, :50])
+
+        # Should keep the unit to µm
+        d = np.arange(512 * 512).reshape(512, 512)
+        s = Signal2D(d)
+        s.axes_manager[0].name = "x"
+        s.axes_manager[0].scale = 0.01
+        s.axes_manager[0].units = "µm"
+        s.axes_manager[1].name = "y"
+        s.axes_manager[1].scale = 0.01
+        s.axes_manager[1].units = "µm"
+        s.crop(0, 0.0, 5.0, convert_units=False)
+        s.crop(1, 0.0, 5.0, convert_units=False)
+        np.testing.assert_almost_equal(s.axes_manager[0].scale, 0.01)
+        assert s.axes_manager[0].units == "µm"
+        np.testing.assert_allclose(s.data, d[:500, :500])
+
+    def test_crop_float_unit_convertion_signal2D(self):
+        # Should convert the unit to nm
+        d = np.arange(512 * 512).reshape(512, 512)
+        s = Signal2D(d)
+        s.axes_manager[0].name = "x"
+        s.axes_manager[0].scale = 0.01
+        s.axes_manager[0].units = "µm"
+        s.axes_manager[1].name = "y"
+        s.axes_manager[1].scale = 0.01
+        s.axes_manager[1].units = "µm"
+        s.crop(0, 0.0, 0.5, convert_units=True)  # also convert the other axis
+        s.crop(1, 0.0, 500.0, convert_units=True)
+        np.testing.assert_almost_equal(s.axes_manager[0].scale, 10.0)
+        np.testing.assert_almost_equal(s.axes_manager[1].scale, 10.0)
+        assert s.axes_manager[0].units == "nm"
+        assert s.axes_manager[1].units == "nm"
+        np.testing.assert_allclose(s.data, d[:50, :50])
+
+        # Should keep the unit to µm
+        d = np.arange(512 * 512).reshape(512, 512)
+        s = Signal2D(d)
+        s.axes_manager[0].name = "x"
+        s.axes_manager[0].scale = 0.01
+        s.axes_manager[0].units = "µm"
+        s.axes_manager[1].name = "y"
+        s.axes_manager[1].scale = 0.01
+        s.axes_manager[1].units = "µm"
+        s.crop(0, 0.0, 5.0, convert_units=True)
+        s.crop(1, 0.0, 5.0, convert_units=True)
+        np.testing.assert_almost_equal(s.axes_manager[0].scale, 0.01)
+        np.testing.assert_almost_equal(s.axes_manager[1].scale, 0.01)
+        assert s.axes_manager[0].units == "µm"
+        assert s.axes_manager[1].units == "µm"
+        np.testing.assert_allclose(s.data, d[:500, :500])
+
+    def test_crop_image_unit_convertion_signal2D(self):
+        # Should not convert the unit
+        d = np.arange(512 * 512).reshape(512, 512)
+        s = Signal2D(d)
+        s.axes_manager[0].name = "x"
+        s.axes_manager[0].scale = 0.01
+        s.axes_manager[0].units = "µm"
+        s.axes_manager[1].name = "y"
+        s.axes_manager[1].scale = 0.01
+        s.axes_manager[1].units = "µm"
+        s.crop_image(0, 0.5, 0.0, 0.5)
+        np.testing.assert_almost_equal(s.axes_manager[0].scale, 0.01)
+        np.testing.assert_almost_equal(s.axes_manager[1].scale, 0.01)
+        assert s.axes_manager[0].units == "µm"
+        assert s.axes_manager[1].units == "µm"
+        np.testing.assert_allclose(s.data, d[:50, :50])
+
+        # Should convert the unit to nm
+        d = np.arange(512 * 512).reshape(512, 512)
+        s = Signal2D(d)
+        s.axes_manager[0].name = "x"
+        s.axes_manager[0].scale = 0.01
+        s.axes_manager[0].units = "µm"
+        s.axes_manager[1].name = "y"
+        s.axes_manager[1].scale = 0.01
+        s.axes_manager[1].units = "µm"
+        s.crop_image(0, 0.5, 0.0, 0.5, convert_units=True)
+        np.testing.assert_almost_equal(s.axes_manager[0].scale, 10.0)
+        np.testing.assert_almost_equal(s.axes_manager[1].scale, 10.0)
+        assert s.axes_manager[0].units == "nm"
+        assert s.axes_manager[1].units == "nm"
+        np.testing.assert_allclose(s.data, d[:50, :50])
+
+        # Should keep the unit to µm
+        d = np.arange(512 * 512).reshape(512, 512)
+        s = Signal2D(d)
+        s.axes_manager[0].name = "x"
+        s.axes_manager[0].scale = 0.01
+        s.axes_manager[0].units = "µm"
+        s.axes_manager[1].name = "y"
+        s.axes_manager[1].scale = 0.01
+        s.axes_manager[1].units = "µm"
+        s.crop_image(0, 5.0, 0.0, 5.0, convert_units=True)
+        np.testing.assert_almost_equal(s.axes_manager[0].scale, 0.01)
+        np.testing.assert_almost_equal(s.axes_manager[1].scale, 0.01)
+        assert s.axes_manager[0].units == "µm"
+        assert s.axes_manager[1].units == "µm"
+        np.testing.assert_allclose(s.data, d[:500, :500])
+
+    def test_split_axis0(self):
+        result = self.signal.split(0, 2)
+        assert len(result) == 2
+        np.testing.assert_array_almost_equal(result[0].data, self.data[:2, :])
+        np.testing.assert_array_almost_equal(result[1].data, self.data[2:4, :])
+
+    def test_split_axis1(self):
+        result = self.signal.split(1, 2)
+        assert len(result) == 2
+        np.testing.assert_array_almost_equal(result[0].data, self.data[:, :5])
+        np.testing.assert_array_almost_equal(result[1].data, self.data[:, 5:])
+
+    def test_split_axisE(self):
+        result = self.signal.split("E", 2)
+        assert len(result) == 2
+        np.testing.assert_array_almost_equal(result[0].data, self.data[:, :5])
+        np.testing.assert_array_almost_equal(result[1].data, self.data[:, 5:])
+
+    def test_split_default(self):
+        result = self.signal.split()
+        assert len(result) == 5
+        np.testing.assert_array_almost_equal(result[0].data, self.data[0])
+
+    def test_split_step_size_list(self):
+        result = self.signal.split(step_sizes=[1, 2])
+        assert len(result) == 2
+        np.testing.assert_array_almost_equal(result[0].data, self.data[:1, :10])
+        np.testing.assert_array_almost_equal(result[1].data, self.data[1:3, :10])
+
+    def test_split_error(self):
+        with pytest.raises(
+            ValueError,
+            match="You can define step_sizes or number_of_parts but not both",
+        ):
+            _ = self.signal.split(number_of_parts=2, step_sizes=2)
+
+        with pytest.raises(
+            ValueError, match="The number of parts is greater than the axis size.",
+        ):
+            _ = self.signal.split(number_of_parts=1e9)
+
+    def test_histogram(self):
+        result = self.signal.get_histogram(3)
+        assert isinstance(result, Signal1D)
+        np.testing.assert_array_equal(result.data, np.array([17, 16, 17]))
+        assert result.metadata.Signal.binned
+
+    def test_noise_variance_helpers(self):
+        assert self.signal.get_noise_variance() is None
+        self.signal.set_noise_variance(2)
+        assert self.signal.get_noise_variance() == 2
+        self.signal.set_noise_variance(self.signal)
+        variance = self.signal.get_noise_variance()
+        np.testing.assert_array_equal(variance.data, self.signal.data)
+        self.signal.set_noise_variance(None)
+        assert self.signal.get_noise_variance() is None
+
+        with pytest.raises(ValueError, match="`variance` must be one of"):
+            self.signal.set_noise_variance(np.array([0, 1, 2]))
+
+    def test_estimate_poissonian_noise_copy_data(self):
+        self.signal.estimate_poissonian_noise_variance()
+        variance = self.signal.metadata.Signal.Noise_properties.variance
+        assert variance.data is not self.signal.data
+
+    def test_estimate_poissonian_noise_copy_data_helper_function(self):
+        self.signal.estimate_poissonian_noise_variance()
+        variance = self.signal.get_noise_variance()
+        assert variance.data is not self.signal.data
+
+    def test_estimate_poissonian_noise_noarg(self):
+        self.signal.estimate_poissonian_noise_variance()
+        variance = self.signal.metadata.Signal.Noise_properties.variance
+        np.testing.assert_array_equal(variance.data, self.signal.data)
+
+    def test_estimate_poissonian_noise_with_args(self):
+        self.signal.estimate_poissonian_noise_variance(
+            expected_value=self.signal,
+            gain_factor=2,
+            gain_offset=1,
+            correlation_factor=0.5,
+        )
+        variance = self.signal.metadata.Signal.Noise_properties.variance
+        np.testing.assert_array_equal(variance.data, (self.signal.data * 2 + 1) * 0.5)
+
+    def test_unfold_image(self):
+        s = self.signal
+        if s._lazy:
+            pytest.skip("LazySignals do not support folding")
+        s = s.transpose(signal_axes=2)
+        s.unfold()
+        assert s.data.shape == (50,)
+
+    def test_unfold_image_returns_true(self):
+        s = self.signal
+        if s._lazy:
+            pytest.skip("LazySignals do not support folding")
+        s = s.transpose(signal_axes=2)
+        assert s.unfold()
+
+    def test_print_summary(self):
+        # Just test if it doesn't raise an exception
+        self.signal._print_summary()
+
+    def test_print_summary_statistics(self):
+        # Just test if it doesn't raise an exception
+        self.signal.print_summary_statistics()
+        if self.signal._lazy:
+            self.signal.print_summary_statistics(rechunk=False)
+
+    def test_numpy_unfunc_one_arg_titled(self):
+        self.signal.metadata.General.title = "yes"
+        result = np.exp(self.signal)
+        assert isinstance(result, Signal1D)
+        np.testing.assert_array_equal(result.data, np.exp(self.signal.data))
+        assert result.metadata.General.title == "exp(yes)"
+
+    def test_numpy_unfunc_one_arg_untitled(self):
+        result = np.exp(self.signal)
+        assert result.metadata.General.title == "exp(Untitled Signal 1)"
+
+    def test_numpy_unfunc_two_arg_titled(self):
+        s1, s2 = self.signal.deepcopy(), self.signal.deepcopy()
+        s1.metadata.General.title = "A"
+        s2.metadata.General.title = "B"
+        result = np.add(s1, s2)
+        assert isinstance(result, Signal1D)
+        np.testing.assert_array_equal(result.data, np.add(s1.data, s2.data))
+        assert result.metadata.General.title == "add(A, B)"
+
+    def test_numpy_unfunc_two_arg_untitled(self):
+        s1, s2 = self.signal.deepcopy(), self.signal.deepcopy()
+        result = np.add(s1, s2)
+        assert (
+            result.metadata.General.title == "add(Untitled Signal 1, Untitled Signal 2)"
+        )
+
+    def test_numpy_func(self):
+        result = np.angle(self.signal)
+        assert isinstance(result, np.ndarray)
+        np.testing.assert_array_equal(result, np.angle(self.signal.data))
+
+    def test_add_gaussian_noise(self):
+        s = self.signal
+        s.change_dtype("float64")
+        kwargs = {}
+        if s._lazy:
+            data = s.data.compute()
+            from dask.array.random import seed, normal
+
+            kwargs["chunks"] = s.data.chunks
+        else:
+            data = s.data.copy()
+            from numpy.random import seed, normal
+        seed(1)
+        s.add_gaussian_noise(std=1.0)
+        seed(1)
+        if s._lazy:
+            s.compute()
+        np.testing.assert_array_almost_equal(
+            s.data - data, normal(scale=1.0, size=data.shape, **kwargs)
+        )
+
+    def test_add_gaussian_noise_seed(self):
+        s = self.signal
+        s.change_dtype("float64")
+        kwargs = {}
+        if s._lazy:
+            data = s.data.compute()
+            from dask.array.random import RandomState
+
+            kwargs["chunks"] = s.data.chunks
+            rng1 = RandomState(123)
+            rng2 = RandomState(123)
+        else:
+            data = s.data.copy()
+            rng1 = np.random.RandomState(123)
+            rng2 = np.random.RandomState(123)
+
+        s.add_gaussian_noise(std=1.0, random_state=rng1)
+        if s._lazy:
+            s.compute()
+
+        np.testing.assert_array_almost_equal(
+            s.data - data, rng2.normal(scale=1.0, size=data.shape, **kwargs)
+        )
+
+    def test_gaussian_noise_error(self):
+        s = self.signal
+        s.change_dtype("int64")
+        with pytest.raises(TypeError, match="float datatype"):
+            s.add_gaussian_noise(std=1.0)
+
+    def test_add_poisson_noise(self):
+        s = self.signal
+        kwargs = {}
+        if s._lazy:
+            data = s.data.compute()
+            from dask.array.random import seed, poisson
+
+            kwargs["chunks"] = s.data.chunks
+        else:
+            data = s.data.copy()
+            from numpy.random import seed, poisson
+        seed(1)
+
+        s.add_poissonian_noise(keep_dtype=False)
+
+        if s._lazy:
+            s.compute()
+        seed(1)
+        np.testing.assert_array_almost_equal(s.data, poisson(lam=data, **kwargs))
+        s.change_dtype("float64")
+        seed(1)
+
+        s.add_poissonian_noise(keep_dtype=True)
+        if s._lazy:
+            s.compute()
+        assert s.data.dtype == np.dtype("float64")
+
+    def test_add_poisson_noise_seed(self):
+        s = self.signal
+        kwargs = {}
+        if s._lazy:
+            data = s.data.compute()
+            from dask.array.random import RandomState
+
+            kwargs["chunks"] = s.data.chunks
+            rng1 = RandomState(123)
+            rng2 = RandomState(123)
+        else:
+            data = s.data.copy()
+            rng1 = np.random.RandomState(123)
+            rng2 = np.random.RandomState(123)
+
+        s.add_poissonian_noise(keep_dtype=False, random_state=rng1)
+
+        if s._lazy:
+            s.compute()
+
+        np.testing.assert_array_almost_equal(s.data, rng2.poisson(lam=data, **kwargs))
+        s.change_dtype("float64")
+
+        s.add_poissonian_noise(keep_dtype=True, random_state=rng1)
+        if s._lazy:
+            s.compute()
+
+        assert s.data.dtype == np.dtype("float64")
+
+    def test_add_poisson_noise_warning(self, caplog):
+        s = self.signal
+        s.change_dtype("float64")
+
+        with caplog.at_level(logging.WARNING):
+            s.add_poissonian_noise(keep_dtype=True)
+
+        assert "Changing data type from" in caplog.text
+
+        with caplog.at_level(logging.WARNING):
+            s.add_poissonian_noise(keep_dtype=False)
+
+        assert "The data type changed from" in caplog.text

--- a/hyperspy/tests/signal/test_3D.py
+++ b/hyperspy/tests/signal/test_3D.py
@@ -1,0 +1,270 @@
+# -*- coding: utf-8 -*-
+# Copyright 2007-2020 The HyperSpy developers
+#
+# This file is part of  HyperSpy.
+#
+#  HyperSpy is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+#  HyperSpy is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with  HyperSpy.  If not, see <http://www.gnu.org/licenses/>.
+
+import numpy as np
+import pytest
+
+from hyperspy.decorators import lazifyTestClass
+from hyperspy.signals import Signal1D
+
+
+def _test_default_navigation_signal_operations_over_many_axes(self, op):
+    s = getattr(self.signal, op)()
+    ar = getattr(self.data, op)(axis=(0, 1))
+    np.testing.assert_array_equal(ar, s.data)
+    assert s.data.ndim == 1
+    assert s.axes_manager.signal_dimension == 1
+    assert s.axes_manager.navigation_dimension == 0
+
+
+@lazifyTestClass
+class Test3D:
+    def setup_method(self, method):
+        self.signal = Signal1D(np.arange(2 * 4 * 6).reshape(2, 4, 6))
+        self.signal.axes_manager[0].name = "x"
+        self.signal.axes_manager[1].name = "y"
+        self.signal.axes_manager[2].name = "E"
+        self.signal.axes_manager[0].scale = 0.5
+        self.data = self.signal.data.copy()
+
+    def test_indexmin(self):
+        s = self.signal.indexmin("E")
+        ar = self.data.argmin(2)
+        np.testing.assert_array_equal(ar, s.data)
+        assert s.data.ndim == 2
+        assert s.axes_manager.signal_dimension == 0
+        assert s.axes_manager.navigation_dimension == 2
+
+    def test_indexmax(self):
+        s = self.signal.indexmax("E")
+        ar = self.data.argmax(2)
+        np.testing.assert_array_equal(ar, s.data)
+        assert s.data.ndim == 2
+        assert s.axes_manager.signal_dimension == 0
+        assert s.axes_manager.navigation_dimension == 2
+
+    def test_valuemin(self):
+        s = self.signal.valuemin("x")
+        ar = self.signal.axes_manager["x"].index2value(self.data.argmin(1))
+        np.testing.assert_array_equal(ar, s.data)
+        assert s.data.ndim == 2
+        assert s.axes_manager.signal_dimension == 1
+        assert s.axes_manager.navigation_dimension == 1
+
+    def test_valuemax(self):
+        s = self.signal.valuemax("x")
+        ar = self.signal.axes_manager["x"].index2value(self.data.argmax(1))
+        np.testing.assert_array_equal(ar, s.data)
+        assert s.data.ndim == 2
+        assert s.axes_manager.signal_dimension == 1
+        assert s.axes_manager.navigation_dimension == 1
+
+    def test_default_navigation_sum(self):
+        _test_default_navigation_signal_operations_over_many_axes(self, "sum")
+
+    def test_default_navigation_max(self):
+        _test_default_navigation_signal_operations_over_many_axes(self, "max")
+
+    def test_default_navigation_min(self):
+        _test_default_navigation_signal_operations_over_many_axes(self, "min")
+
+    def test_default_navigation_mean(self):
+        _test_default_navigation_signal_operations_over_many_axes(self, "mean")
+
+    def test_default_navigation_std(self):
+        _test_default_navigation_signal_operations_over_many_axes(self, "std")
+
+    def test_default_navigation_var(self):
+        _test_default_navigation_signal_operations_over_many_axes(self, "var")
+
+    def test_rebin(self):
+        self.signal.estimate_poissonian_noise_variance()
+        new_s = self.signal.rebin(scale=(2, 2, 1))
+        var = new_s.metadata.Signal.Noise_properties.variance
+        assert new_s.data.shape == (1, 2, 6)
+        assert var.data.shape == (1, 2, 6)
+        from hyperspy.misc.array_tools import rebin
+
+        np.testing.assert_array_equal(
+            rebin(self.signal.data, scale=(2, 2, 1)), var.data
+        )
+        np.testing.assert_array_equal(
+            rebin(self.signal.data, scale=(2, 2, 1)), new_s.data
+        )
+        if self.signal._lazy:
+            new_s = self.signal.rebin(scale=(2, 2, 1), rechunk=False)
+            np.testing.assert_array_equal(
+                rebin(self.signal.data, scale=(2, 2, 1)), var.data
+            )
+            np.testing.assert_array_equal(
+                rebin(self.signal.data, scale=(2, 2, 1)), new_s.data
+            )
+
+    def test_rebin_no_variance(self):
+        new_s = self.signal.rebin(scale=(2, 2, 1))
+        with pytest.raises(AttributeError):
+            _ = new_s.metadata.Signal.Noise_properties
+
+    def test_rebin_const_variance(self):
+        self.signal.metadata.set_item("Signal.Noise_properties.variance", 0.3)
+        new_s = self.signal.rebin(scale=(2, 2, 1))
+        assert new_s.metadata.Signal.Noise_properties.variance == 0.3
+
+    def test_rebin_dtype(self):
+        s = Signal1D(np.arange(1000).reshape(10, 10, 10))
+        s.change_dtype(np.uint8)
+        s2 = s.rebin(scale=(3, 3, 1), crop=False)
+        assert s.sum() == s2.sum()
+
+    def test_swap_axes_simple(self):
+        s = self.signal
+        assert s.swap_axes(0, 1).data.shape == (4, 2, 6)
+        assert s.swap_axes(0, 2).axes_manager.shape == (6, 2, 4)
+        if not s._lazy:
+            assert not s.swap_axes(0, 2).data.flags["C_CONTIGUOUS"]
+            assert s.swap_axes(0, 2, optimize=True).data.flags["C_CONTIGUOUS"]
+        else:
+            cks = s.data.chunks
+            assert s.swap_axes(0, 1).data.chunks == (cks[1], cks[0], cks[2])
+            # This data shape does not require rechunking
+            assert s.swap_axes(0, 1, optimize=True).data.chunks == (
+                cks[1],
+                cks[0],
+                cks[2],
+            )
+
+    def test_swap_axes_iteration(self):
+        s = self.signal
+        s = s.swap_axes(0, 2)
+        assert s.axes_manager._getitem_tuple[:2] == (0, 0)
+        s.axes_manager.indices = (2, 1)
+        assert s.axes_manager._getitem_tuple[:2] == (1, 2)
+
+    def test_get_navigation_signal_nav_dim0(self):
+        s = self.signal
+        s = s.transpose(signal_axes=3)
+        ns = s._get_navigation_signal()
+        assert ns.axes_manager.signal_dimension == 1
+        assert ns.axes_manager.signal_size == 1
+        assert ns.axes_manager.navigation_dimension == 0
+
+    def test_get_navigation_signal_nav_dim1(self):
+        s = self.signal
+        s = s.transpose(signal_axes=2)
+        ns = s._get_navigation_signal()
+        assert ns.axes_manager.signal_shape == s.axes_manager.navigation_shape
+        assert ns.axes_manager.navigation_dimension == 0
+
+    def test_get_navigation_signal_nav_dim2(self):
+        s = self.signal
+        s = s.transpose(signal_axes=1)
+        ns = s._get_navigation_signal()
+        assert ns.axes_manager.signal_shape == s.axes_manager.navigation_shape
+        assert ns.axes_manager.navigation_dimension == 0
+
+    def test_get_navigation_signal_nav_dim3(self):
+        s = self.signal
+        s = s.transpose(signal_axes=0)
+        ns = s._get_navigation_signal()
+        assert ns.axes_manager.signal_shape == s.axes_manager.navigation_shape
+        assert ns.axes_manager.navigation_dimension == 0
+
+    def test_get_navigation_signal_wrong_data_shape(self):
+        s = self.signal
+        s = s.transpose(signal_axes=1)
+        with pytest.raises(ValueError):
+            s._get_navigation_signal(data=np.zeros((3, 2)))
+
+    def test_get_navigation_signal_wrong_data_shape_dim0(self):
+        s = self.signal
+        s = s.transpose(signal_axes=3)
+        with pytest.raises(ValueError):
+            s._get_navigation_signal(data=np.asarray(0))
+
+    def test_get_navigation_signal_given_data(self):
+        s = self.signal
+        s = s.transpose(signal_axes=1)
+        data = np.zeros(s.axes_manager._navigation_shape_in_array)
+        ns = s._get_navigation_signal(data=data)
+        assert ns.data is data
+
+    def test_get_signal_signal_nav_dim0(self):
+        s = self.signal
+        s = s.transpose(signal_axes=0)
+        ns = s._get_signal_signal()
+        assert ns.axes_manager.navigation_dimension == 0
+        assert ns.axes_manager.navigation_size == 0
+        assert ns.axes_manager.signal_dimension == 1
+
+    def test_get_signal_signal_nav_dim1(self):
+        s = self.signal
+        s = s.transpose(signal_axes=1)
+        ns = s._get_signal_signal()
+        assert ns.axes_manager.signal_shape == s.axes_manager.signal_shape
+        assert ns.axes_manager.navigation_dimension == 0
+
+    def test_get_signal_signal_nav_dim2(self):
+        s = self.signal
+        s = s.transpose(signal_axes=2)
+        s._assign_subclass()
+        ns = s._get_signal_signal()
+        assert ns.axes_manager.signal_shape == s.axes_manager.signal_shape
+        assert ns.axes_manager.navigation_dimension == 0
+
+    def test_get_signal_signal_nav_dim3(self):
+        s = self.signal
+        s = s.transpose(signal_axes=3)
+        s._assign_subclass()
+        ns = s._get_signal_signal()
+        assert ns.axes_manager.signal_shape == s.axes_manager.signal_shape
+        assert ns.axes_manager.navigation_dimension == 0
+
+    def test_get_signal_signal_wrong_data_shape(self):
+        s = self.signal
+        s = s.transpose(signal_axes=1)
+        with pytest.raises(ValueError):
+            s._get_signal_signal(data=np.zeros((3, 2)))
+
+    def test_get_signal_signal_wrong_data_shape_dim0(self):
+        s = self.signal
+        s = s.transpose(signal_axes=0)
+        with pytest.raises(ValueError):
+            s._get_signal_signal(data=np.asarray(0))
+
+    def test_get_signal_signal_given_data(self):
+        s = self.signal
+        s = s.transpose(signal_axes=2)
+        data = np.zeros(s.axes_manager._signal_shape_in_array)
+        ns = s._get_signal_signal(data=data)
+        assert ns.data is data
+
+    def test_get_navigation_signal_dtype(self):
+        s = self.signal
+        assert s._get_navigation_signal().data.dtype.name == s.data.dtype.name
+
+    def test_get_signal_signal_dtype(self):
+        s = self.signal
+        assert s._get_signal_signal().data.dtype.name == s.data.dtype.name
+
+    def test_get_navigation_signal_given_dtype(self):
+        s = self.signal
+        assert s._get_navigation_signal(dtype="bool").data.dtype.name == "bool"
+
+    def test_get_signal_signal_given_dtype(self):
+        s = self.signal
+        assert s._get_signal_signal(dtype="bool").data.dtype.name == "bool"

--- a/hyperspy/tests/signal/test_4D.py
+++ b/hyperspy/tests/signal/test_4D.py
@@ -1,0 +1,91 @@
+# -*- coding: utf-8 -*-
+# Copyright 2007-2020 The HyperSpy developers
+#
+# This file is part of  HyperSpy.
+#
+#  HyperSpy is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+#  HyperSpy is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with  HyperSpy.  If not, see <http://www.gnu.org/licenses/>.
+
+import numpy as np
+
+from hyperspy.decorators import lazifyTestClass
+from hyperspy.signals import Signal1D
+
+
+@lazifyTestClass
+class Test4D:
+    def setup_method(self, method):
+        s = Signal1D(np.ones((5, 4, 3, 6)))
+        for axis, name in zip(
+            s.axes_manager._get_axes_in_natural_order(), ["x", "y", "z", "E"]
+        ):
+            axis.name = name
+        self.s = s
+
+    def test_diff_data(self):
+        s = self.s
+        diff = s.diff(axis=2, order=2)
+        diff_data = np.diff(s.data, n=2, axis=0)
+        np.testing.assert_array_equal(diff.data, diff_data)
+
+    def test_diff_axis(self):
+        s = self.s
+        diff = s.diff(axis=2, order=2)
+        assert (
+            diff.axes_manager[2].offset
+            == s.axes_manager[2].offset + s.axes_manager[2].scale
+        )
+
+    def test_rollaxis_int(self):
+        assert self.s.rollaxis(2, 0).data.shape == (4, 3, 5, 6)
+
+    def test_rollaxis_str(self):
+        assert self.s.rollaxis("z", "x").data.shape == (4, 3, 5, 6)
+
+    def test_unfold_spectrum(self):
+        self.s.unfold()
+        assert self.s.data.shape == (60, 6)
+
+    def test_unfold_spectrum_returns_true(self):
+        assert self.s.unfold()
+
+    def test_unfold_spectrum_signal_returns_false(self):
+        assert not self.s.unfold_signal_space()
+
+    def test_unfold_image(self):
+        im = self.s.to_signal2D()
+        im.unfold()
+        assert im.data.shape == (30, 12)
+
+    def test_image_signal_unfolded_deepcopy(self):
+        im = self.s.to_signal2D()
+        im.unfold()
+        # The following could fail if the constructor was not taking the fact
+        # that the signal is unfolded into account when setting the signal
+        # dimension.
+        im.deepcopy()
+
+    def test_image_signal_unfolded_false(self):
+        im = self.s.to_signal2D()
+        assert not im.metadata._HyperSpy.Folding.signal_unfolded
+
+    def test_image_signal_unfolded_true(self):
+        im = self.s.to_signal2D()
+        im.unfold()
+        assert im.metadata._HyperSpy.Folding.signal_unfolded
+
+    def test_image_signal_unfolded_back_to_false(self):
+        im = self.s.to_signal2D()
+        im.unfold()
+        im.fold()
+        assert not im.metadata._HyperSpy.Folding.signal_unfolded

--- a/hyperspy/tests/signal/test_edges_range.py
+++ b/hyperspy/tests/signal/test_edges_range.py
@@ -1,0 +1,419 @@
+# -*- coding: utf-8 -*-
+# Copyright 2007-2020 The HyperSpy developers
+#
+# This file is part of  HyperSpy.
+#
+#  HyperSpy is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+#  HyperSpy is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with  HyperSpy.  If not, see <http://www.gnu.org/licenses/>.
+
+
+import numpy as np
+
+from hyperspy.datasets.artificial_data import \
+    get_core_loss_eels_line_scan_signal
+from hyperspy.signal_tools import EdgesRange
+
+
+class Owner:
+    """for use in Test_EdgesRange"""
+
+    def __init__(self, edge):
+        self.description = edge
+
+
+class Test_EdgesRange:
+    def setup_method(self, method):
+        s = get_core_loss_eels_line_scan_signal(True)
+        self.signal = s
+        er = EdgesRange(self.signal)
+        self.er = er
+
+    def test_init(self):
+        edges_all = np.array(
+            [
+                "Ag_M2",
+                "Cr_L2",
+                "Cd_M3",
+                "Te_M4",
+                "I_M5",
+                "Cr_L3",
+                "Te_M5",
+                "V_L1",
+                "Ag_M3",
+                "I_M4",
+                "Ti_L1",
+                "Pd_M2",
+                "Mn_L3",
+                "Cd_M2",
+                "Mn_L2",
+                "Sb_M4",
+                "In_M3",
+                "O_K",
+                "Pd_M3",
+                "Sb_M5",
+                "Xe_M5",
+                "Rh_M2",
+                "V_L2",
+                "F_K",
+                "Xe_M4",
+                "V_L3",
+                "Cr_L1",
+                "Sc_L1",
+                "In_M2",
+                "Rh_M3",
+                "Sn_M4",
+                "Fe_L3",
+                "Sn_M5",
+                "Sn_M3",
+                "Ru_M2",
+                "Fe_L2",
+                "Cs_M5",
+                "Ti_L2",
+                "Ru_M3",
+                "Cs_M4",
+                "Ti_L3",
+                "In_M4",
+                "Sn_M2",
+                "In_M5",
+                "Ca_L1",
+                "Sb_M3",
+                "Mn_L1",
+                "Co_L3",
+                "Ba_M5",
+                "Cd_M4",
+                "Mo_M2",
+                "Sc_L2",
+                "Co_L2",
+                "Cd_M5",
+                "Ba_M4",
+                "Sc_L3",
+                "N_K",
+            ]
+        )
+        energy_all = np.array(
+            [
+                602.0,
+                584.0,
+                616.0,
+                582.0,
+                620.0,
+                575.0,
+                572.0,
+                628.0,
+                571.0,
+                631.0,
+                564.0,
+                559.0,
+                640.0,
+                651.0,
+                651.0,
+                537.0,
+                664.0,
+                532.0,
+                531.0,
+                528.0,
+                672.0,
+                521.0,
+                521.0,
+                685.0,
+                685.0,
+                513.0,
+                695.0,
+                500.0,
+                702.0,
+                496.0,
+                494.0,
+                708.0,
+                485.0,
+                714.0,
+                483.0,
+                721.0,
+                726.0,
+                462.0,
+                461.0,
+                740.0,
+                456.0,
+                451.0,
+                756.0,
+                443.0,
+                438.0,
+                766.0,
+                769.0,
+                779.0,
+                781.0,
+                411.0,
+                410.0,
+                407.0,
+                794.0,
+                404.0,
+                796.0,
+                402.0,
+                401.0,
+            ]
+        )
+        relevance_all = np.array(
+            [
+                "Minor",
+                "Major",
+                "Minor",
+                "Major",
+                "Major",
+                "Major",
+                "Major",
+                "Minor",
+                "Minor",
+                "Major",
+                "Minor",
+                "Minor",
+                "Major",
+                "Minor",
+                "Major",
+                "Major",
+                "Minor",
+                "Major",
+                "Minor",
+                "Major",
+                "Major",
+                "Minor",
+                "Major",
+                "Major",
+                "Major",
+                "Major",
+                "Minor",
+                "Minor",
+                "Minor",
+                "Minor",
+                "Major",
+                "Major",
+                "Major",
+                "Minor",
+                "Minor",
+                "Major",
+                "Major",
+                "Major",
+                "Minor",
+                "Major",
+                "Major",
+                "Major",
+                "Minor",
+                "Major",
+                "Minor",
+                "Minor",
+                "Minor",
+                "Major",
+                "Major",
+                "Major",
+                "Minor",
+                "Major",
+                "Major",
+                "Major",
+                "Major",
+                "Major",
+                "Major",
+            ]
+        )
+        description_all = np.array(
+            [
+                "Delayed maximum",
+                "Sharp peak. Delayed maximum",
+                "Delayed maximum",
+                "Delayed maximum",
+                "Delayed maximum",
+                "Sharp peak. Delayed maximum",
+                "Delayed maximum",
+                "Abrupt onset",
+                "Delayed maximum",
+                "Delayed maximum",
+                "Abrupt onset",
+                "",
+                "Sharp peak. Delayed maximum",
+                "",
+                "Sharp peak. Delayed maximum",
+                "Delayed maximum",
+                "Delayed maximum",
+                "Abrupt onset",
+                "",
+                "Delayed maximum",
+                "Delayed maximum",
+                "Sharp peak",
+                "Sharp peak. Delayed maximum",
+                "Abrupt onset",
+                "Delayed maximum",
+                "Sharp peak. Delayed maximum",
+                "Abrupt onset",
+                "Abrupt onset",
+                "",
+                "Sharp peak",
+                "Delayed maximum",
+                "Sharp peak. Delayed maximum",
+                "Delayed maximum",
+                "Delayed maximum",
+                "Sharp peak",
+                "Sharp peak. Delayed maximum",
+                "Sharp peak. Delayed maximum",
+                "Sharp peak. Delayed maximum",
+                "Sharp peak",
+                "Sharp peak. Delayed maximum",
+                "Sharp peak. Delayed maximum",
+                "Delayed maximum",
+                "",
+                "Delayed maximum",
+                "Abrupt onset",
+                "Delayed maximum",
+                "Abrupt onset",
+                "Sharp peak. Delayed maximum",
+                "Sharp peak. Delayed maximum",
+                "Delayed maximum",
+                "Sharp peak",
+                "Sharp peak. Delayed maximum",
+                "Sharp peak. Delayed maximum",
+                "Delayed maximum",
+                "Sharp peak. Delayed maximum",
+                "Sharp peak. Delayed maximum",
+                "Abrupt onset",
+            ]
+        )
+
+        assert np.array_equal(self.er.edge_all, edges_all)
+        assert np.array_equal(self.er.energy_all, energy_all)
+        assert np.array_equal(self.er.relevance_all, relevance_all)
+        assert np.array_equal(self.er.description_all, description_all)
+
+    def test_selected_span_selector(self):
+        self.er.ss_left_value = 500
+        self.er.ss_right_value = 550
+
+        edges, energy, relevance, description = self.er.update_table()
+
+        assert set(edges) == set(
+            ("Sb_M4", "O_K", "Pd_M3", "Sb_M5", "Rh_M2", "V_L2", "V_L3", "Sc_L1")
+        )
+        assert set(energy) == set(
+            (537.0, 532.0, 531.0, 528.0, 521.0, 521.0, 513.0, 500.0)
+        )
+        assert set(relevance) == set(
+            ("Major", "Major", "Minor", "Major", "Minor", "Major", "Major", "Minor")
+        )
+        assert set(description) == set(
+            (
+                "Delayed maximum",
+                "Abrupt onset",
+                "",
+                "Delayed maximum",
+                "Sharp peak",
+                "Sharp peak. Delayed maximum",
+                "Sharp peak. Delayed maximum",
+                "Abrupt onset",
+            )
+        )
+
+    def test_none_span_selector(self):
+        self.er.span_selector = None
+
+        edges, energy, relevance, description = self.er.update_table()
+
+        assert len(edges) == 0
+        assert len(energy) == 0
+        assert len(relevance) == 0
+        assert len(description) == 0
+
+    def test_complementary_edge(self):
+        self.signal.plot(plot_edges=["V_L2"])
+        er = EdgesRange(self.signal)
+        er.ss_left_value = 500
+        er.ss_right_value = 550
+        _ = er.update_table()
+
+        assert er.active_edges == ["V_L2"]
+        assert er.active_complementary_edges == ["V_L3", "V_L1"]
+
+    def test_off_complementary_edge(self):
+        self.signal.plot(plot_edges=["V_L2"])
+        er = EdgesRange(self.signal)
+        er.complementary = False
+        er.ss_left_value = 500
+        er.ss_right_value = 550
+        _ = er.update_table()
+
+        assert er.active_edges == ["V_L2"]
+        assert len(er.active_complementary_edges) == 0
+
+    def test_keep_valid_edge(self):
+        self.signal.plot(plot_edges=["V_L2"])
+        er = EdgesRange(self.signal)
+        er.ss_left_value = 500
+        er.ss_right_value = 550
+        _ = er.update_table()
+
+        er.ss_left_value = 600
+        er.ss_right_value = 650
+        _ = er.update_table()
+
+        assert er.active_edges == ["V_L1"]
+        assert er.active_complementary_edges == ["V_L2", "V_L3"]
+
+    def test_remove_out_of_range_edge(self):
+        self.signal.plot(plot_edges=["V_L2"])
+        er = EdgesRange(self.signal)
+        er.ss_left_value = 500
+        er.ss_right_value = 550
+        _ = er.update_table()
+
+        er.ss_left_value = 700
+        er.ss_right_value = 750
+        _ = er.update_table()
+
+        assert len(er.active_edges) == 0
+        assert len(er.active_complementary_edges) == 0
+
+    def test_select_edge_by_button(self):
+        self.er.ss_left_value = 500
+        self.er.ss_right_value = 550
+        _ = self.er.update_table()
+
+        on_V_L2 = {"owner": Owner("V_L2"), "new": True}
+        self.er.update_active_edge(on_V_L2)
+
+        assert self.er.active_edges == ["V_L2"]
+        assert self.er.active_complementary_edges == ["V_L3", "V_L1"]
+
+        off_V_L2 = {"owner": Owner("V_L2"), "new": False}
+        self.er.update_active_edge(off_V_L2)
+
+        assert len(self.er.active_edges) == 0
+        assert len(self.er.active_complementary_edges) == 0
+
+    def test_remove_all_edge_markers(self):
+        self.signal.plot(plot_edges=["V_L2"])
+        er = EdgesRange(self.signal)
+        er.ss_left_value = 500
+        er.ss_right_value = 550
+        _ = er.update_table()
+
+        er._clear_markers()
+
+        assert len(er.active_edges) == 0
+        assert len(er.active_complementary_edges) == 0
+
+    def test_on_figure_changed(self):
+        self.signal.plot(plot_edges=["V_L2"])
+        er = EdgesRange(self.signal)
+        er.ss_left_value = 500
+        er.ss_right_value = 550
+        _ = er.update_table()
+
+        vl1 = self.signal._edge_markers["V_L1"][0]
+        self.signal._plot.pointer.indices = (10,)
+        vl2 = self.signal._edge_markers["V_L1"][0]
+
+        assert not np.array_equal(vl1.data, vl2.data)

--- a/hyperspy/tests/signal/test_fourier_transform.py
+++ b/hyperspy/tests/signal/test_fourier_transform.py
@@ -18,121 +18,152 @@
 
 import numpy as np
 import pytest
-from numpy.testing import assert_allclose
 
+from hyperspy.decorators import lazifyTestClass
 from hyperspy.signals import (BaseSignal, ComplexSignal1D, ComplexSignal2D,
                               Signal1D, Signal2D)
 
 
-@pytest.mark.parametrize('lazy', [True, False])
-def test_fft_signal2d(lazy):
-    im = Signal2D(np.random.random((2, 3, 4, 5)))
-    if lazy:
-        im = im.as_lazy()
-    im.axes_manager.signal_axes[0].units = 'nm'
-    im.axes_manager.signal_axes[1].units = 'nm'
-    im.axes_manager.signal_axes[0].scale = 10.
-    im.axes_manager.signal_axes[1].scale = 10.
-
-    im_fft = im.fft()
-    assert im_fft.axes_manager.signal_axes[0].units == '1 / nm'
-    assert im_fft.axes_manager.signal_axes[1].units == '1 / nm'
-    assert im_fft.axes_manager.signal_axes[0].scale == 1. / 5. / 10.
-    assert im_fft.axes_manager.signal_axes[1].scale == 1. / 4. / 10.
-    assert im_fft.axes_manager.signal_axes[0].offset == 0.
-    assert im_fft.axes_manager.signal_axes[1].offset == 0.
-
-    im_ifft = im_fft.ifft()
-    assert im_ifft.axes_manager.signal_axes[0].units == 'nm'
-    assert im_ifft.axes_manager.signal_axes[1].units == 'nm'
-    assert im_ifft.axes_manager.signal_axes[0].scale == 10.
-    assert im_ifft.axes_manager.signal_axes[1].scale == 10.
-    assert im_ifft.axes_manager.signal_axes[0].offset == 0.
-    assert im_ifft.axes_manager.signal_axes[1].offset == 0.
-
-    assert im_fft.metadata.Signal.FFT.shifted is False
-    assert im_ifft.metadata.has_item('Signal.FFT') is False
-
-    assert isinstance(im_fft, ComplexSignal2D)
-    assert isinstance(im_ifft, Signal2D)
-
-    assert_allclose(im.data, im_ifft.data, atol=1e-3)
-
-    im_fft = im.inav[0].fft()
-    im_ifft = im_fft.ifft()
-    assert_allclose(im.inav[0].data, im_ifft.data, atol=1e-3)
-
-    im_fft = im.inav[0, 0].fft()
-    im_ifft = im_fft.ifft()
-    assert_allclose(im.inav[0, 0].data, im_ifft.data, atol=1e-3)
-    assert_allclose(im_fft.data, np.fft.fft2(im.inav[0, 0]).data)
-
-    im_fft = im.inav[0, 0].fft(shift=True)
-    axis = im_fft.axes_manager.signal_axes[0]
-    assert axis.offset == -axis.high_value
-
-    im_ifft = im_fft.ifft()
-    assert im_ifft.axes_manager.signal_axes[0].offset == 0.
-
-    assert im_fft.metadata.Signal.FFT.shifted is True
-    assert im_ifft.metadata.has_item('Signal.FFT') is False
-
-    assert_allclose(im.inav[0, 0].data, im_ifft.data, atol=1e-3)
-    assert_allclose(im_fft.data, np.fft.fftshift(
-        np.fft.fft2(im.inav[0, 0]).data))
-
-    assert im.fft(apodization=True) == im.apply_apodization().fft()
-    for apodization in ['hann', 'hamming', 'tukey']:
-        assert im.fft(apodization=apodization) == im.apply_apodization(window=apodization).fft()
-
-
-@pytest.mark.parametrize('lazy', [True, False])
-def test_fft_signal1d(lazy):
-    s = Signal1D(np.random.random((2, 3, 4, 5)))
-    if lazy:
-        s = s.as_lazy()
-
-    s.axes_manager.signal_axes[0].scale = 6.
-
-    s_fft = s.fft()
-    s_fft.axes_manager.signal_axes[0].units = 'mrad'
-
-    assert s_fft.axes_manager.signal_axes[0].scale == 1. / 5. / 6.
-
-    s_ifft = s_fft.ifft()
-    assert s_ifft.axes_manager.signal_axes[0].units == '1 / mrad'
-    assert s_ifft.axes_manager.signal_axes[0].scale == 6.
-    assert isinstance(s_fft, ComplexSignal1D)
-    assert isinstance(s_ifft, Signal1D)
-    assert_allclose(s.data, s_ifft.data, atol=1e-3)
-
-    s_fft = s.inav[0].fft()
-    s_ifft = s_fft.ifft()
-    assert_allclose(s.inav[0].data, s_ifft.data, atol=1e-3)
-
-    s_fft = s.inav[0, 0].fft()
-    s_ifft = s_fft.ifft()
-    assert_allclose(s.inav[0, 0].data, s_ifft.data, atol=1e-3)
-
-    s_fft = s.inav[0, 0, 0].fft()
-    s_ifft = s_fft.ifft()
-    assert_allclose(s.inav[0, 0, 0].data, s_ifft.data, atol=1e-3)
-    assert_allclose(np.fft.fft(s.inav[0, 0, 0].data), s_fft.data)
-
-    s_fft = s.inav[0, 0, 0].fft(shift=True)
-    s_ifft = s_fft.ifft(shift=True)
-    assert_allclose(s.inav[0, 0, 0].data, s_ifft.data, atol=1e-3)
-    assert_allclose(np.fft.fftshift(
-        np.fft.fft(s.inav[0, 0, 0].data)), s_fft.data)
-
-    assert s.fft(apodization=True) == s.apply_apodization().fft()
-    for apodization in ['hann', 'hamming', 'tukey']:
-        assert s.fft(apodization=apodization) == s.apply_apodization(window=apodization).fft()
-
-
-def test_nul_signal():
-    s = BaseSignal(np.random.random())
+def test_null_signal():
+    rng = np.random.RandomState(123)
+    s = BaseSignal(rng.uniform())
     with pytest.raises(AttributeError):
         s.T.fft()
     with pytest.raises(AttributeError):
         s.T.ifft()
+
+
+@lazifyTestClass
+class TestFFTSignal2D:
+    def setup_method(self, method):
+        rng = np.random.RandomState(123)
+        self.im = Signal2D(rng.uniform(size=(2, 3, 4, 5)))
+        self.im.axes_manager.signal_axes[0].units = "nm"
+        self.im.axes_manager.signal_axes[1].units = "nm"
+        self.im.axes_manager.signal_axes[0].scale = 10.0
+        self.im.axes_manager.signal_axes[1].scale = 10.0
+
+    def test_fft(self):
+        im_fft = self.im.fft()
+        assert im_fft.axes_manager.signal_axes[0].units == "1 / nm"
+        assert im_fft.axes_manager.signal_axes[1].units == "1 / nm"
+
+        np.testing.assert_allclose(im_fft.axes_manager.signal_axes[0].scale, 0.02)
+        np.testing.assert_allclose(im_fft.axes_manager.signal_axes[1].scale, 0.025)
+        np.testing.assert_allclose(im_fft.axes_manager.signal_axes[0].offset, 0.0)
+        np.testing.assert_allclose(im_fft.axes_manager.signal_axes[1].offset, 0.0)
+
+    def test_ifft(self):
+        im_fft = self.im.fft()
+        im_ifft = im_fft.ifft()
+        assert im_ifft.axes_manager.signal_axes[0].units == "nm"
+        assert im_ifft.axes_manager.signal_axes[1].units == "nm"
+        np.testing.assert_allclose(im_ifft.axes_manager.signal_axes[0].scale, 10.0)
+        np.testing.assert_allclose(im_ifft.axes_manager.signal_axes[1].scale, 10.0)
+        np.testing.assert_allclose(im_ifft.axes_manager.signal_axes[0].offset, 0.0)
+        np.testing.assert_allclose(im_ifft.axes_manager.signal_axes[1].offset, 0.0)
+
+        assert im_fft.metadata.Signal.FFT.shifted is False
+        assert im_ifft.metadata.has_item("Signal.FFT") is False
+
+        assert isinstance(im_fft, ComplexSignal2D)
+        assert isinstance(im_ifft, Signal2D)
+
+        np.testing.assert_allclose(self.im.data, im_ifft.data)
+
+    def test_ifft_nav_0(self):
+        im_fft = self.im.inav[0].fft()
+        im_ifft = im_fft.ifft()
+        np.testing.assert_allclose(self.im.inav[0].data, im_ifft.data)
+
+    def test_ifft_nav_0_0(self):
+        im_fft = self.im.inav[0, 0].fft()
+        im_ifft = im_fft.ifft()
+        np.testing.assert_allclose(self.im.inav[0, 0].data, im_ifft.data)
+        np.testing.assert_allclose(im_fft.data, np.fft.fft2(self.im.inav[0, 0]).data)
+
+    def test_fft_shift(self):
+        im_fft = self.im.inav[0, 0].fft(shift=True)
+        axis = im_fft.axes_manager.signal_axes[0]
+        np.testing.assert_allclose(axis.offset, -axis.high_value)
+
+        im_ifft = im_fft.ifft()
+        np.testing.assert_allclose(im_ifft.axes_manager.signal_axes[0].offset, 0.0)
+
+        assert im_fft.metadata.Signal.FFT.shifted is True
+        assert im_ifft.metadata.has_item("Signal.FFT") is False
+
+        np.testing.assert_allclose(self.im.inav[0, 0].data, im_ifft.data)
+        np.testing.assert_allclose(
+            im_fft.data, np.fft.fftshift(np.fft.fft2(self.im.inav[0, 0]).data)
+        )
+
+    def test_apodization_no_window(self):
+        assert self.im.fft(apodization=True) == self.im.apply_apodization().fft()
+
+    @pytest.mark.parametrize("apodization", ["hann", "hamming", "tukey"])
+    def test_apodization(self, apodization):
+        assert (
+            self.im.fft(apodization=apodization)
+            == self.im.apply_apodization(window=apodization).fft()
+        )
+
+
+@lazifyTestClass
+class TestFFTSignal1D:
+    def setup_method(self, method):
+        rng = np.random.RandomState(123)
+        self.s = Signal1D(rng.uniform(size=(2, 3, 4, 5)))
+        self.s.axes_manager.signal_axes[0].scale = 6.0
+
+    def test_fft(self):
+        s_fft = self.s.fft()
+        s_fft.axes_manager.signal_axes[0].units = "mrad"
+        assert s_fft.axes_manager.signal_axes[0].scale == 1.0 / 5.0 / 6.0
+
+    def test_ifft(self):
+        s_fft = self.s.fft()
+        s_fft.axes_manager.signal_axes[0].units = "mrad"
+
+        s_ifft = s_fft.ifft()
+        assert s_ifft.axes_manager.signal_axes[0].units == "1 / mrad"
+        np.testing.assert_allclose(s_ifft.axes_manager.signal_axes[0].scale, 6.0)
+
+        assert isinstance(s_fft, ComplexSignal1D)
+        assert isinstance(s_ifft, Signal1D)
+
+        np.testing.assert_allclose(self.s.data, s_ifft.data)
+
+    def test_ifft_nav_0(self):
+        s_fft = self.s.inav[0].fft()
+        s_ifft = s_fft.ifft()
+        np.testing.assert_allclose(self.s.inav[0].data, s_ifft.data)
+
+    def test_ifft_nav_0_0(self):
+        s_fft = self.s.inav[0, 0].fft()
+        s_ifft = s_fft.ifft()
+        np.testing.assert_allclose(self.s.inav[0, 0].data, s_ifft.data)
+
+    def test_ifft_nav_0_0_0(self):
+        s_fft = self.s.inav[0, 0, 0].fft()
+        s_ifft = s_fft.ifft()
+        np.testing.assert_allclose(self.s.inav[0, 0, 0].data, s_ifft.data)
+        np.testing.assert_allclose(np.fft.fft(self.s.inav[0, 0, 0].data), s_fft.data)
+
+    def test_fft_shift(self):
+        s_fft = self.s.inav[0, 0, 0].fft(shift=True)
+        s_ifft = s_fft.ifft(shift=True)
+        np.testing.assert_allclose(self.s.inav[0, 0, 0].data, s_ifft.data)
+        np.testing.assert_allclose(
+            np.fft.fftshift(np.fft.fft(self.s.inav[0, 0, 0].data)), s_fft.data
+        )
+
+    def test_apodization_no_window(self):
+        assert self.s.fft(apodization=True) == self.s.apply_apodization().fft()
+
+    @pytest.mark.parametrize("apodization", ["hann", "hamming", "tukey"])
+    def test_apodization(self, apodization):
+        assert (
+            self.s.fft(apodization=apodization)
+            == self.s.apply_apodization(window=apodization).fft()
+        )

--- a/hyperspy/tests/signal/test_hologram_image.py
+++ b/hyperspy/tests/signal/test_hologram_image.py
@@ -21,29 +21,57 @@ import gc
 import numpy as np
 import pytest
 import scipy.constants as constants
-from numpy.testing import assert_allclose
 from scipy.interpolate import interp2d
 
 import hyperspy.api as hs
 from hyperspy.datasets.example_signals import reference_hologram
+from hyperspy.decorators import lazifyTestClass
 
 
-@pytest.mark.parametrize('lazy', [True, False])
+@pytest.mark.parametrize("lazy", [True, False])
 def test_set_microscope_parameters(lazy):
-    holo_image = hs.signals.HologramImage(np.ones((3, 3)))
+    h = hs.signals.HologramImage(np.ones((3, 3)))
     if lazy:
-        holo_image = holo_image.as_lazy()
-    holo_image.set_microscope_parameters(
-        beam_energy=300., biprism_voltage=80.5, tilt_stage=2.2)
-    assert (holo_image.metadata.Acquisition_instrument.TEM.beam_energy == 300.)
-    assert (
-        holo_image.metadata.Acquisition_instrument.TEM.Biprism.voltage == 80.5)
-    assert (holo_image.metadata.Acquisition_instrument.TEM.Stage.tilt_alpha == 2.2)
+        h = h.as_lazy()
+
+    h.set_microscope_parameters(beam_energy=300.0, biprism_voltage=80.5, tilt_stage=2.2)
+
+    metadata = h.metadata.Acquisition_instrument.TEM
+    np.testing.assert_allclose(metadata.beam_energy, 300.0)
+    np.testing.assert_allclose(metadata.Biprism.voltage, 80.5)
+    np.testing.assert_allclose(metadata.Stage.tilt_alpha, 2.2)
+
+
+@lazifyTestClass
+class TestErrors:
+    def setup_method(self, method):
+        self.h = hs.signals.HologramImage(np.ones((5, 4)))
+
+    def test_absent_units(self):
+        with pytest.raises(ValueError, match="Signal axes units should be defined"):
+            self.h.statistics(sb_position=(1, 1))
+
+    def test_absent_beam_energy(self):
+        self.h.axes_manager.signal_axes[0].units = "nm"
+        self.h.axes_manager.signal_axes[1].units = "nm"
+
+        with pytest.raises(AttributeError, match="Please define the beam energy"):
+            self.h.statistics(sb_position=(1, 1))
+
+    def test_wrong_algorithm(self):
+        self.h.axes_manager.signal_axes[0].units = "nm"
+        self.h.axes_manager.signal_axes[1].units = "nm"
+        self.h.set_microscope_parameters(beam_energy=300.0)
+
+        with pytest.raises(ValueError, match="set to fourier or statistical"):
+            self.h.statistics(
+                sb_position=(1, 1), fringe_contrast_algorithm="pure_guess"
+            )
 
 
 def calc_holo(x, y, phase_ref, FRINGE_SPACING, FRINGE_DIRECTION):
-    return 2 * (1 + np.cos(phase_ref + FRINGE_SPACING / (2 * np.pi) * (
-        x * np.cos(FRINGE_DIRECTION) + y * np.sin(FRINGE_DIRECTION))))
+    mult = x * np.cos(FRINGE_DIRECTION) + y * np.sin(FRINGE_DIRECTION)
+    return 2 * (1 + np.cos(phase_ref + FRINGE_SPACING / (2 * np.pi) * mult))
 
 
 def calc_phaseref(x, y, z, img_sizex, img_sizey):
@@ -65,10 +93,8 @@ Y_START = int(IMG_SIZE3Y / 9)
 Y_STOP = IMG_SIZE3Y - 1 - int(IMG_SIZE3Y / 9)
 
 
-@pytest.mark.parametrize('parallel,lazy', [(True, False), (False, False),
-                                           (None, True)])
-def test_reconstruct_phase_single(parallel, lazy):
-
+@pytest.mark.parametrize("lazy", [True, False])
+def test_reconstruct_phase_single(lazy):
     x, y = np.meshgrid(LS, LS)
     phase_ref = calc_phaseref(x, 0, 0, img_size / 2.2, 1)
     holo = calc_holo(x, y, phase_ref, FRINGE_SPACING, FRINGE_DIRECTION)
@@ -78,45 +104,42 @@ def test_reconstruct_phase_single(parallel, lazy):
     if lazy:
         ref_image = ref_image.as_lazy()
         holo_image = holo_image.as_lazy()
-    wave_image = holo_image.reconstruct_phase(
-        ref, store_parameters=True, parallel=parallel)
-    sb_pos_cc = wave_image.metadata.Signal.Holography.Reconstruction_parameters.sb_position * (-1) + \
-        [img_size, img_size]
+    wave_image = holo_image.reconstruct_phase(ref, store_parameters=True)
 
-    sb_size_cc = wave_image.metadata.Signal.Holography.Reconstruction_parameters.sb_size
-    sb_smoothness_cc = wave_image.metadata.Signal.Holography.Reconstruction_parameters.sb_smoothness
-    sb_units_cc = wave_image.metadata.Signal.Holography.Reconstruction_parameters.sb_units
+    metadata = wave_image.metadata.Signal.Holography.Reconstruction_parameters
+    sb_pos_cc = metadata.sb_position * (-1) + [img_size, img_size]
+    sb_size_cc = metadata.sb_size
+    sb_smoothness_cc = metadata.sb_smoothness
+    sb_units_cc = metadata.sb_units
+
     wave_image_cc = holo_image.reconstruct_phase(
         ref_image,
         sb_position=sb_pos_cc,
         sb_size=sb_size_cc,
         sb_smoothness=sb_smoothness_cc,
         sb_unit=sb_units_cc,
-        parallel=parallel)
+    )
     X_START = int(wave_image.axes_manager.signal_shape[0] / 10)
     X_STOP = int(wave_image.axes_manager.signal_shape[0] * 9 / 10)
     wave_crop = wave_image.data[X_START:X_STOP, X_START:X_STOP]
     wave_cc_crop = wave_image_cc.data[X_START:X_STOP, X_START:X_STOP]
 
     # asserts that waves from different
-    assert_allclose(wave_crop, np.conj(wave_cc_crop), rtol=1e-3)
+    np.testing.assert_allclose(wave_crop, np.conj(wave_cc_crop), rtol=1e-3)
     # sidebands are complex conjugate; this also tests possibility of
     # reconstruction with given sideband parameters
 
     # Cropping the reconstructed and original phase images and comparing:
     X_START = int(img_size / 10)
     X_STOP = img_size - 1 - int(img_size / 10)
-    phase_new_crop = wave_image.unwrapped_phase(
-        parallel=parallel).data[X_START:X_STOP, X_START:X_STOP]
+    phase_new_crop = wave_image.unwrapped_phase().data[X_START:X_STOP, X_START:X_STOP]
     phase_ref_crop = phase_ref[X_START:X_STOP, X_START:X_STOP]
-    assert_allclose(phase_new_crop, phase_ref_crop, atol=0.02)
+    np.testing.assert_allclose(phase_new_crop, phase_ref_crop, atol=0.02)
 
 
-@pytest.mark.parametrize('parallel,lazy', [(True, False), (False, False),
-                                           (None, True)])
-def test_reconstruct_phase_nonstandard(parallel, lazy):
-    # 2. Testing reconstruction with non-standard output size for stacked
-    # images:
+@pytest.mark.parametrize("lazy", [True, False])
+def test_reconstruct_phase_nonstandard(lazy):
+    """Testing reconstruction with non-standard output size for stacked images"""
     gc.collect()
     x2, z2, y2 = np.meshgrid(LS, np.array([0, 1]), LS)
     phase_ref2 = calc_phaseref(x2, y2, z2, img_size / 2.2, img_size / 2.2)
@@ -130,21 +153,18 @@ def test_reconstruct_phase_nonstandard(parallel, lazy):
         ref_image2 = ref_image2.as_lazy()
         holo_image2 = holo_image2.as_lazy()
 
-    sb_position2 = ref_image2.estimate_sideband_position(
-        sb='upper', parallel=parallel)
-    sb_position2_lower = ref_image2.estimate_sideband_position(
-        sb='lower', parallel=parallel)
-    sb_position2_left = ref_image2.estimate_sideband_position(
-        sb='left', parallel=parallel)
-    sb_position2_right = ref_image2.estimate_sideband_position(
-        sb='right', parallel=parallel)
-    assert sb_position2 == sb_position2_left
-    assert sb_position2_lower == sb_position2_right
+    sb_position2 = ref_image2.estimate_sideband_position(sb="upper")
+    sb_position2_lower = ref_image2.estimate_sideband_position(sb="lower",)
+    sb_position2_left = ref_image2.estimate_sideband_position(sb="left",)
+    sb_position2_right = ref_image2.estimate_sideband_position(sb="right",)
+    np.testing.assert_allclose(sb_position2, sb_position2_left)
+    np.testing.assert_allclose(sb_position2_lower, sb_position2_right)
 
-    sb_size2 = ref_image2.estimate_sideband_size(
-        sb_position2, parallel=parallel)
-    output_shape = (np.int(sb_size2.inav[0].data * 2),
-                    np.int(sb_size2.inav[0].data * 2))
+    sb_size2 = ref_image2.estimate_sideband_size(sb_position2)
+    output_shape = (
+        np.int(sb_size2.inav[0].data * 2),
+        np.int(sb_size2.inav[0].data * 2),
+    )
 
     wave_image2 = holo_image2.reconstruct_phase(
         reference=ref_image2,
@@ -152,7 +172,7 @@ def test_reconstruct_phase_nonstandard(parallel, lazy):
         sb_size=sb_size2,
         sb_smoothness=sb_size2 * 0.05,
         output_shape=output_shape,
-        parallel=parallel)
+    )
     # a. Reconstruction with parameters provided as ndarrays should be
     # identical to above:
     wave_image2a = holo_image2.reconstruct_phase(
@@ -161,30 +181,28 @@ def test_reconstruct_phase_nonstandard(parallel, lazy):
         sb_size=sb_size2.data,
         sb_smoothness=sb_size2.data * 0.05,
         output_shape=output_shape,
-        parallel=parallel)
-    assert wave_image2 == wave_image2a
+    )
+    np.testing.assert_allclose(wave_image2, wave_image2a)
     del wave_image2a
     gc.collect()
     # interpolate reconstructed phase to compare with the input (reference
     # phase):
     interp_x = np.arange(output_shape[0])
     phase_interp0 = interp2d(
-        interp_x,
-        interp_x,
-        wave_image2.inav[0].unwrapped_phase(parallel=parallel).data,
-        kind='cubic')
+        interp_x, interp_x, wave_image2.inav[0].unwrapped_phase().data, kind="cubic",
+    )
     phase_new0 = phase_interp0(
         np.linspace(0, output_shape[0], img_size),
-        np.linspace(0, output_shape[0], img_size))
+        np.linspace(0, output_shape[0], img_size),
+    )
 
     phase_interp1 = interp2d(
-        interp_x,
-        interp_x,
-        wave_image2.inav[1].unwrapped_phase(parallel=parallel).data,
-        kind='cubic')
+        interp_x, interp_x, wave_image2.inav[1].unwrapped_phase().data, kind="cubic",
+    )
     phase_new1 = phase_interp1(
         np.linspace(0, output_shape[0], img_size),
-        np.linspace(0, output_shape[0], img_size))
+        np.linspace(0, output_shape[0], img_size),
+    )
 
     X_START = int(img_size / 10)
     X_STOP = img_size - 1 - int(img_size / 10)
@@ -192,23 +210,23 @@ def test_reconstruct_phase_nonstandard(parallel, lazy):
     phase_new_crop1 = phase_new1[X_START:X_STOP, X_START:X_STOP]
     phase_ref_crop0 = phase_ref2[0, X_START:X_STOP, X_START:X_STOP]
     phase_ref_crop1 = phase_ref2[1, X_START:X_STOP, X_START:X_STOP]
-    assert_allclose(phase_new_crop0, phase_ref_crop0, atol=0.05)
-    assert_allclose(phase_new_crop1, phase_ref_crop1, atol=0.04)
+    np.testing.assert_allclose(phase_new_crop0, phase_ref_crop0, atol=0.05)
+    np.testing.assert_allclose(phase_new_crop1, phase_ref_crop1, atol=0.04)
 
 
-@pytest.mark.parametrize('parallel,lazy', [(True, False), (False, False),
-                                           (None, True)])
-def test_reconstruct_phase_multi(parallel, lazy):
-
+@pytest.mark.parametrize("lazy", [True, False])
+def test_reconstruct_phase_multi(lazy):
     x3, z3, y3 = np.meshgrid(
         np.linspace(-IMG_SIZE3X / 2, IMG_SIZE3X / 2, IMG_SIZE3X),
-        np.arange(6), np.linspace(-IMG_SIZE3Y / 2, IMG_SIZE3Y / 2, IMG_SIZE3Y))
+        np.arange(6),
+        np.linspace(-IMG_SIZE3Y / 2, IMG_SIZE3Y / 2, IMG_SIZE3Y),
+    )
     phase_ref3 = calc_phaseref(x3, y3, z3 / 6, IMG_SIZE3X * 2, IMG_SIZE3Y * 2)
     newshape = (2, 3, IMG_SIZE3X, IMG_SIZE3Y)
-    holo3 = calc_holo(x3, y3, phase_ref3, FRINGE_SPACING3,
-                      FRINGE_DIRECTION3).reshape(newshape)
-    ref3 = calc_holo(x3, y3, 0, FRINGE_SPACING3,
-                     FRINGE_DIRECTION3).reshape(newshape)
+    holo3 = calc_holo(x3, y3, phase_ref3, FRINGE_SPACING3, FRINGE_DIRECTION3).reshape(
+        newshape
+    )
+    ref3 = calc_holo(x3, y3, 0, FRINGE_SPACING3, FRINGE_DIRECTION3).reshape(newshape)
     del x3, z3, y3
     gc.collect()
     holo_image3 = hs.signals.HologramImage(holo3)
@@ -218,32 +236,35 @@ def test_reconstruct_phase_multi(parallel, lazy):
         ref_image3 = ref_image3.as_lazy()
         holo_image3 = holo_image3.as_lazy()
 
-    wave_image3 = holo_image3.reconstruct_phase(
-        ref_image3.inav[0, 0], sb='upper', parallel=parallel)
+    wave_image3 = holo_image3.reconstruct_phase(ref_image3.inav[0, 0], sb="upper",)
 
     # Cropping the reconstructed and original phase images and comparing:
-    phase3_new_crop = wave_image3.unwrapped_phase(parallel=parallel)
+    phase3_new_crop = wave_image3.unwrapped_phase()
     phase3_new_crop.crop(2, Y_START, Y_STOP)
     phase3_new_crop.crop(3, X_START, X_STOP)
-    phase3_ref_crop = phase_ref3.reshape(newshape)[:, :, X_START:X_STOP,
-                                                   Y_START:Y_STOP]
-    assert_allclose(phase3_new_crop.data, phase3_ref_crop, atol=0.7)
+    phase3_ref_crop = phase_ref3.reshape(newshape)[:, :, X_START:X_STOP, Y_START:Y_STOP]
+    np.testing.assert_allclose(phase3_new_crop.data, phase3_ref_crop, atol=0.7)
 
     # 3a. Testing reconstruction with input parameters in 'nm' and with multiple parameter input,
     # but reference ndim=0:
 
-    sb_position3 = ref_image3.estimate_sideband_position(
-        sb='upper', parallel=parallel)
-    f_sampling = np.divide(1, [
-        a * b
-        for a, b in zip(ref_image3.axes_manager.signal_shape,
-                        (ref_image3.axes_manager.signal_axes[0].scale,
-                         ref_image3.axes_manager.signal_axes[1].scale))
-    ])
-    sb_size3 = ref_image3.estimate_sideband_size(
-        sb_position3, parallel=parallel) * np.mean(f_sampling)
+    sb_position3 = ref_image3.estimate_sideband_position(sb="upper")
+    f_sampling = np.divide(
+        1,
+        [
+            a * b
+            for a, b in zip(
+                ref_image3.axes_manager.signal_shape,
+                (
+                    ref_image3.axes_manager.signal_axes[0].scale,
+                    ref_image3.axes_manager.signal_axes[1].scale,
+                ),
+            )
+        ],
+    )
+    sb_size3 = ref_image3.estimate_sideband_size(sb_position3,) * np.mean(f_sampling)
     sb_smoothness3 = sb_size3 * 0.05
-    sb_units3 = 'nm'
+    sb_units3 = "nm"
 
     wave_image3a = holo_image3.reconstruct_phase(
         ref_image3.inav[0, 0],
@@ -251,185 +272,164 @@ def test_reconstruct_phase_multi(parallel, lazy):
         sb_size=sb_size3,
         sb_smoothness=sb_smoothness3,
         sb_unit=sb_units3,
-        parallel=parallel)
-    phase3a_new_crop = wave_image3a.unwrapped_phase(parallel=parallel)
+    )
+    phase3a_new_crop = wave_image3a.unwrapped_phase()
     phase3a_new_crop.crop(2, Y_START, Y_STOP)
     phase3a_new_crop.crop(3, X_START, X_STOP)
-    assert_allclose(phase3a_new_crop.data, phase3_ref_crop, atol=0.7)
+    np.testing.assert_allclose(phase3a_new_crop.data, phase3_ref_crop, atol=0.7)
+
     # a. Mismatch of navigation dimensions of object and reference
     # holograms, except if reference hologram ndim=0
     with pytest.raises(ValueError):
         holo_image3.reconstruct_phase(ref_image3.inav[0, :])
     reference4a = ref_image3.inav[0, :]
-    reference4a.set_signal_type('signal2d')
+    reference4a.set_signal_type("signal2d")
     with pytest.raises(ValueError):
         holo_image3.reconstruct_phase(reference=reference4a)
     #   b. Mismatch of signal shapes of object and reference holograms
     with pytest.raises(ValueError):
         holo_image3.reconstruct_phase(
-            ref_image3.inav[:, :].isig[Y_START:Y_STOP, X_START:X_STOP])
+            ref_image3.inav[:, :].isig[Y_START:Y_STOP, X_START:X_STOP]
+        )
 
     #   c. Mismatch of signal shape of sb_position
     sb_position_mismatched = hs.signals.Signal2D(np.arange(9).reshape((3, 3)))
     with pytest.raises(ValueError):
-        holo_image3.reconstruct_phase(
-            sb_position=sb_position_mismatched)
+        holo_image3.reconstruct_phase(sb_position=sb_position_mismatched)
     #   d. Mismatch of navigation dimensions of reconstruction parameters
     sb_position_mismatched = hs.signals.Signal1D(np.arange(16).reshape((8, 2)))
     sb_size_mismatched = hs.signals.BaseSignal(np.arange(9)).T
     sb_smoothness_mismatched = hs.signals.BaseSignal(np.arange(9)).T
     with pytest.raises(ValueError):
-        holo_image3.reconstruct_phase(
-            sb_position=sb_position_mismatched)
+        holo_image3.reconstruct_phase(sb_position=sb_position_mismatched)
     with pytest.raises(ValueError):
-        holo_image3.reconstruct_phase(
-            sb_size=sb_size_mismatched)
+        holo_image3.reconstruct_phase(sb_size=sb_size_mismatched)
     with pytest.raises(ValueError):
-        holo_image3.reconstruct_phase(
-            sb_smoothness=sb_smoothness_mismatched)
+        holo_image3.reconstruct_phase(sb_smoothness=sb_smoothness_mismatched)
 
     #   e. Beam energy is not assigned, while 'mrad' units selected
     with pytest.raises(AttributeError):
-        holo_image3.reconstruct_phase(
-            sb_size=40, sb_unit='mrad')
+        holo_image3.reconstruct_phase(sb_size=40, sb_unit="mrad")
 
 
-def _generate_parameters():
-    parameters = []
-    for parallel in [False, True]:
-        for lazy in [False, True]:
-            for single_values in [False, True]:
-                for fcalgo in ['fourier', 'statistical']:
-                    parameters.append([parallel,
-                                       lazy,
-                                       single_values,
-                                       fcalgo])
-    return parameters
+class TestStatistics:
+    def setup_method(self, method):
+        # Parameters measured using Gatan HoloWorks:
+        self.REF_FRINGE_SPACING = 3.48604
+        self.REF_FRINGE_SAMPLING = 3.7902
 
+        # Measured using the definition of fringe contrast from the centre of image
+        self.REF_FRINGE_CONTRAST = 0.0736
 
-@pytest.mark.parametrize('parallel, lazy, single_values, fringe_contrast_algorithm',
-                         _generate_parameters())
-def test_statistics(parallel, lazy, single_values, fringe_contrast_algorithm):
-    # Parameters measured using Gatan HoloWorks:
-    REF_FRINGE_SPACING = 3.48604
-    REF_FRINGE_SAMPLING = 3.7902
+        # Prepare test data and derived statistical parameters
+        self.ref_carrier_freq = 1.0 / self.REF_FRINGE_SAMPLING
+        self.ref_carrier_freq_nm = 1.0 / self.REF_FRINGE_SPACING
 
-    # Measured using the definition of fringe contrast from the centre of image
-    REF_FRINGE_CONTRAST = 0.0736
+        # 3x2 stack
+        self.ref_holo = hs.stack([reference_hologram()] * 2)
+        self.ref_holo = hs.stack([self.ref_holo] * 3)
 
-    RTOL = 1e-5
+        ht = self.ref_holo.metadata.Acquisition_instrument.TEM.beam_energy
+        momentum = (
+            2
+            * constants.m_e
+            * constants.elementary_charge
+            * ht
+            * 1000
+            * (
+                1
+                + constants.elementary_charge
+                * ht
+                * 1000
+                / (2 * constants.m_e * constants.c ** 2)
+            )
+        )
+        wavelength = constants.h / np.sqrt(momentum) * 1e9  # in nm
+        self.ref_carrier_freq_mrad = self.ref_carrier_freq_nm * 1000 * wavelength
 
-    # 0. Prepare test data and derived statistical parameters
+    @pytest.mark.parametrize("lazy", [True, False])
+    @pytest.mark.parametrize("fringe_contrast_algorithm", ["fourier", "statistical"])
+    def test_single_values(self, lazy, fringe_contrast_algorithm):
+        if lazy:
+            self.ref_holo.as_lazy()
 
-    ref_carrier_freq = 1. / REF_FRINGE_SAMPLING
-    ref_carrier_freq_nm = 1. / REF_FRINGE_SPACING
-
-    ref_holo = hs.stack([reference_hologram(), reference_hologram()])
-    ref_holo = hs.stack([ref_holo, ref_holo, ref_holo])
-
-    ht = ref_holo.metadata.Acquisition_instrument.TEM.beam_energy
-    momentum = 2 * constants.m_e * constants.elementary_charge * ht * \
-        1000 * (1 + constants.elementary_charge * ht *
-                1000 / (2 * constants.m_e * constants.c ** 2))
-    wavelength = constants.h / np.sqrt(momentum) * 1e9  # in nm
-    ref_carrier_freq_mrad = ref_carrier_freq_nm * 1000 * wavelength
-
-    if lazy:
-        ref_holo.as_lazy()
-
-    # 1. Test core functionality
-
-    stats = ref_holo.statistics(high_cf=True,
-                                parallel=parallel,
-                                single_values=single_values,
-                                fringe_contrast_algorithm=fringe_contrast_algorithm)
-    if single_values:
-        # Fringe contrast in experimental conditions can be only an estimate
-        # therefore tolerance is 10%:
-        assert_allclose(
-            stats['Fringe contrast'],
-            REF_FRINGE_CONTRAST,
-            rtol=0.1)
-
-        assert_allclose(
-            stats['Fringe sampling (px)'],
-            REF_FRINGE_SAMPLING,
-            rtol=RTOL)
-        assert_allclose(
-            stats['Fringe spacing (nm)'],
-            REF_FRINGE_SPACING,
-            rtol=RTOL)
-        assert_allclose(
-            stats['Carrier frequency (1 / nm)'],
-            ref_carrier_freq_nm,
-            rtol=RTOL)
-        assert_allclose(
-            stats['Carrier frequency (1/px)'],
-            ref_carrier_freq,
-            rtol=RTOL)
-        assert_allclose(
-            stats['Carrier frequency (mrad)'],
-            ref_carrier_freq_mrad,
-            rtol=RTOL)
-    else:
-        ref_fringe_contrast_stack = np.repeat(
-            REF_FRINGE_CONTRAST, 6).reshape((3, 2))
-        ref_fringe_sampling_stack = np.repeat(
-            REF_FRINGE_SAMPLING, 6).reshape((3, 2))
-        ref_fringe_spacing_stack = np.repeat(
-            REF_FRINGE_SPACING, 6).reshape((3, 2))
-        ref_carrier_freq_nm_stack = np.repeat(
-            ref_carrier_freq_nm, 6).reshape((3, 2))
-        ref_carrier_freq_stack = np.repeat(ref_carrier_freq, 6).reshape((3, 2))
-        ref_carrier_freq_mrad_stack = np.repeat(
-            ref_carrier_freq_mrad, 6).reshape((3, 2))
+        stats = self.ref_holo.statistics(
+            high_cf=True,
+            single_values=True,
+            fringe_contrast_algorithm=fringe_contrast_algorithm,
+        )
 
         # Fringe contrast in experimental conditions can be only an estimate
         # therefore tolerance is 10%:
-        assert_allclose(
-            stats['Fringe contrast'].data,
-            ref_fringe_contrast_stack,
-            rtol=0.1)
+        np.testing.assert_allclose(
+            stats["Fringe contrast"], self.REF_FRINGE_CONTRAST, rtol=0.1
+        )
 
-        assert_allclose(
-            stats['Fringe sampling (px)'].data,
-            ref_fringe_sampling_stack,
-            rtol=RTOL)
-        assert_allclose(
-            stats['Fringe spacing (nm)'].data,
-            ref_fringe_spacing_stack,
-            rtol=RTOL)
-        assert_allclose(
-            stats['Carrier frequency (1 / nm)'].data,
+        np.testing.assert_allclose(
+            stats["Fringe sampling (px)"], self.REF_FRINGE_SAMPLING, rtol=1e-5
+        )
+        np.testing.assert_allclose(
+            stats["Fringe spacing (nm)"], self.REF_FRINGE_SPACING, rtol=1e-5
+        )
+        np.testing.assert_allclose(
+            stats["Carrier frequency (1 / nm)"], self.ref_carrier_freq_nm, rtol=1e-5
+        )
+        np.testing.assert_allclose(
+            stats["Carrier frequency (1/px)"], self.ref_carrier_freq, rtol=1e-5
+        )
+        np.testing.assert_allclose(
+            stats["Carrier frequency (mrad)"], self.ref_carrier_freq_mrad, rtol=1e-5
+        )
+
+    @pytest.mark.parametrize("lazy", [True, False])
+    @pytest.mark.parametrize("fringe_contrast_algorithm", ["fourier", "statistical"])
+    def test_no_single_values(self, lazy, fringe_contrast_algorithm):
+        if lazy:
+            self.ref_holo.as_lazy()
+
+        stats = self.ref_holo.statistics(
+            high_cf=True,
+            single_values=False,
+            fringe_contrast_algorithm=fringe_contrast_algorithm,
+        )
+
+        ref_fringe_contrast_stack = np.repeat(self.REF_FRINGE_CONTRAST, 6).reshape(
+            (3, 2)
+        )
+        ref_fringe_sampling_stack = np.repeat(self.REF_FRINGE_SAMPLING, 6).reshape(
+            (3, 2)
+        )
+        ref_fringe_spacing_stack = np.repeat(self.REF_FRINGE_SPACING, 6).reshape((3, 2))
+        ref_carrier_freq_nm_stack = np.repeat(self.ref_carrier_freq_nm, 6).reshape(
+            (3, 2)
+        )
+        ref_carrier_freq_stack = np.repeat(self.ref_carrier_freq, 6).reshape((3, 2))
+        ref_carrier_freq_mrad_stack = np.repeat(self.ref_carrier_freq_mrad, 6).reshape(
+            (3, 2)
+        )
+
+        # Fringe contrast in experimental conditions can be only an estimate
+        # therefore tolerance is 10%:
+        np.testing.assert_allclose(
+            stats["Fringe contrast"].data, ref_fringe_contrast_stack, rtol=0.1
+        )
+
+        np.testing.assert_allclose(
+            stats["Fringe sampling (px)"].data, ref_fringe_sampling_stack, rtol=1e-5
+        )
+        np.testing.assert_allclose(
+            stats["Fringe spacing (nm)"].data, ref_fringe_spacing_stack, rtol=1e-5
+        )
+        np.testing.assert_allclose(
+            stats["Carrier frequency (1 / nm)"].data,
             ref_carrier_freq_nm_stack,
-            rtol=RTOL)
-        assert_allclose(
-            stats['Carrier frequency (1/px)'].data,
-            ref_carrier_freq_stack,
-            rtol=RTOL)
-        assert_allclose(
-            stats['Carrier frequency (mrad)'].data,
+            rtol=1e-5,
+        )
+        np.testing.assert_allclose(
+            stats["Carrier frequency (1/px)"].data, ref_carrier_freq_stack, rtol=1e-5
+        )
+        np.testing.assert_allclose(
+            stats["Carrier frequency (mrad)"].data,
             ref_carrier_freq_mrad_stack,
-            rtol=RTOL)
-
-    # 2. Test raises:
-    holo_raise = hs.signals.HologramImage(np.random.random(20).reshape((5, 4)))
-
-    # 2a. Test raise for absent units:
-    with pytest.raises(ValueError):
-        holo_raise.statistics(sb_position=(1, 1))
-    holo_raise.axes_manager.signal_axes[0].units = 'nm'
-    holo_raise.axes_manager.signal_axes[1].units = 'nm'
-
-    # 2b. Test raise for absent beam_energy:
-    with pytest.raises(AttributeError):
-        holo_raise.statistics(sb_position=(1, 1))
-    holo_raise.set_microscope_parameters(beam_energy=300.)
-
-    # 2c. Test raise for wrong value of `fringe_contrast_algorithm`
-    with pytest.raises(ValueError):
-        holo_raise.statistics(
-            sb_position=(
-                1,
-                1),
-            fringe_contrast_algorithm='pure_guess')
+            rtol=1e-5,
+        )

--- a/hyperspy/tests/signal/test_lazy_tools.py
+++ b/hyperspy/tests/signal/test_lazy_tools.py
@@ -1,0 +1,88 @@
+# -*- coding: utf-8 -*-
+# Copyright 2007-2020 The HyperSpy developers
+#
+# This file is part of  HyperSpy.
+#
+#  HyperSpy is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+#  HyperSpy is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with  HyperSpy.  If not, see <http://www.gnu.org/licenses/>.
+
+import dask.array as da
+import numpy as np
+
+from hyperspy.signals import Signal1D, Signal2D
+
+
+def test_lazy_changetype_rechunk():
+    ar = da.ones((50, 50, 256, 256), chunks=(5, 5, 256, 256), dtype="uint8")
+    s = Signal2D(ar).as_lazy()
+    s._make_lazy(rechunk=True)
+    assert s.data.dtype is np.dtype("uint8")
+    chunks_old = s.data.chunks
+    s.change_dtype("float")
+    assert s.data.dtype is np.dtype("float")
+    chunks_new = s.data.chunks
+    assert len(chunks_old[0]) * len(chunks_old[1]) < len(chunks_new[0]) * len(
+        chunks_new[1]
+    )
+    s.change_dtype("uint8")
+    assert s.data.dtype is np.dtype("uint8")
+    chunks_newest = s.data.chunks
+    assert chunks_newest == chunks_new
+
+
+def test_lazy_changetype_rechunk_False():
+    ar = da.ones((50, 50, 256, 256), chunks=(5, 5, 256, 256), dtype="uint8")
+    s = Signal2D(ar).as_lazy()
+    s._make_lazy(rechunk=True)
+    assert s.data.dtype is np.dtype("uint8")
+    chunks_old = s.data.chunks
+    s.change_dtype("float", rechunk=False)
+    assert s.data.dtype is np.dtype("float")
+    assert chunks_old == s.data.chunks
+
+
+def test_lazy_reduce_rechunk():
+    s = Signal1D(da.ones((10, 100), chunks=(1, 2))).as_lazy()
+    reduce_methods = (
+        s.sum,
+        s.mean,
+        s.max,
+        s.std,
+        s.var,
+        s.nansum,
+        s.nanmax,
+        s.nanmin,
+        s.nanmean,
+        s.nanstd,
+        s.nanvar,
+        s.indexmin,
+        s.indexmax,
+        s.valuemax,
+        s.valuemin,
+    )
+    for rm in reduce_methods:
+        assert rm(axis=0).data.chunks == ((100,),)  # The data has been rechunked
+        assert rm(axis=0, rechunk=False).data.chunks == (
+            (2,) * 50,
+        )  # The data has not been rechunked
+
+
+def test_lazy_diff_rechunk():
+    s = Signal1D(da.ones((10, 100), chunks=(1, 2))).as_lazy()
+    for rm in (s.derivative, s.diff):
+        # The data has been rechunked
+        assert rm(axis=-1).data.chunks == ((10,), (99,))
+        assert rm(axis=-1, rechunk=False).data.chunks == (
+            (1,) * 10,
+            (1,) * 99,
+        )  # The data has not been rechunked

--- a/hyperspy/tests/signal/test_linear_rebin.py
+++ b/hyperspy/tests/signal/test_linear_rebin.py
@@ -1,0 +1,93 @@
+# -*- coding: utf-8 -*-
+# Copyright 2007-2020 The HyperSpy developers
+#
+# This file is part of  HyperSpy.
+#
+#  HyperSpy is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+#  HyperSpy is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with  HyperSpy.  If not, see <http://www.gnu.org/licenses/>.
+
+
+import numpy as np
+
+from hyperspy.signals import EDSTEMSpectrum
+
+
+class TestLinearRebin:
+    def test_linear_downsize(self):
+        spectrum = EDSTEMSpectrum(np.ones([3, 5, 1]))
+        scale = (1.5, 2.5, 1)
+        res = spectrum.rebin(scale=scale, crop=True)
+        np.testing.assert_allclose(res.data, 3.75 * np.ones((1, 3, 1)))
+        for axis in res.axes_manager._axes:
+            assert scale[axis.index_in_axes_manager] == axis.scale
+        res = spectrum.rebin(scale=scale, crop=False)
+        np.testing.assert_allclose(res.data.sum(), spectrum.data.sum())
+
+    def test_linear_upsize(self):
+        spectrum = EDSTEMSpectrum(np.ones([4, 5, 10]))
+        scale = [0.3, 0.2, 0.5]
+        res = spectrum.rebin(scale=scale)
+        np.testing.assert_allclose(res.data, 0.03 * np.ones((20, 16, 20)))
+        for axis in res.axes_manager._axes:
+            assert scale[axis.index_in_axes_manager] == axis.scale
+        res = spectrum.rebin(scale=scale, crop=False)
+        np.testing.assert_allclose(res.data.sum(), spectrum.data.sum())
+
+    def test_linear_downscale_out(self):
+        spectrum = EDSTEMSpectrum(np.ones([4, 1, 1]))
+        scale = [1, 0.4, 1]
+        res = spectrum.rebin(scale=scale)
+        spectrum.data[2][0] = 5
+        spectrum.rebin(scale=scale, out=res)
+        np.testing.assert_allclose(
+            res.data,
+            [
+                [[0.4]],
+                [[0.4]],
+                [[0.4]],
+                [[0.4]],
+                [[0.4]],
+                [[2.0]],
+                [[2.0]],
+                [[1.2]],
+                [[0.4]],
+                [[0.4]],
+            ],
+        )
+        for axis in res.axes_manager._axes:
+            assert scale[axis.index_in_axes_manager] == axis.scale
+
+    def test_linear_upscale_out(self):
+        spectrum = EDSTEMSpectrum(np.ones([4, 1, 1]))
+        scale = [1, 0.4, 1]
+        res = spectrum.rebin(scale=scale)
+        spectrum.data[2][0] = 5
+        spectrum.rebin(scale=scale, out=res)
+        np.testing.assert_allclose(
+            res.data,
+            [
+                [[0.4]],
+                [[0.4]],
+                [[0.4]],
+                [[0.4]],
+                [[0.4]],
+                [[2.0]],
+                [[2.0]],
+                [[1.2]],
+                [[0.4]],
+                [[0.4]],
+            ],
+            atol=1e-3,
+        )
+        for axis in res.axes_manager._axes:
+            assert scale[axis.index_in_axes_manager] == axis.scale

--- a/hyperspy/tests/signal/test_spike_removal_tool.py
+++ b/hyperspy/tests/signal/test_spike_removal_tool.py
@@ -1,0 +1,60 @@
+# -*- coding: utf-8 -*-
+# Copyright 2007-2020 The HyperSpy developers
+#
+# This file is part of  HyperSpy.
+#
+#  HyperSpy is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+#  HyperSpy is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with  HyperSpy.  If not, see <http://www.gnu.org/licenses/>.
+
+import numpy as np
+
+from hyperspy.signal_tools import SpikesRemoval
+from hyperspy.signals import Signal1D
+
+
+def test_spikes_removal_tool():
+    s = Signal1D(np.ones((2, 3, 30)))
+    np.random.seed(1)
+    s.add_gaussian_noise(1e-5)
+    # Add three spikes
+    s.data[1, 0, 1] += 2
+    s.data[0, 2, 29] += 1
+    s.data[1, 2, 14] += 1
+
+    sr = SpikesRemoval(s)
+    sr.threshold = 1.5
+    sr.find()
+    assert s.axes_manager.indices == (0, 1)
+    sr.threshold = 0.5
+    assert s.axes_manager.indices == (0, 0)
+    sr.find()
+    assert s.axes_manager.indices == (2, 0)
+    sr.find()
+    assert s.axes_manager.indices == (0, 1)
+    sr.find(back=True)
+    assert s.axes_manager.indices == (2, 0)
+    sr.add_noise = False
+    sr.apply()
+    np.testing.assert_almost_equal(s.data[0, 2, 29], 1, decimal=5)
+    assert s.axes_manager.indices == (0, 1)
+    sr.apply()
+    np.testing.assert_almost_equal(s.data[1, 0, 1], 1, decimal=5)
+    assert s.axes_manager.indices == (2, 1)
+    np.random.seed(1)
+    sr.add_noise = True
+    sr.default_spike_width = 3
+    sr.interpolator_kind = "Spline"
+    sr.spline_order = 3
+    sr.apply()
+    np.testing.assert_almost_equal(s.data[1, 2, 14], 1, decimal=5)
+    assert s.axes_manager.indices == (0, 0)

--- a/hyperspy/tests/signal/test_tools.py
+++ b/hyperspy/tests/signal/test_tools.py
@@ -17,848 +17,29 @@
 # along with  HyperSpy.  If not, see <http://www.gnu.org/licenses/>.
 
 import sys
-import logging
-
 from unittest import mock
 
-import dask.array as da
 import numpy as np
-import numpy.testing as nt
 import pytest
-from numpy.testing import assert_almost_equal, assert_array_equal
 
 from hyperspy import signals
-from hyperspy.components1d import Gaussian
 from hyperspy.decorators import lazifyTestClass
-from hyperspy.signal_tools import SpikesRemoval, EdgesRange
-from hyperspy.datasets.artificial_data import get_core_loss_eels_line_scan_signal
 
 
 def _verify_test_sum_x_E(self, s):
-    nt.assert_array_equal(self.signal.data.sum(), s.data)
+    np.testing.assert_array_equal(self.signal.data.sum(), s.data)
     assert s.data.ndim == 1
     # Check that there is still one signal axis.
     assert s.axes_manager.signal_dimension == 1
 
 
-@lazifyTestClass
-class Test1D:
-
-    def setup_method(self, method):
-        gaussian = Gaussian()
-        gaussian.A.value = 20
-        gaussian.sigma.value = 10
-        gaussian.centre.value = 50
-        self.signal = signals.Signal1D(
-            gaussian.function(np.arange(0, 100, 0.01)))
-        self.signal.axes_manager[0].scale = 0.01
-
-    def test_integrate1D(self):
-        integrated_signal = self.signal.integrate1D(axis=0)
-        assert np.allclose(integrated_signal.data, 20,)
-
-
-@lazifyTestClass
-class Test2D:
-
-    def setup_method(self, method):
-        self.signal = signals.Signal1D(
-            np.arange(
-                5 *
-                10).reshape(
-                5,
-                10))  # dtype int
-        self.signal.axes_manager[0].name = "x"
-        self.signal.axes_manager[1].name = "E"
-        self.signal.axes_manager[0].scale = 0.5
-        self.data = self.signal.data.copy()
-
-    def test_sum_x(self):
-        s = self.signal.sum("x")
-        nt.assert_array_equal(self.signal.data.sum(0), s.data)
-        assert s.data.ndim == 1
-        assert s.axes_manager.navigation_dimension == 0
-
-    def test_sum_x_E(self):
-        s = self.signal.sum(("x", "E"))
-        _verify_test_sum_x_E(self, s)
-        s = self.signal.sum((0, "E"))
-        _verify_test_sum_x_E(self, s)
-        s = self.signal.sum((self.signal.axes_manager[0], "E"))
-        _verify_test_sum_x_E(self, s)
-        s = self.signal.sum("x").sum("E")
-        _verify_test_sum_x_E(self, s)
-
-    def test_axis_by_str(self):
-        m = mock.Mock()
-        s1 = self.signal.deepcopy()
-        s1.events.data_changed.connect(m.data_changed)
-        s2 = self.signal.deepcopy()
-        s1.crop(0, 2, 4)
-        assert m.data_changed.called
-        s2.crop("x", 2, 4)
-        nt.assert_array_almost_equal(s1.data, s2.data)
-
-    def test_crop_int(self):
-        s = self.signal
-        d = self.data
-        s.crop(0, 2, 4)
-        nt.assert_array_almost_equal(s.data, d[2:4, :])
-
-    def test_crop_float(self):
-        s = self.signal
-        d = self.data
-        s.crop(0, 2, 2.)
-        nt.assert_array_almost_equal(s.data, d[2:4, :])
-
-    def test_crop_start_end_equal(self):
-        s = self.signal
-        with pytest.raises(ValueError):
-            s.crop(0, 2, 2)
-        with pytest.raises(ValueError):
-            s.crop(0, 2., 2.)
-
-    def test_crop_float_no_unit_convertion_signal1D(self):
-        # Should convert the unit to eV
-        d = np.arange(5 * 10 * 2000).reshape(5, 10, 2000)
-        s = signals.Signal1D(d)
-        s.axes_manager.signal_axes[0].name = "E"
-        s.axes_manager.signal_axes[0].scale = 0.05
-        s.axes_manager.signal_axes[0].units = "keV"
-        s.crop('E', 0.0, 1.0, convert_units=False)
-        nt.assert_almost_equal(s.axes_manager.signal_axes[0].scale, 0.05)
-        assert s.axes_manager.signal_axes[0].units == "keV"
-        nt.assert_allclose(s.data, d[:, :, :20])
-
-        # Should keep the unit to keV
-        s = signals.Signal1D(d)
-        s.axes_manager.signal_axes[0].name = "E"
-        s.axes_manager.signal_axes[0].scale = 0.05
-        s.axes_manager.signal_axes[0].units = "keV"
-        s.crop('E', 0.0, 50.0, convert_units=False)
-        nt.assert_almost_equal(s.axes_manager.signal_axes[0].scale, 0.05)
-        assert s.axes_manager.signal_axes[0].units == "keV"
-        nt.assert_allclose(s.data, d[:, :, :1000])
-
-    def test_crop_float_unit_convertion_signal1D(self):
-        # Should convert the unit to eV
-        d = np.arange(5 * 10 * 2000).reshape(5, 10, 2000)
-        s = signals.Signal1D(d)
-        s.axes_manager.signal_axes[0].name = "E"
-        s.axes_manager.signal_axes[0].scale = 0.05
-        s.axes_manager.signal_axes[0].units = "keV"
-        s.crop('E', 0.0, 1.0, convert_units=True)
-        nt.assert_almost_equal(s.axes_manager.signal_axes[0].scale, 50.0)
-        assert s.axes_manager.signal_axes[0].units == "eV"
-        nt.assert_allclose(s.data, d[:, :, :20])
-
-        # Should keep the unit to keV
-        s = signals.Signal1D(d)
-        s.axes_manager.signal_axes[0].name = "E"
-        s.axes_manager.signal_axes[0].scale = 0.05
-        s.axes_manager.signal_axes[0].units = "keV"
-        s.crop('E', 0.0, 50.0, convert_units=True)
-        nt.assert_almost_equal(s.axes_manager.signal_axes[0].scale, 0.05)
-        assert s.axes_manager.signal_axes[0].units == "keV"
-        nt.assert_allclose(s.data, d[:, :, :1000])
-
-    def test_crop_float_no_unit_convertion_signal2D(self):
-        # Should convert the unit to nm
-        d = np.arange(512 * 512).reshape(512, 512)
-        s = signals.Signal2D(d)
-        s.axes_manager[0].name = 'x'
-        s.axes_manager[0].scale = 0.01
-        s.axes_manager[0].units = 'µm'
-        s.axes_manager[1].name = 'y'
-        s.axes_manager[1].scale = 0.01
-        s.axes_manager[1].units = 'µm'
-        s.crop(0, 0.0, 0.5, convert_units=False)
-        s.crop(1, 0.0, 0.5, convert_units=False)
-        nt.assert_almost_equal(s.axes_manager[0].scale, 0.01)
-        assert s.axes_manager[0].units == "µm"
-        nt.assert_allclose(s.data, d[:50, :50])
-
-        # Should keep the unit to µm
-        d = np.arange(512 * 512).reshape(512, 512)
-        s = signals.Signal2D(d)
-        s.axes_manager[0].name = 'x'
-        s.axes_manager[0].scale = 0.01
-        s.axes_manager[0].units = 'µm'
-        s.axes_manager[1].name = 'y'
-        s.axes_manager[1].scale = 0.01
-        s.axes_manager[1].units = 'µm'
-        s.crop(0, 0.0, 5.0, convert_units=False)
-        s.crop(1, 0.0, 5.0, convert_units=False)
-        nt.assert_almost_equal(s.axes_manager[0].scale, 0.01)
-        assert s.axes_manager[0].units == "µm"
-        nt.assert_allclose(s.data, d[:500, :500])
-
-    def test_crop_float_unit_convertion_signal2D(self):
-        # Should convert the unit to nm
-        d = np.arange(512 * 512).reshape(512, 512)
-        s = signals.Signal2D(d)
-        s.axes_manager[0].name = 'x'
-        s.axes_manager[0].scale = 0.01
-        s.axes_manager[0].units = 'µm'
-        s.axes_manager[1].name = 'y'
-        s.axes_manager[1].scale = 0.01
-        s.axes_manager[1].units = 'µm'
-        s.crop(0, 0.0, 0.5, convert_units=True)  # also convert the other axis
-        s.crop(1, 0.0, 500.0, convert_units=True)
-        nt.assert_almost_equal(s.axes_manager[0].scale, 10.0)
-        nt.assert_almost_equal(s.axes_manager[1].scale, 10.0)
-        assert s.axes_manager[0].units == 'nm'
-        assert s.axes_manager[1].units == 'nm'
-        nt.assert_allclose(s.data, d[:50, :50])
-
-        # Should keep the unit to µm
-        d = np.arange(512 * 512).reshape(512, 512)
-        s = signals.Signal2D(d)
-        s.axes_manager[0].name = 'x'
-        s.axes_manager[0].scale = 0.01
-        s.axes_manager[0].units = 'µm'
-        s.axes_manager[1].name = 'y'
-        s.axes_manager[1].scale = 0.01
-        s.axes_manager[1].units = 'µm'
-        s.crop(0, 0.0, 5.0, convert_units=True)
-        s.crop(1, 0.0, 5.0, convert_units=True)
-        nt.assert_almost_equal(s.axes_manager[0].scale, 0.01)
-        nt.assert_almost_equal(s.axes_manager[1].scale, 0.01)
-        assert s.axes_manager[0].units == "µm"
-        assert s.axes_manager[1].units == "µm"
-        nt.assert_allclose(s.data, d[:500, :500])
-
-    def test_crop_image_unit_convertion_signal2D(self):
-        # Should not convert the unit
-        d = np.arange(512 * 512).reshape(512, 512)
-        s = signals.Signal2D(d)
-        s.axes_manager[0].name = 'x'
-        s.axes_manager[0].scale = 0.01
-        s.axes_manager[0].units = 'µm'
-        s.axes_manager[1].name = 'y'
-        s.axes_manager[1].scale = 0.01
-        s.axes_manager[1].units = 'µm'
-        s.crop_image(0, 0.5, 0.0, 0.5)
-        nt.assert_almost_equal(s.axes_manager[0].scale, 0.01)
-        nt.assert_almost_equal(s.axes_manager[1].scale, 0.01)
-        assert s.axes_manager[0].units == 'µm'
-        assert s.axes_manager[1].units == 'µm'
-        nt.assert_allclose(s.data, d[:50, :50])
-
-        # Should convert the unit to nm
-        d = np.arange(512 * 512).reshape(512, 512)
-        s = signals.Signal2D(d)
-        s.axes_manager[0].name = 'x'
-        s.axes_manager[0].scale = 0.01
-        s.axes_manager[0].units = 'µm'
-        s.axes_manager[1].name = 'y'
-        s.axes_manager[1].scale = 0.01
-        s.axes_manager[1].units = 'µm'
-        s.crop_image(0, 0.5, 0.0, 0.5, convert_units=True)
-        nt.assert_almost_equal(s.axes_manager[0].scale, 10.0)
-        nt.assert_almost_equal(s.axes_manager[1].scale, 10.0)
-        assert s.axes_manager[0].units == 'nm'
-        assert s.axes_manager[1].units == 'nm'
-        nt.assert_allclose(s.data, d[:50, :50])
-
-        # Should keep the unit to µm
-        d = np.arange(512 * 512).reshape(512, 512)
-        s = signals.Signal2D(d)
-        s.axes_manager[0].name = 'x'
-        s.axes_manager[0].scale = 0.01
-        s.axes_manager[0].units = 'µm'
-        s.axes_manager[1].name = 'y'
-        s.axes_manager[1].scale = 0.01
-        s.axes_manager[1].units = 'µm'
-        s.crop_image(0, 5.0, 0.0, 5.0, convert_units=True)
-        nt.assert_almost_equal(s.axes_manager[0].scale, 0.01)
-        nt.assert_almost_equal(s.axes_manager[1].scale, 0.01)
-        assert s.axes_manager[0].units == "µm"
-        assert s.axes_manager[1].units == "µm"
-        nt.assert_allclose(s.data, d[:500, :500])
-
-    def test_split_axis0(self):
-        result = self.signal.split(0, 2)
-        assert len(result) == 2
-        nt.assert_array_almost_equal(result[0].data, self.data[:2, :])
-        nt.assert_array_almost_equal(result[1].data, self.data[2:4, :])
-
-    def test_split_axis1(self):
-        result = self.signal.split(1, 2)
-        assert len(result) == 2
-        nt.assert_array_almost_equal(result[0].data, self.data[:, :5])
-        nt.assert_array_almost_equal(result[1].data, self.data[:, 5:])
-
-    def test_split_axisE(self):
-        result = self.signal.split("E", 2)
-        assert len(result) == 2
-        nt.assert_array_almost_equal(result[0].data, self.data[:, :5])
-        nt.assert_array_almost_equal(result[1].data, self.data[:, 5:])
-
-    def test_split_default(self):
-        result = self.signal.split()
-        assert len(result) == 5
-        nt.assert_array_almost_equal(result[0].data, self.data[0])
-
-    def test_split_step_size_list(self):
-        result = self.signal.split(step_sizes=[1, 2])
-        assert len(result) == 2
-        nt.assert_array_almost_equal(result[0].data, self.data[:1, :10])
-        nt.assert_array_almost_equal(result[1].data, self.data[1:3, :10])
-
-    def test_split_error(self):
-        with pytest.raises(
-            ValueError,
-            match="You can define step_sizes or number_of_parts but not both",
-        ):
-            _ = self.signal.split(number_of_parts=2, step_sizes=2)
-
-        with pytest.raises(
-            ValueError,
-            match="The number of parts is greater than the axis size.",
-        ):
-            _ = self.signal.split(number_of_parts=1e9)
-
-    def test_histogram(self):
-        result = self.signal.get_histogram(3)
-        assert isinstance(result, signals.Signal1D)
-        nt.assert_array_equal(result.data, np.array([17, 16, 17]))
-        assert result.metadata.Signal.binned
-
-    def test_noise_variance_helpers(self):
-        assert self.signal.get_noise_variance() is None
-        self.signal.set_noise_variance(2)
-        assert self.signal.get_noise_variance() == 2
-        self.signal.set_noise_variance(self.signal)
-        variance = self.signal.get_noise_variance()
-        nt.assert_array_equal(variance.data, self.signal.data)
-        self.signal.set_noise_variance(None)
-        assert self.signal.get_noise_variance() is None
-
-        with pytest.raises(ValueError, match="`variance` must be one of"):
-            self.signal.set_noise_variance(np.array([0, 1, 2]))
-
-    def test_estimate_poissonian_noise_copy_data(self):
-        self.signal.estimate_poissonian_noise_variance()
-        variance = self.signal.metadata.Signal.Noise_properties.variance
-        assert variance.data is not self.signal.data
-
-    def test_estimate_poissonian_noise_copy_data_helper_function(self):
-        self.signal.estimate_poissonian_noise_variance()
-        variance = self.signal.get_noise_variance()
-        assert variance.data is not self.signal.data
-
-    def test_estimate_poissonian_noise_noarg(self):
-        self.signal.estimate_poissonian_noise_variance()
-        variance = self.signal.metadata.Signal.Noise_properties.variance
-        nt.assert_array_equal(variance.data, self.signal.data)
-
-    def test_estimate_poissonian_noise_with_args(self):
-        self.signal.estimate_poissonian_noise_variance(
-            expected_value=self.signal,
-            gain_factor=2,
-            gain_offset=1,
-            correlation_factor=0.5)
-        variance = self.signal.metadata.Signal.Noise_properties.variance
-        nt.assert_array_equal(variance.data,
-                              (self.signal.data * 2 + 1) * 0.5)
-
-    def test_unfold_image(self):
-        s = self.signal
-        if s._lazy:
-            pytest.skip("LazyS do not support folding")
-        s = s.transpose(signal_axes=2)
-        s.unfold()
-        assert s.data.shape == (50,)
-
-    def test_unfold_image_returns_true(self):
-        s = self.signal
-        if s._lazy:
-            pytest.skip("LazyS do not support folding")
-        s = s.transpose(signal_axes=2)
-        assert s.unfold()
-
-    def test_print_summary(self):
-        # Just test if it doesn't raise an exception
-        self.signal._print_summary()
-
-    def test_print_summary_statistics(self):
-        # Just test if it doesn't raise an exception
-        self.signal.print_summary_statistics()
-        if self.signal._lazy:
-            self.signal.print_summary_statistics(rechunk=False)
-
-    def test_numpy_unfunc_one_arg_titled(self):
-        self.signal.metadata.General.title = "yes"
-        result = np.exp(self.signal)
-        assert isinstance(result, signals.Signal1D)
-        nt.assert_array_equal(result.data, np.exp(self.signal.data))
-        assert result.metadata.General.title == "exp(yes)"
-
-    def test_numpy_unfunc_one_arg_untitled(self):
-        result = np.exp(self.signal)
-        assert (result.metadata.General.title ==
-                "exp(Untitled Signal 1)")
-
-    def test_numpy_unfunc_two_arg_titled(self):
-        s1, s2 = self.signal.deepcopy(), self.signal.deepcopy()
-        s1.metadata.General.title = "A"
-        s2.metadata.General.title = "B"
-        result = np.add(s1, s2)
-        assert isinstance(result, signals.Signal1D)
-        nt.assert_array_equal(result.data, np.add(s1.data, s2.data))
-        assert result.metadata.General.title == "add(A, B)"
-
-    def test_numpy_unfunc_two_arg_untitled(self):
-        s1, s2 = self.signal.deepcopy(), self.signal.deepcopy()
-        result = np.add(s1, s2)
-        assert (result.metadata.General.title ==
-                "add(Untitled Signal 1, Untitled Signal 2)")
-
-    def test_numpy_func(self):
-        result = np.angle(self.signal)
-        assert isinstance(result, np.ndarray)
-        nt.assert_array_equal(result, np.angle(self.signal.data))
-
-    def test_add_gaussian_noise(self):
-        s = self.signal
-        s.change_dtype("float64")
-        kwargs = {}
-        if s._lazy:
-            data = s.data.compute()
-            from dask.array.random import seed, normal
-            kwargs["chunks"] = s.data.chunks
-        else:
-            data = s.data.copy()
-            from numpy.random import seed, normal
-        seed(1)
-        s.add_gaussian_noise(std=1.0)
-        seed(1)
-        if s._lazy:
-            s.compute()
-        np.testing.assert_array_almost_equal(
-            s.data - data, normal(scale=1.0, size=data.shape, **kwargs))
-
-    def test_add_gaussian_noise_seed(self):
-        s = self.signal
-        s.change_dtype("float64")
-        kwargs = {}
-        if s._lazy:
-            data = s.data.compute()
-            from dask.array.random import RandomState
-            kwargs["chunks"] = s.data.chunks
-            rng1 = RandomState(123)
-            rng2 = RandomState(123)
-        else:
-            data = s.data.copy()
-            rng1 = np.random.RandomState(123)
-            rng2 = np.random.RandomState(123)
-
-        s.add_gaussian_noise(std=1.0, random_state=rng1)
-        if s._lazy:
-            s.compute()
-
-        np.testing.assert_array_almost_equal(
-            s.data - data, rng2.normal(scale=1.0, size=data.shape, **kwargs))
-
-    def test_gaussian_noise_error(self):
-        s = self.signal
-        s.change_dtype("int64")
-        with pytest.raises(TypeError, match="float datatype"):
-            s.add_gaussian_noise(std=1.0)
-
-
-    def test_add_poisson_noise(self):
-        s = self.signal
-        kwargs = {}
-        if s._lazy:
-            data = s.data.compute()
-            from dask.array.random import seed, poisson
-            kwargs["chunks"] = s.data.chunks
-        else:
-            data = s.data.copy()
-            from numpy.random import seed, poisson
-        seed(1)
-
-        s.add_poissonian_noise(keep_dtype=False)
-
-        if s._lazy:
-            s.compute()
-        seed(1)
-        np.testing.assert_array_almost_equal(
-            s.data, poisson(lam=data, **kwargs))
-        s.change_dtype("float64")
-        seed(1)
-
-        s.add_poissonian_noise(keep_dtype=True)
-        if s._lazy:
-            s.compute()
-        assert s.data.dtype == np.dtype("float64")
-
-    def test_add_poisson_noise_seed(self):
-        s = self.signal
-        kwargs = {}
-        if s._lazy:
-            data = s.data.compute()
-            from dask.array.random import RandomState
-            kwargs["chunks"] = s.data.chunks
-            rng1 = RandomState(123)
-            rng2 = RandomState(123)
-        else:
-            data = s.data.copy()
-            rng1 = np.random.RandomState(123)
-            rng2 = np.random.RandomState(123)
-
-        s.add_poissonian_noise(keep_dtype=False, random_state=rng1)
-
-        if s._lazy:
-            s.compute()
-
-        np.testing.assert_array_almost_equal(
-            s.data, rng2.poisson(lam=data, **kwargs))
-        s.change_dtype("float64")
-
-        s.add_poissonian_noise(keep_dtype=True, random_state=rng1)
-        if s._lazy:
-            s.compute()
-
-        assert s.data.dtype == np.dtype("float64")
-
-    def test_add_poisson_noise_warning(self, caplog):
-        s = self.signal
-        s.change_dtype("float64")
-
-        with caplog.at_level(logging.WARNING):
-            s.add_poissonian_noise(keep_dtype=True)
-
-        assert "Changing data type from" in caplog.text
-
-        with caplog.at_level(logging.WARNING):
-            s.add_poissonian_noise(keep_dtype=False)
-
-        assert "The data type changed from" in caplog.text
-
-
 def _test_default_navigation_signal_operations_over_many_axes(self, op):
     s = getattr(self.signal, op)()
     ar = getattr(self.data, op)(axis=(0, 1))
-    nt.assert_array_equal(ar, s.data)
+    np.testing.assert_array_equal(ar, s.data)
     assert s.data.ndim == 1
     assert s.axes_manager.signal_dimension == 1
     assert s.axes_manager.navigation_dimension == 0
-
-
-@lazifyTestClass
-class Test3D:
-
-    def setup_method(self, method):
-        self.signal = signals.Signal1D(np.arange(2 * 4 * 6).reshape(2, 4, 6))
-        self.signal.axes_manager[0].name = "x"
-        self.signal.axes_manager[1].name = "y"
-        self.signal.axes_manager[2].name = "E"
-        self.signal.axes_manager[0].scale = 0.5
-        self.data = self.signal.data.copy()
-
-    def test_indexmin(self):
-        s = self.signal.indexmin('E')
-        ar = self.data.argmin(2)
-        nt.assert_array_equal(ar, s.data)
-        assert s.data.ndim == 2
-        assert s.axes_manager.signal_dimension == 0
-        assert s.axes_manager.navigation_dimension == 2
-
-    def test_indexmax(self):
-        s = self.signal.indexmax('E')
-        ar = self.data.argmax(2)
-        nt.assert_array_equal(ar, s.data)
-        assert s.data.ndim == 2
-        assert s.axes_manager.signal_dimension == 0
-        assert s.axes_manager.navigation_dimension == 2
-
-    def test_valuemin(self):
-        s = self.signal.valuemin('x')
-        ar = self.signal.axes_manager['x'].index2value(self.data.argmin(1))
-        nt.assert_array_equal(ar, s.data)
-        assert s.data.ndim == 2
-        assert s.axes_manager.signal_dimension == 1
-        assert s.axes_manager.navigation_dimension == 1
-
-    def test_valuemax(self):
-        s = self.signal.valuemax('x')
-        ar = self.signal.axes_manager['x'].index2value(self.data.argmax(1))
-        nt.assert_array_equal(ar, s.data)
-        assert s.data.ndim == 2
-        assert s.axes_manager.signal_dimension == 1
-        assert s.axes_manager.navigation_dimension == 1
-
-    def test_default_navigation_sum(self):
-        _test_default_navigation_signal_operations_over_many_axes(self, 'sum')
-
-    def test_default_navigation_max(self):
-        _test_default_navigation_signal_operations_over_many_axes(self, 'max')
-
-    def test_default_navigation_min(self):
-        _test_default_navigation_signal_operations_over_many_axes(self, 'min')
-
-    def test_default_navigation_mean(self):
-        _test_default_navigation_signal_operations_over_many_axes(self, 'mean')
-
-    def test_default_navigation_std(self):
-        _test_default_navigation_signal_operations_over_many_axes(self, 'std')
-
-    def test_default_navigation_var(self):
-        _test_default_navigation_signal_operations_over_many_axes(self, 'var')
-
-    def test_rebin(self):
-        self.signal.estimate_poissonian_noise_variance()
-        new_s = self.signal.rebin(scale=(2, 2, 1))
-        var = new_s.metadata.Signal.Noise_properties.variance
-        assert new_s.data.shape == (1, 2, 6)
-        assert var.data.shape == (1, 2, 6)
-        from hyperspy.misc.array_tools import rebin
-
-        np.testing.assert_array_equal(rebin(self.signal.data, scale=(2, 2, 1)),
-                                      var.data)
-        np.testing.assert_array_equal(rebin(self.signal.data, scale=(2, 2, 1)),
-                                      new_s.data)
-        if self.signal._lazy:
-            new_s = self.signal.rebin(scale=(2, 2, 1), rechunk=False)
-            np.testing.assert_array_equal(rebin(self.signal.data, scale=(2, 2, 1)),
-                                          var.data)
-            np.testing.assert_array_equal(rebin(self.signal.data, scale=(2, 2, 1)),
-                                          new_s.data)
-
-    def test_rebin_no_variance(self):
-        new_s = self.signal.rebin(scale=(2, 2, 1))
-        with pytest.raises(AttributeError):
-            _ = new_s.metadata.Signal.Noise_properties
-
-    def test_rebin_const_variance(self):
-        self.signal.metadata.set_item(
-            'Signal.Noise_properties.variance', 0.3)
-        new_s = self.signal.rebin(scale=(2, 2, 1))
-        assert new_s.metadata.Signal.Noise_properties.variance == 0.3
-
-    def test_rebin_dtype(self):
-        s = signals.Signal1D(np.arange(1000).reshape(10, 10, 10))
-        s.change_dtype(np.uint8)
-        s2 = s.rebin(scale=(3, 3, 1), crop=False)
-        assert s.sum() == s2.sum()
-
-    def test_swap_axes_simple(self):
-        s = self.signal
-        assert s.swap_axes(0, 1).data.shape == (4, 2, 6)
-        assert s.swap_axes(0, 2).axes_manager.shape == (6, 2, 4)
-        if not s._lazy:
-            assert not s.swap_axes(0, 2).data.flags['C_CONTIGUOUS']
-            assert s.swap_axes(0, 2, optimize=True).data.flags['C_CONTIGUOUS']
-        else:
-            cks = s.data.chunks
-            assert s.swap_axes(0, 1).data.chunks == (cks[1], cks[0], cks[2])
-            # This data shape does not require rechunking
-            assert s.swap_axes(
-                0, 1, optimize=True).data.chunks == (
-                cks[1], cks[0], cks[2])
-
-    def test_swap_axes_iteration(self):
-        s = self.signal
-        s = s.swap_axes(0, 2)
-        assert s.axes_manager._getitem_tuple[:2] == (0, 0)
-        s.axes_manager.indices = (2, 1)
-        assert s.axes_manager._getitem_tuple[:2] == (1, 2)
-
-    def test_get_navigation_signal_nav_dim0(self):
-        s = self.signal
-        s = s.transpose(signal_axes=3)
-        ns = s._get_navigation_signal()
-        assert ns.axes_manager.signal_dimension == 1
-        assert ns.axes_manager.signal_size == 1
-        assert ns.axes_manager.navigation_dimension == 0
-
-    def test_get_navigation_signal_nav_dim1(self):
-        s = self.signal
-        s = s.transpose(signal_axes=2)
-        ns = s._get_navigation_signal()
-        assert (ns.axes_manager.signal_shape ==
-                s.axes_manager.navigation_shape)
-        assert ns.axes_manager.navigation_dimension == 0
-
-    def test_get_navigation_signal_nav_dim2(self):
-        s = self.signal
-        s = s.transpose(signal_axes=1)
-        ns = s._get_navigation_signal()
-        assert (ns.axes_manager.signal_shape ==
-                s.axes_manager.navigation_shape)
-        assert ns.axes_manager.navigation_dimension == 0
-
-    def test_get_navigation_signal_nav_dim3(self):
-        s = self.signal
-        s = s.transpose(signal_axes=0)
-        ns = s._get_navigation_signal()
-        assert (ns.axes_manager.signal_shape ==
-                s.axes_manager.navigation_shape)
-        assert ns.axes_manager.navigation_dimension == 0
-
-    def test_get_navigation_signal_wrong_data_shape(self):
-        s = self.signal
-        s = s.transpose(signal_axes=1)
-        with pytest.raises(ValueError):
-            s._get_navigation_signal(data=np.zeros((3, 2)))
-
-    def test_get_navigation_signal_wrong_data_shape_dim0(self):
-        s = self.signal
-        s = s.transpose(signal_axes=3)
-        with pytest.raises(ValueError):
-            s._get_navigation_signal(data=np.asarray(0))
-
-    def test_get_navigation_signal_given_data(self):
-        s = self.signal
-        s = s.transpose(signal_axes=1)
-        data = np.zeros(s.axes_manager._navigation_shape_in_array)
-        ns = s._get_navigation_signal(data=data)
-        assert ns.data is data
-
-    def test_get_signal_signal_nav_dim0(self):
-        s = self.signal
-        s = s.transpose(signal_axes=0)
-        ns = s._get_signal_signal()
-        assert ns.axes_manager.navigation_dimension == 0
-        assert ns.axes_manager.navigation_size == 0
-        assert ns.axes_manager.signal_dimension == 1
-
-    def test_get_signal_signal_nav_dim1(self):
-        s = self.signal
-        s = s.transpose(signal_axes=1)
-        ns = s._get_signal_signal()
-        assert (ns.axes_manager.signal_shape ==
-                s.axes_manager.signal_shape)
-        assert ns.axes_manager.navigation_dimension == 0
-
-    def test_get_signal_signal_nav_dim2(self):
-        s = self.signal
-        s = s.transpose(signal_axes=2)
-        s._assign_subclass()
-        ns = s._get_signal_signal()
-        assert (ns.axes_manager.signal_shape ==
-                s.axes_manager.signal_shape)
-        assert ns.axes_manager.navigation_dimension == 0
-
-    def test_get_signal_signal_nav_dim3(self):
-        s = self.signal
-        s = s.transpose(signal_axes=3)
-        s._assign_subclass()
-        ns = s._get_signal_signal()
-        assert (ns.axes_manager.signal_shape ==
-                s.axes_manager.signal_shape)
-        assert ns.axes_manager.navigation_dimension == 0
-
-    def test_get_signal_signal_wrong_data_shape(self):
-        s = self.signal
-        s = s.transpose(signal_axes=1)
-        with pytest.raises(ValueError):
-            s._get_signal_signal(data=np.zeros((3, 2)))
-
-    def test_get_signal_signal_wrong_data_shape_dim0(self):
-        s = self.signal
-        s = s.transpose(signal_axes=0)
-        with pytest.raises(ValueError):
-            s._get_signal_signal(data=np.asarray(0))
-
-    def test_get_signal_signal_given_data(self):
-        s = self.signal
-        s = s.transpose(signal_axes=2)
-        data = np.zeros(s.axes_manager._signal_shape_in_array)
-        ns = s._get_signal_signal(data=data)
-        assert ns.data is data
-
-    def test_get_navigation_signal_dtype(self):
-        s = self.signal
-        assert (s._get_navigation_signal().data.dtype.name ==
-                s.data.dtype.name)
-
-    def test_get_signal_signal_dtype(self):
-        s = self.signal
-        assert (s._get_signal_signal().data.dtype.name ==
-                s.data.dtype.name)
-
-    def test_get_navigation_signal_given_dtype(self):
-        s = self.signal
-        assert (
-            s._get_navigation_signal(dtype="bool").data.dtype.name == "bool")
-
-    def test_get_signal_signal_given_dtype(self):
-        s = self.signal
-        assert (
-            s._get_signal_signal(dtype="bool").data.dtype.name == "bool")
-
-
-@lazifyTestClass
-class Test4D:
-
-    def setup_method(self, method):
-        s = signals.Signal1D(np.ones((5, 4, 3, 6)))
-        for axis, name in zip(
-                s.axes_manager._get_axes_in_natural_order(),
-                ['x', 'y', 'z', 'E']):
-            axis.name = name
-        self.s = s
-
-    def test_diff_data(self):
-        s = self.s
-        diff = s.diff(axis=2, order=2)
-        diff_data = np.diff(s.data, n=2, axis=0)
-        nt.assert_array_equal(diff.data, diff_data)
-
-    def test_diff_axis(self):
-        s = self.s
-        diff = s.diff(axis=2, order=2)
-        assert (
-            diff.axes_manager[2].offset ==
-            s.axes_manager[2].offset + s.axes_manager[2].scale)
-
-    def test_rollaxis_int(self):
-        assert self.s.rollaxis(2, 0).data.shape == (4, 3, 5, 6)
-
-    def test_rollaxis_str(self):
-        assert self.s.rollaxis("z", "x").data.shape == (4, 3, 5, 6)
-
-    def test_unfold_spectrum(self):
-        self.s.unfold()
-        assert self.s.data.shape == (60, 6)
-
-    def test_unfold_spectrum_returns_true(self):
-        assert self.s.unfold()
-
-    def test_unfold_spectrum_signal_returns_false(self):
-        assert not self.s.unfold_signal_space()
-
-    def test_unfold_image(self):
-        im = self.s.to_signal2D()
-        im.unfold()
-        assert im.data.shape == (30, 12)
-
-    def test_image_signal_unfolded_deepcopy(self):
-        im = self.s.to_signal2D()
-        im.unfold()
-        # The following could fail if the constructor was not taking the fact
-        # that the signal is unfolded into account when setting the signal
-        # dimension.
-        im.deepcopy()
-
-    def test_image_signal_unfolded_false(self):
-        im = self.s.to_signal2D()
-        assert not im.metadata._HyperSpy.Folding.signal_unfolded
-
-    def test_image_signal_unfolded_true(self):
-        im = self.s.to_signal2D()
-        im.unfold()
-        assert im.metadata._HyperSpy.Folding.signal_unfolded
-
-    def test_image_signal_unfolded_back_to_false(self):
-        im = self.s.to_signal2D()
-        im.unfold()
-        im.fold()
-        assert not im.metadata._HyperSpy.Folding.signal_unfolded
 
 
 def test_signal_iterator():
@@ -873,7 +54,6 @@ def test_signal_iterator():
 
 @lazifyTestClass
 class TestDerivative:
-
     def setup_method(self, method):
         offset = 3
         scale = 0.1
@@ -885,20 +65,20 @@ class TestDerivative:
 
     def test_derivative_data(self):
         der = self.s.derivative(axis=0, order=4)
-        nt.assert_allclose(der.data, np.sin(
-            der.axes_manager[0].axis), atol=1e-2)
+        np.testing.assert_allclose(
+            der.data, np.sin(der.axes_manager[0].axis), atol=1e-2
+        )
 
 
 @lazifyTestClass
 class TestOutArg:
-
     def setup_method(self, method):
         # Some test require consistent random data for reference to be correct
         np.random.seed(0)
         s = signals.Signal1D(np.random.rand(5, 4, 3, 6))
         for axis, name in zip(
-                s.axes_manager._get_axes_in_natural_order(),
-                ['x', 'y', 'z', 'E']):
+            s.axes_manager._get_axes_in_natural_order(), ["x", "y", "z", "E"]
+        ):
             axis.name = name
         self.s = s
 
@@ -911,7 +91,7 @@ class TestOutArg:
         r = f(out=s1, **kwargs)
         m.data_changed.assert_called_with(obj=s1)
         assert r is None
-        assert_array_equal(s1.data, s2.data)
+        np.testing.assert_array_equal(s1.data, s2.data)
 
     def test_get_histogram(self):
         self._run_single(self.s.get_histogram, self.s, {})
@@ -919,30 +99,27 @@ class TestOutArg:
             self._run_single(self.s.get_histogram, self.s, {"rechunk": False})
 
     def test_sum(self):
-        self._run_single(self.s.sum, self.s, dict(axis=('x', 'z')))
-        self._run_single(self.s.sum, self.s.get_current_signal(),
-                         dict(axis=0))
+        self._run_single(self.s.sum, self.s, dict(axis=("x", "z")))
+        self._run_single(self.s.sum, self.s.get_current_signal(), dict(axis=0))
 
     def test_sum_return_1d_signal(self):
-        self._run_single(self.s.sum, self.s, dict(
-            axis=self.s.axes_manager._axes))
-        self._run_single(self.s.sum, self.s.get_current_signal(),
-                         dict(axis=0))
+        self._run_single(self.s.sum, self.s, dict(axis=self.s.axes_manager._axes))
+        self._run_single(self.s.sum, self.s.get_current_signal(), dict(axis=0))
 
     def test_mean(self):
-        self._run_single(self.s.mean, self.s, dict(axis=('x', 'z')))
+        self._run_single(self.s.mean, self.s, dict(axis=("x", "z")))
 
     def test_max(self):
-        self._run_single(self.s.max, self.s, dict(axis=('x', 'z')))
+        self._run_single(self.s.max, self.s, dict(axis=("x", "z")))
 
     def test_min(self):
-        self._run_single(self.s.min, self.s, dict(axis=('x', 'z')))
+        self._run_single(self.s.min, self.s, dict(axis=("x", "z")))
 
     def test_std(self):
-        self._run_single(self.s.std, self.s, dict(axis=('x', 'z')))
+        self._run_single(self.s.std, self.s, dict(axis=("x", "z")))
 
     def test_var(self):
-        self._run_single(self.s.var, self.s, dict(axis=('x', 'z')))
+        self._run_single(self.s.var, self.s, dict(axis=("x", "z")))
 
     def test_diff(self):
         self._run_single(self.s.diff, self.s, dict(axis=0))
@@ -962,8 +139,9 @@ class TestOutArg:
     def test_valuemax(self):
         self._run_single(self.s.valuemax, self.s, dict(axis=0))
 
-    @pytest.mark.xfail(sys.platform == 'win32',
-                       reason="sometimes it does not run lazily on windows")
+    @pytest.mark.xfail(
+        sys.platform == "win32", reason="sometimes it does not run lazily on windows"
+    )
     def test_rebin(self):
         s = self.s
         scale = (1, 2, 1, 2)
@@ -975,79 +153,98 @@ class TestOutArg:
 
     def test_as_image(self):
         s = self.s
-        self._run_single(s.as_signal2D, s, dict(image_axes=(
-            s.axes_manager.navigation_axes[0:2])))
+        self._run_single(
+            s.as_signal2D, s, dict(image_axes=(s.axes_manager.navigation_axes[0:2]))
+        )
 
     def test_inav(self):
         s = self.s
-        self._run_single(s.inav.__getitem__, s, {
-            "slices": (slice(2, 4, None), slice(None), slice(0, 2, None))})
+        self._run_single(
+            s.inav.__getitem__,
+            s,
+            {"slices": (slice(2, 4, None), slice(None), slice(0, 2, None))},
+        )
 
     def test_isig(self):
         s = self.s
-        self._run_single(s.isig.__getitem__, s, {
-            "slices": (slice(2, 4, None),)})
+        self._run_single(s.isig.__getitem__, s, {"slices": (slice(2, 4, None),)})
 
     def test_inav_variance(self):
         s = self.s
-        s.metadata.set_item("Signal.Noise_properties.variance",
-                            s.deepcopy())
+        s.metadata.set_item("Signal.Noise_properties.variance", s.deepcopy())
         s1 = s.inav[2:4, 0:2]
         s2 = s.inav[2:4, 1:3]
-        s.inav.__getitem__(slices=(slice(2, 4, None), slice(1, 3, None),
-                                   slice(None)), out=s1)
-        assert_array_equal(s1.metadata.Signal.Noise_properties.variance.data,
-                           s2.metadata.Signal.Noise_properties.variance.data,)
+        s.inav.__getitem__(
+            slices=(slice(2, 4, None), slice(1, 3, None), slice(None)), out=s1
+        )
+        np.testing.assert_array_equal(
+            s1.metadata.Signal.Noise_properties.variance.data,
+            s2.metadata.Signal.Noise_properties.variance.data,
+        )
 
     def test_isig_variance(self):
         s = self.s
-        s.metadata.set_item("Signal.Noise_properties.variance",
-                            s.deepcopy())
+        s.metadata.set_item("Signal.Noise_properties.variance", s.deepcopy())
         s1 = s.isig[2:4]
         s2 = s.isig[1:5]
         s.isig.__getitem__(slices=(slice(1, 5, None)), out=s1)
-        assert_array_equal(s1.metadata.Signal.Noise_properties.variance.data,
-                           s2.metadata.Signal.Noise_properties.variance.data,)
+        np.testing.assert_array_equal(
+            s1.metadata.Signal.Noise_properties.variance.data,
+            s2.metadata.Signal.Noise_properties.variance.data,
+        )
 
     def test_histogram_axis_changes(self):
         s = self.s
         h1 = s.get_histogram(bins=4)
         h2 = s.get_histogram(bins=5)
         s.get_histogram(bins=5, out=h1)
-        assert_array_equal(h1.data, h2.data)
-        assert (h1.axes_manager[-1].size ==
-                h2.axes_manager[-1].size)
+        np.testing.assert_array_equal(h1.data, h2.data)
+        assert h1.axes_manager[-1].size == h2.axes_manager[-1].size
 
     def test_masked_array_mean(self):
         s = self.s
         if s._lazy:
-            pytest.skip("LazyS do not support masked arrays")
-        mask = (s.data > 0.5)
+            pytest.skip("LazySignals do not support masked arrays")
+        mask = s.data > 0.5
         s.data = np.arange(s.data.size).reshape(s.data.shape)
         s.data = np.ma.masked_array(s.data, mask=mask)
-        sr = s.mean(axis=('x', 'z',))
-        nt.assert_array_equal(
-            sr.data.shape, [ax.size for ax in s.axes_manager[('y', 'E')]])
+        sr = s.mean(axis=("x", "z",))
+        np.testing.assert_array_equal(
+            sr.data.shape, [ax.size for ax in s.axes_manager[("y", "E")]]
+        )
         print(sr.data.tolist())
-        ref = [[202.28571428571428, 203.28571428571428, 182.0,
-                197.66666666666666, 187.0, 177.8],
-               [134.0, 190.0, 191.27272727272728, 170.14285714285714, 172.0,
-                209.85714285714286],
-               [168.0, 161.8, 162.8, 185.4, 197.71428571428572,
-                178.14285714285714],
-               [240.0, 184.33333333333334, 260.0, 229.0, 173.2, 167.0]]
-        nt.assert_array_equal(sr.data, ref)
+        ref = [
+            [
+                202.28571428571428,
+                203.28571428571428,
+                182.0,
+                197.66666666666666,
+                187.0,
+                177.8,
+            ],
+            [
+                134.0,
+                190.0,
+                191.27272727272728,
+                170.14285714285714,
+                172.0,
+                209.85714285714286,
+            ],
+            [168.0, 161.8, 162.8, 185.4, 197.71428571428572, 178.14285714285714],
+            [240.0, 184.33333333333334, 260.0, 229.0, 173.2, 167.0],
+        ]
+        np.testing.assert_array_equal(sr.data, ref)
 
     def test_masked_array_sum(self):
         s = self.s
         if s._lazy:
-            pytest.skip("LazyS do not support masked arrays")
-        mask = (s.data > 0.5)
+            pytest.skip("LazySignals do not support masked arrays")
+        mask = s.data > 0.5
         s.data = np.ma.masked_array(np.ones_like(s.data), mask=mask)
-        sr = s.sum(axis=('x', 'z',))
-        nt.assert_array_equal(sr.data.sum(), (~mask).sum())
+        sr = s.sum(axis=("x", "z",))
+        np.testing.assert_array_equal(sr.data.sum(), (~mask).sum())
 
-    @pytest.mark.parametrize('mask', (True, False))
+    @pytest.mark.parametrize("mask", (True, False))
     def test_sum_no_navigation_axis(self, mask):
         s = signals.Signal1D(np.arange(100))
         if mask:
@@ -1061,11 +258,11 @@ class TestOutArg:
     def test_masked_arrays_out(self):
         s = self.s
         if s._lazy:
-            pytest.skip("LazyS do not support masked arrays")
-        mask = (s.data > 0.5)
+            pytest.skip("LazySignals do not support masked arrays")
+        mask = s.data > 0.5
         s.data = np.ones_like(s.data)
         s.data = np.ma.masked_array(s.data, mask=mask)
-        self._run_single(s.sum, s, dict(axis=('x', 'z')))
+        self._run_single(s.sum, s, dict(axis=("x", "z")))
 
     def test_wrong_out_shape(self):
         s = self.s
@@ -1079,455 +276,3 @@ class TestOutArg:
         ss = s.sum()  # Sum over navigation, data shape (6,)
         with pytest.raises(ValueError):
             s.sum(axis=s.axes_manager._axes, out=ss)
-
-
-@lazifyTestClass
-class TestTranspose:
-
-    def setup_method(self, method):
-        self.s = signals.BaseSignal(np.random.rand(1, 2, 3, 4, 5, 6))
-        for ax, name in zip(self.s.axes_manager._axes, 'abcdef'):
-            ax.name = name
-        # just to make sure in case default changes
-        self.s.axes_manager.set_signal_dimension(6)
-        self.s.estimate_poissonian_noise_variance()
-
-    def test_signal_int_transpose(self):
-        t = self.s.transpose(signal_axes=2)
-        var = t.metadata.Signal.Noise_properties.variance
-        assert t.axes_manager.signal_shape == (6, 5)
-        assert var.axes_manager.signal_shape == (6, 5)
-        assert ([ax.name for ax in t.axes_manager.signal_axes] ==
-                ['f', 'e'])
-        assert isinstance(t, signals.Signal2D)
-        assert isinstance(t.metadata.Signal.Noise_properties.variance,
-                          signals.Signal2D)
-
-    def test_signal_iterable_int_transpose(self):
-        t = self.s.transpose(signal_axes=[0, 5, 4])
-        var = t.metadata.Signal.Noise_properties.variance
-        assert t.axes_manager.signal_shape == (6, 1, 2)
-        assert var.axes_manager.signal_shape == (6, 1, 2)
-        assert ([ax.name for ax in t.axes_manager.signal_axes] ==
-                ['f', 'a', 'b'])
-
-    def test_signal_iterable_names_transpose(self):
-        t = self.s.transpose(signal_axes=['f', 'a', 'b'])
-        var = t.metadata.Signal.Noise_properties.variance
-        assert t.axes_manager.signal_shape == (6, 1, 2)
-        assert var.axes_manager.signal_shape == (6, 1, 2)
-        assert ([ax.name for ax in t.axes_manager.signal_axes] ==
-                ['f', 'a', 'b'])
-
-    def test_signal_iterable_axes_transpose(self):
-        t = self.s.transpose(signal_axes=self.s.axes_manager.signal_axes[:2])
-        var = t.metadata.Signal.Noise_properties.variance
-        assert t.axes_manager.signal_shape == (6, 5)
-        assert var.axes_manager.signal_shape == (6, 5)
-        assert ([ax.name for ax in t.axes_manager.signal_axes] ==
-                ['f', 'e'])
-
-    def test_signal_one_name(self):
-        with pytest.raises(ValueError):
-            self.s.transpose(signal_axes='a')
-
-    def test_too_many_signal_axes(self):
-        with pytest.raises(ValueError):
-            self.s.transpose(signal_axes=10)
-
-    def test_navigation_int_transpose(self):
-        t = self.s.transpose(navigation_axes=2)
-        var = t.metadata.Signal.Noise_properties.variance
-        assert t.axes_manager.navigation_shape == (2, 1)
-        assert var.axes_manager.navigation_shape == (2, 1)
-        assert ([ax.name for ax in t.axes_manager.navigation_axes] ==
-                ['b', 'a'])
-
-    def test_navigation_iterable_int_transpose(self):
-        t = self.s.transpose(navigation_axes=[0, 5, 4])
-        var = t.metadata.Signal.Noise_properties.variance
-        assert t.axes_manager.navigation_shape == (6, 1, 2)
-        assert var.axes_manager.navigation_shape == (6, 1, 2)
-        assert ([ax.name for ax in t.axes_manager.navigation_axes] ==
-                ['f', 'a', 'b'])
-
-    def test_navigation_iterable_names_transpose(self):
-        t = self.s.transpose(navigation_axes=['f', 'a', 'b'])
-        var = t.metadata.Signal.Noise_properties.variance
-        assert var.axes_manager.navigation_shape == (6, 1, 2)
-        assert t.axes_manager.navigation_shape == (6, 1, 2)
-        assert ([ax.name for ax in t.axes_manager.navigation_axes] ==
-                ['f', 'a', 'b'])
-
-    def test_navigation_iterable_axes_transpose(self):
-        t = self.s.transpose(
-            navigation_axes=self.s.axes_manager.signal_axes[
-                :2])
-        var = t.metadata.Signal.Noise_properties.variance
-        assert t.axes_manager.navigation_shape == (6, 5)
-        assert var.axes_manager.navigation_shape == (6, 5)
-        assert ([ax.name for ax in t.axes_manager.navigation_axes] ==
-                ['f', 'e'])
-
-    def test_navigation_one_name(self):
-        with pytest.raises(ValueError):
-            self.s.transpose(navigation_axes='a')
-
-    def test_too_many_navigation_axes(self):
-        with pytest.raises(ValueError):
-            self.s.transpose(navigation_axes=10)
-
-    def test_transpose_shortcut(self):
-        s = self.s.transpose(signal_axes=2)
-        t = s.T
-        assert t.axes_manager.navigation_shape == (6, 5)
-        assert ([ax.name for ax in t.axes_manager.navigation_axes] ==
-                ['f', 'e'])
-
-    def test_optimize(self):
-        if self.s._lazy:
-            pytest.skip(
-                "LazyS optimization is tested in test_lazy_tranpose_rechunk")
-        t = self.s.transpose(signal_axes=['f', 'a', 'b'], optimize=False)
-        assert t.data.base is self.s.data
-
-        t = self.s.transpose(signal_axes=['f', 'a', 'b'], optimize=True)
-        assert t.data.base is not self.s.data
-
-
-def test_lazy_transpose_rechunks():
-    ar = da.ones((50, 50, 256, 256), chunks=(5, 5, 256, 256))
-    s = signals.Signal2D(ar).as_lazy()
-    s1 = s.T  # By default it does not rechunk
-    cks = s.data.chunks
-    assert s1.data.chunks == (cks[2], cks[3], cks[0], cks[1])
-    s2 = s.transpose(optimize=True)
-    assert s2.data.chunks != s1.data.chunks
-
-
-def test_lazy_changetype_rechunk():
-    ar = da.ones((50, 50, 256, 256), chunks=(5, 5, 256, 256), dtype='uint8')
-    s = signals.Signal2D(ar).as_lazy()
-    s._make_lazy(rechunk=True)
-    assert s.data.dtype is np.dtype('uint8')
-    chunks_old = s.data.chunks
-    s.change_dtype('float')
-    assert s.data.dtype is np.dtype('float')
-    chunks_new = s.data.chunks
-    assert (len(chunks_old[0]) * len(chunks_old[1]) <
-            len(chunks_new[0]) * len(chunks_new[1]))
-    s.change_dtype('uint8')
-    assert s.data.dtype is np.dtype('uint8')
-    chunks_newest = s.data.chunks
-    assert chunks_newest == chunks_new
-
-
-def test_lazy_changetype_rechunk_False():
-    ar = da.ones((50, 50, 256, 256), chunks=(5, 5, 256, 256), dtype='uint8')
-    s = signals.Signal2D(ar).as_lazy()
-    s._make_lazy(rechunk=True)
-    assert s.data.dtype is np.dtype('uint8')
-    chunks_old = s.data.chunks
-    s.change_dtype('float', rechunk=False)
-    assert s.data.dtype is np.dtype('float')
-    assert chunks_old == s.data.chunks
-
-
-def test_lazy_reduce_rechunk():
-    s = signals.Signal1D(da.ones((10, 100), chunks=(1, 2))).as_lazy()
-    reduce_methods = (s.sum, s.mean, s.max, s.std, s.var, s.nansum, s.nanmax, s.nanmin,
-                      s.nanmean, s.nanstd, s.nanvar, s.indexmin, s.indexmax, s.valuemax,
-                      s.valuemin)
-    for rm in reduce_methods:
-        assert rm(
-            axis=0).data.chunks == (
-            (100,),)  # The data has been rechunked
-        assert rm(
-            axis=0, rechunk=False).data.chunks == (
-            (2,) * 50,)  # The data has not been rechunked
-
-
-def test_lazy_diff_rechunk():
-    s = signals.Signal1D(da.ones((10, 100), chunks=(1, 2))).as_lazy()
-    for rm in (s.derivative, s.diff):
-        # The data has been rechunked
-        assert rm(axis=-1).data.chunks == ((10,), (99,))
-        assert rm(axis=-1, rechunk=False).data.chunks == ((1,) *
-                                                          10, (1,) * 99)  # The data has not been rechunked
-
-
-def test_spikes_removal_tool():
-    s = signals.Signal1D(np.ones((2, 3, 30)))
-    np.random.seed(1)
-    s.add_gaussian_noise(1E-5)
-    # Add three spikes
-    s.data[1, 0, 1] += 2
-    s.data[0, 2, 29] += 1
-    s.data[1, 2, 14] += 1
-
-    sr = SpikesRemoval(s)
-    sr.threshold = 1.5
-    sr.find()
-    assert s.axes_manager.indices == (0, 1)
-    sr.threshold = 0.5
-    assert s.axes_manager.indices == (0, 0)
-    sr.find()
-    assert s.axes_manager.indices == (2, 0)
-    sr.find()
-    assert s.axes_manager.indices == (0, 1)
-    sr.find(back=True)
-    assert s.axes_manager.indices == (2, 0)
-    sr.add_noise = False
-    sr.apply()
-    assert_almost_equal(s.data[0, 2, 29], 1, decimal=5)
-    assert s.axes_manager.indices == (0, 1)
-    sr.apply()
-    assert_almost_equal(s.data[1, 0, 1], 1, decimal=5)
-    assert s.axes_manager.indices == (2, 1)
-    np.random.seed(1)
-    sr.add_noise = True
-    sr.default_spike_width = 3
-    sr.interpolator_kind = "Spline"
-    sr.spline_order = 3
-    sr.apply()
-    assert_almost_equal(s.data[1, 2, 14], 1, decimal=5)
-    assert s.axes_manager.indices == (0, 0)
-
-
-class TestLinearRebin:
-
-    def test_linear_downsize(self):
-        spectrum = signals.EDSTEMSpectrum(np.ones([3, 5, 1]))
-        scale = (1.5, 2.5, 1)
-        res = spectrum.rebin(scale=scale, crop=True)
-        nt.assert_allclose(res.data, 3.75 * np.ones((1, 3, 1)))
-        for axis in res.axes_manager._axes:
-            assert scale[axis.index_in_axes_manager] == axis.scale
-        res = spectrum.rebin(scale=scale, crop=False)
-        nt.assert_allclose(res.data.sum(), spectrum.data.sum())
-
-    def test_linear_upsize(self):
-        spectrum = signals.EDSTEMSpectrum(np.ones([4, 5, 10]))
-        scale = [0.3, 0.2, .5]
-        res = spectrum.rebin(scale=scale)
-        nt.assert_allclose(res.data, 0.03 * np.ones((20, 16, 20)))
-        for axis in res.axes_manager._axes:
-            assert scale[axis.index_in_axes_manager] == axis.scale
-        res = spectrum.rebin(scale=scale, crop=False)
-        nt.assert_allclose(res.data.sum(), spectrum.data.sum())
-
-    def test_linear_downscale_out(self):
-        spectrum = signals.EDSTEMSpectrum(np.ones([4, 1, 1]))
-        scale = [1, 0.4, 1]
-        res = spectrum.rebin(scale=scale)
-        spectrum.data[2][0] = 5
-        spectrum.rebin(scale=scale, out=res)
-        nt.assert_allclose(res.data, [[[0.4]],
-                                      [[0.4]], [[0.4]], [
-            [0.4]], [[0.4]], [[2.]],
-            [[2.]], [[1.2]], [[0.4]], [[0.4]]])
-        for axis in res.axes_manager._axes:
-            assert scale[axis.index_in_axes_manager] == axis.scale
-
-    def test_linear_upscale_out(self):
-        spectrum = signals.EDSTEMSpectrum(np.ones([4, 1, 1]))
-        scale = [1, 0.4, 1]
-        res = spectrum.rebin(scale=scale)
-        spectrum.data[2][0] = 5
-        spectrum.rebin(scale=scale, out=res)
-        nt.assert_allclose(res.data, [[[0.4]],
-                                      [[0.4]], [[0.4]], [
-            [0.4]], [[0.4]], [[2.]],
-            [[2.]], [[1.2]], [[0.4]], [[0.4]]], atol=1e-3)
-        for axis in res.axes_manager._axes:
-            assert scale[axis.index_in_axes_manager] == axis.scale
-
-class Owner():
-    '''for use in Test_EdgesRange'''
-    def __init__(self, edge):
-        self.description = edge
-
-class Test_EdgesRange:
-    def setup_method(self, method):
-        s = get_core_loss_eels_line_scan_signal(True)
-        self.signal = s
-        er = EdgesRange(self.signal)
-        self.er = er
-
-    def test_init(self):
-        edges_all = np.array(['Ag_M2', 'Cr_L2', 'Cd_M3', 'Te_M4', 'I_M5',
-                              'Cr_L3', 'Te_M5','V_L1', 'Ag_M3', 'I_M4',
-                              'Ti_L1', 'Pd_M2', 'Mn_L3', 'Cd_M2', 'Mn_L2',
-                              'Sb_M4', 'In_M3', 'O_K', 'Pd_M3', 'Sb_M5',
-                              'Xe_M5', 'Rh_M2', 'V_L2', 'F_K', 'Xe_M4',
-                              'V_L3', 'Cr_L1', 'Sc_L1', 'In_M2', 'Rh_M3',
-                              'Sn_M4', 'Fe_L3', 'Sn_M5', 'Sn_M3', 'Ru_M2',
-                              'Fe_L2', 'Cs_M5', 'Ti_L2', 'Ru_M3', 'Cs_M4',
-                              'Ti_L3', 'In_M4', 'Sn_M2', 'In_M5', 'Ca_L1',
-                              'Sb_M3', 'Mn_L1', 'Co_L3', 'Ba_M5', 'Cd_M4',
-                              'Mo_M2', 'Sc_L2', 'Co_L2', 'Cd_M5', 'Ba_M4',
-                              'Sc_L3', 'N_K'])
-        energy_all = np.array([602., 584., 616., 582., 620., 575., 572., 628.,
-                               571., 631., 564., 559., 640., 651., 651., 537.,
-                               664., 532., 531., 528., 672., 521., 521., 685.,
-                               685., 513., 695., 500., 702., 496., 494., 708.,
-                               485., 714., 483., 721., 726., 462., 461., 740.,
-                               456., 451., 756., 443., 438., 766., 769., 779.,
-                               781., 411., 410., 407., 794., 404., 796., 402.,
-                               401.])
-        relevance_all = np.array(['Minor', 'Major', 'Minor', 'Major', 'Major',
-                                  'Major', 'Major', 'Minor', 'Minor', 'Major',
-                                  'Minor', 'Minor', 'Major', 'Minor', 'Major',
-                                  'Major', 'Minor', 'Major', 'Minor', 'Major',
-                                  'Major', 'Minor', 'Major', 'Major', 'Major',
-                                  'Major', 'Minor', 'Minor', 'Minor', 'Minor',
-                                  'Major', 'Major', 'Major', 'Minor', 'Minor',
-                                  'Major', 'Major', 'Major', 'Minor', 'Major',
-                                  'Major', 'Major', 'Minor', 'Major', 'Minor',
-                                  'Minor', 'Minor', 'Major', 'Major', 'Major',
-                                  'Minor', 'Major', 'Major', 'Major', 'Major',
-                                  'Major', 'Major'])
-        description_all = np.array(['Delayed maximum', 'Sharp peak. Delayed maximum',
-       'Delayed maximum', 'Delayed maximum', 'Delayed maximum',
-       'Sharp peak. Delayed maximum', 'Delayed maximum', 'Abrupt onset',
-       'Delayed maximum', 'Delayed maximum', 'Abrupt onset', '',
-       'Sharp peak. Delayed maximum', '', 'Sharp peak. Delayed maximum',
-       'Delayed maximum', 'Delayed maximum', 'Abrupt onset', '',
-       'Delayed maximum', 'Delayed maximum', 'Sharp peak',
-       'Sharp peak. Delayed maximum', 'Abrupt onset', 'Delayed maximum',
-       'Sharp peak. Delayed maximum', 'Abrupt onset', 'Abrupt onset', '',
-       'Sharp peak', 'Delayed maximum', 'Sharp peak. Delayed maximum',
-       'Delayed maximum', 'Delayed maximum', 'Sharp peak',
-       'Sharp peak. Delayed maximum', 'Sharp peak. Delayed maximum',
-       'Sharp peak. Delayed maximum', 'Sharp peak',
-       'Sharp peak. Delayed maximum', 'Sharp peak. Delayed maximum',
-       'Delayed maximum', '', 'Delayed maximum', 'Abrupt onset',
-       'Delayed maximum', 'Abrupt onset', 'Sharp peak. Delayed maximum',
-       'Sharp peak. Delayed maximum', 'Delayed maximum', 'Sharp peak',
-       'Sharp peak. Delayed maximum', 'Sharp peak. Delayed maximum',
-       'Delayed maximum', 'Sharp peak. Delayed maximum',
-       'Sharp peak. Delayed maximum', 'Abrupt onset'])
-
-        assert np.array_equal(self.er.edge_all, edges_all)
-        assert np.array_equal(self.er.energy_all, energy_all)
-        assert np.array_equal(self.er.relevance_all, relevance_all)
-        assert np.array_equal(self.er.description_all, description_all)
-
-    def test_selected_span_selector(self):
-        self.er.ss_left_value = 500
-        self.er.ss_right_value = 550
-
-        edges, energy, relevance, description = self.er.update_table()
-
-        assert set(edges) == set(('Sb_M4', 'O_K', 'Pd_M3', 'Sb_M5', 'Rh_M2',
-                                  'V_L2', 'V_L3', 'Sc_L1'))
-        assert set(energy) == set((537.0, 532.0, 531.0, 528.0, 521.0, 521.0,
-                                   513.0, 500.0))
-        assert set(relevance) == set(('Major', 'Major', 'Minor', 'Major',
-                                      'Minor', 'Major', 'Major', 'Minor'))
-        assert set(description) == set(('Delayed maximum', 'Abrupt onset', '',
-                                        'Delayed maximum', 'Sharp peak',
-                                        'Sharp peak. Delayed maximum',
-                                        'Sharp peak. Delayed maximum',
-                                        'Abrupt onset'))
-
-    def test_none_span_selector(self):
-        self.er.span_selector = None
-
-        edges, energy, relevance, description = self.er.update_table()
-
-        assert len(edges) == 0
-        assert len(energy) == 0
-        assert len(relevance) == 0
-        assert len(description) == 0
-
-    def test_complementary_edge(self):
-        self.signal.plot(plot_edges=['V_L2'])
-        er = EdgesRange(self.signal)
-        er.ss_left_value = 500
-        er.ss_right_value = 550
-        ret = er.update_table()
-
-        assert er.active_edges == ['V_L2']
-        assert er.active_complementary_edges == ['V_L3', 'V_L1']
-
-    def test_off_complementary_edge(self):
-        self.signal.plot(plot_edges=['V_L2'])
-        er = EdgesRange(self.signal)
-        er.complementary = False
-        er.ss_left_value = 500
-        er.ss_right_value = 550
-        ret = er.update_table()
-
-        assert er.active_edges == ['V_L2']
-        assert len(er.active_complementary_edges) == 0
-
-    def test_keep_valid_edge(self):
-        self.signal.plot(plot_edges=['V_L2'])
-        er = EdgesRange(self.signal)
-        er.ss_left_value = 500
-        er.ss_right_value = 550
-        ret = er.update_table()
-
-        er.ss_left_value = 600
-        er.ss_right_value = 650
-        ret = er.update_table()
-
-        assert er.active_edges == ['V_L1']
-        assert er.active_complementary_edges == ['V_L2', 'V_L3']
-
-    def test_remove_out_of_range_edge(self):
-        self.signal.plot(plot_edges=['V_L2'])
-        er = EdgesRange(self.signal)
-        er.ss_left_value = 500
-        er.ss_right_value = 550
-        ret = er.update_table()
-
-        er.ss_left_value = 700
-        er.ss_right_value = 750
-        ret = er.update_table()
-
-        assert len(er.active_edges) == 0
-        assert len(er.active_complementary_edges) == 0
-
-    def test_select_edge_by_button(self):
-        self.er.ss_left_value = 500
-        self.er.ss_right_value = 550
-        ret = self.er.update_table()
-
-        on_V_L2 = {'owner': Owner('V_L2'), 'new': True}
-        self.er.update_active_edge(on_V_L2)
-
-        assert self.er.active_edges == ['V_L2']
-        assert self.er.active_complementary_edges == ['V_L3', 'V_L1']
-
-        off_V_L2 = {'owner': Owner('V_L2'), 'new': False}
-        self.er.update_active_edge(off_V_L2)
-
-        assert len(self.er.active_edges) == 0
-        assert len(self.er.active_complementary_edges) == 0
-
-    def test_remove_all_edge_markers(self):
-        self.signal.plot(plot_edges=['V_L2'])
-        er = EdgesRange(self.signal)
-        er.ss_left_value = 500
-        er.ss_right_value = 550
-        ret = er.update_table()
-
-        er._clear_markers()
-
-        assert len(er.active_edges) == 0
-        assert len(er.active_complementary_edges) == 0
-
-    def test_on_figure_changed(self):
-        self.signal.plot(plot_edges=['V_L2'])
-        er = EdgesRange(self.signal)
-        er.ss_left_value = 500
-        er.ss_right_value = 550
-        ret = er.update_table()
-
-        vl1 = self.signal._edge_markers['V_L1'][0]
-        self.signal._plot.pointer.indices = (10,)
-        vl2 = self.signal._edge_markers['V_L1'][0]
-
-        assert not np.array_equal(vl1.data, vl2.data)

--- a/hyperspy/tests/signal/test_transpose.py
+++ b/hyperspy/tests/signal/test_transpose.py
@@ -1,0 +1,136 @@
+# -*- coding: utf-8 -*-
+# Copyright 2007-2020 The HyperSpy developers
+#
+# This file is part of  HyperSpy.
+#
+#  HyperSpy is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+#  HyperSpy is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with  HyperSpy.  If not, see <http://www.gnu.org/licenses/>.
+
+import dask.array as da
+import numpy as np
+import pytest
+
+from hyperspy.decorators import lazifyTestClass
+from hyperspy.signals import BaseSignal, Signal2D
+
+
+@lazifyTestClass
+class TestTranspose:
+    def setup_method(self, method):
+        self.s = BaseSignal(np.random.rand(1, 2, 3, 4, 5, 6))
+        for ax, name in zip(self.s.axes_manager._axes, "abcdef"):
+            ax.name = name
+        # just to make sure in case default changes
+        self.s.axes_manager.set_signal_dimension(6)
+        self.s.estimate_poissonian_noise_variance()
+
+    def test_signal_int_transpose(self):
+        t = self.s.transpose(signal_axes=2)
+        var = t.metadata.Signal.Noise_properties.variance
+        assert t.axes_manager.signal_shape == (6, 5)
+        assert var.axes_manager.signal_shape == (6, 5)
+        assert [ax.name for ax in t.axes_manager.signal_axes] == ["f", "e"]
+        assert isinstance(t, Signal2D)
+        assert isinstance(t.metadata.Signal.Noise_properties.variance, Signal2D)
+
+    def test_signal_iterable_int_transpose(self):
+        t = self.s.transpose(signal_axes=[0, 5, 4])
+        var = t.metadata.Signal.Noise_properties.variance
+        assert t.axes_manager.signal_shape == (6, 1, 2)
+        assert var.axes_manager.signal_shape == (6, 1, 2)
+        assert [ax.name for ax in t.axes_manager.signal_axes] == ["f", "a", "b"]
+
+    def test_signal_iterable_names_transpose(self):
+        t = self.s.transpose(signal_axes=["f", "a", "b"])
+        var = t.metadata.Signal.Noise_properties.variance
+        assert t.axes_manager.signal_shape == (6, 1, 2)
+        assert var.axes_manager.signal_shape == (6, 1, 2)
+        assert [ax.name for ax in t.axes_manager.signal_axes] == ["f", "a", "b"]
+
+    def test_signal_iterable_axes_transpose(self):
+        t = self.s.transpose(signal_axes=self.s.axes_manager.signal_axes[:2])
+        var = t.metadata.Signal.Noise_properties.variance
+        assert t.axes_manager.signal_shape == (6, 5)
+        assert var.axes_manager.signal_shape == (6, 5)
+        assert [ax.name for ax in t.axes_manager.signal_axes] == ["f", "e"]
+
+    def test_signal_one_name(self):
+        with pytest.raises(ValueError):
+            self.s.transpose(signal_axes="a")
+
+    def test_too_many_signal_axes(self):
+        with pytest.raises(ValueError):
+            self.s.transpose(signal_axes=10)
+
+    def test_navigation_int_transpose(self):
+        t = self.s.transpose(navigation_axes=2)
+        var = t.metadata.Signal.Noise_properties.variance
+        assert t.axes_manager.navigation_shape == (2, 1)
+        assert var.axes_manager.navigation_shape == (2, 1)
+        assert [ax.name for ax in t.axes_manager.navigation_axes] == ["b", "a"]
+
+    def test_navigation_iterable_int_transpose(self):
+        t = self.s.transpose(navigation_axes=[0, 5, 4])
+        var = t.metadata.Signal.Noise_properties.variance
+        assert t.axes_manager.navigation_shape == (6, 1, 2)
+        assert var.axes_manager.navigation_shape == (6, 1, 2)
+        assert [ax.name for ax in t.axes_manager.navigation_axes] == ["f", "a", "b"]
+
+    def test_navigation_iterable_names_transpose(self):
+        t = self.s.transpose(navigation_axes=["f", "a", "b"])
+        var = t.metadata.Signal.Noise_properties.variance
+        assert var.axes_manager.navigation_shape == (6, 1, 2)
+        assert t.axes_manager.navigation_shape == (6, 1, 2)
+        assert [ax.name for ax in t.axes_manager.navigation_axes] == ["f", "a", "b"]
+
+    def test_navigation_iterable_axes_transpose(self):
+        t = self.s.transpose(navigation_axes=self.s.axes_manager.signal_axes[:2])
+        var = t.metadata.Signal.Noise_properties.variance
+        assert t.axes_manager.navigation_shape == (6, 5)
+        assert var.axes_manager.navigation_shape == (6, 5)
+        assert [ax.name for ax in t.axes_manager.navigation_axes] == ["f", "e"]
+
+    def test_navigation_one_name(self):
+        with pytest.raises(ValueError):
+            self.s.transpose(navigation_axes="a")
+
+    def test_too_many_navigation_axes(self):
+        with pytest.raises(ValueError):
+            self.s.transpose(navigation_axes=10)
+
+    def test_transpose_shortcut(self):
+        s = self.s.transpose(signal_axes=2)
+        t = s.T
+        assert t.axes_manager.navigation_shape == (6, 5)
+        assert [ax.name for ax in t.axes_manager.navigation_axes] == ["f", "e"]
+
+    def test_optimize(self):
+        if self.s._lazy:
+            pytest.skip(
+                "LazySignal optimization is tested in test_lazy_tranpose_rechunk"
+            )
+        t = self.s.transpose(signal_axes=["f", "a", "b"], optimize=False)
+        assert t.data.base is self.s.data
+
+        t = self.s.transpose(signal_axes=["f", "a", "b"], optimize=True)
+        assert t.data.base is not self.s.data
+
+
+def test_lazy_transpose_rechunks():
+    ar = da.ones((50, 50, 256, 256), chunks=(5, 5, 256, 256))
+    s = Signal2D(ar).as_lazy()
+    s1 = s.T  # By default it does not rechunk
+    cks = s.data.chunks
+    assert s1.data.chunks == (cks[2], cks[3], cks[0], cks[1])
+    s2 = s.transpose(optimize=True)
+    assert s2.data.chunks != s1.data.chunks


### PR DESCRIPTION
### Description of the change
- `test_cluster.py` had far too many parameter combinations, including needless duplications, to the extent that it currently constitutes ~15% of all the unit tests by count. This has been reduced considerably for now, it can probably go further.
- `test_hologram_image.py` had unnecessary parameter combinations of `parallel=True/False` which have been removed.
- `test_tools.py` was >1500 lines long and really hard to parse. It has been split up into a number of new files to make it easier to improve the coverage etc. in future. The file names are open for renaming, I chose them based on what seemed like a natural grouping.

This doesn't need to go in v1.6 @francisco-dlp  if you don't want it to! 

### Progress of the PR
- [x] Change implemented (can be split into several points),
- [x] update docstring (if appropriate),
- [x] update user guide (if appropriate),
- [x] add tests,
- [x] ready for review.


