### PR TITLE
Build wheels

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,6 +1,10 @@
-name: Build
+name: Release
 
-on: [push, pull_request]
+on:
+  push:
+    # Sequence of patterns matched against refs/tags
+    tags:
+    - 'v*' # Push events to matching v*, i.e. v1.0, v20.15.10
 
 jobs:
   build_wheels:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,7 +4,7 @@ on: [push, pull_request]
 
 jobs:
   build_wheels:
-    name: Build wheels on ${{ matrix.os }}
+    name: Wheels on ${{ matrix.os }}/py${{ matrix.python-version }}
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
@@ -13,6 +13,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
+      - uses: docker://quay.io/pypa/manylinux2010_x86_64
+        if: startsWith(matrix.os, 'ubuntu')
 
       - uses: actions/setup-python@v2
         name: Install Python

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,40 @@
+name: Build
+
+on: [push, pull_request]
+
+jobs:
+  build_wheels:
+    name: Build wheels on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-18.04, windows-latest, macos-latest]
+        #python-version: [ '3.6', '3.7', '3.8' ]
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: actions/setup-python@v2
+        name: Install Python
+        with:
+          python-version: '3.7'
+
+      - name: install pep517
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install pep517
+
+      - name: Install Visual C++ for Python 2.7
+        if: runner.os == 'Windows'
+        run: |
+          choco install vcpython27 -f -y
+
+      - name: Build wheels
+        env:
+          CIBW_BUILD: cp3*
+        run: |
+          python -m pep517.build --binary --out-dir dist/ .
+
+      - uses: actions/upload-artifact@v2
+        with:
+          path: ./dist/*.whl

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-18.04, windows-latest, macos-latest]
-        #python-version: [ '3.6', '3.7', '3.8' ]
+        python-version: [3.6, 3.7, 3.8]
 
     steps:
       - uses: actions/checkout@v2
@@ -17,7 +17,7 @@ jobs:
       - uses: actions/setup-python@v2
         name: Install Python
         with:
-          python-version: '3.7'
+          python-version: ${{ matrix.python-version }}
 
       - name: install pep517
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,10 +1,10 @@
 name: Release
 
-on:
-  push:
-    # Sequence of patterns matched against refs/tags
-    tags:
-    - 'v*' # Push events to matching v*, i.e. v1.0, v20.15.10
+on: [push, pull_request]
+#  push:
+#    # Sequence of patterns matched against refs/tags
+#    tags:
+#    - 'v*' # Push events to matching v*, i.e. v1.0, v20.15.10
 
 jobs:
   build_wheels:
@@ -12,18 +12,25 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-18.04, windows-latest, macos-latest]
+        #os: [ubuntu-18.04, windows-latest, macos-latest]
+        os: [ubuntu-16.04]
         python-version: [3.6, 3.7, 3.8]
 
     steps:
       - uses: actions/checkout@v2
-      - uses: docker://quay.io/pypa/manylinux2010_x86_64
+      - uses: docker://quay.io/pypa/manylinux1_x86_64
         if: runner.os == 'Linux'
 
       - uses: actions/setup-python@v2
         name: Install Python
         with:
           python-version: ${{ matrix.python-version }}
+
+      - name: What OS and Python version
+        run: |
+          uname -a
+          python --version
+          which python
 
       - name: install pep517
         run: |
@@ -39,10 +46,10 @@ jobs:
         run: |
           python -m pep517.build --binary --out-dir dist/ .
 
-      #- name: auditwheel
-      #  if: runner.os == 'Linux'
-      #  run: |
-      #    auditwheel repair dist/*.whl
+      - name: auditwheel
+        if: runner.os == 'Linux'
+        run: |
+          auditwheel repair dist/*.whl
 
       - uses: actions/upload-artifact@v2
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,14 +12,11 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        #os: [ubuntu-18.04, windows-latest, macos-latest]
-        os: [ubuntu-16.04]
+        os: [windows-latest, macos-latest]
         python-version: [3.6, 3.7, 3.8]
 
     steps:
       - uses: actions/checkout@v2
-      - uses: docker://quay.io/pypa/manylinux1_x86_64
-        if: runner.os == 'Linux'
 
       - uses: actions/setup-python@v2
         name: Install Python
@@ -32,24 +29,39 @@ jobs:
           python --version
           which python
 
-      - name: install pep517
-        run: |
-          python -m pip install --upgrade pip
-          python -m pip install pep517 auditwheel
-
       - name: Install Visual C++ for Python 2.7
         if: runner.os == 'Windows'
         run: |
           choco install vcpython27 -f -y
 
+      - name: install pep517
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install pep517 cython
+
       - name: Build wheels
         run: |
           python -m pep517.build --binary --out-dir dist/ .
 
-      - name: auditwheel
-        if: runner.os == 'Linux'
-        run: |
-          auditwheel repair dist/*.whl
+      - uses: actions/upload-artifact@v2
+        with:
+          path: ./dist/*.whl
+
+  build_wheels_linux:
+    name: Wheels on ubuntu-latest
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.8
+
+      - name: Build manylinux Python wheels
+        uses: RalfG/python-wheels-manylinux-build@v0.3.1-manylinux2010_x86_64
+        with:
+          build-requirements: 'cython'
 
       - uses: actions/upload-artifact@v2
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,14 +1,34 @@
 name: Release
 
-on: [push, pull_request]
-#  push:
-#    # Sequence of patterns matched against refs/tags
-#    tags:
-#    - 'v*' # Push events to matching v*, i.e. v1.0, v20.15.10
+on:
+  push:
+    # Sequence of patterns matched against refs/tags
+    tags:
+    - 'v*' # Push events to matching v*, i.e. v1.0, v20.15.10
 
 jobs:
+  create_release:
+    name: Create Release
+    runs-on: ubuntu-latest
+    outputs: 
+      upload_url: ${{ steps.create_release.outputs.upload_url }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+      - name: Create Release
+        id: create_release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # This token is provided by Actions
+        with:
+          tag_name: ${{ github.ref }}
+          release_name: Release ${{ github.ref }}
+          draft: false
+          prerelease: false
+  
   build_wheels:
     name: Wheels on ${{ matrix.os }}/py${{ matrix.python-version }}
+    needs: create_release
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
@@ -34,7 +54,7 @@ jobs:
         run: |
           choco install vcpython27 -f -y
 
-      - name: install pep517
+      - name: install pep517 and cython
         run: |
           python -m pip install --upgrade pip
           python -m pip install pep517 cython
@@ -47,8 +67,27 @@ jobs:
         with:
           path: ./dist/*.whl
 
+      #- name: Upload Release Asset
+      #  uses: actions/upload-release-asset@v1
+      #  env:
+      #    GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      #  with:
+      #    upload_url: ${{ needs.create_release.outputs.upload_url }}
+      #    asset_path: ./dist/*.whl
+      #    asset_name: 
+      #    asset_content_type: 
+
+      #- name: Publish wheels to PyPI
+      #  env:
+      #    TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
+      #    TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
+      #  run: |
+      #    python -m pip install twine
+      #    python -m twine upload dist/*.whl
+
   build_wheels_linux:
     name: Wheels on ubuntu-latest
+    needs: create_release
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -66,3 +105,23 @@ jobs:
       - uses: actions/upload-artifact@v2
         with:
           path: ./dist/*.whl
+
+      #- name: Upload Release Asset
+      #  uses: actions/upload-release-asset@v1
+      #  env:
+      #    GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      #  with:
+      #    upload_url: ${{ needs.create_release.outputs.upload_url }}
+      #    asset_path: ./dist/*-manylinux*.whl
+      #    asset_name: 
+      #    asset_content_type: 
+
+      #- name: Publish wheels to PyPI
+      #  env:
+      #    TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
+      #    TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
+      #  run: |
+      #    python -m pip install --upgrade setuptools twine
+      #    python setup.py sdist
+      #    twine upload dist/*-manylinux*.whl
+      #    twine upload dist/*.tar.gz

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,7 +14,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - uses: docker://quay.io/pypa/manylinux2010_x86_64
-        if: startsWith(matrix.os, 'ubuntu')
+        if: runner.os == 'Linux'
 
       - uses: actions/setup-python@v2
         name: Install Python
@@ -24,7 +24,7 @@ jobs:
       - name: install pep517
         run: |
           python -m pip install --upgrade pip
-          python -m pip install pep517
+          python -m pip install pep517 auditwheel
 
       - name: Install Visual C++ for Python 2.7
         if: runner.os == 'Windows'
@@ -32,10 +32,13 @@ jobs:
           choco install vcpython27 -f -y
 
       - name: Build wheels
-        env:
-          CIBW_BUILD: cp3*
         run: |
           python -m pep517.build --binary --out-dir dist/ .
+
+      #- name: auditwheel
+      #  if: runner.os == 'Linux'
+      #  run: |
+      #    auditwheel repair dist/*.whl
 
       - uses: actions/upload-artifact@v2
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,7 @@
 name: Release
+# This workflow builds the wheels "on tag".
+# If run from the hyperspy/hyperspy repository, the wheels will be uploaded to pypi ;
+# otherwise, the wheels will be available as a github artifact.
 
 on:
   push:
@@ -78,20 +81,12 @@ jobs:
         with:
           path: ./dist/*.whl
 
-      #- name: Upload Release Asset
-      #  uses: actions/upload-release-asset@v1
-      #  env:
-      #    GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      #  with:
-      #    upload_url: ${{ needs.create_release.outputs.upload_url }}
-      #    asset_path: ./dist/*.whl
-      #    asset_name: 
-      #    asset_content_type: 
-
       - name: Publish distribution 📦 to PyPI
         if: github.repository_owner == 'hyperspy'
         uses: pypa/gh-action-pypi-publish@master
         with:
+           # Github secret set in the hyperspy/hyperspy repository
+           # not available from fork
            password: ${{ secrets.pypi_password }}
 
   build_wheels_linux:
@@ -134,19 +129,11 @@ jobs:
             ./dist/*-manylinux*.whl
             ./sdist/*.tar.gz
 
-      #- name: Upload Release Asset
-      #  uses: actions/upload-release-asset@v1
-      #  env:
-      #    GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      #  with:
-      #    upload_url: ${{ needs.create_release.outputs.upload_url }}
-      #    asset_path: ./dist/*-manylinux*.whl
-      #    asset_name: 
-      #    asset_content_type: 
-
       - name: Publish distribution 📦 to PyPI
         if: github.repository_owner == 'hyperspy'
         uses: pypa/gh-action-pypi-publish@master
         with:
+           # Github secret set in the hyperspy/hyperspy repository
+           # not available from fork
            password: ${{ secrets.pypi_password }}
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -104,7 +104,7 @@ jobs:
 
       - uses: actions/upload-artifact@v2
         with:
-          path: ./dist/*.whl
+          path: ./dist/*-manylinux*.whl
 
       #- name: Upload Release Asset
       #  uses: actions/upload-release-asset@v1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -89,6 +89,7 @@ jobs:
       #    asset_content_type: 
 
       - name: Publish distribution 📦 to PyPI
+        if: github.repository_owner == 'hyperspy'
         uses: pypa/gh-action-pypi-publish@master
         with:
            password: ${{ secrets.pypi_password }}
@@ -144,6 +145,7 @@ jobs:
       #    asset_content_type: 
 
       - name: Publish distribution 📦 to PyPI
+        if: github.repository_owner == 'hyperspy'
         uses: pypa/gh-action-pypi-publish@master
         with:
            password: ${{ secrets.pypi_password }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,7 +25,7 @@ jobs:
           release_name: Release ${{ github.ref }}
           draft: false
           prerelease: false
-  
+
   build_wheels:
     name: Wheels on ${{ matrix.os }}/py${{ matrix.python-version }}
     needs: create_release
@@ -63,6 +63,17 @@ jobs:
         run: |
           python -m pep517.build --binary --out-dir dist/ .
 
+      - name: Display content dist folder
+        run: |
+          ls dist/
+
+      - name: Install and test distribution
+        env:
+          MPLBACKEND: agg
+        run: |
+          pip install --pre --find-links dist hyperspy[tests]
+          pytest --pyargs hyperspy
+
       - uses: actions/upload-artifact@v2
         with:
           path: ./dist/*.whl
@@ -99,9 +110,28 @@ jobs:
         with:
           build-requirements: 'cython'
 
+      - name: Build source distribution
+        run: |
+          pip install pep517
+          python -m pep517.build --source --out-dir sdist/ .
+
+      - name: Display content dist folder
+        run: |
+          ls dist/
+          ls sdist/
+
+      - name: Install and test distribution
+        env:
+          MPLBACKEND: agg
+        run: |
+          pip install --pre --find-links dist hyperspy[tests]
+          pytest --pyargs hyperspy
+
       - uses: actions/upload-artifact@v2
         with:
-          path: ./dist/*-manylinux*.whl
+          path: |
+            ./dist/*-manylinux*.whl
+            ./sdist/*.tar.gz
 
       #- name: Upload Release Asset
       #  uses: actions/upload-release-asset@v1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -54,10 +54,10 @@ jobs:
         run: |
           choco install vcpython27 -f -y
 
-      - name: install pep517 and cython
+      - name: install pep517
         run: |
           python -m pip install --upgrade pip
-          python -m pip install pep517 cython
+          python -m pip install pep517
 
       - name: Build wheels
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -77,13 +77,10 @@ jobs:
       #    asset_name: 
       #    asset_content_type: 
 
-      #- name: Publish wheels to PyPI
-      #  env:
-      #    TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
-      #    TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
-      #  run: |
-      #    python -m pip install twine
-      #    python -m twine upload dist/*.whl
+      - name: Publish distribution 📦 to PyPI
+        uses: pypa/gh-action-pypi-publish@master
+        with:
+           password: ${{ secrets.pypi_password }}
 
   build_wheels_linux:
     name: Wheels on ubuntu-latest
@@ -116,12 +113,8 @@ jobs:
       #    asset_name: 
       #    asset_content_type: 
 
-      #- name: Publish wheels to PyPI
-      #  env:
-      #    TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
-      #    TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
-      #  run: |
-      #    python -m pip install --upgrade setuptools twine
-      #    python setup.py sdist
-      #    twine upload dist/*-manylinux*.whl
-      #    twine upload dist/*.tar.gz
+      - name: Publish distribution 📦 to PyPI
+        uses: pypa/gh-action-pypi-publish@master
+        with:
+           password: ${{ secrets.pypi_password }}
+

--- a/hyperspy/Release.py
+++ b/hyperspy/Release.py
@@ -25,7 +25,7 @@ name = 'hyperspy'
 # When running setup.py the ".dev" string will be replaced (if possible)
 # by the output of "git describe" if git is available or the git
 # hash if .git is present.
-version = "1.6.0.dev"
+version = "1.6.1.dev0"
 description = "Multidimensional data analysis toolbox"
 license = 'GPL v3'
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["setuptools>=40.8.0", "wheel", "cython"]
+build-backend = "setuptools.build_meta:__legacy__"

--- a/setup.py
+++ b/setup.py
@@ -139,7 +139,7 @@ def count_c_extensions(extensions):
 def cythonize_extensions(extensions):
     try:
         from Cython.Build import cythonize
-        return cythonize(extensions)
+        return cythonize(extensions, compiler_directives={'language_level' : "3"})
     except ImportError:
         warnings.warn("""WARNING: cython required to generate fast c code is not found on this system.
 Only slow pure python alternative functions will be available.


### PR DESCRIPTION
### Description of the change
- Build wheels for windows, mac and linux (manylinux1, manylinux2010),
- Use github action to run the build _on tag_ only,
- fix development version (`1.6.0.dev` to `1.6.1.dev0`),
- Fix cython `FutureWarning`.

When a tag is made or push to github, this workflow will run and do the following:
1. create a release on github
2. build the wheels according to [PEP517](https://www.python.org/dev/peps/pep-0517/)
3. Install the wheels and run the test suite
4. the wheels will be available as an artifact (see for example: https://github.com/ericpre/hyperspy/actions/runs/220801777)
5. if running from the upstream repository (`hyperspy/hyperspy`), the wheels will be uploaded to pypi. Obviously, this hasn't been tested yet but the github secret has been set in the repository and this should be ready to go for the next release. If run from a fork, the upload to pypi will be skip to avoid failure of the workflow (missing github secret only available from the `hyperspy/hyperspy` repository). Useful link: https://packaging.python.org/guides/publishing-package-distribution-releases-using-github-actions-ci-cd-workflows/