### PR TITLE
Additional test suite improvements

### DIFF
--- a/hyperspy/_signals/eds_tem.py
+++ b/hyperspy/_signals/eds_tem.py
@@ -457,9 +457,11 @@ class EDSTEM_mixin:
                                                                 thickness)
                         mass_thickness.metadata.General.title = 'Mass thickness'
                     else:
-                        warnings.warn('Thickness is required for absorption '
-                        'correction with k-factor method. Results will contain '
-                        'no correction for absorption.')
+                        raise ValueError(
+                            'Thickness is required for absorption '
+                            'correction with k-factor method. Results will contain '
+                            'no correction for absorption.'
+                        )
 
             elif method == 'zeta':
                 composition.data = results[0] * 100

--- a/hyperspy/_signals/lazy.py
+++ b/hyperspy/_signals/lazy.py
@@ -902,7 +902,7 @@ class LazySignal(BaseSignal):
                     if len(this_data):
                         thedata = np.concatenate(this_data, axis=0)
                         method(thedata)
-                except KeyboardInterrupt:
+                except KeyboardInterrupt:  # pragma: no cover
                     pass
 
             # GET ALREADY CALCULATED RESULTS
@@ -952,7 +952,7 @@ class LazySignal(BaseSignal):
                 try:
                     for thing in progressbar(_map, total=nblocks, desc="Project"):
                         H.append(thing)
-                except KeyboardInterrupt:
+                except KeyboardInterrupt:  # pragma: no cover
                     pass
                 loadings = post(H)
 

--- a/hyperspy/axes.py
+++ b/hyperspy/axes.py
@@ -646,7 +646,7 @@ def serpentine_iter(shape):
                 idx[j] += drc[j]
                 break
             drc[j] *= -1
-        else:
+        else:  # pragma: no cover
             break
 
 @add_gui_method(toolkey="hyperspy.AxesManager")

--- a/hyperspy/learn/mlpca.py
+++ b/hyperspy/learn/mlpca.py
@@ -119,7 +119,7 @@ def mlpca(
 
     # Loop for alternating least squares
     _logger.info("Optimization iteration loop")
-    for itr in range(max_iter):
+    for itr in range(max_iter):  # pragma: no branch
         s_obj = 0.0
 
         for i in range(n):

--- a/hyperspy/learn/orthomax.py
+++ b/hyperspy/learn/orthomax.py
@@ -66,7 +66,7 @@ def orthomax(A, gamma=1.0, tol=1.4901e-07, max_iter=256):
 
         while not converged:
             S = 0.0
-            for _ in range(max_iter):
+            for _ in range(max_iter):  # pragma: no branch
                 Sold = S
                 Bsq = B ** 2
                 U, S, V = svd(
@@ -86,7 +86,7 @@ def orthomax(A, gamma=1.0, tol=1.4901e-07, max_iter=256):
         # someone with more knowledge can either fix
         # or remove this?
         # Use a sequence of bivariate rotations
-        for _ in range(max_iter):
+        for _ in range(max_iter):  # pragma: no branch
             maxTheta = 0.0
 
             for i in range(m - 1):

--- a/hyperspy/learn/svd_pca.py
+++ b/hyperspy/learn/svd_pca.py
@@ -145,14 +145,15 @@ def svd_solve(
             svd_solver = "full"
 
     if svd_solver == "randomized":
-        if not sklearn_installed:
+        if not sklearn_installed:  # pragma: no cover
             raise ImportError(
                 "svd_solver='randomized' requires scikit-learn to be installed"
             )
         U, S, V = randomized_svd(data, n_components=output_dimension, **kwargs)
     elif svd_solver == "arpack":
-        if LooseVersion(scipy.__version__) < LooseVersion("1.4.0"):
+        if LooseVersion(scipy.__version__) < LooseVersion("1.4.0"):  # pragma: no cover
             raise ValueError('`svd_solver="arpack"` requires scipy >= 1.4.0')
+
         if output_dimension >= min(m, n):
             raise ValueError(
                 "svd_solver='arpack' requires output_dimension "

--- a/hyperspy/samfire.py
+++ b/hyperspy/samfire.py
@@ -258,7 +258,7 @@ class Samfire:
                     # last one just finished running
                     break
                 self.change_strategy(self._active_strategy_ind + 1)
-        except KeyboardInterrupt:
+        except KeyboardInterrupt:  # pragma: no cover
             if self.pool is not None:
                 _logger.warning(
                     'Collecting already started pixels, please wait')

--- a/hyperspy/signal.py
+++ b/hyperspy/signal.py
@@ -3404,7 +3404,8 @@ class BaseSignal(FancySlicing,
         if self.axes_manager.navigation_size < 2:
             while True:
                 yield self()
-            return
+            return  # pragma: no cover
+
         self._make_sure_data_is_contiguous()
         axes = [axis.index_in_array for
                 axis in self.axes_manager.signal_axes]
@@ -3430,8 +3431,7 @@ class BaseSignal(FancySlicing,
             getitem[unfolded_axis] = i
             yield(data[tuple(getitem)])
             i += 1
-            if i == Ni:
-                i = 0
+            i = 0 if i == Ni else i
 
     def _remove_axis(self, axes):
         am = self.axes_manager

--- a/hyperspy/tests/axes/test_conversion_units.py
+++ b/hyperspy/tests/axes/test_conversion_units.py
@@ -16,7 +16,7 @@
 # You should have received a copy of the GNU General Public License
 # along with  HyperSpy.  If not, see <http://www.gnu.org/licenses/>.
 
-import numpy.testing as nt
+import numpy as np
 import pytest
 import traits.api as t
 
@@ -62,65 +62,65 @@ class TestUnitConversion:
                 category=UserWarning):
             self.uc._convert_compact_units()
         assert self.uc.units == 'toto'
-        nt.assert_almost_equal(self.uc.scale, 1.0E-3)
+        np.testing.assert_almost_equal(self.uc.scale, 1.0E-3)
 
     def test_convert_to_units(self):
         self._set_units_scale_size(t.Undefined, 1.0)
         out = self.uc._convert_units('nm')
         assert out is None
         assert self.uc.units == t.Undefined
-        nt.assert_almost_equal(self.uc.scale, 1.0)
+        np.testing.assert_almost_equal(self.uc.scale, 1.0)
 
         self._set_units_scale_size('m', 1.0E-3)
         out = self.uc._convert_units('µm')
         assert out is None
         assert self.uc.units == 'µm'
-        nt.assert_almost_equal(self.uc.scale, 1E3)
+        np.testing.assert_almost_equal(self.uc.scale, 1E3)
 
         self._set_units_scale_size('µm', 0.5)
         out = self.uc._convert_units('nm')
         assert out is None
         assert self.uc.units == 'nm'
-        nt.assert_almost_equal(self.uc.scale, 500)
+        np.testing.assert_almost_equal(self.uc.scale, 500)
 
         self._set_units_scale_size('µm', 5)
         out = self.uc._convert_units('cm')
         assert out is None
         assert self.uc.units == 'cm'
-        nt.assert_almost_equal(self.uc.scale, 0.0005)
+        np.testing.assert_almost_equal(self.uc.scale, 0.0005)
 
         self._set_units_scale_size('1/µm', 5)
         out = self.uc._convert_units('1/nm')
         assert out is None
         assert self.uc.units == '1 / nm'
-        nt.assert_almost_equal(self.uc.scale, 0.005)
+        np.testing.assert_almost_equal(self.uc.scale, 0.005)
 
         self._set_units_scale_size('eV', 5)
         out = self.uc._convert_units('keV')
         assert out is None
         assert self.uc.units == 'keV'
-        nt.assert_almost_equal(self.uc.scale, 0.005)
+        np.testing.assert_almost_equal(self.uc.scale, 0.005)
 
     def test_convert_to_units_not_in_place(self):
         self._set_units_scale_size(t.Undefined, 1.0)
         out = self.uc.convert_to_units('nm', inplace=False)
         assert out is None  # unit conversion is ignored
         assert self.uc.units == t.Undefined
-        nt.assert_almost_equal(self.uc.scale, 1.0)
+        np.testing.assert_almost_equal(self.uc.scale, 1.0)
 
         self._set_units_scale_size('m', 1.0E-3)
         out = self.uc.convert_to_units('µm', inplace=False)
         assert out == (1E3, 0.0, 'µm')
         assert self.uc.units == 'm'
-        nt.assert_almost_equal(self.uc.scale, 1.0E-3)
-        nt.assert_almost_equal(self.uc.offset, 0.0)
+        np.testing.assert_almost_equal(self.uc.scale, 1.0E-3)
+        np.testing.assert_almost_equal(self.uc.offset, 0.0)
 
         self._set_units_scale_size('µm', 0.5)
         out = self.uc.convert_to_units('nm', inplace=False)
         assert out[1:] == (0.0, 'nm')
-        nt.assert_almost_equal(out[0], 500.0)
+        np.testing.assert_almost_equal(out[0], 500.0)
         assert self.uc.units == 'µm'
-        nt.assert_almost_equal(self.uc.scale, 0.5)
+        np.testing.assert_almost_equal(self.uc.scale, 0.5)
 
     def test_get_compact_unit(self):
         ##### Imaging #####
@@ -128,56 +128,56 @@ class TestUnitConversion:
         self._set_units_scale_size('m', 12E-12, 2048, 2E-9)
         self.uc._convert_compact_units()
         assert self.uc.units == 'nm'
-        nt.assert_almost_equal(self.uc.scale, 0.012)
-        nt.assert_almost_equal(self.uc.offset, 2.0)
+        np.testing.assert_almost_equal(self.uc.scale, 0.012)
+        np.testing.assert_almost_equal(self.uc.offset, 2.0)
 
         # typical setting for nm resolution image
         self._set_units_scale_size('m', 0.5E-9, 1024)
         self.uc._convert_compact_units()
         assert self.uc.units == 'nm'
-        nt.assert_almost_equal(self.uc.scale, 0.5)
-        nt.assert_almost_equal(self.uc.offset, 0.0)
+        np.testing.assert_almost_equal(self.uc.scale, 0.5)
+        np.testing.assert_almost_equal(self.uc.offset, 0.0)
 
         ##### Diffraction #####
         # typical TEM diffraction
         self._set_units_scale_size('1/m', 0.1E9, 1024)
         self.uc._convert_compact_units()
         assert self.uc.units == '1 / nm'
-        nt.assert_almost_equal(self.uc.scale, 0.1)
+        np.testing.assert_almost_equal(self.uc.scale, 0.1)
 
         # typical TEM diffraction
         self._set_units_scale_size('1/m', 0.01E9, 256)
         self.uc._convert_compact_units()
         assert self.uc.units == '1 / µm'
-        nt.assert_almost_equal(self.uc.scale, 10.0)
+        np.testing.assert_almost_equal(self.uc.scale, 10.0)
 
         # high camera length diffraction
         self._set_units_scale_size('1/m', 0.1E9, 4096)
         self.uc._convert_compact_units()
         assert self.uc.units == '1 / nm'
-        nt.assert_almost_equal(self.uc.scale, 0.1)
+        np.testing.assert_almost_equal(self.uc.scale, 0.1)
 
         # typical EDS resolution
         self._set_units_scale_size('eV', 50, 4096, 0.0)
         self.uc._convert_compact_units()
         assert self.uc.units == 'keV'
-        nt.assert_almost_equal(self.uc.scale, 0.05)
-        nt.assert_almost_equal(self.uc.offset, 0.0)
+        np.testing.assert_almost_equal(self.uc.scale, 0.05)
+        np.testing.assert_almost_equal(self.uc.offset, 0.0)
 
         ##### Spectroscopy #####
         # typical EELS resolution
         self._set_units_scale_size('eV', 0.2, 2048, 200.0)
         self.uc._convert_compact_units()
         assert self.uc.units == 'eV'
-        nt.assert_almost_equal(self.uc.scale, 0.2)
-        nt.assert_almost_equal(self.uc.offset, 200.0)
+        np.testing.assert_almost_equal(self.uc.scale, 0.2)
+        np.testing.assert_almost_equal(self.uc.offset, 200.0)
 
         # typical EELS resolution
         self._set_units_scale_size('eV', 1.0, 2048, 500.0)
         self.uc._convert_compact_units()
         assert self.uc.units == 'eV'
-        nt.assert_almost_equal(self.uc.scale, 1.0)
-        nt.assert_almost_equal(self.uc.offset, 500)
+        np.testing.assert_almost_equal(self.uc.scale, 1.0)
+        np.testing.assert_almost_equal(self.uc.offset, 500)
 
         # typical high resolution EELS resolution
         self._set_units_scale_size('eV', 0.05, 100)
@@ -198,17 +198,17 @@ class TestDataAxis:
     def test_scale_as_quantity_setter_string(self):
         self.axis.scale_as_quantity = '2.5 nm'
         assert self.axis.scale == 2.5
-        nt.assert_almost_equal(self.axis.offset, 5.0)
+        np.testing.assert_almost_equal(self.axis.offset, 5.0)
         assert self.axis.units == 'nm'
         # Test that the axis array has been recomputed
-        nt.assert_almost_equal(self.axis.axis[1], 7.5)
+        np.testing.assert_almost_equal(self.axis.axis[1], 7.5)
 
     def test_scale_as_quantity_setter_string_no_previous_units(self):
         axis = DataAxis(size=2048, scale=12E-12, offset=5.0)
         axis.scale_as_quantity = '2.5 nm'
         assert axis.scale == 2.5
         # the units haven't been set previously, so the offset is not converted
-        nt.assert_almost_equal(axis.offset, 5.0)
+        np.testing.assert_almost_equal(axis.offset, 5.0)
         assert axis.units == 'nm'
 
     def test_offset_as_quantity_setter_string(self):
@@ -239,15 +239,15 @@ class TestDataAxis:
 
     def test_convert_to_compact_units(self):
         self.axis.convert_to_units(units=None)
-        nt.assert_almost_equal(self.axis.scale, 0.012)
+        np.testing.assert_almost_equal(self.axis.scale, 0.012)
         assert self.axis.units == 'nm'
-        nt.assert_almost_equal(self.axis.offset, 5.0)
+        np.testing.assert_almost_equal(self.axis.offset, 5.0)
 
     def test_convert_to_units(self):
         self.axis.convert_to_units(units='µm')
-        nt.assert_almost_equal(self.axis.scale, 12E-6)
+        np.testing.assert_almost_equal(self.axis.scale, 12E-6)
         assert self.axis.units == 'µm'
-        nt.assert_almost_equal(self.axis.offset, 0.005)
+        np.testing.assert_almost_equal(self.axis.offset, 0.005)
 
     def test_units_not_supported_by_pint_warning_raised(self):
         # raising a warning, not converting scale
@@ -256,7 +256,7 @@ class TestDataAxis:
                 message="not supported for conversion.",
                 category=UserWarning):
             self.axis.convert_to_units('m')
-        nt.assert_almost_equal(self.axis.scale, 12E-12)
+        np.testing.assert_almost_equal(self.axis.scale, 12E-12)
         assert self.axis.units == 'toto'
 
     def test_units_not_supported_by_pint_warning_raised2(self):
@@ -266,7 +266,7 @@ class TestDataAxis:
                 message="not supported for conversion.",
                 category=UserWarning):
             self.axis.convert_to_units('toto')
-        nt.assert_almost_equal(self.axis.scale, 12E-12)
+        np.testing.assert_almost_equal(self.axis.scale, 12E-12)
         assert self.axis.units == 'µm'
 
 
@@ -319,56 +319,56 @@ class TestAxesManager:
     def test_compact_unit(self):
         self.am.convert_units()
         assert self.am['x'].units == 'nm'
-        nt.assert_almost_equal(self.am['x'].scale, 1.5)
+        np.testing.assert_almost_equal(self.am['x'].scale, 1.5)
         assert self.am['y'].units == 'nm'
-        nt.assert_almost_equal(self.am['y'].scale, 0.5)
+        np.testing.assert_almost_equal(self.am['y'].scale, 0.5)
         assert self.am['energy'].units == 'keV'
-        nt.assert_almost_equal(self.am['energy'].scale, 0.005)
+        np.testing.assert_almost_equal(self.am['energy'].scale, 0.005)
 
     def test_convert_to_navigation_units(self):
         self.am.convert_units(axes='navigation', units='mm')
-        nt.assert_almost_equal(self.am['x'].scale, 1.5E-6)
+        np.testing.assert_almost_equal(self.am['x'].scale, 1.5E-6)
         assert self.am['x'].units == 'mm'
-        nt.assert_almost_equal(self.am['y'].scale, 0.5E-6)
+        np.testing.assert_almost_equal(self.am['y'].scale, 0.5E-6)
         assert self.am['y'].units == 'mm'
-        nt.assert_almost_equal(self.am['energy'].scale,
+        np.testing.assert_almost_equal(self.am['energy'].scale,
                                self.axes_list[-1]['scale'])
 
     def test_convert_units_axes_integer(self):
         # convert only the first axis
         self.am.convert_units(axes=0, units='nm', same_units=False)
-        nt.assert_almost_equal(self.am[0].scale, 0.5)
+        np.testing.assert_almost_equal(self.am[0].scale, 0.5)
         assert self.am[0].units == 'nm'
-        nt.assert_almost_equal(self.am['x'].scale, 1.5E-9)
+        np.testing.assert_almost_equal(self.am['x'].scale, 1.5E-9)
         assert self.am['x'].units == 'm'
-        nt.assert_almost_equal(self.am['energy'].scale,
+        np.testing.assert_almost_equal(self.am['energy'].scale,
                                self.axes_list[-1]['scale'])
 
         self.am.convert_units(axes=0, units='nm', same_units=True)
-        nt.assert_almost_equal(self.am[0].scale, 0.5)
+        np.testing.assert_almost_equal(self.am[0].scale, 0.5)
         assert self.am[0].units == 'nm'
-        nt.assert_almost_equal(self.am['x'].scale, 1.5)
+        np.testing.assert_almost_equal(self.am['x'].scale, 1.5)
         assert self.am['x'].units == 'nm'
 
     def test_convert_to_navigation_units_list(self):
         self.am.convert_units(axes='navigation', units=['mm', 'nm'],
                               same_units=False)
-        nt.assert_almost_equal(self.am['x'].scale, 1.5)
+        np.testing.assert_almost_equal(self.am['x'].scale, 1.5)
         assert self.am['x'].units == 'nm'
-        nt.assert_almost_equal(self.am['y'].scale, 0.5E-6)
+        np.testing.assert_almost_equal(self.am['y'].scale, 0.5E-6)
         assert self.am['y'].units == 'mm'
-        nt.assert_almost_equal(self.am['energy'].scale,
+        np.testing.assert_almost_equal(self.am['energy'].scale,
                                self.axes_list[-1]['scale'])
 
     def test_convert_to_navigation_units_list_same_units(self):
         self.am.convert_units(axes='navigation', units=['mm', 'nm'],
                               same_units=True)
         assert self.am['x'].units == 'mm'
-        nt.assert_almost_equal(self.am['x'].scale, 1.5e-6)
+        np.testing.assert_almost_equal(self.am['x'].scale, 1.5e-6)
         assert self.am['y'].units == 'mm'
-        nt.assert_almost_equal(self.am['y'].scale, 0.5e-6)
+        np.testing.assert_almost_equal(self.am['y'].scale, 0.5e-6)
         assert self.am['energy'].units == 'eV'
-        nt.assert_almost_equal(self.am['energy'].scale, 5)
+        np.testing.assert_almost_equal(self.am['energy'].scale, 5)
 
     def test_convert_to_navigation_units_different(self):
         # Don't convert the units since the units of the navigation axes are
@@ -383,61 +383,61 @@ class TestAxesManager:
         am = AxesManager(self.axes_list)
         am.convert_units(axes='navigation', same_units=True)
         assert am['time'].units == 's'
-        nt.assert_almost_equal(am['time'].scale, 1.5)
+        np.testing.assert_almost_equal(am['time'].scale, 1.5)
         assert am['x'].units == 'nm'
-        nt.assert_almost_equal(am['x'].scale, 1.5)
+        np.testing.assert_almost_equal(am['x'].scale, 1.5)
         assert am['y'].units == 'nm'
-        nt.assert_almost_equal(am['y'].scale, 0.5)
+        np.testing.assert_almost_equal(am['y'].scale, 0.5)
         assert am['energy'].units == 'eV'
-        nt.assert_almost_equal(am['energy'].scale, 5)
+        np.testing.assert_almost_equal(am['energy'].scale, 5)
 
     def test_convert_to_navigation_units_Undefined(self):
         self.axes_list[0]['units'] = t.Undefined
         am = AxesManager(self.axes_list)
         am.convert_units(axes='navigation', same_units=True)
         assert am['x'].units == t.Undefined
-        nt.assert_almost_equal(am['x'].scale, 1.5E-9)
+        np.testing.assert_almost_equal(am['x'].scale, 1.5E-9)
         assert am['y'].units == 'm'
-        nt.assert_almost_equal(am['y'].scale, 0.5E-9)
+        np.testing.assert_almost_equal(am['y'].scale, 0.5E-9)
         assert am['energy'].units == 'eV'
-        nt.assert_almost_equal(am['energy'].scale, 5)
+        np.testing.assert_almost_equal(am['energy'].scale, 5)
 
     def test_convert_to_signal_units(self):
         self.am.convert_units(axes='signal', units='keV')
-        nt.assert_almost_equal(self.am['x'].scale, self.axes_list[0]['scale'])
+        np.testing.assert_almost_equal(self.am['x'].scale, self.axes_list[0]['scale'])
         assert self.am['x'].units == self.axes_list[0]['units']
-        nt.assert_almost_equal(self.am['y'].scale, self.axes_list[1]['scale'])
+        np.testing.assert_almost_equal(self.am['y'].scale, self.axes_list[1]['scale'])
         assert self.am['y'].units == self.axes_list[1]['units']
-        nt.assert_almost_equal(self.am['energy'].scale, 0.005)
+        np.testing.assert_almost_equal(self.am['energy'].scale, 0.005)
         assert self.am['energy'].units == 'keV'
 
     def test_convert_to_units_list(self):
         self.am.convert_units(units=['µm', 'nm', 'meV'], same_units=False)
-        nt.assert_almost_equal(self.am['x'].scale, 1.5)
+        np.testing.assert_almost_equal(self.am['x'].scale, 1.5)
         assert self.am['x'].units == 'nm'
-        nt.assert_almost_equal(self.am['y'].scale, 0.5E-3)
+        np.testing.assert_almost_equal(self.am['y'].scale, 0.5E-3)
         assert self.am['y'].units == 'µm'
-        nt.assert_almost_equal(self.am['energy'].scale, 5E3)
+        np.testing.assert_almost_equal(self.am['energy'].scale, 5E3)
         assert self.am['energy'].units == 'meV'
 
     def test_convert_to_units_list_same_units(self):
         self.am2.convert_units(units=['µm', 'eV', 'meV'], same_units=True)
-        nt.assert_almost_equal(self.am2['x'].scale, 0.0015)
+        np.testing.assert_almost_equal(self.am2['x'].scale, 0.0015)
         assert self.am2['x'].units == 'µm'
-        nt.assert_almost_equal(self.am2['energy'].scale,
+        np.testing.assert_almost_equal(self.am2['energy'].scale,
                                self.axes_list2[1]['scale'])
         assert self.am2['energy'].units == self.axes_list2[1]['units']
-        nt.assert_almost_equal(self.am2['energy2'].scale,
+        np.testing.assert_almost_equal(self.am2['energy2'].scale,
                                self.axes_list2[2]['scale'])
         assert self.am2['energy2'].units == self.axes_list2[2]['units']
 
     def test_convert_to_units_list_signal2D(self):
         self.am2.convert_units(units=['µm', 'eV', 'meV'], same_units=False)
-        nt.assert_almost_equal(self.am2['x'].scale, 0.0015)
+        np.testing.assert_almost_equal(self.am2['x'].scale, 0.0015)
         assert self.am2['x'].units == 'µm'
-        nt.assert_almost_equal(self.am2['energy'].scale, 2500)
+        np.testing.assert_almost_equal(self.am2['energy'].scale, 2500)
         assert self.am2['energy'].units == 'meV'
-        nt.assert_almost_equal(self.am2['energy2'].scale, 5.0)
+        np.testing.assert_almost_equal(self.am2['energy2'].scale, 5.0)
         assert self.am2['energy2'].units == 'eV'
 
     @pytest.mark.parametrize("same_units", (True, False))

--- a/hyperspy/tests/component/test_EELSarctan.py
+++ b/hyperspy/tests/component/test_EELSarctan.py
@@ -17,7 +17,6 @@
 # along with  HyperSpy.  If not, see <http://www.gnu.org/licenses/>.
 
 import numpy as np
-from numpy.testing import assert_allclose
 
 from hyperspy.components1d import EELSArctan
 
@@ -27,6 +26,6 @@ def test_function2():
     g.A.value = 10
     g.k.value = 2
     g.x0.value = 1
-    assert_allclose(g.function(0), 4.63647609)
-    assert_allclose(g.function(1), 10*np.pi/2)
-    assert_allclose(g.function(1e4), 10*np.pi,1e-4)
+    np.testing.assert_allclose(g.function(0), 4.63647609)
+    np.testing.assert_allclose(g.function(1), 10*np.pi/2)
+    np.testing.assert_allclose(g.function(1e4), 10*np.pi,1e-4)

--- a/hyperspy/tests/component/test_arctan.py
+++ b/hyperspy/tests/component/test_arctan.py
@@ -16,10 +16,11 @@
 # You should have received a copy of the GNU General Public License
 # along with  HyperSpy.  If not, see <http://www.gnu.org/licenses/>.
 
+import pytest
 import numpy as np
-from numpy.testing import assert_allclose
 
 from hyperspy.components1d import Arctan
+from hyperspy.exceptions import VisibleDeprecationWarning
 
 
 def test_function():
@@ -27,9 +28,9 @@ def test_function():
     g.A.value = 10
     g.k.value = 2
     g.x0.value = 1
-    assert_allclose(g.function(0), -11.07148718)
-    assert_allclose(g.function(1), 0)
-    assert_allclose(g.function(1e4), 10*np.pi/2,1e-4)
+    np.testing.assert_allclose(g.function(0), -11.07148718)
+    np.testing.assert_allclose(g.function(1), 0)
+    np.testing.assert_allclose(g.function(1e4), 10*np.pi/2,1e-4)
 
 # Legacy tests
 def test_function_legacyF():
@@ -37,15 +38,20 @@ def test_function_legacyF():
     g.A.value = 10
     g.k.value = 2
     g.x0.value = 1
-    assert_allclose(g.function(0), -11.07148718)
-    assert_allclose(g.function(1), 0)
-    assert_allclose(g.function(1e4), 10*np.pi/2,1e-4)
+    np.testing.assert_allclose(g.function(0), -11.07148718)
+    np.testing.assert_allclose(g.function(1), 0)
+    np.testing.assert_allclose(g.function(1e4), 10*np.pi/2,1e-4)
 
 def test_function_legacyT():
-    g = Arctan(minimum_at_zero=True)
+    with pytest.warns(
+            VisibleDeprecationWarning,
+            match="component will change in v2.0.",
+        ):
+        g = Arctan(minimum_at_zero=True)
+
     g.A.value = 10
     g.k.value = 2
     g.x0.value = 1
-    assert_allclose(g.function(0), 4.63647609)
-    assert_allclose(g.function(1), 10*np.pi/2)
-    assert_allclose(g.function(1e4), 10*np.pi,1e-4)
+    np.testing.assert_allclose(g.function(0), 4.63647609)
+    np.testing.assert_allclose(g.function(1), 10*np.pi/2)
+    np.testing.assert_allclose(g.function(1e4), 10*np.pi,1e-4)

--- a/hyperspy/tests/component/test_bleasdale.py
+++ b/hyperspy/tests/component/test_bleasdale.py
@@ -17,7 +17,7 @@
 # along with  HyperSpy.  If not, see <http://www.gnu.org/licenses/>.
 
 
-from numpy.testing import assert_allclose
+import numpy as np
 
 from hyperspy.components1d import Bleasdale
 
@@ -30,7 +30,7 @@ def test_function():
     assert g.function(-0.5) == 0
     assert g.function(0) == 1
     assert g.function(12) == 0.2
-    assert_allclose(g.function(-.48),5)
+    np.testing.assert_allclose(g.function(-.48),5)
     assert g.grad_a(0) == -0.5
     assert g.grad_b(0) == 0
     assert g.grad_c(0) == 0

--- a/hyperspy/tests/component/test_components.py
+++ b/hyperspy/tests/component/test_components.py
@@ -21,7 +21,6 @@ import itertools
 
 import numpy as np
 import pytest
-from numpy.testing import assert_allclose
 
 import hyperspy.api as hs
 from hyperspy import components1d
@@ -90,16 +89,16 @@ class TestPowerLaw:
         g.estimate_parameters(s, None, None, only_current=only_current)
         A_value = 1008.4913 if binned else 1006.4378
         r_value = 4.001768 if binned else 4.001752
-        assert_allclose(g.A.value, A_value)
-        assert_allclose(g.r.value, r_value)
+        np.testing.assert_allclose(g.A.value, A_value)
+        np.testing.assert_allclose(g.r.value, r_value)
 
         if only_current:
             A_value, r_value = 0, 0
         # Test that it all works when calling it with a different signal
         s2 = hs.stack((s, s))
         g.estimate_parameters(s2, None, None, only_current=only_current)
-        assert_allclose(g.A.map["values"][1], A_value)
-        assert_allclose(g.r.map["values"][1], r_value)
+        np.testing.assert_allclose(g.A.map["values"][1], A_value)
+        np.testing.assert_allclose(g.r.map["values"][1], r_value)
 
     def test_EDS_missing_data(self):
         g = hs.model.components1D.PowerLaw()
@@ -113,7 +112,7 @@ class TestPowerLaw:
         axis = self.s.axes_manager[0].axis
         for attr in ['function', 'grad_A', 'grad_r', 'grad_origin']:
             values = getattr(pl, attr)((axis))
-            assert_allclose(values[:501], np.zeros((501)))
+            np.testing.assert_allclose(values[:501], np.zeros((501)))
             assert getattr(pl, attr)((axis))[500] == 0
             getattr(pl, attr)((axis))[502] > 0
 
@@ -149,9 +148,9 @@ class TestDoublePowerLaw:
         m = s.create_model()
         m.append(g)
         m.fit_component(g, signal_range=(None, None))
-        assert_allclose(g.A.value, 1000.0)
-        assert_allclose(g.r.value, 4.0)
-        assert_allclose(g.ratio.value, 200.)
+        np.testing.assert_allclose(g.A.value, 1000.0)
+        np.testing.assert_allclose(g.r.value, 4.0)
+        np.testing.assert_allclose(g.ratio.value, 200.)
 
 class TestOffset:
 
@@ -170,7 +169,7 @@ class TestOffset:
         assert s.metadata.Signal.binned == binned
         o = hs.model.components1D.Offset()
         o.estimate_parameters(s, None, None, only_current=only_current)
-        assert_allclose(o.offset.value, 10)
+        np.testing.assert_allclose(o.offset.value, 10)
 
     def test_function_nd(self):
         s = self.m.as_signal(parallel=False)
@@ -178,7 +177,7 @@ class TestOffset:
         o = hs.model.components1D.Offset()
         o.estimate_parameters(s, None, None, only_current=False)
         axis = s.axes_manager.signal_axes[0]
-        assert_allclose(o.function_nd(axis.axis), s.data)
+        np.testing.assert_allclose(o.function_nd(axis.axis), s.data)
 
 
 @pytest.mark.filterwarnings("ignore:The API of the `Polynomial` component")
@@ -216,9 +215,9 @@ class TestDeprecatedPolynomial:
         assert s.metadata.Signal.binned == binned
         g = hs.model.components1D.Polynomial(order=2)
         g.estimate_parameters(s, None, None, only_current=only_current)
-        assert_allclose(g.coefficients.value[0], 0.5)
-        assert_allclose(g.coefficients.value[1], 2)
-        assert_allclose(g.coefficients.value[2], 3)
+        np.testing.assert_allclose(g.coefficients.value[0], 0.5)
+        np.testing.assert_allclose(g.coefficients.value[1], 2)
+        np.testing.assert_allclose(g.coefficients.value[2], 3)
 
     def test_2d_signal(self):
         # This code should run smoothly, any exceptions should trigger failure
@@ -304,9 +303,9 @@ class TestPolynomial:
         s.metadata.Signal.binned = binned
         p = hs.model.components1D.Polynomial(order=2, legacy=False)
         p.estimate_parameters(s, None, None, only_current=only_current)
-        assert_allclose(p.a2.value, 0.5)
-        assert_allclose(p.a1.value, 2)
-        assert_allclose(p.a0.value, 3)
+        np.testing.assert_allclose(p.a2.value, 0.5)
+        np.testing.assert_allclose(p.a1.value, 2)
+        np.testing.assert_allclose(p.a0.value, 3)
 
     def test_zero_order(self):
         m = self.m_offset
@@ -341,7 +340,7 @@ class TestPolynomial:
         p = hs.model.components1D.Polynomial(order=2, legacy=False)
         p.estimate_parameters(s, None, None, only_current=False)
         axis = s.axes_manager.signal_axes[0]
-        assert_allclose(p.function_nd(axis.axis), s.data)
+        np.testing.assert_allclose(p.function_nd(axis.axis), s.data)
 
 
 class TestGaussian:
@@ -364,9 +363,9 @@ class TestGaussian:
         assert s.metadata.Signal.binned == binned
         g = hs.model.components1D.Gaussian()
         g.estimate_parameters(s, None, None, only_current=only_current)
-        assert_allclose(g.sigma.value, 0.5)
-        assert_allclose(g.A.value, 2)
-        assert_allclose(g.centre.value, 1)
+        np.testing.assert_allclose(g.sigma.value, 0.5)
+        np.testing.assert_allclose(g.A.value, 2)
+        np.testing.assert_allclose(g.centre.value, 1)
 
     @pytest.mark.parametrize("binned", (True, False))
     def test_function_nd(self, binned):
@@ -378,7 +377,7 @@ class TestGaussian:
         assert g.binned == binned
         axis = s.axes_manager.signal_axes[0]
         factor = axis.scale if binned else 1
-        assert_allclose(g.function_nd(axis.axis) * factor, s2.data)
+        np.testing.assert_allclose(g.function_nd(axis.axis) * factor, s2.data)
 
 
 class TestExpression:
@@ -403,17 +402,17 @@ class TestExpression:
         assert self.g.function(0) == 1
 
     def test_grad_height(self):
-        assert_allclose(
+        np.testing.assert_allclose(
             self.g.grad_height(2),
             1.5258789062500007e-05)
 
     def test_grad_x0(self):
-        assert_allclose(
+        np.testing.assert_allclose(
             self.g.grad_x0(2),
             0.00016922538587889289)
 
     def test_grad_fwhm(self):
-        assert_allclose(
+        np.testing.assert_allclose(
             self.g.grad_fwhm(2),
             0.00033845077175778578)
 

--- a/hyperspy/tests/component/test_components2D.py
+++ b/hyperspy/tests/component/test_components2D.py
@@ -17,7 +17,6 @@
 # along with  HyperSpy.  If not, see <http://www.gnu.org/licenses/>.
 
 import numpy as np
-from numpy.testing import assert_allclose
 
 import hyperspy.api as hs
 
@@ -43,11 +42,11 @@ class TestGaussian2D:
     def test_values(self):
         gt = self.gt
         g = self.g
-        assert_allclose(g.fwhm_x, 2.35482004503)
-        assert_allclose(g.fwhm_y, 4.70964009006)
-        assert_allclose(gt.max(), 0.0795774715459)
-        assert_allclose(gt.argmax(axis=0)[0], 500)
-        assert_allclose(gt.argmax(axis=1)[0], 500)
+        np.testing.assert_allclose(g.fwhm_x, 2.35482004503)
+        np.testing.assert_allclose(g.fwhm_y, 4.70964009006)
+        np.testing.assert_allclose(gt.max(), 0.0795774715459)
+        np.testing.assert_allclose(gt.argmax(axis=0)[0], 500)
+        np.testing.assert_allclose(gt.argmax(axis=1)[0], 500)
 
 
 class TestExpression2D:
@@ -76,7 +75,7 @@ class TestExpression2D:
         g.y0.value = 1
         l = np.linspace(-2, 2, 5)
         x, y = np.meshgrid(l, l)
-        assert_allclose(
+        np.testing.assert_allclose(
             g.function(x, y),
             np.array([[6.68025544e-06, 8.55249949e-04, 6.49777231e-03,
                        2.92959352e-03, 7.83829650e-05],
@@ -89,7 +88,7 @@ class TestExpression2D:
                       [1.73553850e-07, 4.22437802e-04, 6.10186705e-02,
                        5.23039095e-01, 2.66058420e-01]])
         )
-        assert_allclose(
+        np.testing.assert_allclose(
             g.grad_sx(x, y),
             np.array([[1.20880828e-04, 3.17536657e-03, 1.04030848e-03,
                        2.17878745e-02, 2.00221335e-03],
@@ -115,7 +114,7 @@ class TestExpression2D:
         g.y0.value = 0
         l = np.linspace(-2, 2, 5)
         x, y = np.meshgrid(l, l)
-        assert_allclose(
+        np.testing.assert_allclose(
             g.function(x, y),
             np.array([[1.77220718e-208, 1.97005871e-181, 1.00498099e-181,
                        2.35261319e-209, 2.52730239e-264],
@@ -139,7 +138,7 @@ class TestExpression2D:
         g.y0.value = 0
         l = np.linspace(-2, 2, 5)
         x, y = np.meshgrid(l, l)
-        assert_allclose(
+        np.testing.assert_allclose(
             g.function(x, y),
             np.array([[9.64172248e-175, 5.46609733e-099, 5.03457536e-045,
                        7.53374790e-013, 1.83156389e-002],
@@ -159,7 +158,7 @@ class TestExpression2D:
             sx=.5, sy=.1, x0=0, y0=0, rotation_angle=np.radians(45))
         l = np.linspace(-2, 2, 5)
         x, y = np.meshgrid(l, l)
-        assert_allclose(
+        np.testing.assert_allclose(
             g.function(x, y),
             np.array([[9.64172248e-175, 5.46609733e-099, 5.03457536e-045,
                        7.53374790e-013, 1.83156389e-002],
@@ -184,8 +183,8 @@ class TestExpression2D:
         g.y0.value = 1
         l = np.linspace(-2, 2, 5)
         x, y = np.meshgrid(l, l)
-        assert_allclose(g.function(x, y), self.array0)
-        assert_allclose(
+        np.testing.assert_allclose(g.function(x, y), self.array0)
+        np.testing.assert_allclose(
             g.grad_sx(x, y),
             np.array([[1.21816650e-08, 1.19252902e-04, 1.20275135e-02,
                        0.00000000e+00, 1.20275135e-02],
@@ -211,7 +210,7 @@ class TestExpression2D:
         g.y0.value = 1
         l = np.linspace(-2, 2, 5)
         x, y = np.meshgrid(l, l)
-        assert_allclose(g.function_nd(x, y), self.array0)
+        np.testing.assert_allclose(g.function_nd(x, y), self.array0)
 
     def test_no_function_nd_signal(self):
         g = hs.model.components2D.Expression(
@@ -232,4 +231,4 @@ class TestExpression2D:
         m.multifit(iterpath='serpentine')
         res = g.function_nd(x, y)
         assert res.shape == (2, 3, 3)
-        assert_allclose(res, s2.data)
+        np.testing.assert_allclose(res, s2.data)

--- a/hyperspy/tests/component/test_doniach.py
+++ b/hyperspy/tests/component/test_doniach.py
@@ -17,7 +17,6 @@
 # along with  HyperSpy.  If not, see <http://www.gnu.org/licenses/>.
 
 import numpy as np
-from numpy.testing import assert_allclose
 import pytest
 
 from hyperspy.components1d import Doniach
@@ -33,8 +32,8 @@ def test_function():
     g.sigma.value = 2 / sigma2fwhm
     g.A.value = 3 * sqrt2pi * g.sigma.value
     g.alpha.value = 1.0e-7
-    assert_allclose(g.function(2), 3.151281311482424)
-    assert_allclose(g.function(1), 7.519884823893001)
+    np.testing.assert_allclose(g.function(2), 3.151281311482424)
+    np.testing.assert_allclose(g.function(1), 7.519884823893001)
 
 
 @pytest.mark.parametrize(("lazy"), (True, False))
@@ -55,6 +54,6 @@ def test_estimate_parameters_binned(only_current, binned, lazy):
     assert g2.estimate_parameters(s, axis.low_value, axis.high_value,
                                   only_current=only_current)
     assert g2.binned == binned
-    assert_allclose(g2.sigma.value, 2.331764, 0.01)
-    assert_allclose(g1.A.value, g2.A.value * factor, 0.3)
-    assert_allclose(g2.centre.value, -0.4791825)
+    np.testing.assert_allclose(g2.sigma.value, 2.331764, 0.01)
+    np.testing.assert_allclose(g1.A.value, g2.A.value * factor, 0.3)
+    np.testing.assert_allclose(g2.centre.value, -0.4791825)

--- a/hyperspy/tests/component/test_double_power_law.py
+++ b/hyperspy/tests/component/test_double_power_law.py
@@ -17,7 +17,6 @@
 # along with  HyperSpy.  If not, see <http://www.gnu.org/licenses/>.
 
 import numpy as np
-from numpy.testing import assert_allclose
 
 from hyperspy.components1d import DoublePowerLaw
 
@@ -34,9 +33,9 @@ def test_function():
     assert g.function(-1) == 0
     assert g.function(0) == 0
     assert g.function(2) == 9
-    assert_allclose(g.function(10), 0.15948602)
+    np.testing.assert_allclose(g.function(10), 0.15948602)
     assert g.grad_A(2) == 3
-    assert_allclose(g.grad_r(4), -0.3662041)
+    np.testing.assert_allclose(g.grad_r(4), -0.3662041)
     assert g.grad_origin(2)  == -6
     assert g.grad_shift(2)  == -12
     assert g.grad_ratio(2)  == 3

--- a/hyperspy/tests/component/test_erf.py
+++ b/hyperspy/tests/component/test_erf.py
@@ -21,7 +21,7 @@ from distutils.version import LooseVersion
 
 import pytest
 import sympy
-from numpy.testing import assert_allclose
+import numpy as np
 
 from hyperspy.components1d import Erf
 
@@ -35,5 +35,5 @@ def test_function():
     g.sigma.value = 2
     g.origin.value = 3
     assert g.function(3) == 0.
-    assert_allclose(g.function(15),0.5)
-    assert_allclose(g.function(1.951198),-0.2,rtol=1e-6)
+    np.testing.assert_allclose(g.function(15),0.5)
+    np.testing.assert_allclose(g.function(1.951198),-0.2,rtol=1e-6)

--- a/hyperspy/tests/component/test_exponential.py
+++ b/hyperspy/tests/component/test_exponential.py
@@ -20,7 +20,6 @@ import itertools
 
 import numpy as np
 import pytest
-from numpy.testing import assert_allclose
 
 from hyperspy.components1d import Exponential
 from hyperspy.signals import Signal1D
@@ -36,8 +35,8 @@ def test_function():
 
     test_value = 200.
     test_result = g.A.value * np.exp(-test_value / g.tau.value)
-    assert_allclose(g.function(0.), g.A.value)
-    assert_allclose(g.function(test_value), test_result)
+    np.testing.assert_allclose(g.function(0.), g.A.value)
+    np.testing.assert_allclose(g.function(test_value), test_result)
 
 
 @pytest.mark.parametrize(("lazy"), (True, False))
@@ -57,8 +56,8 @@ def test_estimate_parameters_binned(only_current, binned, lazy):
     assert g2.estimate_parameters(s, axis.low_value, axis.high_value,
                                   only_current=only_current)
     assert g2.binned == binned
-    assert_allclose(g1.A.value, g2.A.value * factor, rtol=0.05)
-    assert_allclose(g1.tau.value, g2.tau.value)
+    np.testing.assert_allclose(g1.A.value, g2.A.value * factor, rtol=0.05)
+    np.testing.assert_allclose(g1.tau.value, g2.tau.value)
 
 
 @pytest.mark.parametrize(("lazy"), (True, False))
@@ -81,4 +80,4 @@ def test_function_nd(binned, lazy):
     g2.estimate_parameters(s2, axis.low_value, axis.high_value, False)
 
     assert g2.binned == binned
-    assert_allclose(g2.function_nd(axis.axis) * factor, s2.data, rtol=0.05)
+    np.testing.assert_allclose(g2.function_nd(axis.axis) * factor, s2.data, rtol=0.05)

--- a/hyperspy/tests/component/test_gaussian.py
+++ b/hyperspy/tests/component/test_gaussian.py
@@ -20,7 +20,6 @@ import itertools
 
 import numpy as np
 import pytest
-from numpy.testing import assert_allclose
 
 from hyperspy.components1d import Gaussian
 from hyperspy.signals import Signal1D
@@ -37,8 +36,8 @@ def test_function():
     g.centre.value = 1
     g.sigma.value = 2 / sigma2fwhm
     g.A.value = 3 * sqrt2pi * g.sigma.value
-    assert_allclose(g.function(2), 1.5)
-    assert_allclose(g.function(1), 3)
+    np.testing.assert_allclose(g.function(2), 1.5)
+    np.testing.assert_allclose(g.function(1), 3)
 
 
 @pytest.mark.parametrize(("lazy"), (True, False))
@@ -58,7 +57,7 @@ def test_estimate_parameters_binned(only_current, binned, lazy):
     assert g2.estimate_parameters(s, axis.low_value, axis.high_value,
                                   only_current=only_current)
     assert g2.binned == binned
-    assert_allclose(g1.A.value, g2.A.value * factor)
+    np.testing.assert_allclose(g1.A.value, g2.A.value * factor)
     assert abs(g2.centre.value - g1.centre.value) <= 1e-3
     assert abs(g2.sigma.value - g1.sigma.value) <= 0.1
 
@@ -80,39 +79,39 @@ def test_function_nd(binned, lazy):
     factor = axis.scale if binned else 1
     g2.estimate_parameters(s2, axis.low_value, axis.high_value, False)
     assert g2.binned == binned
-    assert_allclose(g2.function_nd(axis.axis) * factor, s2.data)
+    np.testing.assert_allclose(g2.function_nd(axis.axis) * factor, s2.data)
 
 
 def test_util_fwhm_set():
     g1 = Gaussian()
     g1.fwhm = 1.0
-    assert_allclose(g1.sigma.value, 1.0 / sigma2fwhm)
+    np.testing.assert_allclose(g1.sigma.value, 1.0 / sigma2fwhm)
 
 
 def test_util_fwhm_get():
     g1 = Gaussian()
     g1.sigma.value = 1.0
-    assert_allclose(g1.fwhm, 1.0 * sigma2fwhm)
+    np.testing.assert_allclose(g1.fwhm, 1.0 * sigma2fwhm)
 
 
 def test_util_fwhm_getset():
     g1 = Gaussian()
     g1.fwhm = 1.0
-    assert_allclose(g1.fwhm, 1.0)
+    np.testing.assert_allclose(g1.fwhm, 1.0)
 
 def test_util_height_set():
     g1 = Gaussian()
     g1.sigma.value = 3.0
     g1.height = 2.0/sqrt2pi
-    assert_allclose(g1.A.value, 6)
+    np.testing.assert_allclose(g1.A.value, 6)
 
 def test_util_height_get():
     g1 = Gaussian()
     g1.sigma.value = 4.0
     g1.A.value = sqrt2pi*8
-    assert_allclose(g1.height, 2)
+    np.testing.assert_allclose(g1.height, 2)
 
 def test_util_height_getset():
     g1 = Gaussian()
     g1.height = 4.0
-    assert_allclose(g1.height, 4.0)
+    np.testing.assert_allclose(g1.height, 4.0)

--- a/hyperspy/tests/component/test_gaussian2d.py
+++ b/hyperspy/tests/component/test_gaussian2d.py
@@ -19,7 +19,6 @@
 import math
 
 import numpy as np
-from numpy.testing import assert_allclose
 
 from hyperspy.components2d import Gaussian2D
 
@@ -33,8 +32,8 @@ def test_function():
     g.sigma_y.value = 2.
     g.centre_x.value = -5.
     g.centre_y.value = -5.
-    assert_allclose(g.function(-5, -5), 1.1140846)
-    assert_allclose(g.function(-2, -3), 0.007506643)
+    np.testing.assert_allclose(g.function(-5, -5), 1.1140846)
+    np.testing.assert_allclose(g.function(-2, -3), 0.007506643)
     assert g._is2D
     assert g._position_x == g.centre_x
     assert g._position_y == g.centre_y
@@ -45,15 +44,15 @@ def test_util_fwhm_set():
     g1.fwhm_x = 0.33
     g1.fwhm_y = 0.33
     g1.A.value = 1.0
-    assert_allclose(g1.fwhm_x, g1.sigma_x.value * sigma2fwhm)
-    assert_allclose(g1.fwhm_y, g1.sigma_y.value * sigma2fwhm)
+    np.testing.assert_allclose(g1.fwhm_x, g1.sigma_x.value * sigma2fwhm)
+    np.testing.assert_allclose(g1.fwhm_y, g1.sigma_y.value * sigma2fwhm)
 
 
 def test_util_fwhm_get():
     g1 = Gaussian2D(sigma_x=0.33, sigma_y=0.33)
     g1.A.value = 1.0
-    assert_allclose(g1.fwhm_x, g1.sigma_x.value * sigma2fwhm)
-    assert_allclose(g1.fwhm_y, g1.sigma_y.value * sigma2fwhm)
+    np.testing.assert_allclose(g1.fwhm_x, g1.sigma_x.value * sigma2fwhm)
+    np.testing.assert_allclose(g1.fwhm_y, g1.sigma_y.value * sigma2fwhm)
 
 
 def test_util_fwhm_getset():
@@ -68,11 +67,11 @@ def test_properties():
     g = Gaussian2D(add_rotation=True)
     angle = np.radians(20)
     g.rotation_angle.value = angle
-    assert_allclose(g.rotation_angle_wrapped, angle)
+    np.testing.assert_allclose(g.rotation_angle_wrapped, angle)
 
     angle = np.radians(380)
     g.rotation_angle.value = angle
-    assert_allclose(g.rotation_angle_wrapped, math.fmod(angle, 2 * np.pi))
+    np.testing.assert_allclose(g.rotation_angle_wrapped, math.fmod(angle, 2 * np.pi))
 
     g = Gaussian2D(add_rotation=True)
     g.sigma_x.value = 0.5
@@ -83,8 +82,8 @@ def test_properties():
     assert g.sigma_minor == 0.1
     angle = np.radians(20)
     g.rotation_angle.value = angle
-    assert_allclose(g.rotation_angle_wrapped, angle)
-    assert_allclose(g.rotation_major_axis, angle)
+    np.testing.assert_allclose(g.rotation_angle_wrapped, angle)
+    np.testing.assert_allclose(g.rotation_major_axis, angle)
 
     g = Gaussian2D(add_rotation=True)
     g.sigma_x.value = 0.1
@@ -95,5 +94,5 @@ def test_properties():
     assert g.sigma_minor == 0.1
     angle = np.radians(20)
     g.rotation_angle.value = angle
-    assert_allclose(g.rotation_angle_wrapped, angle)
-    assert_allclose(g.rotation_major_axis, angle - np.pi / 2)
+    np.testing.assert_allclose(g.rotation_angle_wrapped, angle)
+    np.testing.assert_allclose(g.rotation_major_axis, angle - np.pi / 2)

--- a/hyperspy/tests/component/test_gaussianhf.py
+++ b/hyperspy/tests/component/test_gaussianhf.py
@@ -20,7 +20,6 @@ import itertools
 
 import numpy as np
 import pytest
-from numpy.testing import assert_allclose
 
 from hyperspy.components1d import GaussianHF
 from hyperspy.signals import Signal1D
@@ -55,7 +54,7 @@ def test_integral_as_signal():
     m.multifit(iterpath='serpentine')
     s_out = g2.integral_as_signal()
     ref = (h_ref * 3.33 * sqrt2pi / sigma2fwhm).reshape(s_out.data.shape)
-    assert_allclose(s_out.data, ref)
+    np.testing.assert_allclose(s_out.data, ref)
 
 @pytest.mark.parametrize(("only_current", "binned"), TRUE_FALSE_2_TUPLE)
 def test_estimate_parameters_binned(only_current, binned):
@@ -71,7 +70,7 @@ def test_estimate_parameters_binned(only_current, binned):
     assert g2.estimate_parameters(s, axis.low_value, axis.high_value,
                                   only_current=only_current)
     assert g2.binned == binned
-    assert_allclose(g1.height.value, g2.height.value * factor)
+    np.testing.assert_allclose(g1.height.value, g2.height.value * factor)
     assert abs(g2.centre.value - g1.centre.value) <= 1e-3
     assert abs(g2.fwhm.value - g1.fwhm.value) <= 0.1
 
@@ -91,35 +90,35 @@ def test_function_nd(binned):
     g2.estimate_parameters(s2, axis.low_value, axis.high_value, False)
     assert g2.binned == binned
     # TODO: sort out while the rtol to be so high...
-    assert_allclose(g2.function_nd(axis.axis) * factor, s2.data, rtol=0.05)
+    np.testing.assert_allclose(g2.function_nd(axis.axis) * factor, s2.data, rtol=0.05)
 
 def test_util_sigma_set():
     g1 = GaussianHF()
     g1.sigma = 1.0
-    assert_allclose(g1.fwhm.value, 1.0 * sigma2fwhm)
+    np.testing.assert_allclose(g1.fwhm.value, 1.0 * sigma2fwhm)
 
 def test_util_sigma_get():
     g1 = GaussianHF()
     g1.fwhm.value = 1.0
-    assert_allclose(g1.sigma, 1.0 / sigma2fwhm)
+    np.testing.assert_allclose(g1.sigma, 1.0 / sigma2fwhm)
 
 def test_util_sigma_getset():
     g1 = GaussianHF()
     g1.sigma = 1.0
-    assert_allclose(g1.sigma, 1.0)
+    np.testing.assert_allclose(g1.sigma, 1.0)
 
 def test_util_fwhm_set():
     g1 = GaussianHF(fwhm=0.33)
     g1.A = 1.0
-    assert_allclose(g1.height.value, 1.0 * sigma2fwhm / (
+    np.testing.assert_allclose(g1.height.value, 1.0 * sigma2fwhm / (
                     0.33 * sqrt2pi))
 
 def test_util_fwhm_get():
     g1 = GaussianHF(fwhm=0.33)
     g1.height.value = 1.0
-    assert_allclose(g1.A, 1.0 * sqrt2pi * 0.33 / sigma2fwhm)
+    np.testing.assert_allclose(g1.A, 1.0 * sqrt2pi * 0.33 / sigma2fwhm)
 
 def test_util_fwhm_getset():
     g1 = GaussianHF(fwhm=0.33)
     g1.A = 1.0
-    assert_allclose(g1.A, 1.0)
+    np.testing.assert_allclose(g1.A, 1.0)

--- a/hyperspy/tests/component/test_logistic.py
+++ b/hyperspy/tests/component/test_logistic.py
@@ -16,7 +16,7 @@
 # You should have received a copy of the GNU General Public License
 # along with  HyperSpy.  If not, see <http://www.gnu.org/licenses/>.
 
-from numpy.testing import assert_allclose
+import numpy as np
 
 from hyperspy.components1d import Logistic
 
@@ -27,6 +27,6 @@ def test_function():
     g.b.value = 2
     g.c.value = 3
     g.origin.value = 4
-    assert_allclose(g.function(10), 1)
-    assert_allclose(g.function(4), 1/3)
-    assert_allclose(g.function(0), 3.07209674e-06)
+    np.testing.assert_allclose(g.function(10), 1)
+    np.testing.assert_allclose(g.function(4), 1/3)
+    np.testing.assert_allclose(g.function(0), 3.07209674e-06)

--- a/hyperspy/tests/component/test_lorentzian.py
+++ b/hyperspy/tests/component/test_lorentzian.py
@@ -20,7 +20,6 @@ import itertools
 
 import numpy as np
 import pytest
-from numpy.testing import assert_allclose
 
 from hyperspy.components1d import Lorentzian
 from hyperspy.signals import Signal1D
@@ -34,8 +33,8 @@ def test_function():
     g.A.value = 1.5 * np.pi
     g.gamma.value = 1
     g.centre.value = 2
-    assert_allclose(g.function(2), 1.5)
-    assert_allclose(g.function(4), 0.3)
+    np.testing.assert_allclose(g.function(2), 1.5)
+    np.testing.assert_allclose(g.function(4), 0.3)
 
 
 @pytest.mark.parametrize(("lazy"), (True, False))
@@ -55,7 +54,7 @@ def test_estimate_parameters_binned(only_current, binned, lazy):
     assert g2.estimate_parameters(s, axis.low_value, axis.high_value,
                                   only_current=only_current)
     assert g2.binned == binned
-    assert_allclose(g1.A.value, g2.A.value * factor,0.1)
+    np.testing.assert_allclose(g1.A.value, g2.A.value * factor,0.1)
     assert abs(g2.centre.value - g1.centre.value) <= 0.2
     assert abs(g2.gamma.value - g1.gamma.value) <= 0.1
 
@@ -77,48 +76,48 @@ def test_function_nd(binned, lazy):
     factor = axis.scale if binned else 1
     g2.estimate_parameters(s2, axis.low_value, axis.high_value, False)
     assert g2.binned == binned
-    assert_allclose(g2.function_nd(axis.axis) * factor, s2.data,0.16)
+    np.testing.assert_allclose(g2.function_nd(axis.axis) * factor, s2.data,0.16)
 
 
 def test_util_gamma_getset():
     g1 = Lorentzian()
     g1.gamma.value = 3.0
-    assert_allclose(g1.gamma.value, 3.0)
+    np.testing.assert_allclose(g1.gamma.value, 3.0)
 
 
 def test_util_fwhm_set():
     g1 = Lorentzian()
     g1.fwhm = 1.0
-    assert_allclose(g1.gamma.value, 0.5)
+    np.testing.assert_allclose(g1.gamma.value, 0.5)
 
 
 def test_util_fwhm_get():
     g1 = Lorentzian()
     g1.gamma.value = 2.0
-    assert_allclose(g1.fwhm, 4.0)
+    np.testing.assert_allclose(g1.fwhm, 4.0)
 
 
 def test_util_fwhm_getset():
     g1 = Lorentzian()
     g1.fwhm = 4.0
-    assert_allclose(g1.fwhm, 4.0)
+    np.testing.assert_allclose(g1.fwhm, 4.0)
 
 
 def test_util_height_set():
     g1 = Lorentzian()
     g1.gamma.value = 4.0
     g1.height = 2.0/np.pi
-    assert_allclose(g1.A.value, 8)
+    np.testing.assert_allclose(g1.A.value, 8)
 
 
 def test_util_height_get():
     g1 = Lorentzian()
     g1.gamma.value = 3.0
     g1.A.value = np.pi*1.5
-    assert_allclose(g1.height, 0.5)
+    np.testing.assert_allclose(g1.height, 0.5)
 
 
 def test_util_height_getset():
     g1 = Lorentzian()
     g1.height = 4.0
-    assert_allclose(g1.height, 4.0)
+    np.testing.assert_allclose(g1.height, 4.0)

--- a/hyperspy/tests/component/test_pesvoigt.py
+++ b/hyperspy/tests/component/test_pesvoigt.py
@@ -21,7 +21,6 @@ import itertools
 
 import numpy as np
 import pytest
-from numpy.testing import assert_allclose
 
 #Legacy test, to be removed in v2.0
 from hyperspy.components1d import PESVoigt, Voigt
@@ -37,8 +36,8 @@ def test_function():
     g.FWHM.value = 0.5
     g.gamma.value = 0.2
     g.centre.value = 1
-    assert_allclose(g.function(0), 0.35380168)
-    assert_allclose(g.function(1), 5.06863535)
+    np.testing.assert_allclose(g.function(0), 0.35380168)
+    np.testing.assert_allclose(g.function(1), 5.06863535)
 
 
 @pytest.mark.parametrize(("lazy"), (True, False))
@@ -62,9 +61,9 @@ def test_estimate_parameters_binned(only_current, binned, lazy):
     assert g2.estimate_parameters(s, axis.low_value, axis.high_value,
                                   only_current=only_current)
     assert g2.binned == binned
-    assert_allclose(g2.FWHM.value, 1, 0.5)
-    assert_allclose(g1.area.value, g2.area.value * factor, 0.04)
-    assert_allclose(g2.centre.value, 1, 1e-3)
+    np.testing.assert_allclose(g2.FWHM.value, 1, 0.5)
+    np.testing.assert_allclose(g1.area.value, g2.area.value * factor, 0.04)
+    np.testing.assert_allclose(g2.centre.value, 1, 1e-3)
 
 
 def test_legacy():
@@ -78,5 +77,5 @@ def test_legacy():
         g.FWHM.value = 0.5
         g.gamma.value = 0.2
         g.centre.value = 1
-        assert_allclose(g.function(0), 0.35380168)
-        assert_allclose(g.function(1), 5.06863535)
+        np.testing.assert_allclose(g.function(0), 0.35380168)
+        np.testing.assert_allclose(g.function(1), 5.06863535)

--- a/hyperspy/tests/component/test_powerlaw.py
+++ b/hyperspy/tests/component/test_powerlaw.py
@@ -20,7 +20,6 @@ import itertools
 
 import numpy as np
 import pytest
-from numpy.testing import assert_allclose
 
 from hyperspy.components1d import PowerLaw
 from hyperspy.signals import Signal1D
@@ -52,7 +51,7 @@ def test_estimate_parameters_binned(only_current, binned):
                                   only_current=only_current)
     assert g2.binned == binned
     # error of the estimate function is rather large, esp. when binned=FALSE
-    assert_allclose(g1.A.value, g2.A.value * factor, rtol=0.05)
+    np.testing.assert_allclose(g1.A.value, g2.A.value * factor, rtol=0.05)
     assert abs(g2.r.value - g1.r.value) <= 2e-2
 
 @pytest.mark.parametrize(("binned"), (True, False))
@@ -69,4 +68,4 @@ def test_function_nd(binned):
     factor = axis.scale if binned else 1
     g2.estimate_parameters(s2, axis.low_value, axis.high_value, False)
     assert g2.binned == binned
-    assert_allclose(g2.function_nd(axis.axis) * factor, s2.data, rtol=0.05)
+    np.testing.assert_allclose(g2.function_nd(axis.axis) * factor, s2.data, rtol=0.05)

--- a/hyperspy/tests/component/test_rc.py
+++ b/hyperspy/tests/component/test_rc.py
@@ -18,7 +18,6 @@
 
 
 import numpy as np
-from numpy.testing import assert_allclose
 
 from hyperspy.components1d import RC
 
@@ -29,5 +28,5 @@ def test_function():
     g.Vmax.value = 2
     g.tau.value = 3
     assert g.function(0) == 1
-    assert_allclose(g.function(50), 3)
-    assert_allclose(g.function(-3), 3-2*np.e)
+    np.testing.assert_allclose(g.function(50), 3)
+    np.testing.assert_allclose(g.function(-3), 3-2*np.e)

--- a/hyperspy/tests/component/test_skewnormal.py
+++ b/hyperspy/tests/component/test_skewnormal.py
@@ -23,7 +23,6 @@ from distutils.version import LooseVersion
 import numpy as np
 import pytest
 import sympy
-from numpy.testing import assert_allclose
 
 from hyperspy.components1d import SkewNormal
 from hyperspy.signals import Signal1D
@@ -42,14 +41,14 @@ def test_function():
     g.x0.value = 0
     g.scale.value = 1
     g.shape.value = 0
-    assert_allclose(g.function(0), 1, rtol=3e-3)
-    assert_allclose(g.function(6), 1.52e-8, rtol=1e-3)
+    np.testing.assert_allclose(g.function(0), 1, rtol=3e-3)
+    np.testing.assert_allclose(g.function(6), 1.52e-8, rtol=1e-3)
     g.A.value = 5
     g.x0.value = 4
     g.scale.value = 3
     g.shape.value = 2
-    assert_allclose(g.function(0), 6.28e-3, rtol=1e-3)
-    assert_allclose(g.function(g.mean), 2.855, rtol=1e-3)
+    np.testing.assert_allclose(g.function(0), 6.28e-3, rtol=1e-3)
+    np.testing.assert_allclose(g.function(g.mean), 2.855, rtol=1e-3)
 
 
 @pytest.mark.parametrize(("lazy"), (True, False))
@@ -69,7 +68,7 @@ def test_estimate_parameters_binned(only_current, binned, lazy):
     assert g2.estimate_parameters(s, axis.low_value, axis.high_value,
                                   only_current=only_current)
     assert g2.binned == binned
-    assert_allclose(g1.A.value, g2.A.value * factor)
+    np.testing.assert_allclose(g1.A.value, g2.A.value * factor)
     assert abs(g2.x0.value - g1.x0.value) <= 0.002
     assert abs(g2.shape.value - g1.shape.value) <= 0.01
     assert abs(g2.scale.value - g1.scale.value) <= 0.01
@@ -92,7 +91,7 @@ def test_function_nd(binned, lazy):
     factor = axis.scale if binned else 1
     assert g2.estimate_parameters(s2, axis.low_value, axis.high_value, False)
     assert g2.binned == binned
-    assert_allclose(g2.function_nd(axis.axis) * factor, s2.data, 0.06)
+    np.testing.assert_allclose(g2.function_nd(axis.axis) * factor, s2.data, 0.06)
 
 
 def test_util_mean_get():
@@ -100,7 +99,7 @@ def test_util_mean_get():
     g1.shape.value = 0
     g1.scale.value = 1
     g1.x0.value = 1
-    assert_allclose(g1.mean, 1.0)
+    np.testing.assert_allclose(g1.mean, 1.0)
 
 
 def test_util_variance_get():
@@ -108,7 +107,7 @@ def test_util_variance_get():
     g1.shape.value = 0
     g1.scale.value = 2
     g1.x0.value = 1
-    assert_allclose(g1.variance, 4.0)
+    np.testing.assert_allclose(g1.variance, 4.0)
 
 
 def test_util_skewness_get():
@@ -116,7 +115,7 @@ def test_util_skewness_get():
     g1.shape.value = 30
     g1.scale.value = 1
     g1.x0.value = 1
-    assert_allclose(g1.skewness, 0.99, rtol=1e-3)
+    np.testing.assert_allclose(g1.skewness, 0.99, rtol=1e-3)
 
 
 def test_util_mode_get():
@@ -124,4 +123,4 @@ def test_util_mode_get():
     g1.shape.value = 0
     g1.scale.value = 1
     g1.x0.value = 1
-    assert_allclose(g1.mode, 1.0)
+    np.testing.assert_allclose(g1.mode, 1.0)

--- a/hyperspy/tests/component/test_splitvoigt.py
+++ b/hyperspy/tests/component/test_splitvoigt.py
@@ -20,7 +20,6 @@
 import itertools
 
 import numpy as np
-from numpy.testing import assert_allclose
 import pytest
 
 from hyperspy.components1d import SplitVoigt
@@ -37,8 +36,8 @@ def test_function():
     g.centre.value = 0
     g.sigma1.value = 2
     g.sigma2.value = 2
-    assert_allclose(g.function(0), 0.49867785, rtol=1e-3)
-    assert_allclose(g.function(6), 0.00553981, rtol=1e-3)
+    np.testing.assert_allclose(g.function(0), 0.49867785, rtol=1e-3)
+    np.testing.assert_allclose(g.function(6), 0.00553981, rtol=1e-3)
 
 
 @pytest.mark.parametrize(("lazy"), (True, False))
@@ -58,7 +57,7 @@ def test_estimate_parameters_binned(only_current, binned, lazy):
     assert g2.estimate_parameters(s, axis.low_value, axis.high_value,
                                   only_current=only_current)
     assert g2.binned == binned
-    assert_allclose(g1.A.value, g2.A.value * factor, rtol=0.2)
+    np.testing.assert_allclose(g1.A.value, g2.A.value * factor, rtol=0.2)
     assert abs(g2.centre.value - g1.centre.value) <= 0.1
     assert abs(g2.sigma1.value - g1.sigma1.value) <= 0.1
     assert abs(g2.sigma2.value - g1.sigma2.value) <= 0.1
@@ -86,4 +85,4 @@ def test_function_nd(lazy):
     g2.fraction.map['values'] = [fraction] * 2
     g2.centre.map['values'] = [centre] * 2
 
-    assert_allclose(g2.function_nd(axis.axis), s2.data)
+    np.testing.assert_allclose(g2.function_nd(axis.axis), s2.data)

--- a/hyperspy/tests/component/test_voigt.py
+++ b/hyperspy/tests/component/test_voigt.py
@@ -21,7 +21,6 @@ import itertools
 
 import numpy as np
 import pytest
-from numpy.testing import assert_allclose
 
 from hyperspy.components1d import Voigt
 from hyperspy.signals import Signal1D
@@ -36,8 +35,8 @@ def test_function():
     g.sigma.value = 0.5
     g.gamma.value = 0.2
     g.centre.value = 1
-    assert_allclose(g.function(0), 0.78853024)
-    assert_allclose(g.function(1), 2.97832092)
+    np.testing.assert_allclose(g.function(0), 0.78853024)
+    np.testing.assert_allclose(g.function(1), 2.97832092)
 
 
 @pytest.mark.parametrize(("lazy"), (True, False))
@@ -57,9 +56,9 @@ def test_estimate_parameters_binned(only_current, binned, lazy):
     assert g2.estimate_parameters(s, axis.low_value, axis.high_value,
                                   only_current=only_current)
     assert g2.binned == binned
-    assert_allclose(g2.sigma.value, 0.5, 0.01)
-    assert_allclose(g1.area.value, g2.area.value * factor, 0.01)
-    assert_allclose(g2.centre.value, 1, 1e-3)
+    np.testing.assert_allclose(g2.sigma.value, 0.5, 0.01)
+    np.testing.assert_allclose(g1.area.value, g2.area.value * factor, 0.01)
+    np.testing.assert_allclose(g2.centre.value, 1, 1e-3)
 
 
 @pytest.mark.parametrize(("lazy"), (True, False))
@@ -79,50 +78,50 @@ def test_function_nd(binned, lazy):
     factor = axis.scale if binned else 1
     g2.estimate_parameters(s2, axis.low_value, axis.high_value, False)
     assert g2.binned == binned
-    assert_allclose(g2.function_nd(axis.axis) * factor, s2.data)
+    np.testing.assert_allclose(g2.function_nd(axis.axis) * factor, s2.data)
 
 
 def test_util_lwidth_set():
     g1 = Voigt(legacy=False)
     g1.lwidth = 3.0
-    assert_allclose(g1.lwidth / 2, g1.gamma.value)
+    np.testing.assert_allclose(g1.lwidth / 2, g1.gamma.value)
 
 def test_util_lwidth_get():
     g1 = Voigt(legacy=False)
     g1.gamma.value = 3.0
-    assert_allclose(g1.lwidth / 2, g1.gamma.value)
+    np.testing.assert_allclose(g1.lwidth / 2, g1.gamma.value)
 
 def test_util_lwidth_getset():
     g1 = Voigt(legacy=False)
     g1.lwidth = 3.0
-    assert_allclose(g1.lwidth, 3.0)
+    np.testing.assert_allclose(g1.lwidth, 3.0)
 
 def test_util_gwidth_set():
     g1 = Voigt(legacy=False)
     g1.gwidth = 1.0
-    assert_allclose(g1.sigma.value, 1.0 / (2 * np.sqrt(2 * np.log(2))))
+    np.testing.assert_allclose(g1.sigma.value, 1.0 / (2 * np.sqrt(2 * np.log(2))))
 
 def test_util_gwidth_get():
     g1 = Voigt(legacy=False)
     g1.sigma.value = 1.0
-    assert_allclose(g1.gwidth, 1.0 * (2 * np.sqrt(2 * np.log(2))))
+    np.testing.assert_allclose(g1.gwidth, 1.0 * (2 * np.sqrt(2 * np.log(2))))
 
 def test_util_gwidth_getset():
     g1 = Voigt(legacy=False)
     g1.gwidth = 1.0
-    assert_allclose(g1.gwidth, 1.0)
+    np.testing.assert_allclose(g1.gwidth, 1.0)
 
 def test_util_FWHM_set():
     g1 = Voigt(legacy=False)
     g1.FWHM = 1.0
-    assert_allclose(g1.sigma.value, 1.0 / (2 * np.sqrt(2 * np.log(2))))
+    np.testing.assert_allclose(g1.sigma.value, 1.0 / (2 * np.sqrt(2 * np.log(2))))
 
 def test_util_FWHM_get():
     g1 = Voigt(legacy=False)
     g1.sigma.value = 1.0
-    assert_allclose(g1.FWHM, 1.0 * (2 * np.sqrt(2 * np.log(2))))
+    np.testing.assert_allclose(g1.FWHM, 1.0 * (2 * np.sqrt(2 * np.log(2))))
 
 def test_util_FWHM_getset():
     g1 = Voigt(legacy=False)
     g1.FWHM = 1.0
-    assert_allclose(g1.FWHM, 1.0)
+    np.testing.assert_allclose(g1.FWHM, 1.0)

--- a/hyperspy/tests/component/test_volume_plasmon_drude.py
+++ b/hyperspy/tests/component/test_volume_plasmon_drude.py
@@ -16,7 +16,7 @@
 # You should have received a copy of the GNU General Public License
 # along with  HyperSpy.  If not, see <http://www.gnu.org/licenses/>.
 
-from numpy.testing import assert_allclose
+import numpy as np
 
 from hyperspy.components1d import VolumePlasmonDrude
 
@@ -27,6 +27,6 @@ def test_function():
     g.plasmon_energy.value = 8.0
     g.fwhm.value = 2.0
     assert g.function(0) == 0
-    assert_allclose(g.function(8), 12)
-    assert_allclose(g.function(1), 9.66524e-2, rtol=1e-6)
-    assert_allclose(g.function(30), 1.639867e-2, rtol=1e-6)
+    np.testing.assert_allclose(g.function(8), 12)
+    np.testing.assert_allclose(g.function(1), 9.66524e-2, rtol=1e-6)
+    np.testing.assert_allclose(g.function(30), 1.639867e-2, rtol=1e-6)

--- a/hyperspy/tests/drawing/test_plot_model.py
+++ b/hyperspy/tests/drawing/test_plot_model.py
@@ -19,7 +19,6 @@
 import os
 
 import numpy as np
-import numpy.testing as nt
 import pytest
 
 import hyperspy.api as hs
@@ -124,13 +123,13 @@ def test_plot_gaussian_eelsmodel(convolved, plot_component, binned):
             return component.A.value
 
     if convolved:
-        nt.assert_almost_equal(A_value(s, m[0], binned), 0.014034, decimal=5)
-        nt.assert_almost_equal(A_value(s, m[1], binned), 0.008420, decimal=5)
-        nt.assert_almost_equal(A_value(s, m[2], binned), 0.028068, decimal=5)
+        np.testing.assert_almost_equal(A_value(s, m[0], binned), 0.014034, decimal=5)
+        np.testing.assert_almost_equal(A_value(s, m[1], binned), 0.008420, decimal=5)
+        np.testing.assert_almost_equal(A_value(s, m[2], binned), 0.028068, decimal=5)
     else:
-        nt.assert_almost_equal(A_value(s, m[0], binned), 100.0, decimal=5)
-        nt.assert_almost_equal(A_value(s, m[1], binned), 60.0, decimal=5)
-        nt.assert_almost_equal(A_value(s, m[2], binned), 200.0, decimal=5)
+        np.testing.assert_almost_equal(A_value(s, m[0], binned), 100.0, decimal=5)
+        np.testing.assert_almost_equal(A_value(s, m[1], binned), 60.0, decimal=5)
+        np.testing.assert_almost_equal(A_value(s, m[2], binned), 200.0, decimal=5)
 
     return m._plot.signal_plot.figure
 

--- a/hyperspy/tests/drawing/test_plot_widgets.py
+++ b/hyperspy/tests/drawing/test_plot_widgets.py
@@ -18,7 +18,6 @@
 
 import matplotlib
 import numpy as np
-import numpy.testing as nt
 import pytest
 
 from hyperspy.drawing import widgets
@@ -43,34 +42,34 @@ class TestPlotLine2DWidget():
         assert self.line2d.linewidth == 1
         assert self.line2d.color == 'red'
         assert self.line2d._size == np.array([0])
-        nt.assert_allclose(self.line2d._pos, np.array([[0, 0], [1.2, 0]]))
+        np.testing.assert_allclose(self.line2d._pos, np.array([[0, 0], [1.2, 0]]))
 
         assert self.line2d.position == ([0.0, 0.0], [1.2, 0.0])
-        nt.assert_allclose(self.line2d.indices[0], np.array([0, 0]))
-        nt.assert_allclose(self.line2d.indices[1], np.array([1, 0]))
-        nt.assert_allclose(self.line2d.get_centre(), np.array([0.6, 0.]))
+        np.testing.assert_allclose(self.line2d.indices[0], np.array([0, 0]))
+        np.testing.assert_allclose(self.line2d.indices[1], np.array([1, 0]))
+        np.testing.assert_allclose(self.line2d.get_centre(), np.array([0.6, 0.]))
 
     def test_position(self):
         self.line2d.position = ([12.0, 60.0], [36.0, 96.0])
         assert self.line2d.position == ([12.0, 60.0], [36.0, 96.0])
-        nt.assert_allclose(self.line2d.indices[0], np.array([10, 50]))
-        nt.assert_allclose(self.line2d.indices[1], np.array([30, 80]))
-        nt.assert_allclose(self.line2d.get_centre(), np.array([24., 78.]))
+        np.testing.assert_allclose(self.line2d.indices[0], np.array([10, 50]))
+        np.testing.assert_allclose(self.line2d.indices[1], np.array([30, 80]))
+        np.testing.assert_allclose(self.line2d.get_centre(), np.array([24., 78.]))
 
     def test_position_snap_position(self):
         self.line2d.snap_position = True
         self.line2d.position = ([12.5, 61.0], [36.0, 96.0])
-        nt.assert_allclose(self.line2d.position, ([12.0, 61.2], [36.0, 96.0]))
-        nt.assert_allclose(self.line2d.indices[0], np.array([10, 51]))
-        nt.assert_allclose(self.line2d.indices[1], np.array([30, 80]))
-        nt.assert_allclose(self.line2d.get_centre(), np.array([24., 78.6]))
+        np.testing.assert_allclose(self.line2d.position, ([12.0, 61.2], [36.0, 96.0]))
+        np.testing.assert_allclose(self.line2d.indices[0], np.array([10, 51]))
+        np.testing.assert_allclose(self.line2d.indices[1], np.array([30, 80]))
+        np.testing.assert_allclose(self.line2d.get_centre(), np.array([24., 78.6]))
 
     def test_indices(self):
         self.line2d.indices = ([10, 50], [30, 80])
-        nt.assert_allclose(self.line2d.indices[0], np.array([10, 50]))
-        nt.assert_allclose(self.line2d.indices[1], np.array([30, 80]))
+        np.testing.assert_allclose(self.line2d.indices[0], np.array([10, 50]))
+        np.testing.assert_allclose(self.line2d.indices[1], np.array([30, 80]))
         assert self.line2d.position == ([12.0, 60.0], [36.0, 96.0])
-        nt.assert_allclose(self.line2d.get_centre(), np.array([24., 78.]))
+        np.testing.assert_allclose(self.line2d.get_centre(), np.array([24., 78.]))
 
     def test_length(self):
         x = 10
@@ -79,7 +78,7 @@ class TestPlotLine2DWidget():
 
         y = 20
         self.line2d.position = ([20.0, 10.0], [20.0 + x, 10 + y])
-        nt.assert_almost_equal(self.line2d.get_line_length(),
+        np.testing.assert_almost_equal(self.line2d.get_line_length(),
                                np.sqrt(x**2 + y**2))
 
     def test_change_size(self):
@@ -107,19 +106,19 @@ class TestPlotLine2DWidget():
         self.line2d.snap_size = True
         self.line2d.position = ([12.0, 60.0], [36.0, 96.0])
         assert self.line2d.position == ([12.0, 60.0], [36.0, 96.0])
-        nt.assert_allclose(self.line2d.indices[0], np.array([10, 50]))
-        nt.assert_allclose(self.line2d.indices[1], np.array([30, 80]))
-        nt.assert_allclose(self.line2d.get_centre(), np.array([24., 78.]))
+        np.testing.assert_allclose(self.line2d.indices[0], np.array([10, 50]))
+        np.testing.assert_allclose(self.line2d.indices[1], np.array([30, 80]))
+        np.testing.assert_allclose(self.line2d.get_centre(), np.array([24., 78.]))
         assert self.line2d.size == np.array([0])
 
         self.line2d.size = [3]
-        nt.assert_allclose(self.line2d.size, np.array([2.4]))
+        np.testing.assert_allclose(self.line2d.size, np.array([2.4]))
         self.line2d.size = (5, )
-        nt.assert_allclose(self.line2d.size, np.array([4.8]))
+        np.testing.assert_allclose(self.line2d.size, np.array([4.8]))
         self.line2d.size = np.array([7.4])
-        nt.assert_allclose(self.line2d.size, np.array([7.2]))
+        np.testing.assert_allclose(self.line2d.size, np.array([7.2]))
         self.line2d.increase_size()
-        nt.assert_allclose(self.line2d.size, np.array([8.4]))
+        np.testing.assert_allclose(self.line2d.size, np.array([8.4]))
 
     def test_change_size_snap_size_different_scale(self):
         self.line2d.axes[0].scale = 0.8
@@ -150,12 +149,12 @@ class TestPlotLine2DWidget():
         line2d_snap_all.snap_all = True
         line2d_snap_all.set_mpl_ax(self.im._plot.signal_plot.ax)
         line2d_snap_all.position = ([50.0, 60.0], [96.0, 54.0])
-        nt.assert_allclose(line2d_snap_all.position[0], [50.4, 60.0])
-        nt.assert_allclose(line2d_snap_all.position[1], [96.0, 54.0])
+        np.testing.assert_allclose(line2d_snap_all.position[0], [50.4, 60.0])
+        np.testing.assert_allclose(line2d_snap_all.position[1], [96.0, 54.0])
 
         line2d_snap_all.size = (15.0, )
-        nt.assert_allclose(line2d_snap_all.size[0], 14.4)
-        nt.assert_allclose(line2d_snap_all.size[0], 14.4)
+        np.testing.assert_allclose(line2d_snap_all.size[0], 14.4)
+        np.testing.assert_allclose(line2d_snap_all.size[0], 14.4)
 
         return self.im._plot.signal_plot.figure
 
@@ -185,8 +184,8 @@ class TestPlotRangeWidget():
         color_rgba = matplotlib.colors.to_rgba('blue', alpha=0.5)
         assert w.span.rect.get_fc() == color_rgba
         assert w.span.rect.get_ec() == color_rgba
-        nt.assert_allclose(w.position[0], 4.8)
-        nt.assert_allclose(w.size[0], 3.6)
+        np.testing.assert_allclose(w.position[0], 4.8)
+        np.testing.assert_allclose(w.size[0], 3.6)
 
         w2 = widgets.RangeWidget(self.s.axes_manager)
         w2.set_mpl_ax(self.s._plot.signal_plot.ax)
@@ -243,8 +242,8 @@ class TestPlotRangeWidget():
         assert span_h.rect.get_fc() == color_rgba
         assert span_h.rect.get_ec() == color_rgba
         span_h.set_initial((50.4, 55.2))
-        nt.assert_allclose(span_h.range[0], 50.4)
-        nt.assert_allclose(span_h.range[1], 55.2)
+        np.testing.assert_allclose(span_h.range[0], 50.4)
+        np.testing.assert_allclose(span_h.range[1], 55.2)
 
         span_h.range = (40, 45)
         assert span_h.range == (40, 45)

--- a/hyperspy/tests/io/test_blockfile.py
+++ b/hyperspy/tests/io/test_blockfile.py
@@ -24,7 +24,6 @@ import warnings
 
 import numpy as np
 import pytest
-from numpy.testing import assert_allclose
 
 import hyperspy.api as hs
 from hyperspy.io_plugins.blockfile import get_default_header
@@ -189,11 +188,11 @@ def test_different_x_y_scale_units(save_path):
     signal.axes_manager[0].scale = 50.0
     signal.save(save_path, overwrite=True)
     sig_reload = hs.load(save_path)
-    assert_allclose(sig_reload.axes_manager[0].scale, 50.0,
+    np.testing.assert_allclose(sig_reload.axes_manager[0].scale, 50.0,
                     rtol=1E-5)
-    assert_allclose(sig_reload.axes_manager[1].scale, 64.0,
+    np.testing.assert_allclose(sig_reload.axes_manager[1].scale, 64.0,
                     rtol=1E-5)
-    assert_allclose(sig_reload.axes_manager[2].scale, 0.0160616,
+    np.testing.assert_allclose(sig_reload.axes_manager[2].scale, 0.0160616,
                     rtol=1E-5)
 
 

--- a/hyperspy/tests/io/test_bruker.py
+++ b/hyperspy/tests/io/test_bruker.py
@@ -3,7 +3,6 @@ import os
 
 import numpy as np
 import pytest
-from numpy.testing import assert_allclose
 
 from hyperspy import signals
 from hyperspy.io import load
@@ -77,17 +76,17 @@ def test_hyperspy_wrap():
     with pytest.warns(VisibleDeprecationWarning):
         hype = load(filename, select_type='spectrum')
     hype = load(filename, select_type='spectrum_image')
-    assert_allclose(
+    np.testing.assert_allclose(
         hype.axes_manager[0].scale,
         1.66740910949362,
         atol=1E-12)
-    assert_allclose(
+    np.testing.assert_allclose(
         hype.axes_manager[1].scale,
         1.66740910949362,
         atol=1E-12)
     assert hype.axes_manager[1].units == 'µm'
-    assert_allclose(hype.axes_manager[2].scale, 0.009999)
-    assert_allclose(hype.axes_manager[2].offset, -0.47225277)
+    np.testing.assert_allclose(hype.axes_manager[2].scale, 0.009999)
+    np.testing.assert_allclose(hype.axes_manager[2].offset, -0.47225277)
     assert hype.axes_manager[2].units == 'keV'
 
     md_ref = {
@@ -149,11 +148,11 @@ def test_hyperspy_wrap_downsampled():
     filename = os.path.join(my_path, 'bruker_data', test_files[0])
     print('testing bcf wrap to hyperspy signal...')
     hype = load(filename, select_type='spectrum_image', downsample=5)
-    assert_allclose(
+    np.testing.assert_allclose(
         hype.axes_manager[0].scale,
         8.337045547468101,
         atol=1E-12)
-    assert_allclose(
+    np.testing.assert_allclose(
         hype.axes_manager[1].scale,
         8.337045547468101,
         atol=1E-12)

--- a/hyperspy/tests/io/test_dens.py
+++ b/hyperspy/tests/io/test_dens.py
@@ -21,7 +21,6 @@ import os
 
 import numpy as np
 import pytest
-from numpy.testing import assert_allclose
 
 import hyperspy.api as hs
 
@@ -38,8 +37,8 @@ ref_t = np.array([15.091, 16.828, 13.232, 50.117, 49.927, 49.986, 49.981])
 def test_read1():
     s = hs.load(file1)
     np.testing.assert_allclose(s.data, ref_T)
-    assert_allclose(s.axes_manager[0].scale, 0.33)
-    assert_allclose(s.axes_manager[0].offset, 50077.68)
+    np.testing.assert_allclose(s.axes_manager[0].scale, 0.33)
+    np.testing.assert_allclose(s.axes_manager[0].offset, 50077.68)
     assert s.axes_manager[0].units == 's'
     ref_date, ref_time = "2015-04-16", "13:53:00"
     assert s.metadata.General.date == ref_date
@@ -51,19 +50,19 @@ def test_read1():
 def test_read_convert_units():
     s = hs.load(file1, convert_units=None)
     np.testing.assert_allclose(s.data, ref_T)
-    assert_allclose(s.axes_manager[0].scale, 0.33)
-    assert_allclose(s.axes_manager[0].offset, 50077.68)
+    np.testing.assert_allclose(s.axes_manager[0].scale, 0.33)
+    np.testing.assert_allclose(s.axes_manager[0].offset, 50077.68)
     assert s.axes_manager[0].units == 's'
 
     s = hs.load(file1, convert_units=False)
-    assert_allclose(s.axes_manager[0].scale, 0.33)
-    assert_allclose(s.axes_manager[0].offset, 50077.68)
+    np.testing.assert_allclose(s.axes_manager[0].scale, 0.33)
+    np.testing.assert_allclose(s.axes_manager[0].offset, 50077.68)
     assert s.axes_manager[0].units == 's'
 
     s = hs.load(file1, convert_units=True)
     np.testing.assert_allclose(s.data, ref_T)
-    assert_allclose(s.axes_manager[0].scale, 330.0)
-    assert_allclose(s.axes_manager[0].offset, 50077680.0)
+    np.testing.assert_allclose(s.axes_manager[0].scale, 330.0)
+    np.testing.assert_allclose(s.axes_manager[0].offset, 50077680.0)
     assert s.axes_manager[0].units == 'ms'
 
 

--- a/hyperspy/tests/io/test_dm3.py
+++ b/hyperspy/tests/io/test_dm3.py
@@ -22,7 +22,6 @@ import os
 
 import numpy as np
 import pytest
-from numpy.testing import assert_allclose
 
 from hyperspy.io import load
 from hyperspy.io_plugins.digital_micrograph import (DigitalMicrographReader,
@@ -77,8 +76,8 @@ def test_missing_tag():
                          "test_diffraction_pattern_tags_removed.dm3")
     s = load(fname)
     md = s.metadata
-    assert_allclose(md.Acquisition_instrument.TEM.beam_energy, 200.0)
-    assert_allclose(md.Acquisition_instrument.TEM.Camera.exposure, 0.2)
+    np.testing.assert_allclose(md.Acquisition_instrument.TEM.beam_energy, 200.0)
+    np.testing.assert_allclose(md.Acquisition_instrument.TEM.Camera.exposure, 0.2)
     assert md.General.date == "2014-07-09"
     assert md.General.time == "18:56:37"
     assert md.General.title == "test_diffraction_pattern_tags_removed"
@@ -89,9 +88,9 @@ def test_read_TEM_metadata():
     s = load(fname)
     md = s.metadata
     assert md.Acquisition_instrument.TEM.acquisition_mode == "TEM"
-    assert_allclose(md.Acquisition_instrument.TEM.beam_energy, 200.0)
-    assert_allclose(md.Acquisition_instrument.TEM.Camera.exposure, 0.5)
-    assert_allclose(md.Acquisition_instrument.TEM.magnification, 51.0)
+    np.testing.assert_allclose(md.Acquisition_instrument.TEM.beam_energy, 200.0)
+    np.testing.assert_allclose(md.Acquisition_instrument.TEM.Camera.exposure, 0.5)
+    np.testing.assert_allclose(md.Acquisition_instrument.TEM.magnification, 51.0)
     assert md.Acquisition_instrument.TEM.microscope == "FEI Tecnai"
     assert md.General.date == "2015-07-20"
     assert md.General.original_filename == "test_dm_image_um_unit.dm3"
@@ -109,9 +108,9 @@ def test_read_Diffraction_metadata():
     s = load(fname)
     md = s.metadata
     assert md.Acquisition_instrument.TEM.acquisition_mode == "TEM"
-    assert_allclose(md.Acquisition_instrument.TEM.beam_energy, 200.0)
-    assert_allclose(md.Acquisition_instrument.TEM.Camera.exposure, 0.2)
-    assert_allclose(md.Acquisition_instrument.TEM.camera_length, 320.0)
+    np.testing.assert_allclose(md.Acquisition_instrument.TEM.beam_energy, 200.0)
+    np.testing.assert_allclose(md.Acquisition_instrument.TEM.Camera.exposure, 0.2)
+    np.testing.assert_allclose(md.Acquisition_instrument.TEM.camera_length, 320.0)
     assert md.Acquisition_instrument.TEM.microscope == "FEI Tecnai"
     assert md.General.date == "2014-07-09"
     assert (
@@ -128,10 +127,10 @@ def test_read_STEM_metadata():
     s = load(fname)
     md = s.metadata
     assert md.Acquisition_instrument.TEM.acquisition_mode == "STEM"
-    assert_allclose(md.Acquisition_instrument.TEM.beam_energy, 200.0)
-    assert_allclose(md.Acquisition_instrument.TEM.dwell_time, 3.5E-6)
-    assert_allclose(md.Acquisition_instrument.TEM.camera_length, 135.0)
-    assert_allclose(
+    np.testing.assert_allclose(md.Acquisition_instrument.TEM.beam_energy, 200.0)
+    np.testing.assert_allclose(md.Acquisition_instrument.TEM.dwell_time, 3.5E-6)
+    np.testing.assert_allclose(md.Acquisition_instrument.TEM.camera_length, 135.0)
+    np.testing.assert_allclose(
         md.Acquisition_instrument.TEM.magnification,
         225000.0)
     assert md.Acquisition_instrument.TEM.microscope == "FEI Titan"
@@ -148,28 +147,28 @@ def test_read_EELS_metadata():
     s = load(fname)
     md = s.metadata
     assert md.Acquisition_instrument.TEM.acquisition_mode == "STEM"
-    assert_allclose(md.Acquisition_instrument.TEM.beam_energy, 200.0)
+    np.testing.assert_allclose(md.Acquisition_instrument.TEM.beam_energy, 200.0)
     assert md.Acquisition_instrument.TEM.microscope == "FEI Titan"
-    assert_allclose(md.Acquisition_instrument.TEM.camera_length, 135.0)
-    assert_allclose(
+    np.testing.assert_allclose(md.Acquisition_instrument.TEM.camera_length, 135.0)
+    np.testing.assert_allclose(
         md.Acquisition_instrument.TEM.magnification,
         640000.0)
-    assert_allclose(md.Acquisition_instrument.TEM.Stage.tilt_alpha, 24.95,
+    np.testing.assert_allclose(md.Acquisition_instrument.TEM.Stage.tilt_alpha, 24.95,
                     atol=1E-2)
-    assert_allclose(md.Acquisition_instrument.TEM.Stage.x, -0.478619,
+    np.testing.assert_allclose(md.Acquisition_instrument.TEM.Stage.x, -0.478619,
                     atol=1E-2)
-    assert_allclose(md.Acquisition_instrument.TEM.Stage.y, 0.0554612,
+    np.testing.assert_allclose(md.Acquisition_instrument.TEM.Stage.y, 0.0554612,
                     atol=1E-2)
-    assert_allclose(md.Acquisition_instrument.TEM.Stage.z, 0.036348,
+    np.testing.assert_allclose(md.Acquisition_instrument.TEM.Stage.z, 0.036348,
                     atol=1E-2)
-    assert_allclose(
+    np.testing.assert_allclose(
         md.Acquisition_instrument.TEM.convergence_angle, 21.0)
-    assert_allclose(
+    np.testing.assert_allclose(
         md.Acquisition_instrument.TEM.Detector.EELS.collection_angle, 0.0)
-    assert_allclose(
+    np.testing.assert_allclose(
         md.Acquisition_instrument.TEM.Detector.EELS.exposure,
         0.0035)
-    assert_allclose(
+    np.testing.assert_allclose(
         md.Acquisition_instrument.TEM.Detector.EELS.frame_number, 50)
     assert (
         md.Acquisition_instrument.TEM.Detector.EELS.spectrometer ==
@@ -183,10 +182,10 @@ def test_read_EELS_metadata():
     assert md.General.time == "19:35:17"
     assert md.Signal.quantity == "Electrons (Counts)"
     assert md.Signal.signal_type == "EELS"
-    assert_allclose(
+    np.testing.assert_allclose(
         md.Signal.Noise_properties.Variance_linear_model.gain_factor,
         0.1285347)
-    assert_allclose(
+    np.testing.assert_allclose(
         md.Signal.Noise_properties.Variance_linear_model.gain_offset,
         0.0)
 
@@ -198,15 +197,15 @@ def test_read_SI_metadata():
     assert md.Acquisition_instrument.TEM.acquisition_mode == "STEM"
     assert md.General.date == "2019-05-14"
     assert md.General.time == "20:50:13"
-    assert_allclose(
+    np.testing.assert_allclose(
         md.Acquisition_instrument.TEM.Detector.EELS.aperture_size, 5.0)
-    assert_allclose(
+    np.testing.assert_allclose(
         md.Acquisition_instrument.TEM.convergence_angle, 21.0)
-    assert_allclose(
+    np.testing.assert_allclose(
         md.Acquisition_instrument.TEM.Detector.EELS.collection_angle, 62.0)
-    assert_allclose(
+    np.testing.assert_allclose(
         md.Acquisition_instrument.TEM.Detector.EELS.frame_number, 1)
-    assert_allclose(
+    np.testing.assert_allclose(
         md.Acquisition_instrument.TEM.Detector.EELS.dwell_time,
         1.9950125E-2)
 
@@ -216,22 +215,22 @@ def test_read_EDS_metadata():
     s = load(fname)
     md = s.metadata
     assert md.Acquisition_instrument.TEM.acquisition_mode == "STEM"
-    assert_allclose(
+    np.testing.assert_allclose(
         md.Acquisition_instrument.TEM.Detector.EDS.azimuth_angle, 45.0)
-    assert_allclose(
+    np.testing.assert_allclose(
         md.Acquisition_instrument.TEM.Detector.EDS.elevation_angle, 18.0)
-    assert_allclose(
+    np.testing.assert_allclose(
         md.Acquisition_instrument.TEM.Detector.EDS.energy_resolution_MnKa, 130.0)
-    assert_allclose(
+    np.testing.assert_allclose(
         md.Acquisition_instrument.TEM.Detector.EDS.live_time, 3.806)
-    assert_allclose(
+    np.testing.assert_allclose(
         md.Acquisition_instrument.TEM.Detector.EDS.real_time, 4.233)
-    assert_allclose(md.Acquisition_instrument.TEM.Stage.tilt_alpha, 24.95,
+    np.testing.assert_allclose(md.Acquisition_instrument.TEM.Stage.tilt_alpha, 24.95,
                     atol=1E-2)
-    assert_allclose(md.Acquisition_instrument.TEM.beam_energy, 200.0)
+    np.testing.assert_allclose(md.Acquisition_instrument.TEM.beam_energy, 200.0)
     assert md.Acquisition_instrument.TEM.microscope == "FEI Titan"
-    assert_allclose(md.Acquisition_instrument.TEM.camera_length, 135.0)
-    assert_allclose(
+    np.testing.assert_allclose(md.Acquisition_instrument.TEM.camera_length, 135.0)
+    np.testing.assert_allclose(
         md.Acquisition_instrument.TEM.magnification,
         320000.0)
     assert md.General.date == "2016-08-08"
@@ -240,10 +239,10 @@ def test_read_EDS_metadata():
     assert md.General.time == "21:46:19"
     assert md.Signal.quantity == "X-rays (Counts)"
     assert md.Signal.signal_type == "EDS_TEM"
-    assert_allclose(
+    np.testing.assert_allclose(
         md.Signal.Noise_properties.Variance_linear_model.gain_factor,
         1.0)
-    assert_allclose(
+    np.testing.assert_allclose(
         md.Signal.Noise_properties.Variance_linear_model.gain_offset,
         0.0)
 

--- a/hyperspy/tests/io/test_dm_stackbuilder_plugin.py
+++ b/hyperspy/tests/io/test_dm_stackbuilder_plugin.py
@@ -18,8 +18,7 @@
 
 
 import os
-
-from numpy.testing import assert_allclose
+import numpy as np
 
 from hyperspy.io import load
 
@@ -37,12 +36,12 @@ class TestStackBuilder:
         assert data_dimensions == axes_dimensions
         md = image_stack.metadata
         assert md.Acquisition_instrument.TEM.acquisition_mode == "STEM"
-        assert_allclose(md.Acquisition_instrument.TEM.beam_current, 0.0)
-        assert_allclose(md.Acquisition_instrument.TEM.beam_energy, 200.0)
-        assert_allclose(md.Acquisition_instrument.TEM.camera_length, 15.0)
-        assert_allclose(
+        np.testing.assert_allclose(md.Acquisition_instrument.TEM.beam_current, 0.0)
+        np.testing.assert_allclose(md.Acquisition_instrument.TEM.beam_energy, 200.0)
+        np.testing.assert_allclose(md.Acquisition_instrument.TEM.camera_length, 15.0)
+        np.testing.assert_allclose(
             md.Acquisition_instrument.TEM.dwell_time, 0.03000005078125)
-        assert_allclose(md.Acquisition_instrument.TEM.magnification, 200000.0)
+        np.testing.assert_allclose(md.Acquisition_instrument.TEM.magnification, 200000.0)
         assert md.Acquisition_instrument.TEM.microscope == "JEM-ARM200F"
         assert md.General.date == "2015-05-17"
         assert md.General.original_filename == "test_stackbuilder_imagestack.dm3"
@@ -52,7 +51,7 @@ class TestStackBuilder:
         assert md.Signal.quantity == "Electrons (Counts)"
         assert md.Signal.signal_type == ""
         assert md.Signal.binned == False
-        assert_allclose(md.Signal.Noise_properties.Variance_linear_model.gain_factor,
+        np.testing.assert_allclose(md.Signal.Noise_properties.Variance_linear_model.gain_factor,
                         0.15674974)
-        assert_allclose(md.Signal.Noise_properties.Variance_linear_model.gain_offset,
+        np.testing.assert_allclose(md.Signal.Noise_properties.Variance_linear_model.gain_offset,
                         2228741.5)

--- a/hyperspy/tests/io/test_edax.py
+++ b/hyperspy/tests/io/test_edax.py
@@ -8,7 +8,6 @@ import zipfile
 import numpy as np
 import pytest
 import requests
-from numpy.testing import assert_allclose, assert_equal
 
 from hyperspy import signals
 from hyperspy.io import load
@@ -94,15 +93,15 @@ class TestSpcSpectrum_v061_xrf:
             'Signal']
 
         # Testing SEM parameters
-        assert_allclose(30, sem_dict['beam_energy'])
-        assert_allclose(0, sem_dict['Stage']['tilt_alpha'])
+        np.testing.assert_allclose(30, sem_dict['beam_energy'])
+        np.testing.assert_allclose(0, sem_dict['Stage']['tilt_alpha'])
 
         # Testing EDS parameters
-        assert_allclose(45, eds_dict['azimuth_angle'])
-        assert_allclose(35, eds_dict['elevation_angle'])
-        assert_allclose(137.92946, eds_dict['energy_resolution_MnKa'],
+        np.testing.assert_allclose(45, eds_dict['azimuth_angle'])
+        np.testing.assert_allclose(35, eds_dict['elevation_angle'])
+        np.testing.assert_allclose(137.92946, eds_dict['energy_resolution_MnKa'],
                         atol=1E-5)
-        assert_allclose(2561.0, eds_dict['live_time'], atol=1E-6)
+        np.testing.assert_allclose(2561.0, eds_dict['live_time'], atol=1E-6)
 
         # Testing elements
         assert ({'Al', 'Ca', 'Cl', 'Cr', 'Fe', 'K', 'Mg', 'Mn', 'Si', 'Y'} ==
@@ -127,13 +126,13 @@ class TestSpcSpectrum_v061_xrf:
         spc_header = TestSpcSpectrum_v061_xrf.spc_loadAll.original_metadata[
             'spc_header']
 
-        assert_allclose(4, spc_header['analysisType'])
-        assert_allclose(4, spc_header['analyzerType'])
-        assert_allclose(2013, spc_header['collectDateYear'])
-        assert_allclose(9, spc_header['collectDateMon'])
-        assert_allclose(26, spc_header['collectDateDay'])
-        assert_equal(b'Garnet1.', spc_header['fileName'].view('|S8')[0])
-        assert_allclose(45, spc_header['xRayTubeZ'])
+        np.testing.assert_allclose(4, spc_header['analysisType'])
+        np.testing.assert_allclose(4, spc_header['analyzerType'])
+        np.testing.assert_allclose(2013, spc_header['collectDateYear'])
+        np.testing.assert_allclose(9, spc_header['collectDateMon'])
+        np.testing.assert_allclose(26, spc_header['collectDateDay'])
+        np.testing.assert_equal(b'Garnet1.', spc_header['fileName'].view('|S8')[0])
+        np.testing.assert_allclose(45, spc_header['xRayTubeZ'])
 
 
 class TestSpcSpectrum_v070_eds:
@@ -170,15 +169,15 @@ class TestSpcSpectrum_v070_eds:
             'Signal']
 
         # Testing SEM parameters
-        assert_allclose(22, sem_dict['beam_energy'])
-        assert_allclose(0, sem_dict['Stage']['tilt_alpha'])
+        np.testing.assert_allclose(22, sem_dict['beam_energy'])
+        np.testing.assert_allclose(0, sem_dict['Stage']['tilt_alpha'])
 
         # Testing EDS parameters
-        assert_allclose(0, eds_dict['azimuth_angle'])
-        assert_allclose(34, eds_dict['elevation_angle'])
-        assert_allclose(129.31299, eds_dict['energy_resolution_MnKa'],
+        np.testing.assert_allclose(0, eds_dict['azimuth_angle'])
+        np.testing.assert_allclose(34, eds_dict['elevation_angle'])
+        np.testing.assert_allclose(129.31299, eds_dict['energy_resolution_MnKa'],
                         atol=1E-5)
-        assert_allclose(50.000004, eds_dict['live_time'], atol=1E-6)
+        np.testing.assert_allclose(50.000004, eds_dict['live_time'], atol=1E-6)
 
         # Testing elements
         assert ({'Al', 'C', 'Ce', 'Cu', 'F', 'Ho', 'Mg', 'O'} ==
@@ -203,15 +202,15 @@ class TestSpcSpectrum_v070_eds:
         spc_header = TestSpcSpectrum_v070_eds.spc_loadAll.original_metadata[
             'spc_header']
 
-        assert_allclose(4, spc_header['analysisType'])
-        assert_allclose(5, spc_header['analyzerType'])
-        assert_allclose(2016, spc_header['collectDateYear'])
-        assert_allclose(4, spc_header['collectDateMon'])
-        assert_allclose(19, spc_header['collectDateDay'])
-        assert_equal(b'C:\\ProgramData\\EDAX\\jtaillon\\Cole\\Mapping\\Lsm\\'
+        np.testing.assert_allclose(4, spc_header['analysisType'])
+        np.testing.assert_allclose(5, spc_header['analyzerType'])
+        np.testing.assert_allclose(2016, spc_header['collectDateYear'])
+        np.testing.assert_allclose(4, spc_header['collectDateMon'])
+        np.testing.assert_allclose(19, spc_header['collectDateDay'])
+        np.testing.assert_equal(b'C:\\ProgramData\\EDAX\\jtaillon\\Cole\\Mapping\\Lsm\\'
                      b'GFdCr\\950\\Area 1\\spectrum20160419153851427_0.spc',
                      spc_header['longFileName'].view('|S256')[0])
-        assert_allclose(0, spc_header['xRayTubeZ'])
+        np.testing.assert_allclose(0, spc_header['xRayTubeZ'])
 
 
 class TestSpdMap_070_eds:
@@ -267,15 +266,15 @@ class TestSpdMap_070_eds:
         signal_dict = TestSpdMap_070_eds.spd.metadata.as_dictionary()['Signal']
 
         # Testing SEM parameters
-        assert_allclose(22, sem_dict['beam_energy'])
-        assert_allclose(0, sem_dict['Stage']['tilt_alpha'])
+        np.testing.assert_allclose(22, sem_dict['beam_energy'])
+        np.testing.assert_allclose(0, sem_dict['Stage']['tilt_alpha'])
 
         # Testing EDS parameters
-        assert_allclose(0, eds_dict['azimuth_angle'])
-        assert_allclose(34, eds_dict['elevation_angle'])
-        assert_allclose(126.60252, eds_dict['energy_resolution_MnKa'],
+        np.testing.assert_allclose(0, eds_dict['azimuth_angle'])
+        np.testing.assert_allclose(34, eds_dict['elevation_angle'])
+        np.testing.assert_allclose(126.60252, eds_dict['energy_resolution_MnKa'],
                         atol=1E-5)
-        assert_allclose(2621.4399, eds_dict['live_time'], atol=1E-4)
+        np.testing.assert_allclose(2621.4399, eds_dict['live_time'], atol=1E-4)
 
         # Testing elements
         assert {'Ce', 'Co', 'Cr', 'Fe', 'Gd', 'La', 'Mg', 'O',
@@ -310,8 +309,8 @@ class TestSpdMap_070_eds:
 
     def test_ipr_reading(self):
         ipr_header = TestSpdMap_070_eds.spd.original_metadata['ipr_header']
-        assert_allclose(0.014235896, ipr_header['mppX'])
-        assert_allclose(0.014227346, ipr_header['mppY'])
+        np.testing.assert_allclose(0.014235896, ipr_header['mppX'])
+        np.testing.assert_allclose(0.014227346, ipr_header['mppY'])
 
     def test_spc_reading(self):
         # Test to make sure that spc metadata matches spd metadata
@@ -323,19 +322,19 @@ class TestSpdMap_070_eds:
             'Acquisition_instrument']['SEM']
         eds_dict = sem_dict['Detector']['EDS']
 
-        assert_allclose(spc_header.azimuth,
+        np.testing.assert_allclose(spc_header.azimuth,
                         eds_dict['azimuth_angle'])
-        assert_allclose(spc_header.detReso,
+        np.testing.assert_allclose(spc_header.detReso,
                         eds_dict['energy_resolution_MnKa'])
-        assert_allclose(spc_header.elevation,
+        np.testing.assert_allclose(spc_header.elevation,
                         eds_dict['elevation_angle'])
-        assert_allclose(spc_header.liveTime,
+        np.testing.assert_allclose(spc_header.liveTime,
                         eds_dict['live_time'])
-        assert_allclose(spc_header.evPerChan,
+        np.testing.assert_allclose(spc_header.evPerChan,
                         TestSpdMap_070_eds.spd.axes_manager[2].scale * 1000)
-        assert_allclose(spc_header.kV,
+        np.testing.assert_allclose(spc_header.kV,
                         sem_dict['beam_energy'])
-        assert_allclose(spc_header.numElem,
+        np.testing.assert_allclose(spc_header.numElem,
                         len(elements))
 
 
@@ -392,15 +391,15 @@ class TestSpdMap_061_xrf:
         signal_dict = TestSpdMap_061_xrf.spd.metadata.as_dictionary()['Signal']
 
         # Testing SEM parameters
-        assert_allclose(30, sem_dict['beam_energy'])
-        assert_allclose(0, sem_dict['Stage']['tilt_alpha'])
+        np.testing.assert_allclose(30, sem_dict['beam_energy'])
+        np.testing.assert_allclose(0, sem_dict['Stage']['tilt_alpha'])
 
         # Testing EDS parameters
-        assert_allclose(45, eds_dict['azimuth_angle'])
-        assert_allclose(35, eds_dict['elevation_angle'])
-        assert_allclose(137.92946, eds_dict['energy_resolution_MnKa'],
+        np.testing.assert_allclose(45, eds_dict['azimuth_angle'])
+        np.testing.assert_allclose(35, eds_dict['elevation_angle'])
+        np.testing.assert_allclose(137.92946, eds_dict['energy_resolution_MnKa'],
                         atol=1E-5)
-        assert_allclose(2561.0, eds_dict['live_time'], atol=1E-4)
+        np.testing.assert_allclose(2561.0, eds_dict['live_time'], atol=1E-4)
 
         # Testing elements
         assert {'Al', 'Ca', 'Cl', 'Cr', 'Fe', 'K', 'Mg', 'Mn', 'Si',
@@ -435,8 +434,8 @@ class TestSpdMap_061_xrf:
 
     def test_ipr_reading(self):
         ipr_header = TestSpdMap_061_xrf.spd.original_metadata['ipr_header']
-        assert_allclose(565.1920166015625, ipr_header['mppX'])
-        assert_allclose(565.1920166015625, ipr_header['mppY'])
+        np.testing.assert_allclose(565.1920166015625, ipr_header['mppX'])
+        np.testing.assert_allclose(565.1920166015625, ipr_header['mppY'])
 
     def test_spc_reading(self):
         # Test to make sure that spc metadata matches spd_061_xrf metadata
@@ -448,17 +447,17 @@ class TestSpdMap_061_xrf:
             'Acquisition_instrument']['SEM']
         eds_dict = sem_dict['Detector']['EDS']
 
-        assert_allclose(spc_header.azimuth,
+        np.testing.assert_allclose(spc_header.azimuth,
                         eds_dict['azimuth_angle'])
-        assert_allclose(spc_header.detReso,
+        np.testing.assert_allclose(spc_header.detReso,
                         eds_dict['energy_resolution_MnKa'])
-        assert_allclose(spc_header.elevation,
+        np.testing.assert_allclose(spc_header.elevation,
                         eds_dict['elevation_angle'])
-        assert_allclose(spc_header.liveTime,
+        np.testing.assert_allclose(spc_header.liveTime,
                         eds_dict['live_time'])
-        assert_allclose(spc_header.evPerChan,
+        np.testing.assert_allclose(spc_header.evPerChan,
                         TestSpdMap_061_xrf.spd.axes_manager[2].scale * 1000)
-        assert_allclose(spc_header.kV,
+        np.testing.assert_allclose(spc_header.kV,
                         sem_dict['beam_energy'])
-        assert_allclose(spc_header.numElem,
+        np.testing.assert_allclose(spc_header.numElem,
                         len(elements))

--- a/hyperspy/tests/io/test_emd.py
+++ b/hyperspy/tests/io/test_emd.py
@@ -32,7 +32,6 @@ import h5py
 import numpy as np
 import pytest
 from dateutil import tz
-from numpy.testing import assert_allclose
 
 from hyperspy.io import load
 from hyperspy.misc.test_utils import assert_deep_almost_equal
@@ -342,11 +341,11 @@ class TestFeiEMD():
                                          'fei_emd_image.npy'))
         assert signal.axes_manager[0].name == 'x'
         assert signal.axes_manager[0].units == 'µm'
-        assert_allclose(signal.axes_manager[0].scale, 0.00530241, rtol=1E-5)
+        np.testing.assert_allclose(signal.axes_manager[0].scale, 0.00530241, rtol=1E-5)
         assert signal.axes_manager[1].name == 'y'
         assert signal.axes_manager[1].units == 'µm'
-        assert_allclose(signal.axes_manager[1].scale, 0.00530241, rtol=1E-5)
-        assert_allclose(signal.data, fei_image)
+        np.testing.assert_allclose(signal.axes_manager[1].scale, 0.00530241, rtol=1E-5)
+        np.testing.assert_allclose(signal.data, fei_image)
         assert_deep_almost_equal(signal.metadata.as_dictionary(), md)
         assert isinstance(signal, Signal2D)
 
@@ -386,15 +385,15 @@ class TestFeiEMD():
         assert signal.axes_manager[0].name == 'x'
         assert signal.axes_manager[0].size == 10
         assert signal.axes_manager[0].units == 'nm'
-        assert_allclose(signal.axes_manager[0].scale, 1.234009, atol=1E-5)
+        np.testing.assert_allclose(signal.axes_manager[0].scale, 1.234009, atol=1E-5)
         assert signal.axes_manager[1].name == 'y'
         assert signal.axes_manager[1].size == 50
         assert signal.axes_manager[1].units == 'nm'
-        assert_allclose(signal.axes_manager[1].scale, 1.234009, atol=1E-5)
+        np.testing.assert_allclose(signal.axes_manager[1].scale, 1.234009, atol=1E-5)
         assert signal.axes_manager[2].name == 'X-ray energy'
         assert signal.axes_manager[2].size == 4096
         assert signal.axes_manager[2].units == 'keV'
-        assert_allclose(signal.axes_manager[2].scale, 0.005, atol=1E-5)
+        np.testing.assert_allclose(signal.axes_manager[2].scale, 0.005, atol=1E-5)
 
         signal0 = s[0]
         if lazy:
@@ -404,7 +403,7 @@ class TestFeiEMD():
         assert signal0.axes_manager[0].name == 'x'
         assert signal0.axes_manager[0].size == 10
         assert signal0.axes_manager[0].units == 'nm'
-        assert_allclose(signal0.axes_manager[0].scale, 1.234009, atol=1E-5)
+        np.testing.assert_allclose(signal0.axes_manager[0].scale, 1.234009, atol=1E-5)
         assert signal0.axes_manager[1].name == 'y'
         assert signal0.axes_manager[1].size == 50
         assert signal0.axes_manager[1].units == 'nm'
@@ -424,19 +423,19 @@ class TestFeiEMD():
         assert signal.axes_manager[0].name == 'x'
         assert signal.axes_manager[0].size == 10
         assert signal.axes_manager[0].units == 'nm'
-        assert_allclose(signal.axes_manager[0].scale, 1.234009, atol=1E-5)
+        np.testing.assert_allclose(signal.axes_manager[0].scale, 1.234009, atol=1E-5)
         assert signal.axes_manager[1].name == 'y'
         assert signal.axes_manager[1].size == 50
         assert signal.axes_manager[1].units == 'nm'
-        assert_allclose(signal.axes_manager[1].scale, 1.234009, atol=1E-5)
+        np.testing.assert_allclose(signal.axes_manager[1].scale, 1.234009, atol=1E-5)
         assert signal.axes_manager[2].name == 'Time'
         assert signal.axes_manager[2].size == 10
         assert signal.axes_manager[2].units == 's'
-        assert_allclose(signal.axes_manager[2].scale, 0.76800, atol=1E-5)
+        np.testing.assert_allclose(signal.axes_manager[2].scale, 0.76800, atol=1E-5)
         assert signal.axes_manager[3].name == 'X-ray energy'
         assert signal.axes_manager[3].size == 16
         assert signal.axes_manager[3].units == 'keV'
-        assert_allclose(signal.axes_manager[3].scale, 1.28, atol=1E-5)
+        np.testing.assert_allclose(signal.axes_manager[3].scale, 1.28, atol=1E-5)
 
         s = load(os.path.join(self.fei_files_path,
                               'fei_SI_SuperX-HAADF_10frames_10x50.emd'),
@@ -454,19 +453,19 @@ class TestFeiEMD():
         assert signal.axes_manager[0].name == 'x'
         assert signal.axes_manager[0].size == 10
         assert signal.axes_manager[0].units == 'nm'
-        assert_allclose(signal.axes_manager[0].scale, 1.234009, atol=1E-5)
+        np.testing.assert_allclose(signal.axes_manager[0].scale, 1.234009, atol=1E-5)
         assert signal.axes_manager[1].name == 'y'
         assert signal.axes_manager[1].size == 50
         assert signal.axes_manager[1].units == 'nm'
-        assert_allclose(signal.axes_manager[1].scale, 1.234009, atol=1E-5)
+        np.testing.assert_allclose(signal.axes_manager[1].scale, 1.234009, atol=1E-5)
         assert signal.axes_manager[2].name == 'Time'
         assert signal.axes_manager[2].size == 5
         assert signal.axes_manager[2].units == 's'
-        assert_allclose(signal.axes_manager[2].scale, 0.76800, atol=1E-5)
+        np.testing.assert_allclose(signal.axes_manager[2].scale, 0.76800, atol=1E-5)
         assert signal.axes_manager[3].name == 'X-ray energy'
         assert signal.axes_manager[3].size == 16
         assert signal.axes_manager[3].units == 'keV'
-        assert_allclose(signal.axes_manager[3].scale, 1.28, atol=1E-5)
+        np.testing.assert_allclose(signal.axes_manager[3].scale, 1.28, atol=1E-5)
 
         s = load(os.path.join(self.fei_files_path,
                               'fei_SI_SuperX-HAADF_10frames_10x50.emd'),
@@ -484,19 +483,19 @@ class TestFeiEMD():
         assert signal.axes_manager[0].name == 'x'
         assert signal.axes_manager[0].size == 10
         assert signal.axes_manager[0].units == 'nm'
-        assert_allclose(signal.axes_manager[0].scale, 1.234009, atol=1E-5)
+        np.testing.assert_allclose(signal.axes_manager[0].scale, 1.234009, atol=1E-5)
         assert signal.axes_manager[1].name == 'y'
         assert signal.axes_manager[1].size == 50
         assert signal.axes_manager[1].units == 'nm'
-        assert_allclose(signal.axes_manager[1].scale, 1.234009, atol=1E-5)
+        np.testing.assert_allclose(signal.axes_manager[1].scale, 1.234009, atol=1E-5)
         assert signal.axes_manager[2].name == 'Time'
         assert signal.axes_manager[2].size == 6
         assert signal.axes_manager[2].units == 's'
-        assert_allclose(signal.axes_manager[2].scale, 0.76800, atol=1E-5)
+        np.testing.assert_allclose(signal.axes_manager[2].scale, 0.76800, atol=1E-5)
         assert signal.axes_manager[3].name == 'X-ray energy'
         assert signal.axes_manager[3].size == 16
         assert signal.axes_manager[3].units == 'keV'
-        assert_allclose(signal.axes_manager[3].scale, 1.28, atol=1E-5)
+        np.testing.assert_allclose(signal.axes_manager[3].scale, 1.28, atol=1E-5)
 
     @pytest.mark.parametrize("lazy", (True, False))
     def test_fei_emd_si_non_square_20frames(self, lazy):
@@ -512,15 +511,15 @@ class TestFeiEMD():
         assert signal.axes_manager[0].name == 'x'
         assert signal.axes_manager[0].size == 10
         assert signal.axes_manager[0].units == 'nm'
-        assert_allclose(signal.axes_manager[0].scale, 1.234009, atol=1E-5)
+        np.testing.assert_allclose(signal.axes_manager[0].scale, 1.234009, atol=1E-5)
         assert signal.axes_manager[1].name == 'y'
         assert signal.axes_manager[1].size == 50
         assert signal.axes_manager[1].units == 'nm'
-        assert_allclose(signal.axes_manager[1].scale, 1.234009, atol=1E-5)
+        np.testing.assert_allclose(signal.axes_manager[1].scale, 1.234009, atol=1E-5)
         assert signal.axes_manager[2].name == 'X-ray energy'
         assert signal.axes_manager[2].size == 4096
         assert signal.axes_manager[2].units == 'keV'
-        assert_allclose(signal.axes_manager[2].scale, 0.005, atol=1E-5)
+        np.testing.assert_allclose(signal.axes_manager[2].scale, 0.005, atol=1E-5)
 
     @pytest.mark.parametrize("lazy", (True, False))
     def test_fei_emd_si_non_square_20frames_2eV(self, lazy):
@@ -536,15 +535,15 @@ class TestFeiEMD():
         assert signal.axes_manager[0].name == 'x'
         assert signal.axes_manager[0].size == 10
         assert signal.axes_manager[0].units == 'nm'
-        assert_allclose(signal.axes_manager[0].scale, 1.234009, atol=1E-5)
+        np.testing.assert_allclose(signal.axes_manager[0].scale, 1.234009, atol=1E-5)
         assert signal.axes_manager[1].name == 'y'
         assert signal.axes_manager[1].size == 50
         assert signal.axes_manager[1].units == 'nm'
-        assert_allclose(signal.axes_manager[1].scale, 1.234009, atol=1E-5)
+        np.testing.assert_allclose(signal.axes_manager[1].scale, 1.234009, atol=1E-5)
         assert signal.axes_manager[2].name == 'X-ray energy'
         assert signal.axes_manager[2].size == 4096
         assert signal.axes_manager[2].units == 'keV'
-        assert_allclose(signal.axes_manager[2].scale, 0.002, atol=1E-5)
+        np.testing.assert_allclose(signal.axes_manager[2].scale, 0.002, atol=1E-5)
 
     @pytest.mark.parametrize("lazy", (True, False))
     def test_fei_emd_si_frame_range(self, lazy):
@@ -578,7 +577,7 @@ class TestFeiEMD():
             os.path.join(
                 self.fei_files_path,
                 '1532 Camera Ceta.emd'))
-        assert_allclose(signal.data, np.zeros((64, 64)))
+        np.testing.assert_allclose(signal.data, np.zeros((64, 64)))
         assert isinstance(signal, Signal2D)
         date, time = self._convert_datetime(1512055942.914275).split('T')
         assert signal.metadata.General.date == date
@@ -589,7 +588,7 @@ class TestFeiEMD():
             os.path.join(
                 self.fei_files_path,
                 '1854 Camera Ceta.emd'))
-        assert_allclose(signal.data, np.zeros((64, 64)))
+        np.testing.assert_allclose(signal.data, np.zeros((64, 64)))
         assert isinstance(signal, Signal2D)
 
     def _convert_datetime(self, unix_time):

--- a/hyperspy/tests/io/test_empad.py
+++ b/hyperspy/tests/io/test_empad.py
@@ -3,7 +3,6 @@ import os
 import struct
 
 import numpy as np
-import numpy.testing as nt
 import pytest
 import traits.api as t
 
@@ -37,7 +36,7 @@ def test_read_stack(lazy):
     s = hs.load(os.path.join(DATA_DIR, 'stack_images.xml'), lazy=lazy)
     assert s.data.dtype == 'float32'
     ref_data = np.arange(166400).reshape((10, 130, 128))[..., :128, :]
-    nt.assert_allclose(s.data, ref_data.astype('float32'))
+    np.testing.assert_allclose(s.data, ref_data.astype('float32'))
     signal_axes = s.axes_manager.signal_axes
     assert signal_axes[0].name == 'width'
     assert signal_axes[1].name == 'height'
@@ -63,21 +62,21 @@ def test_read_map(lazy):
     s = hs.load(os.path.join(DATA_DIR, 'map4x4.xml'), lazy=lazy)
     assert s.data.dtype == 'float32'
     ref_data = np.arange(266240).reshape((4, 4, 130, 128))[..., :128, :]
-    nt.assert_allclose(s.data, ref_data.astype('float32'))
+    np.testing.assert_allclose(s.data, ref_data.astype('float32'))
     signal_axes = s.axes_manager.signal_axes
     assert signal_axes[0].name == 'width'
     assert signal_axes[1].name == 'height'
     for axis in signal_axes:
         assert axis.units == '1/nm'
-        nt.assert_allclose(axis.scale, 0.1826537)
-        nt.assert_allclose(axis.offset, -11.689837)
+        np.testing.assert_allclose(axis.scale, 0.1826537)
+        np.testing.assert_allclose(axis.offset, -11.689837)
     navigation_axes = s.axes_manager.navigation_axes
     assert navigation_axes[0].name == 'scan_y'
     assert navigation_axes[1].name == 'scan_x'
     for axis in navigation_axes:
         assert axis.units == 'µm'
-        nt.assert_allclose(axis.scale, 1.1415856)
-        nt.assert_allclose(axis.offset, 0.0)
+        np.testing.assert_allclose(axis.scale, 1.1415856)
+        np.testing.assert_allclose(axis.offset, 0.0)
 
     assert s.metadata.General.date == '2019-06-06'
     assert s.metadata.General.time == '13:30:00.164675'

--- a/hyperspy/tests/io/test_fei.py
+++ b/hyperspy/tests/io/test_fei.py
@@ -21,7 +21,6 @@ import os
 import numpy as np
 import pytest
 import traits.api as t
-from numpy.testing import assert_allclose
 
 from hyperspy.io import load
 from hyperspy.io_plugins.fei import load_ser_file
@@ -70,10 +69,10 @@ class TestFEIReader():
         assert s0.axes_manager.signal_dimension == 2
         assert (
             s0.metadata.Acquisition_instrument.TEM.acquisition_mode == 'TEM')
-        assert_allclose(s0.axes_manager[0].scale, 0.101571, rtol=1E-5)
+        np.testing.assert_allclose(s0.axes_manager[0].scale, 0.101571, rtol=1E-5)
         assert s0.axes_manager[0].units == '1 / nm'
         assert (s0.axes_manager[0].name == 'x')
-        assert_allclose(s0.axes_manager[1].scale, 0.101571, rtol=1E-5)
+        np.testing.assert_allclose(s0.axes_manager[1].scale, 0.101571, rtol=1E-5)
         assert s0.axes_manager[1].units == '1 / nm'
         assert (s0.axes_manager[1].name == 'y')
 
@@ -86,9 +85,9 @@ class TestFEIReader():
         assert s0[0].axes_manager.signal_dimension == 1
         assert (
             s0[0].metadata.Acquisition_instrument.TEM.acquisition_mode == 'STEM')
-        assert_allclose(s0[0].axes_manager[0].scale, 3.68864, rtol=1E-5)
+        np.testing.assert_allclose(s0[0].axes_manager[0].scale, 3.68864, rtol=1E-5)
         assert s0[0].axes_manager[0].units == 'nm'
-        assert_allclose(s0[0].axes_manager[1].scale, 5.0, rtol=1E-5)
+        np.testing.assert_allclose(s0[0].axes_manager[1].scale, 5.0, rtol=1E-5)
         assert s0[0].axes_manager[1].units == 'eV'
         assert (s0[0].axes_manager[0].name == 'x')
         assert (s0[0].axes_manager[1].name == 'Energy')
@@ -97,12 +96,12 @@ class TestFEIReader():
         assert s0[1].axes_manager.signal_dimension == 2
         assert (
             s0[1].metadata.Acquisition_instrument.TEM.acquisition_mode == 'STEM')
-        assert_allclose(s0[1].axes_manager[0].scale, 3.68864, rtol=1E-5)
+        np.testing.assert_allclose(s0[1].axes_manager[0].scale, 3.68864, rtol=1E-5)
         assert s0[1].axes_manager[0].units == 'nm'
         assert s0[1].axes_manager[1].units == '1 / nm'
         assert (s0[1].axes_manager[0].name == 'x')
-        assert_allclose(s0[1].axes_manager[1].scale, 0.174353, rtol=1E-5)
-        assert_allclose(s0[1].axes_manager[2].scale, 0.174353, rtol=1E-5)
+        np.testing.assert_allclose(s0[1].axes_manager[1].scale, 0.174353, rtol=1E-5)
+        np.testing.assert_allclose(s0[1].axes_manager[2].scale, 0.174353, rtol=1E-5)
         assert s0[1].axes_manager[2].units == '1 / nm'
         assert (s0[1].axes_manager[1].units == '1 / nm')
         assert (s0[1].axes_manager[1].name == 'x')
@@ -117,31 +116,31 @@ class TestFEIReader():
         assert s0[0].axes_manager.signal_dimension == 1
         assert (
             s0[0].metadata.Acquisition_instrument.TEM.acquisition_mode == 'STEM')
-        assert_allclose(s0[0].axes_manager[0].scale, 1.87390, rtol=1E-5)
+        np.testing.assert_allclose(s0[0].axes_manager[0].scale, 1.87390, rtol=1E-5)
         assert s0[0].axes_manager[0].units == 'nm'
-        assert_allclose(s0[0].axes_manager[1].scale, -1.87390, rtol=1E-5)
+        np.testing.assert_allclose(s0[0].axes_manager[1].scale, -1.87390, rtol=1E-5)
         assert s0[0].axes_manager[1].units == 'nm'
-        assert_allclose(s0[0].axes_manager[2].scale, 5.0, rtol=1E-5)
+        np.testing.assert_allclose(s0[0].axes_manager[2].scale, 5.0, rtol=1E-5)
         assert s0[0].axes_manager[2].units == 'eV'
         # s0[1] contains diffraction patterns
         assert s0[1].data.shape == (5, 5, 256, 256)
         assert s0[1].axes_manager.signal_dimension == 2
         assert (
             s0[1].metadata.Acquisition_instrument.TEM.acquisition_mode == 'STEM')
-        assert_allclose(s0[1].axes_manager[0].scale, 1.87390, rtol=1E-5)
+        np.testing.assert_allclose(s0[1].axes_manager[0].scale, 1.87390, rtol=1E-5)
         assert s0[1].axes_manager[0].units == 'nm'
-        assert_allclose(s0[1].axes_manager[2].scale, 0.174353, rtol=1E-5)
+        np.testing.assert_allclose(s0[1].axes_manager[2].scale, 0.174353, rtol=1E-5)
         assert s0[1].axes_manager[2].units == '1 / nm'
         assert (s0[0].axes_manager[0].name == 'x')
         assert (s0[0].axes_manager[1].name == 'y')
         assert (s0[0].axes_manager[2].name == 'Energy')
-        assert_allclose(s0[1].axes_manager[0].scale, 1.87390, rtol=1E-5)
+        np.testing.assert_allclose(s0[1].axes_manager[0].scale, 1.87390, rtol=1E-5)
         assert (s0[1].axes_manager[0].name == 'x')
-        assert_allclose(s0[1].axes_manager[1].scale, -1.87390, rtol=1E-5)
+        np.testing.assert_allclose(s0[1].axes_manager[1].scale, -1.87390, rtol=1E-5)
         assert (s0[1].axes_manager[1].units == 'nm')
         assert (s0[1].axes_manager[1].name == 'y')
         assert (s0[1].axes_manager[2].name == 'x')
-        assert_allclose(s0[1].axes_manager[3].scale, 0.174353, rtol=1E-5)
+        np.testing.assert_allclose(s0[1].axes_manager[3].scale, 0.174353, rtol=1E-5)
         assert (s0[1].axes_manager[3].units == '1 / nm')
         assert (s0[1].axes_manager[3].name == 'y')
 
@@ -159,11 +158,11 @@ class TestFEIReader():
         # case of point spectra. However, the position seems to be saved in
         # 'PositionX' and 'PositionY' arrays of the ser header, so it should
         # be possible to workaround using the position arrays.
-#        nt.assert_almost_equal(
+#        np.testing.assert_almost_equal(
 #            s0.axes_manager[0].scale, 1.0, places=5)
-#        nt.assert_equal(s0.axes_manager[0].units, '')
-#        nt.assert_is(s0.axes_manager[0].name, 'Position index')
-        assert_allclose(s0.axes_manager[1].scale, 0.2, rtol=1E-5)
+#        np.testing.assert_equal(s0.axes_manager[0].units, '')
+#        np.testing.assert_is(s0.axes_manager[0].name, 'Position index')
+        np.testing.assert_allclose(s0.axes_manager[1].scale, 0.2, rtol=1E-5)
         assert s0.axes_manager[1].units == 'eV'
         assert (s0.axes_manager[1].name == 'Energy')
 
@@ -174,7 +173,7 @@ class TestFEIReader():
         assert s1.axes_manager.signal_dimension == 1
         assert (
             s1.metadata.Acquisition_instrument.TEM.acquisition_mode == 'STEM')
-        assert_allclose(s0.axes_manager[1].scale, 0.2, rtol=1E-5)
+        np.testing.assert_allclose(s0.axes_manager[1].scale, 0.2, rtol=1E-5)
         assert s0.axes_manager[1].units == 'eV'
         assert (s0.axes_manager[1].name == 'Energy')
 
@@ -186,9 +185,9 @@ class TestFEIReader():
         assert s0.axes_manager.signal_dimension == 1
         assert (
             s0.metadata.Acquisition_instrument.TEM.acquisition_mode == 'STEM')
-        assert_allclose(s0.axes_manager[0].scale, 0.123034, rtol=1E-5)
+        np.testing.assert_allclose(s0.axes_manager[0].scale, 0.123034, rtol=1E-5)
         assert s0.axes_manager[0].units == 'nm'
-        assert_allclose(s0.axes_manager[1].scale, 0.2, rtol=1E-5)
+        np.testing.assert_allclose(s0.axes_manager[1].scale, 0.2, rtol=1E-5)
         assert s0.axes_manager[1].units == 'eV'
         assert (s0.axes_manager[0].name == 'x')
         assert (s0.axes_manager[1].name == 'Energy')
@@ -200,9 +199,9 @@ class TestFEIReader():
         assert s1.axes_manager.signal_dimension == 1
         assert (
             s1.metadata.Acquisition_instrument.TEM.acquisition_mode == 'STEM')
-        assert_allclose(s1.axes_manager[0].scale, 0.166318, rtol=1E-5)
+        np.testing.assert_allclose(s1.axes_manager[0].scale, 0.166318, rtol=1E-5)
         assert s1.axes_manager[0].units == 'nm'
-        assert_allclose(s1.axes_manager[1].scale, 0.2, rtol=1E-5)
+        np.testing.assert_allclose(s1.axes_manager[1].scale, 0.2, rtol=1E-5)
         assert s1.axes_manager[1].units == 'eV'
         assert (s0.axes_manager[0].name == 'x')
 
@@ -214,11 +213,11 @@ class TestFEIReader():
         assert s0.axes_manager.signal_dimension == 1
         assert (
             s0.metadata.Acquisition_instrument.TEM.acquisition_mode == 'STEM')
-        assert_allclose(s0.axes_manager[0].scale, 0.120539, rtol=1E-5)
+        np.testing.assert_allclose(s0.axes_manager[0].scale, 0.120539, rtol=1E-5)
         assert s0.axes_manager[0].units == 'nm'
-        assert_allclose(s0.axes_manager[1].scale, -0.120539, rtol=1E-5)
+        np.testing.assert_allclose(s0.axes_manager[1].scale, -0.120539, rtol=1E-5)
         assert s0.axes_manager[1].units == 'nm'
-        assert_allclose(s0.axes_manager[2].scale, 0.2, rtol=1E-5)
+        np.testing.assert_allclose(s0.axes_manager[2].scale, 0.2, rtol=1E-5)
         assert s0.axes_manager[2].units == 'eV'
         assert (s0.axes_manager[2].name == 'Energy')
         assert (s0.axes_manager[1].name == 'y')
@@ -232,20 +231,20 @@ class TestFEIReader():
         assert s0.axes_manager.signal_dimension == 1
         assert (
             s0.metadata.Acquisition_instrument.TEM.acquisition_mode == 'STEM')
-        assert_allclose(s0.axes_manager[0].scale, 1.98591, rtol=1E-5)
+        np.testing.assert_allclose(s0.axes_manager[0].scale, 1.98591, rtol=1E-5)
         assert s0.axes_manager[0].units == 'nm'
-        assert_allclose(s0.axes_manager[1].scale, -4.25819, rtol=1E-5)
+        np.testing.assert_allclose(s0.axes_manager[1].scale, -4.25819, rtol=1E-5)
         assert s0.axes_manager[1].units == 'nm'
-        assert_allclose(s0.axes_manager[2].scale, 5.0, rtol=1E-5)
+        np.testing.assert_allclose(s0.axes_manager[2].scale, 5.0, rtol=1E-5)
         assert s0.axes_manager[2].units == 'eV'
 
     def test_load_search(self):
         fname0 = os.path.join(self.dirpathnew, '128x128-TEM_search.emi')
         s0 = load(fname0)
         assert s0.data.shape == (128, 128)
-        assert_allclose(s0.axes_manager[0].scale, 5.26121, rtol=1E-5)
+        np.testing.assert_allclose(s0.axes_manager[0].scale, 5.26121, rtol=1E-5)
         assert s0.axes_manager[0].units == 'nm'
-        assert_allclose(s0.axes_manager[1].scale, 5.26121, rtol=1E-5)
+        np.testing.assert_allclose(s0.axes_manager[1].scale, 5.26121, rtol=1E-5)
         assert s0.axes_manager[1].units == 'nm'
 
         fname1 = os.path.join(self.dirpathold, '16x16_STEM_BF_DF_search.emi')
@@ -255,10 +254,10 @@ class TestFEIReader():
             assert s.data.shape == (16, 16)
             assert (
                 s.metadata.Acquisition_instrument.TEM.acquisition_mode == 'STEM')
-            assert_allclose(
+            np.testing.assert_allclose(
                 s.axes_manager[0].scale, 22.026285, rtol=1E-5)
             assert s.axes_manager[0].units == 'nm'
-            assert_allclose(
+            np.testing.assert_allclose(
                 s.axes_manager[1].scale, 22.026285, rtol=1E-5)
             assert s.axes_manager[1].units == 'nm'
 
@@ -269,11 +268,11 @@ class TestFEIReader():
         assert s0.axes_manager.signal_dimension == 2
         assert (
             s0.metadata.Acquisition_instrument.TEM.acquisition_mode == 'TEM')
-        assert_allclose(s0.axes_manager[0].scale, 1.0, rtol=1E-5)
+        np.testing.assert_allclose(s0.axes_manager[0].scale, 1.0, rtol=1E-5)
         assert s0.axes_manager[0].units is t.Undefined
-        assert_allclose(s0.axes_manager[1].scale, 6.281833, rtol=1E-5)
+        np.testing.assert_allclose(s0.axes_manager[1].scale, 6.281833, rtol=1E-5)
         assert s0.axes_manager[1].units == 'nm'
-        assert_allclose(s0.axes_manager[2].scale, 6.281833, rtol=1E-5)
+        np.testing.assert_allclose(s0.axes_manager[2].scale, 6.281833, rtol=1E-5)
         assert s0.axes_manager[2].units == 'nm'
         assert s0.axes_manager[0].units is t.Undefined
         assert (s0.axes_manager[0].scale == 1.0)
@@ -285,10 +284,10 @@ class TestFEIReader():
             self.dirpathnew, '128x128x5-diffraction_preview.emi')
         s2 = load(fname2)
         assert s2.data.shape == (5, 128, 128)
-        assert_allclose(s2.axes_manager[1].scale, 0.042464, rtol=1E-5)
+        np.testing.assert_allclose(s2.axes_manager[1].scale, 0.042464, rtol=1E-5)
         assert s0.axes_manager[0].units is t.Undefined
         assert s2.axes_manager[1].units == '1 / nm'
-        assert_allclose(s2.axes_manager[2].scale, 0.042464, rtol=1E-5)
+        np.testing.assert_allclose(s2.axes_manager[2].scale, 0.042464, rtol=1E-5)
         assert s2.axes_manager[2].units == '1 / nm'
 
         fname1 = os.path.join(
@@ -299,9 +298,9 @@ class TestFEIReader():
             assert s.data.shape == (5, 16, 16)
             assert (
                 s.metadata.Acquisition_instrument.TEM.acquisition_mode == 'STEM')
-            assert_allclose(s.axes_manager[0].scale, 1.0, rtol=1E-5)
+            np.testing.assert_allclose(s.axes_manager[0].scale, 1.0, rtol=1E-5)
             assert s.axes_manager[1].units == 'nm'
-            assert_allclose(
+            np.testing.assert_allclose(
                 s.axes_manager[1].scale, 21.510044, rtol=1E-5)
 
     def test_load_acquire(self):
@@ -310,9 +309,9 @@ class TestFEIReader():
         assert s0.axes_manager.signal_dimension == 2
         assert (
             s0.metadata.Acquisition_instrument.TEM.acquisition_mode == 'TEM')
-        assert_allclose(s0.axes_manager[0].scale, 6.281833, rtol=1E-5)
+        np.testing.assert_allclose(s0.axes_manager[0].scale, 6.281833, rtol=1E-5)
         assert s0.axes_manager[0].units == 'nm'
-        assert_allclose(s0.axes_manager[1].scale, 6.281833, rtol=1E-5)
+        np.testing.assert_allclose(s0.axes_manager[1].scale, 6.281833, rtol=1E-5)
         assert s0.axes_manager[1].units == 'nm'
         assert (s0.axes_manager[0].name == 'x')
         assert (s0.axes_manager[1].name == 'y')
@@ -324,10 +323,10 @@ class TestFEIReader():
             assert s.data.shape == (16, 16)
             assert (
                 s.metadata.Acquisition_instrument.TEM.acquisition_mode == 'STEM')
-            assert_allclose(
+            np.testing.assert_allclose(
                 s.axes_manager[0].scale, 21.510044, rtol=1E-5)
             assert s.axes_manager[0].units == 'nm'
-            assert_allclose(
+            np.testing.assert_allclose(
                 s.axes_manager[1].scale, 21.510044, rtol=1E-5)
             assert s.axes_manager[1].units == 'nm'
             assert (s.axes_manager[0].name == 'x')
@@ -341,8 +340,8 @@ class TestFEIReader():
         nav_shape = () if only_valid_data else (2, )
         assert s0.data.shape == nav_shape + (2048, )
         assert len(s0.axes_manager.navigation_axes) == len(nav_shape)
-        assert_allclose(s0.axes_manager[-1].offset, 2160, rtol=1E-5)
-        assert_allclose(s0.axes_manager[-1].scale, 0.2, rtol=1E-5)
+        np.testing.assert_allclose(s0.axes_manager[-1].offset, 2160, rtol=1E-5)
+        np.testing.assert_allclose(s0.axes_manager[-1].scale, 0.2, rtol=1E-5)
 
         fname1 = os.path.join(self.dirpathold, '03_Scanning Preview.emi')
         s1 = load(fname1, only_valid_data=only_valid_data)
@@ -352,8 +351,8 @@ class TestFEIReader():
         sig_axes = s1.axes_manager.signal_axes
         assert len(nav_axes) == len(nav_shape)
         assert sig_axes[-1].size == sig_axes[1].size == 128
-        assert_allclose(sig_axes[0].scale, 0.38435, rtol=1E-5)
-        assert_allclose(sig_axes[1].scale, 0.38435, rtol=1E-5)
+        np.testing.assert_allclose(sig_axes[0].scale, 0.38435, rtol=1E-5)
+        np.testing.assert_allclose(sig_axes[1].scale, 0.38435, rtol=1E-5)
 
     def test_read_STEM_TEM_mode(self):
         # TEM image
@@ -378,23 +377,23 @@ class TestFEIReader():
         # TEM image
         fname0 = os.path.join(self.dirpathold, '64x64_TEM_images_acquire.emi')
         s0 = load(fname0)
-        assert_allclose(s0.axes_manager[0].scale, 6.28183, rtol=1E-5)
+        np.testing.assert_allclose(s0.axes_manager[0].scale, 6.28183, rtol=1E-5)
         assert s0.axes_manager[0].units == 'nm'
-        assert_allclose(s0.metadata.Acquisition_instrument.TEM.magnification,
+        np.testing.assert_allclose(s0.metadata.Acquisition_instrument.TEM.magnification,
                         19500.0, rtol=1E-5)
         # TEM diffraction
         fname1 = os.path.join(self.dirpathold, '64x64_diffraction_acquire.emi')
         s1 = load(fname1)
-        assert_allclose(s1.axes_manager[0].scale, 0.101571, rtol=1E-5)
+        np.testing.assert_allclose(s1.axes_manager[0].scale, 0.101571, rtol=1E-5)
         assert s1.axes_manager[0].units == '1 / nm'
-        assert_allclose(s1.metadata.Acquisition_instrument.TEM.camera_length,
+        np.testing.assert_allclose(s1.metadata.Acquisition_instrument.TEM.camera_length,
                         490.0, rtol=1E-5)
         # STEM diffraction
         fname2 = os.path.join(self.dirpathold, '16x16_STEM_BF_DF_acquire.emi')
         s2 = load(fname2)
         assert s2[0].axes_manager[0].units == 'nm'
-        assert_allclose(s2[0].axes_manager[0].scale, 21.5100, rtol=1E-5)
-        assert_allclose(s2[0].metadata.Acquisition_instrument.TEM.magnification,
+        np.testing.assert_allclose(s2[0].axes_manager[0].scale, 21.5100, rtol=1E-5)
+        np.testing.assert_allclose(s2[0].metadata.Acquisition_instrument.TEM.magnification,
                         10000.0, rtol=1E-5)
 
     def test_guess_units_from_mode(self):
@@ -460,7 +459,7 @@ class TestFEIReader():
         assert (
             s.metadata.Acquisition_instrument.TEM.microscope ==
             "Tecnai 200 kV D2267 SuperTwin")
-        assert_allclose(s.metadata.Acquisition_instrument.TEM.Stage.tilt_alpha,
+        np.testing.assert_allclose(s.metadata.Acquisition_instrument.TEM.Stage.tilt_alpha,
                         0.0, rtol=1E-5)
 
     def test_metadata_STEM(self):
@@ -476,15 +475,15 @@ class TestFEIReader():
         assert (
             s.metadata.Acquisition_instrument.TEM.microscope ==
             "Tecnai 200 kV D2267 SuperTwin")
-        assert_allclose(s.metadata.Acquisition_instrument.TEM.Stage.tilt_alpha,
+        np.testing.assert_allclose(s.metadata.Acquisition_instrument.TEM.Stage.tilt_alpha,
                         0.0, rtol=1E-6)
-        assert_allclose(s.metadata.Acquisition_instrument.TEM.Stage.tilt_beta,
+        np.testing.assert_allclose(s.metadata.Acquisition_instrument.TEM.Stage.tilt_beta,
                         0.0, rtol=1E-6)
-        assert_allclose(s.metadata.Acquisition_instrument.TEM.Stage.x,
+        np.testing.assert_allclose(s.metadata.Acquisition_instrument.TEM.Stage.x,
                         -0.000158, rtol=1E-6)
-        assert_allclose(s.metadata.Acquisition_instrument.TEM.Stage.y,
+        np.testing.assert_allclose(s.metadata.Acquisition_instrument.TEM.Stage.y,
                         1.9e-05, rtol=1E-6)
-        assert_allclose(s.metadata.Acquisition_instrument.TEM.Stage.z,
+        np.testing.assert_allclose(s.metadata.Acquisition_instrument.TEM.Stage.z,
                         0.0, rtol=1E-6)
 
     def test_metadata_diffraction(self):

--- a/hyperspy/tests/io/test_mrcz.py
+++ b/hyperspy/tests/io/test_mrcz.py
@@ -29,7 +29,7 @@ from hyperspy.io import load, save
 from hyperspy.misc.test_utils import assert_deep_almost_equal
 
 
-mrcz = pytest.importorskip("mrcz", reason="skipping test_mrcz tests, requires mrcz")
+mrcz = pytest.importorskip("mrcz", reason="mrcz not installed")
 
 
 #==============================================================================

--- a/hyperspy/tests/io/test_protochips.py
+++ b/hyperspy/tests/io/test_protochips.py
@@ -20,7 +20,6 @@ import os
 
 import numpy as np
 import pytest
-from numpy.testing import assert_allclose
 
 import hyperspy.api as hs
 from hyperspy.io_plugins.protochips import ProtochipsCSV, invalid_file_error
@@ -101,7 +100,7 @@ class TestProtochipsGasCellCSV():
             assert s.metadata.General.date == date
             assert s.metadata.General.time == time
             assert s.axes_manager[0].units == 's'
-            assert_allclose(s.axes_manager[0].scale, 0.25995, atol=1E-5)
+            np.testing.assert_allclose(s.axes_manager[0].scale, 0.25995, atol=1E-5)
             assert s.axes_manager[0].offset == 0
 
     def test_read_original_metadata(self):
@@ -132,7 +131,7 @@ class TestProtochipsGasCellCSVNoUser():
             assert s.metadata.General.date == date
             assert s.metadata.General.time == time
             assert s.axes_manager[0].units == 's'
-            assert_allclose(s.axes_manager[0].scale, 0.26029, atol=1E-5)
+            np.testing.assert_allclose(s.axes_manager[0].scale, 0.26029, atol=1E-5)
             assert s.axes_manager[0].offset == 0
 
     def test_read_original_metadata(self):

--- a/hyperspy/tests/io/test_sur.py
+++ b/hyperspy/tests/io/test_sur.py
@@ -18,8 +18,7 @@
 
 import os
 
-from numpy import dtype
-from numpy.testing import assert_allclose
+import numpy as np
 
 from hyperspy.io import load
 
@@ -141,9 +140,9 @@ def test_load_profile():
 
     #Verifying signal shape and axes dimensions, navigation (not data themselves)
     assert s.data.shape == (128,)
-    assert s.data.dtype == dtype(float)
-    assert_allclose(s.axes_manager[0].scale,8.252197e-05)
-    assert_allclose(s.axes_manager[0].offset,0.0)
+    assert s.data.dtype == np.dtype(float)
+    np.testing.assert_allclose(s.axes_manager[0].scale,8.252197e-05)
+    np.testing.assert_allclose(s.axes_manager[0].offset,0.0)
     assert s.axes_manager[0].name == 'Width'
     assert s.axes_manager[0].units == 'mm'
     assert s.axes_manager[0].size == 128
@@ -166,12 +165,12 @@ def test_load_RGB():
                          "test_RGB.sur")
     s = load(fname)
     assert s.data.shape == (200, 200)
-    assert s.data.dtype == dtype([('R', 'u1'), ('G', 'u1'), ('B', 'u1')])
+    assert s.data.dtype == np.dtype([('R', 'u1'), ('G', 'u1'), ('B', 'u1')])
 
-    assert_allclose(s.axes_manager[0].scale,0.35277777)
-    assert_allclose(s.axes_manager[0].offset,208.8444519)
-    assert_allclose(s.axes_manager[1].scale,0.35277777)
-    assert_allclose(s.axes_manager[1].offset,210.608337)
+    np.testing.assert_allclose(s.axes_manager[0].scale,0.35277777)
+    np.testing.assert_allclose(s.axes_manager[0].offset,208.8444519)
+    np.testing.assert_allclose(s.axes_manager[1].scale,0.35277777)
+    np.testing.assert_allclose(s.axes_manager[1].offset,210.608337)
     assert s.axes_manager[0].name == 'X'
     assert s.axes_manager[0].units == 'mm'
     assert s.axes_manager[1].name == 'Y'
@@ -197,14 +196,14 @@ def test_load_spectra():
     s = load(fname)
 
     assert s.data.shape == (65, 512)
-    assert s.data.dtype == dtype('float64')
+    assert s.data.dtype == np.dtype('float64')
 
     md = s.metadata
     assert md.Signal.quantity == 'CL Intensity (a.u.)'
-    assert_allclose(s.axes_manager[0].scale,0.00011458775406936184)
-    assert_allclose(s.axes_manager[0].offset,0.0)
-    assert_allclose(s.axes_manager[1].scale,1.084000246009964e-06)
-    assert_allclose(s.axes_manager[1].offset,0.00017284281784668565)
+    np.testing.assert_allclose(s.axes_manager[0].scale,0.00011458775406936184)
+    np.testing.assert_allclose(s.axes_manager[0].offset,0.0)
+    np.testing.assert_allclose(s.axes_manager[1].scale,1.084000246009964e-06)
+    np.testing.assert_allclose(s.axes_manager[1].offset,0.00017284281784668565)
     assert s.axes_manager[0].name == 'Spectrum positi'
     assert s.axes_manager[0].units == 'mm'
     assert s.axes_manager[1].name == 'Wavelength'
@@ -226,16 +225,16 @@ def test_load_spectral_map_compressed():
     s = load(fname)
 
     assert s.data.shape == (12, 10, 281)
-    assert s.data.dtype == dtype('float64')
+    assert s.data.dtype == np.dtype('float64')
 
     md = s.metadata
     assert md.Signal.quantity == 'CL Intensity (a.u.)'
-    assert_allclose(s.axes_manager[0].scale,8.252198e-05)
-    assert_allclose(s.axes_manager[0].offset,0.005694016348570585)
-    assert_allclose(s.axes_manager[1].scale,8.252198e-05)
-    assert_allclose(s.axes_manager[1].offset,0.0054464503191411495)
-    assert_allclose(s.axes_manager[2].scale,1.084000246009964e-06)
-    assert_allclose(s.axes_manager[2].offset,0.00034411484375596046)
+    np.testing.assert_allclose(s.axes_manager[0].scale,8.252198e-05)
+    np.testing.assert_allclose(s.axes_manager[0].offset,0.005694016348570585)
+    np.testing.assert_allclose(s.axes_manager[1].scale,8.252198e-05)
+    np.testing.assert_allclose(s.axes_manager[1].offset,0.0054464503191411495)
+    np.testing.assert_allclose(s.axes_manager[2].scale,1.084000246009964e-06)
+    np.testing.assert_allclose(s.axes_manager[2].offset,0.00034411484375596046)
     assert s.axes_manager[0].name == 'Width'
     assert s.axes_manager[0].units == 'mm'
     assert s.axes_manager[1].name == 'Height'
@@ -271,16 +270,16 @@ def test_load_spectral_map():
     s = load(fname)
 
     assert s.data.shape == (12, 10, 310)
-    assert s.data.dtype == dtype('float64')
+    assert s.data.dtype == np.dtype('float64')
 
     md = s.metadata
     assert md.Signal.quantity == 'CL Intensity (a.u.)'
-    assert_allclose(s.axes_manager[0].scale,8.252197585534304e-05)
-    assert_allclose(s.axes_manager[0].offset,0.00701436772942543)
-    assert_allclose(s.axes_manager[1].scale,8.252197585534304e-05)
-    assert_allclose(s.axes_manager[1].offset,0.003053313121199608)
-    assert_allclose(s.axes_manager[2].scale,1.084000246009964e-6)
-    assert_allclose(s.axes_manager[2].offset,0.0003332748601678759)
+    np.testing.assert_allclose(s.axes_manager[0].scale,8.252197585534304e-05)
+    np.testing.assert_allclose(s.axes_manager[0].offset,0.00701436772942543)
+    np.testing.assert_allclose(s.axes_manager[1].scale,8.252197585534304e-05)
+    np.testing.assert_allclose(s.axes_manager[1].offset,0.003053313121199608)
+    np.testing.assert_allclose(s.axes_manager[2].scale,1.084000246009964e-6)
+    np.testing.assert_allclose(s.axes_manager[2].offset,0.0003332748601678759)
     assert s.axes_manager[0].name == 'Width'
     assert s.axes_manager[0].units == 'mm'
     assert s.axes_manager[1].name == 'Height'
@@ -317,10 +316,10 @@ def test_load_spectrum_compressed():
     md = s.metadata
     assert md.Signal.quantity == 'CL Intensity (a.u.)'
     assert s.data.shape == (512,)
-    #assert_allclose(s.axes_manager[0].scale,1.0)
-    #assert_allclose(s.axes_manager[0].offset,0.0)
-    assert_allclose(s.axes_manager[0].scale,1.084000246009964e-6)
-    assert_allclose(s.axes_manager[0].offset,172.84281784668565e-6)
+    #np.testing.assert_allclose(s.axes_manager[0].scale,1.0)
+    #np.testing.assert_allclose(s.axes_manager[0].offset,0.0)
+    np.testing.assert_allclose(s.axes_manager[0].scale,1.084000246009964e-6)
+    np.testing.assert_allclose(s.axes_manager[0].offset,172.84281784668565e-6)
 
     #assert s.axes_manager[0].name == 'T'
     #assert s.axes_manager[0].units == ''
@@ -345,10 +344,10 @@ def test_load_spectrum():
 
     md = s.metadata
     assert md.Signal.quantity == 'CL Intensity (a.u.)'
-    #assert_allclose(s.axes_manager[0].scale,1.0)
-    #assert_allclose(s.axes_manager[0].offset,0.0)
-    assert_allclose(s.axes_manager[0].scale,1.084000246009964e-6)
-    assert_allclose(s.axes_manager[0].offset,172.84281784668565e-6)
+    #np.testing.assert_allclose(s.axes_manager[0].scale,1.0)
+    #np.testing.assert_allclose(s.axes_manager[0].offset,0.0)
+    np.testing.assert_allclose(s.axes_manager[0].scale,1.084000246009964e-6)
+    np.testing.assert_allclose(s.axes_manager[0].offset,172.84281784668565e-6)
 
     #assert s.axes_manager[0].name == 'T'
     #assert s.axes_manager[0].units == ''
@@ -372,10 +371,10 @@ def test_load_surface():
     md = s.metadata
     assert md.Signal.quantity == 'CL Intensity (a.u.)'
     assert s.data.shape == (128,128)
-    assert_allclose(s.axes_manager[0].scale,8.252198e-05)
-    assert_allclose(s.axes_manager[0].offset,0.0)
-    assert_allclose(s.axes_manager[1].scale,8.252198e-05)
-    assert_allclose(s.axes_manager[1].offset,0.0)
+    np.testing.assert_allclose(s.axes_manager[0].scale,8.252198e-05)
+    np.testing.assert_allclose(s.axes_manager[0].offset,0.0)
+    np.testing.assert_allclose(s.axes_manager[1].scale,8.252198e-05)
+    np.testing.assert_allclose(s.axes_manager[1].offset,0.0)
 
     assert s.axes_manager[0].name == 'Width'
     assert s.axes_manager[0].units == 'mm'

--- a/hyperspy/tests/io/test_tiff.py
+++ b/hyperspy/tests/io/test_tiff.py
@@ -4,7 +4,6 @@ import tempfile
 import numpy as np
 import pytest
 import traits.api as t
-from numpy.testing import assert_allclose
 
 import hyperspy.api as hs
 from hyperspy.misc.test_utils import assert_deep_almost_equal
@@ -20,9 +19,9 @@ def test_rgba16():
     assert s.axes_manager[0].units == t.Undefined
     assert s.axes_manager[1].units == t.Undefined
     assert s.axes_manager[2].units == t.Undefined
-    assert_allclose(s.axes_manager[0].scale, 1.0, atol=1E-5)
-    assert_allclose(s.axes_manager[1].scale, 1.0, atol=1E-5)
-    assert_allclose(s.axes_manager[2].scale, 1.0, atol=1E-5)
+    np.testing.assert_allclose(s.axes_manager[0].scale, 1.0, atol=1E-5)
+    np.testing.assert_allclose(s.axes_manager[1].scale, 1.0, atol=1E-5)
+    np.testing.assert_allclose(s.axes_manager[2].scale, 1.0, atol=1E-5)
     assert s.metadata.General.date == '2014-03-31'
     assert s.metadata.General.time == '16:35:46'
 
@@ -37,8 +36,8 @@ def test_read_unit_um():
     s = hs.load(os.path.join(MY_PATH2, 'test_dm_image_um_unit.dm3'))
     assert s.axes_manager[0].units == 'µm'
     assert s.axes_manager[1].units == 'µm'
-    assert_allclose(s.axes_manager[0].scale, 0.16867, atol=1E-5)
-    assert_allclose(s.axes_manager[1].scale, 0.16867, atol=1E-5)
+    np.testing.assert_allclose(s.axes_manager[0].scale, 0.16867, atol=1E-5)
+    np.testing.assert_allclose(s.axes_manager[1].scale, 0.16867, atol=1E-5)
     assert s.metadata.General.date == '2015-07-20'
     assert s.metadata.General.time == '18:48:25'
     with tempfile.TemporaryDirectory() as tmpdir:
@@ -48,8 +47,8 @@ def test_read_unit_um():
         s2 = hs.load(fname)
         assert s.axes_manager[0].units == 'µm'
         assert s.axes_manager[1].units == 'µm'
-        assert_allclose(s2.axes_manager[0].scale, 0.16867, atol=1E-5)
-        assert_allclose(s2.axes_manager[1].scale, 0.16867, atol=1E-5)
+        np.testing.assert_allclose(s2.axes_manager[0].scale, 0.16867, atol=1E-5)
+        np.testing.assert_allclose(s2.axes_manager[1].scale, 0.16867, atol=1E-5)
         assert s2.metadata.General.date == s.metadata.General.date
         assert s2.metadata.General.time == s.metadata.General.time
 
@@ -74,8 +73,8 @@ def test_read_unit_from_imagej():
     s = hs.load(fname)
     assert s.axes_manager[0].units == 'µm'
     assert s.axes_manager[1].units == 'µm'
-    assert_allclose(s.axes_manager[0].scale, 0.16867, atol=1E-5)
-    assert_allclose(s.axes_manager[1].scale, 0.16867, atol=1E-5)
+    np.testing.assert_allclose(s.axes_manager[0].scale, 0.16867, atol=1E-5)
+    np.testing.assert_allclose(s.axes_manager[1].scale, 0.16867, atol=1E-5)
 
 
 def test_read_unit_from_imagej_stack():
@@ -86,9 +85,9 @@ def test_read_unit_from_imagej_stack():
     assert s.axes_manager[0].units == t.Undefined
     assert s.axes_manager[1].units == 'µm'
     assert s.axes_manager[2].units == 'µm'
-    assert_allclose(s.axes_manager[0].scale, 2.5, atol=1E-5)
-    assert_allclose(s.axes_manager[1].scale, 0.16867, atol=1E-5)
-    assert_allclose(s.axes_manager[2].scale, 0.16867, atol=1E-5)
+    np.testing.assert_allclose(s.axes_manager[0].scale, 2.5, atol=1E-5)
+    np.testing.assert_allclose(s.axes_manager[1].scale, 0.16867, atol=1E-5)
+    np.testing.assert_allclose(s.axes_manager[2].scale, 0.16867, atol=1E-5)
 
 
 @pytest.mark.parametrize("lazy", [True, False])
@@ -100,9 +99,9 @@ def test_read_unit_from_DM_stack(lazy):
     assert s.axes_manager[0].units == 's'
     assert s.axes_manager[1].units == 'µm'
     assert s.axes_manager[2].units == 'µm'
-    assert_allclose(s.axes_manager[0].scale, 2.5, atol=1E-5)
-    assert_allclose(s.axes_manager[1].scale, 0.16867, atol=1E-5)
-    assert_allclose(s.axes_manager[2].scale, 1.68674, atol=1E-5)
+    np.testing.assert_allclose(s.axes_manager[0].scale, 2.5, atol=1E-5)
+    np.testing.assert_allclose(s.axes_manager[1].scale, 0.16867, atol=1E-5)
+    np.testing.assert_allclose(s.axes_manager[2].scale, 1.68674, atol=1E-5)
     with tempfile.TemporaryDirectory() as tmpdir:
         fname2 = os.path.join(
             tmpdir, 'test_loading_image_saved_with_DM_stack2.tif')
@@ -112,17 +111,17 @@ def test_read_unit_from_DM_stack(lazy):
         assert s2.axes_manager[0].units == s.axes_manager[0].units
         assert s2.axes_manager[1].units == 'µm'
         assert s2.axes_manager[2].units == 'µm'
-        assert_allclose(
+        np.testing.assert_allclose(
             s2.axes_manager[0].scale, s.axes_manager[0].scale, atol=1E-5)
-        assert_allclose(
+        np.testing.assert_allclose(
             s2.axes_manager[1].scale, s.axes_manager[1].scale, atol=1E-5)
-        assert_allclose(
+        np.testing.assert_allclose(
             s2.axes_manager[2].scale, s.axes_manager[2].scale, atol=1E-5)
-        assert_allclose(
+        np.testing.assert_allclose(
             s2.axes_manager[0].offset, s.axes_manager[0].offset, atol=1E-5)
-        assert_allclose(
+        np.testing.assert_allclose(
             s2.axes_manager[1].offset, s.axes_manager[1].offset, atol=1E-5)
-        assert_allclose(
+        np.testing.assert_allclose(
             s2.axes_manager[2].offset, s.axes_manager[2].offset, atol=1E-5)
 
 
@@ -134,9 +133,9 @@ def test_read_unit_from_imagej_stack_no_scale():
     assert s.axes_manager[0].units == t.Undefined
     assert s.axes_manager[1].units == t.Undefined
     assert s.axes_manager[2].units == t.Undefined
-    assert_allclose(s.axes_manager[0].scale, 1.0, atol=1E-5)
-    assert_allclose(s.axes_manager[1].scale, 1.0, atol=1E-5)
-    assert_allclose(s.axes_manager[2].scale, 1.0, atol=1E-5)
+    np.testing.assert_allclose(s.axes_manager[0].scale, 1.0, atol=1E-5)
+    np.testing.assert_allclose(s.axes_manager[1].scale, 1.0, atol=1E-5)
+    np.testing.assert_allclose(s.axes_manager[2].scale, 1.0, atol=1E-5)
 
 
 def test_read_unit_from_imagej_no_scale():
@@ -145,8 +144,8 @@ def test_read_unit_from_imagej_no_scale():
     s = hs.load(fname)
     assert s.axes_manager[0].units == t.Undefined
     assert s.axes_manager[1].units == t.Undefined
-    assert_allclose(s.axes_manager[0].scale, 1.0, atol=1E-5)
-    assert_allclose(s.axes_manager[1].scale, 1.0, atol=1E-5)
+    np.testing.assert_allclose(s.axes_manager[0].scale, 1.0, atol=1E-5)
+    np.testing.assert_allclose(s.axes_manager[1].scale, 1.0, atol=1E-5)
 
 
 def test_write_read_unit_imagej():
@@ -171,24 +170,24 @@ def test_write_read_unit_imagej_with_description():
     s = hs.load(fname)
     s.axes_manager[0].units = 'µm'
     s.axes_manager[1].units = 'µm'
-    assert_allclose(s.axes_manager[0].scale, 0.16867, atol=1E-5)
-    assert_allclose(s.axes_manager[1].scale, 0.16867, atol=1E-5)
+    np.testing.assert_allclose(s.axes_manager[0].scale, 0.16867, atol=1E-5)
+    np.testing.assert_allclose(s.axes_manager[1].scale, 0.16867, atol=1E-5)
     with tempfile.TemporaryDirectory() as tmpdir:
         fname2 = os.path.join(tmpdir, 'description.tif')
         s.save(fname2, export_scale=False, overwrite=True, description='test')
         s2 = hs.load(fname2)
         assert s2.axes_manager[0].units == t.Undefined
         assert s2.axes_manager[1].units == t.Undefined
-        assert_allclose(s2.axes_manager[0].scale, 1.0, atol=1E-5)
-        assert_allclose(s2.axes_manager[1].scale, 1.0, atol=1E-5)
+        np.testing.assert_allclose(s2.axes_manager[0].scale, 1.0, atol=1E-5)
+        np.testing.assert_allclose(s2.axes_manager[1].scale, 1.0, atol=1E-5)
 
         fname3 = os.path.join(tmpdir, 'description2.tif')
         s.save(fname3, export_scale=True, overwrite=True, description='test')
         s3 = hs.load(fname3, convert_units=True)
         assert s3.axes_manager[0].units == 'µm'
         assert s3.axes_manager[1].units == 'µm'
-        assert_allclose(s3.axes_manager[0].scale, 0.16867, atol=1E-5)
-        assert_allclose(s3.axes_manager[1].scale, 0.16867, atol=1E-5)
+        np.testing.assert_allclose(s3.axes_manager[0].scale, 0.16867, atol=1E-5)
+        np.testing.assert_allclose(s3.axes_manager[1].scale, 0.16867, atol=1E-5)
 
 
 def test_saving_with_custom_tag():
@@ -212,10 +211,10 @@ def _test_read_unit_from_dm():
     s = hs.load(fname)
     assert s.axes_manager[0].units == 'µm'
     assert s.axes_manager[1].units == 'µm'
-    assert_allclose(s.axes_manager[0].scale, 0.16867, atol=1E-5)
-    assert_allclose(s.axes_manager[1].scale, 0.16867, atol=1E-5)
-    assert_allclose(s.axes_manager[0].offset, 139.66264, atol=1E-5)
-    assert_allclose(s.axes_manager[1].offset, 128.19276, atol=1E-5)
+    np.testing.assert_allclose(s.axes_manager[0].scale, 0.16867, atol=1E-5)
+    np.testing.assert_allclose(s.axes_manager[1].scale, 0.16867, atol=1E-5)
+    np.testing.assert_allclose(s.axes_manager[0].offset, 139.66264, atol=1E-5)
+    np.testing.assert_allclose(s.axes_manager[1].offset, 128.19276, atol=1E-5)
     with tempfile.TemporaryDirectory() as tmpdir:
         fname2 = os.path.join(tmpdir, "DM2.tif")
         s.save(fname2, overwrite=True)
@@ -223,13 +222,13 @@ def _test_read_unit_from_dm():
         _compare_signal_shape_data(s, s2)
         assert s2.axes_manager[0].units == 'micron'
         assert s2.axes_manager[1].units == 'micron'
-        assert_allclose(s2.axes_manager[0].scale, s.axes_manager[0].scale,
+        np.testing.assert_allclose(s2.axes_manager[0].scale, s.axes_manager[0].scale,
                         atol=1E-5)
-        assert_allclose(s2.axes_manager[1].scale, s.axes_manager[1].scale,
+        np.testing.assert_allclose(s2.axes_manager[1].scale, s.axes_manager[1].scale,
                         atol=1E-5)
-        assert_allclose(s2.axes_manager[0].offset, s.axes_manager[0].offset,
+        np.testing.assert_allclose(s2.axes_manager[0].offset, s.axes_manager[0].offset,
                         atol=1E-5)
-        assert_allclose(s2.axes_manager[1].offset, s.axes_manager[1].offset,
+        np.testing.assert_allclose(s2.axes_manager[1].offset, s.axes_manager[1].offset,
                         atol=1E-5)
 
 
@@ -357,9 +356,9 @@ def test_write_scale_unit_image_stack():
         # only one unit can be read
         assert s1.axes_manager[1].units == 'µm'
         assert s1.axes_manager[2].units == 'µm'
-        assert_allclose(s1.axes_manager[0].scale, 250.0)
-        assert_allclose(s1.axes_manager[1].scale, s.axes_manager[1].scale)
-        assert_allclose(s1.axes_manager[2].scale, s.axes_manager[2].scale)
+        np.testing.assert_allclose(s1.axes_manager[0].scale, 250.0)
+        np.testing.assert_allclose(s1.axes_manager[1].scale, s.axes_manager[1].scale)
+        np.testing.assert_allclose(s1.axes_manager[2].scale, s.axes_manager[2].scale)
 
 
 def test_saving_loading_stack_no_scale():
@@ -399,8 +398,8 @@ def test_read_FEI_SEM_scale_metadata_8bits():
     s = hs.load(fname, convert_units=True)
     assert s.axes_manager[0].units == 'µm'
     assert s.axes_manager[1].units == 'µm'
-    assert_allclose(s.axes_manager[0].scale, 3.3724, rtol=1E-5)
-    assert_allclose(s.axes_manager[1].scale, 3.3724, rtol=1E-5)
+    np.testing.assert_allclose(s.axes_manager[0].scale, 3.3724, rtol=1E-5)
+    np.testing.assert_allclose(s.axes_manager[1].scale, 3.3724, rtol=1E-5)
     assert s.data.dtype == 'uint8'
     FEI_Helios_metadata['General'][
         'original_filename'] = 'FEI-Helios-Ebeam-8bits.tif'
@@ -412,8 +411,8 @@ def test_read_FEI_SEM_scale_metadata_16bits():
     s = hs.load(fname, convert_units=True)
     assert s.axes_manager[0].units == 'µm'
     assert s.axes_manager[1].units == 'µm'
-    assert_allclose(s.axes_manager[0].scale, 3.3724, rtol=1E-5)
-    assert_allclose(s.axes_manager[1].scale, 3.3724, rtol=1E-5)
+    np.testing.assert_allclose(s.axes_manager[0].scale, 3.3724, rtol=1E-5)
+    np.testing.assert_allclose(s.axes_manager[1].scale, 3.3724, rtol=1E-5)
     assert s.data.dtype == 'uint16'
     FEI_Helios_metadata['General'][
         'original_filename'] = 'FEI-Helios-Ebeam-16bits.tif'
@@ -449,8 +448,8 @@ def test_read_Zeiss_SEM_scale_metadata_1k_image():
     s = hs.load(fname, convert_units=True)
     assert s.axes_manager[0].units == 'µm'
     assert s.axes_manager[1].units == 'µm'
-    assert_allclose(s.axes_manager[0].scale, 2.614514, rtol=1E-6)
-    assert_allclose(s.axes_manager[1].scale, 2.614514, rtol=1E-6)
+    np.testing.assert_allclose(s.axes_manager[0].scale, 2.614514, rtol=1E-6)
+    np.testing.assert_allclose(s.axes_manager[1].scale, 2.614514, rtol=1E-6)
     assert s.data.dtype == 'uint8'
     assert_deep_almost_equal(s.metadata.as_dictionary(), md)
 
@@ -480,8 +479,8 @@ def test_read_Zeiss_SEM_scale_metadata_512_image():
     s = hs.load(fname, convert_units=True)
     assert s.axes_manager[0].units == 'µm'
     assert s.axes_manager[1].units == 'µm'
-    assert_allclose(s.axes_manager[0].scale, 0.011649976, rtol=1E-6)
-    assert_allclose(s.axes_manager[1].scale, 0.011649976, rtol=1E-6)
+    np.testing.assert_allclose(s.axes_manager[0].scale, 0.011649976, rtol=1E-6)
+    np.testing.assert_allclose(s.axes_manager[1].scale, 0.011649976, rtol=1E-6)
     assert s.data.dtype == 'uint8'
     assert_deep_almost_equal(s.metadata.as_dictionary(), md)
 
@@ -494,8 +493,8 @@ def test_read_RGB_Zeiss_optical_scale_metadata():
     assert s.data.shape == (10, 13)
     assert s.axes_manager[0].units == t.Undefined
     assert s.axes_manager[1].units == t.Undefined
-    assert_allclose(s.axes_manager[0].scale, 1.0, rtol=1E-5)
-    assert_allclose(s.axes_manager[1].scale, 1.0, rtol=1E-5)
+    np.testing.assert_allclose(s.axes_manager[0].scale, 1.0, rtol=1E-5)
+    np.testing.assert_allclose(s.axes_manager[1].scale, 1.0, rtol=1E-5)
     assert s.metadata.General.date == '2016-06-13'
     assert s.metadata.General.time == '15:59:52'
 
@@ -507,8 +506,8 @@ def test_read_BW_Zeiss_optical_scale_metadata():
     assert s.data.shape == (10, 13)
     assert s.axes_manager[0].units == 'µm'
     assert s.axes_manager[1].units == 'µm'
-    assert_allclose(s.axes_manager[0].scale, 169.333, rtol=1E-5)
-    assert_allclose(s.axes_manager[1].scale, 169.333, rtol=1E-5)
+    np.testing.assert_allclose(s.axes_manager[0].scale, 169.333, rtol=1E-5)
+    np.testing.assert_allclose(s.axes_manager[1].scale, 169.333, rtol=1E-5)
     assert s.metadata.General.date == '2016-06-13'
     assert s.metadata.General.time == '16:08:49'
 
@@ -520,8 +519,8 @@ def test_read_BW_Zeiss_optical_scale_metadata_convert_units_false():
     assert s.data.shape == (10, 13)
     assert s.axes_manager[0].units == 'µm'
     assert s.axes_manager[1].units == 'µm'
-    assert_allclose(s.axes_manager[0].scale, 169.333, rtol=1E-5)
-    assert_allclose(s.axes_manager[1].scale, 169.333, rtol=1E-5)
+    np.testing.assert_allclose(s.axes_manager[0].scale, 169.333, rtol=1E-5)
+    np.testing.assert_allclose(s.axes_manager[1].scale, 169.333, rtol=1E-5)
 
 
 def test_read_BW_Zeiss_optical_scale_metadata2():
@@ -531,8 +530,8 @@ def test_read_BW_Zeiss_optical_scale_metadata2():
     assert s.data.shape == (10, 13)
     assert s.axes_manager[0].units == 'µm'
     assert s.axes_manager[1].units == 'µm'
-    assert_allclose(s.axes_manager[0].scale, 169.333, rtol=1E-5)
-    assert_allclose(s.axes_manager[1].scale, 169.333, rtol=1E-5)
+    np.testing.assert_allclose(s.axes_manager[0].scale, 169.333, rtol=1E-5)
+    np.testing.assert_allclose(s.axes_manager[1].scale, 169.333, rtol=1E-5)
     assert s.metadata.General.date == '2016-06-13'
     assert s.metadata.General.time == '16:08:49'
 
@@ -544,8 +543,8 @@ def test_read_BW_Zeiss_optical_scale_metadata3():
     assert s.data.shape == (10, 13)
     assert s.axes_manager[0].units == t.Undefined
     assert s.axes_manager[1].units == t.Undefined
-    assert_allclose(s.axes_manager[0].scale, 1.0, rtol=1E-5)
-    assert_allclose(s.axes_manager[1].scale, 1.0, rtol=1E-5)
+    np.testing.assert_allclose(s.axes_manager[0].scale, 1.0, rtol=1E-5)
+    np.testing.assert_allclose(s.axes_manager[1].scale, 1.0, rtol=1E-5)
     assert s.metadata.General.date == '2016-06-13'
     assert s.metadata.General.time == '16:08:49'
 
@@ -574,6 +573,6 @@ def test_read_TVIPS_metadata():
     assert s.data.shape == (1024, 1024)
     assert s.axes_manager[0].units == 'nm'
     assert s.axes_manager[1].units == 'nm'
-    assert_allclose(s.axes_manager[0].scale, 1.42080, rtol=1E-5)
-    assert_allclose(s.axes_manager[1].scale, 1.42080, rtol=1E-5)
+    np.testing.assert_allclose(s.axes_manager[0].scale, 1.42080, rtol=1E-5)
+    np.testing.assert_allclose(s.axes_manager[1].scale, 1.42080, rtol=1E-5)
     assert_deep_almost_equal(s.metadata.as_dictionary(), md)

--- a/hyperspy/tests/io/test_usid.py
+++ b/hyperspy/tests/io/test_usid.py
@@ -59,7 +59,7 @@ def _compare_axes(hs_axes, dim_descriptors, usid_val_func, axes_defined=True,
                                   axis.offset + axis.size * axis.scale,
                                   axis.scale)
             usid_vals = usid_val_func(usid_descriptors[real_dim_ind][0])
-            assert np.allclose(axis_vals, usid_vals)
+            np.testing.assert_allclose(axis_vals, usid_vals)
 
 
 def _assert_empty_dims(hs_axes, usid_labels, usid_val_func):
@@ -125,7 +125,7 @@ def compare_usid_from_signal(sig, h5_path, empty_pos=False, empty_spec=False,
 
         usid_data = h5_main.get_n_dim_form().squeeze()
         # 2. Validate that raw data has been written correctly:
-        assert np.allclose(sig.data, usid_data)
+        np.testing.assert_allclose(sig.data, usid_data)
         # 3. Validate that axes / dimensions have been translated correctly:
         if empty_pos:
             _assert_empty_dims(sig.axes_manager.navigation_axes,
@@ -156,7 +156,7 @@ def compare_signal_from_usid(file_path, ndata, new_sig, axes_to_spec=[],
         new_sig = new_sig.as_signal2D(axes_to_spec)
 
     # 2. Validate that data has been read in correctly:
-    assert np.allclose(new_sig.data, ndata)
+    np.testing.assert_allclose(new_sig.data, ndata)
     with h5py.File(file_path, mode='r') as h5_f:
         if dataset_path is None:
             h5_main = usid.hdf_utils.get_all_main(h5_f)[0]

--- a/hyperspy/tests/io/test_usid.py
+++ b/hyperspy/tests/io/test_usid.py
@@ -7,14 +7,7 @@ import pytest
 
 from hyperspy import api as hs
 
-try:
-    import pyUSID as usid
-    pyusid_installed = True
-except BaseException:
-    pyusid_installed = False
-
-pytestmark = pytest.mark.skipif(not pyusid_installed,
-                                reason="pyUSID not installed")
+usid = pytest.importorskip("pyUSID", reason="pyUSID not installed")
 
 
 # ##################### HELPER FUNCTIONS ######################################

--- a/hyperspy/tests/learn/test_bss.py
+++ b/hyperspy/tests/learn/test_bss.py
@@ -271,8 +271,8 @@ class TestReverseBSS:
 class TestBSS1D:
     def setup_method(self, method):
         rng = np.random.RandomState(123)
-        ics = rng.laplace(size=(3, 1000))
-        mixing_matrix = rng.random((100, 3))
+        ics = rng.laplace(size=(3, 500))
+        mixing_matrix = rng.uniform(size=(100, 3))
         s = Signal1D(mixing_matrix @ ics)
         s.decomposition()
 
@@ -321,9 +321,9 @@ class TestBSS1D:
 class TestBSS2D:
     def setup_method(self, method):
         rng = np.random.RandomState(123)
-        ics = rng.laplace(size=(3, 1024))
+        ics = rng.laplace(size=(3, 256))
         mixing_matrix = rng.random((100, 3))
-        s = Signal2D((mixing_matrix @ ics).reshape((100, 32, 32)))
+        s = Signal2D((mixing_matrix @ ics).reshape((100, 16, 16)))
         for (axis, name) in zip(s.axes_manager._axes, ("z", "y", "x")):
             axis.name = name
         s.decomposition()
@@ -365,7 +365,7 @@ class TestBSS2D:
             mask=self.mask_sig,
         )
         np.testing.assert_allclose(
-            matrix, self.s.learning_results.unmixing_matrix, atol=1e-6
+            matrix, self.s.learning_results.unmixing_matrix, atol=1e-5
         )
 
     def test_diff_axes_string_without_mask(self):

--- a/hyperspy/tests/learn/test_cluster.py
+++ b/hyperspy/tests/learn/test_cluster.py
@@ -20,25 +20,27 @@ import numpy as np
 import pytest
 
 from hyperspy import signals
-from hyperspy.misc.machine_learning.import_sklearn import sklearn_installed
+from hyperspy.misc.machine_learning import import_sklearn
 
-pytestmark = pytest.mark.skipif(not sklearn_installed, reason="sklearn not installed")
+sklearn = pytest.importorskip("sklearn", reason="sklearn not installed")
 
-import hyperspy.misc.machine_learning.import_sklearn  as import_sklearn
+if import_sklearn.sklearn_installed:
+    # Create the data once, since the parametrizations
+    # will repeat the decomposition and BSS unnecessarily
+    rng1 = np.random.RandomState(123)
+    signal1 = signals.Signal1D(rng1.uniform(size=(7, 5, 7)))
+    signal1.decomposition()
+    signal1.blind_source_separation(number_of_components=3)
 
-
-# Create the data once, since the parametrizations
-# will repeat the decomposition and BSS unnecessarily
-rng1 = np.random.RandomState(123)
-signal1 = signals.Signal1D(rng1.uniform(size=(7, 5, 7)))
-signal1.decomposition()
-signal1.blind_source_separation(number_of_components=3)
-
-rng2 = np.random.RandomState(123)
-signal2 = signals.Signal2D(rng2.uniform(size=(7, 5, 7)))
-signal2.decomposition()
-signal2.blind_source_separation(number_of_components=3)
-
+    rng2 = np.random.RandomState(123)
+    signal2 = signals.Signal2D(rng2.uniform(size=(7, 5, 7)))
+    signal2.decomposition()
+    signal2.blind_source_separation(number_of_components=3)
+else:
+    # No need to create the data, since BSS will fail
+    # if sklearn is missing, and the pytest.importorskip
+    # will skip the rest of the file anyway
+    pass
 
 class TestCluster1D:
     def setup_method(self):

--- a/hyperspy/tests/learn/test_cluster.py
+++ b/hyperspy/tests/learn/test_cluster.py
@@ -20,90 +20,105 @@ import numpy as np
 import pytest
 
 from hyperspy import signals
-from hyperspy.misc.machine_learning.import_sklearn import sklearn_installed
+from hyperspy.misc.machine_learning import import_sklearn
+
+pytestmark = pytest.mark.skipif(
+    not import_sklearn.sklearn_installed, reason="sklearn not installed"
+)
 
 
-pytestmark = pytest.mark.skipif(not sklearn_installed,
-                                reason="sklearn not installed")
-import hyperspy.misc.machine_learning.import_sklearn  as import_sklearn
+# Create the data once, since the parametrizations
+# will repeat the decomposition and BSS unnecessarily
+rng1 = np.random.RandomState(123)
+signal1 = signals.Signal1D(rng1.uniform(size=(7, 5, 7)))
+signal1.decomposition()
+signal1.blind_source_separation(number_of_components=3)
+
+rng2 = np.random.RandomState(123)
+signal2 = signals.Signal2D(rng2.uniform(size=(7, 5, 7)))
+signal2.decomposition()
+signal2.blind_source_separation(number_of_components=3)
 
 
-class TestCluster1d:
+class TestCluster1D:
     def setup_method(self):
-        # Use prime numbers to avoid fluke equivalences
-        self.signal = signals.Signal1D(np.random.rand(11, 5, 7))
-        self.signal.decomposition()
-        self.signal.blind_source_separation(number_of_components=3)
-        self.navigation_mask = np.zeros((11, 5), dtype=bool)
+        self.signal = signal1.deepcopy()
+        self.navigation_mask = np.zeros((7, 5), dtype=bool)
         self.navigation_mask[4:6, 1:4] = True
         self.signal_mask = np.zeros((7,), dtype=bool)
         self.signal_mask[2:6] = True
 
     @pytest.mark.parametrize("algorithm", (None, "agglomerative", "spectralclustering"))
     @pytest.mark.parametrize("cluster_source", ("signal", "bss", "decomposition"))
-    @pytest.mark.parametrize("source_for_centers", (None, "signal", "bss", "decomposition"))
+    @pytest.mark.parametrize(
+        "source_for_centers", (None, "signal", "bss", "decomposition")
+    )
     @pytest.mark.parametrize("preprocessing", (None, "standard", "norm", "minmax"))
     @pytest.mark.parametrize("use_masks", (True, False))
-    def test_combinations(self, algorithm,
-                          cluster_source,
-                          preprocessing,
-                          source_for_centers,
-                          use_masks):
+    def test_combinations(
+        self, algorithm, cluster_source, preprocessing, source_for_centers, use_masks
+    ):
         if use_masks:
             navigation_mask = self.navigation_mask
             signal_mask = self.signal_mask
         else:
             navigation_mask = None
             signal_mask = None
-        self.signal.cluster_analysis(cluster_source,
-                                     n_clusters=3,
-                                     source_for_centers=source_for_centers,
-                                     preprocessing=preprocessing,
-                                     navigation_mask=navigation_mask,
-                                     signal_mask=signal_mask,
-                                     algorithm=algorithm)
+        self.signal.cluster_analysis(
+            cluster_source,
+            n_clusters=3,
+            source_for_centers=source_for_centers,
+            preprocessing=preprocessing,
+            navigation_mask=navigation_mask,
+            signal_mask=signal_mask,
+            algorithm=algorithm,
+        )
         np.testing.assert_array_equal(
-            self.signal.learning_results.cluster_labels.shape, (3, 55))
+            self.signal.learning_results.cluster_labels.shape, (3, 35)
+        )
         np.testing.assert_array_equal(
-            self.signal.learning_results.cluster_centroid_signals.shape, (3, 7))
+            self.signal.learning_results.cluster_centroid_signals.shape, (3, 7)
+        )
         np.testing.assert_array_equal(
-            self.signal.learning_results.cluster_sum_signals.shape, (3, 7))
+            self.signal.learning_results.cluster_sum_signals.shape, (3, 7)
+        )
         self.signal.get_cluster_labels()
         self.signal.get_cluster_signals()
 
     def test_custom_algorithm(self):
-        self.signal.cluster_analysis("signal",
-                                     n_clusters=3,
-                                     preprocessing="norm",
-                                     )
+        self.signal.cluster_analysis(
+            "signal", n_clusters=3, preprocessing="norm",
+        )
         np.testing.assert_array_equal(
-            self.signal.learning_results.cluster_labels.shape, (3, 55))
+            self.signal.learning_results.cluster_labels.shape, (3, 35)
+        )
         np.testing.assert_array_equal(
-            self.signal.learning_results.cluster_centroid_signals.shape, (3, 7))
+            self.signal.learning_results.cluster_centroid_signals.shape, (3, 7)
+        )
         np.testing.assert_array_equal(
-            self.signal.learning_results.cluster_sum_signals.shape, (3, 7))
+            self.signal.learning_results.cluster_sum_signals.shape, (3, 7)
+        )
 
     def test_custom_preprocessing(self):
         custom_method = import_sklearn.sklearn.preprocessing.Normalizer()
-        self.signal.cluster_analysis("signal",
-                                     n_clusters=3,
-                                     preprocessing=custom_method,
-                                     algorithm="kmeans"
-                                     )
+        self.signal.cluster_analysis(
+            "signal", n_clusters=3, preprocessing=custom_method, algorithm="kmeans"
+        )
         np.testing.assert_array_equal(
-            self.signal.learning_results.cluster_labels.shape, (3, 55))
+            self.signal.learning_results.cluster_labels.shape, (3, 35)
+        )
         np.testing.assert_array_equal(
-            self.signal.learning_results.cluster_centroid_signals.shape, (3, 7))
+            self.signal.learning_results.cluster_centroid_signals.shape, (3, 7)
+        )
         np.testing.assert_array_equal(
-            self.signal.learning_results.cluster_sum_signals.shape, (3, 7))
+            self.signal.learning_results.cluster_sum_signals.shape, (3, 7)
+        )
 
 
 class TestClusterSignalSources:
     def setup_method(self):
-        self.signal = signals.Signal2D(np.random.rand(11, 5, 7))
-        self.signal.decomposition()
-        self.signal.blind_source_separation(number_of_components=3)
-        self.navigation_mask = np.zeros((11,), dtype=bool)
+        self.signal = signal2.deepcopy()
+        self.navigation_mask = np.zeros((7,), dtype=bool)
         self.navigation_mask[4:6] = True
         self.signal_mask = np.zeros((5, 7), dtype=bool)
         self.signal_mask[1:4, 2:6] = True
@@ -118,20 +133,25 @@ class TestClusterSignalSources:
             signal_mask = None
         # test using cluster source centre is a signal
         signal_copy = self.signal.deepcopy()
-        self.signal.cluster_analysis(signal_copy,
-                                     n_clusters=3,
-                                     source_for_centers="signal",
-                                     preprocessing="norm",
-                                     navigation_mask=navigation_mask,
-                                     signal_mask=signal_mask,
-                                     algorithm="kmeans")
+        self.signal.cluster_analysis(
+            signal_copy,
+            n_clusters=3,
+            source_for_centers="signal",
+            preprocessing="norm",
+            navigation_mask=navigation_mask,
+            signal_mask=signal_mask,
+            algorithm="kmeans",
+        )
 
         np.testing.assert_array_equal(
-            self.signal.learning_results.cluster_labels.shape, (3, 11))
+            self.signal.learning_results.cluster_labels.shape, (3, 7)
+        )
         np.testing.assert_array_equal(
-            self.signal.learning_results.cluster_centroid_signals.shape, (3, 35))
+            self.signal.learning_results.cluster_centroid_signals.shape, (3, 35)
+        )
         np.testing.assert_array_equal(
-            self.signal.learning_results.cluster_sum_signals.shape, (3, 35))
+            self.signal.learning_results.cluster_sum_signals.shape, (3, 35)
+        )
 
     @pytest.mark.parametrize("use_masks", (True, False))
     def test_source_center(self, use_masks):
@@ -143,38 +163,43 @@ class TestClusterSignalSources:
             signal_mask = None
         # test using cluster source centre is a signal
         signal_copy = self.signal.deepcopy()
-        self.signal.cluster_analysis("signal",
-                                     n_clusters=3,
-                                     source_for_centers=signal_copy,
-                                     preprocessing="norm",
-                                     navigation_mask=navigation_mask,
-                                     signal_mask=signal_mask,
-                                     algorithm="kmeans")
+        self.signal.cluster_analysis(
+            "signal",
+            n_clusters=3,
+            source_for_centers=signal_copy,
+            preprocessing="norm",
+            navigation_mask=navigation_mask,
+            signal_mask=signal_mask,
+            algorithm="kmeans",
+        )
 
         np.testing.assert_array_equal(
-            self.signal.learning_results.cluster_labels.shape, (3, 11))
+            self.signal.learning_results.cluster_labels.shape, (3, 7)
+        )
         np.testing.assert_array_equal(
-            self.signal.learning_results.cluster_centroid_signals.shape, (3, 35))
+            self.signal.learning_results.cluster_centroid_signals.shape, (3, 35)
+        )
         np.testing.assert_array_equal(
-            self.signal.learning_results.cluster_sum_signals.shape, (3, 35))
+            self.signal.learning_results.cluster_sum_signals.shape, (3, 35)
+        )
 
 
+@pytest.mark.filterwarnings("ignore:FastICA did not converge")
 class TestClusterEstimate:
-
     def setup_method(self):
-        np.random.seed(1)
+        rng = np.random.RandomState(123)
         # Use prime numbers to avoid fluke equivalences
         # create 3 random clusters
         n_samples = [100] * 3
         std = [0.05] * 3
         X = []
-        centers = np.array([[-1., -1., 1, 1],
-                            [1., -1., -1., -1],
-                            [-1., 1., 1., -1.]])
+        centers = np.array(
+            [[-1.0, -1.0, 1, 1], [1.0, -1.0, -1.0, -1], [-1.0, 1.0, 1.0, -1.0]]
+        )
         for i, (n, std) in enumerate(zip(n_samples, std)):
-            X.append(centers[i] + np.random.normal(scale=std, size=(n, 4)))
+            X.append(centers[i] + rng.normal(scale=std, size=(n, 4)))
         X = np.concatenate(X)
-        np.random.shuffle(X)
+        rng.shuffle(X)
         self.signal = signals.Signal1D(X)
         self.signal.decomposition()
         self.signal.blind_source_separation(number_of_components=3)
@@ -187,7 +212,8 @@ class TestClusterEstimate:
             max_clusters=max_clusters,
             preprocessing="norm",
             algorithm="kmeans",
-            metric=metric)
+            metric=metric,
+        )
         k_range = self.signal.learning_results.cluster_metric_index
         best_k = self.signal.learning_results.estimated_number_of_clusters
         if isinstance(best_k, list):
@@ -208,14 +234,15 @@ class TestClusterEstimate:
             max_clusters=max_clusters,
             preprocessing="norm",
             algorithm=algorithm,
-            metric="elbow")
+            metric="elbow",
+        )
         k_range = self.signal.learning_results.cluster_metric_index
         best_k = self.signal.learning_results.estimated_number_of_clusters
         if isinstance(best_k, list):
             best_k = best_k[0]
 
         test_k_range = list(range(1, max_clusters + 1))
-        if(algorithm == "agglomerative"):
+        if algorithm == "agglomerative":
             test_k_range = list(range(2, max_clusters + 1))
 
         np.testing.assert_allclose(k_range, test_k_range)
@@ -223,7 +250,6 @@ class TestClusterEstimate:
 
 
 class DummyClusterAlgorithm:
-
     def __init__(self):
         self.test = None
 
@@ -232,7 +258,6 @@ class DummyClusterAlgorithm:
 
 
 class DummyScalingAlgorithm:
-
     def __init__(self):
         self.test = None
 
@@ -241,128 +266,133 @@ class DummyScalingAlgorithm:
 
 
 class TestClusterExceptions:
-
     def setup_method(self):
-        rng = np.random.RandomState(123)
-        x = rng.random((20, 100))
-        self.s = signals.Signal1D(x)
+        self.rng = np.random.RandomState(123)
+        self.s = signals.Signal1D(self.rng.uniform(size=(20, 100)))
 
     def test_cluster_source_error(self):
-        with pytest.raises(ValueError,
-                           match="cluster source needs to be set "
-                           "to `decomposition` , `signal` , `bss` "
-                           "or a suitable Signal"):
-            self.s.cluster_analysis("randtest",
-                                    n_clusters=2)
+        with pytest.raises(
+            ValueError,
+            match="cluster source needs to be set "
+            "to `decomposition` , `signal` , `bss` "
+            "or a suitable Signal",
+        ):
+            self.s.cluster_analysis("randtest", n_clusters=2)
 
     def test_cluster_source_size_error(self):
-        x2 = np.random.random((10, 80))
+        x2 = self.rng.uniform(size=(10, 80))
         s2 = signals.Signal1D(x2)
-        with pytest.raises(ValueError,
-                           match="cluster_source does not have the same "
-                           "navigation size as the this signal"):
+        with pytest.raises(
+            ValueError,
+            match="cluster_source does not have the same "
+            "navigation size as the this signal",
+        ):
             self.s.cluster_analysis(s2, n_clusters=2)
 
     def test_cluster_source_center_size_error(self):
-        x2 = np.random.random((10, 80))
+        x2 = self.rng.uniform(size=(10, 80))
         s2 = signals.Signal1D(x2)
-        with pytest.raises(ValueError,
-                           match="cluster_source does not have the same "
-                           "navigation size as the this signal"):
-            self.s.cluster_analysis("signal",
-                                    n_clusters=2,
-                                    source_for_centers=s2)
+        with pytest.raises(
+            ValueError,
+            match="cluster_source does not have the same "
+            "navigation size as the this signal",
+        ):
+            self.s.cluster_analysis("signal", n_clusters=2, source_for_centers=s2)
 
     def test_cluster_bss_error(self):
-        with pytest.raises(ValueError,
-                           match="A cluster source has been set to bss "
-                           " but no blind source separation results found. "
-                           " Please run blind source separation method first"):
+        with pytest.raises(
+            ValueError,
+            match="A cluster source has been set to bss "
+            " but no blind source separation results found. "
+            " Please run blind source separation method first",
+        ):
             self.s.cluster_analysis("bss", n_clusters=2)
 
     def test_cluster_decomposition_error(self):
-        with pytest.raises(ValueError,
-                           match="A cluster source has been set to "
-                           "decomposition but no decomposition results found. "
-                           "Please run decomposition method first"):
-            self.s.cluster_analysis("decomposition",
-                                    n_clusters=2)
+        with pytest.raises(
+            ValueError,
+            match="A cluster source has been set to "
+            "decomposition but no decomposition results found. "
+            "Please run decomposition method first",
+        ):
+            self.s.cluster_analysis("decomposition", n_clusters=2)
 
     def test_cluster_nav_mask_error(self):
         nav_mask = np.zeros((11,), dtype=bool)
-        with pytest.raises(ValueError,
-                           match="Navigation mask size does not match "
-                           "signal navigation size"):
-            self.s.cluster_analysis("signal",
-                                    n_clusters=2,
-                                    navigation_mask=nav_mask)
+        with pytest.raises(
+            ValueError,
+            match="Navigation mask size does not match " "signal navigation size",
+        ):
+            self.s.cluster_analysis("signal", n_clusters=2, navigation_mask=nav_mask)
 
     def test_cluster_sig_mask_error(self):
         sig_mask = np.zeros((11,), dtype=bool)
-        with pytest.raises(ValueError,
-                           match="signal mask size does not match your "
-                           "cluster source signal size"):
-            self.s.cluster_analysis("signal",
-                                    n_clusters=2,
-                                    signal_mask=sig_mask)
+        with pytest.raises(
+            ValueError,
+            match="signal mask size does not match your " "cluster source signal size",
+        ):
+            self.s.cluster_analysis("signal", n_clusters=2, signal_mask=sig_mask)
 
     def test_cluster_basesig_mask_error(self):
         sig_mask = np.zeros((11,), dtype=bool)
-        with pytest.raises(ValueError,
-                           match="signal mask size does not match your "
-                           "cluster source signal size"):
-            self.s.cluster_analysis(self.s.deepcopy(),
-                                    n_clusters=2,
-                                    signal_mask=sig_mask)
+        with pytest.raises(
+            ValueError,
+            match="signal mask size does not match your " "cluster source signal size",
+        ):
+            self.s.cluster_analysis(
+                self.s.deepcopy(), n_clusters=2, signal_mask=sig_mask
+            )
 
     def test_max_cluster_error(self):
         max_clusters = 1
-        with pytest.raises(ValueError,
-                           match="The max number of clusters, max_clusters, "
-                           "must be specified and be >= 2."):
+        with pytest.raises(
+            ValueError,
+            match="The max number of clusters, max_clusters, "
+            "must be specified and be >= 2.",
+        ):
 
             self.s.estimate_number_of_clusters(
-               "signal",
-               max_clusters=max_clusters,
-               preprocessing=None,
-               algorithm="kmeans",
-               metric="elbow")
+                "signal",
+                max_clusters=max_clusters,
+                preprocessing=None,
+                algorithm="kmeans",
+                metric="elbow",
+            )
 
     def test_cluster_preprocessing_object_error(self):
         preprocessing = object()
-        with pytest.raises(ValueError,
-                           match=r"The cluster preprocessing method should be either \w*"):
-            self.s.cluster_analysis("signal",
-                                    n_clusters=2,
-                                    preprocessing=preprocessing)
+        with pytest.raises(
+            ValueError, match=r"The cluster preprocessing method should be either \w*"
+        ):
+            self.s.cluster_analysis("signal", n_clusters=2, preprocessing=preprocessing)
 
     def test_clustering_object_error(self):
         empty_object = object()
-        with pytest.raises(ValueError,
-                           match=r"The clustering method should be either \w*"):
-            self.s.cluster_analysis("signal",
-                                    n_clusters=2,
-                                    algorithm=empty_object)
+        with pytest.raises(
+            ValueError, match=r"The clustering method should be either \w*"
+        ):
+            self.s.cluster_analysis("signal", n_clusters=2, algorithm=empty_object)
 
     def test_estimate_alg_error(self):
-        with pytest.raises(ValueError,
-                           match="Estimate number of clusters only works with "
-                           "supported clustering algorithms"):
-            self.s.estimate_number_of_clusters("signal",
-                                               algorithm="orange")
+        with pytest.raises(
+            ValueError,
+            match="Estimate number of clusters only works with "
+            "supported clustering algorithms",
+        ):
+            self.s.estimate_number_of_clusters("signal", algorithm="orange")
 
     def test_estimate_pre_error(self):
-        with pytest.raises(ValueError,
-                           match="Estimate number of clusters only works with "
-                           "supported preprocessing algorithms"):
-            self.s.estimate_number_of_clusters("signal",
-                                               preprocessing="orange")
+        with pytest.raises(
+            ValueError,
+            match="Estimate number of clusters only works with "
+            "supported preprocessing algorithms",
+        ):
+            self.s.estimate_number_of_clusters("signal", preprocessing="orange")
 
     def test_sklearn_exception(self):
         import_sklearn.sklearn_installed = False
         with pytest.raises(ImportError):
-            self.s.cluster_analysis("signal",
-                                    n_clusters=2)
+            self.s.cluster_analysis("signal", n_clusters=2)
         import_sklearn.sklearn_installed = True
 
     def test_sklearn_exception2(self):
@@ -379,47 +409,45 @@ class TestClusterExceptions:
 
     def test_preprocess_alg_exception(self):
         sc = DummyScalingAlgorithm()
-        with pytest.raises(ValueError,
-                           match=r"The cluster preprocessing method should be \w*"):
-            self.s.cluster_analysis("signal",
-                                    n_clusters=2,
-                                    preprocessing=sc)
+        with pytest.raises(
+            ValueError, match=r"The cluster preprocessing method should be \w*"
+        ):
+            self.s.cluster_analysis("signal", n_clusters=2, preprocessing=sc)
 
     def test_cluster_alg_exception(self):
         sc = DummyClusterAlgorithm()
-        with pytest.raises(AttributeError,
-                           match=r"Fited cluster estimator \w*"):
-            self.s.cluster_analysis("signal",
-                                    n_clusters=2,
-                                    algorithm=sc)
+        with pytest.raises(AttributeError, match=r"Fited cluster estimator \w*"):
+            self.s.cluster_analysis("signal", n_clusters=2, algorithm=sc)
+
 
 def test_get_methods():
-    signal = signals.Signal1D(np.random.rand(11, 5, 7))
+    rng = np.random.RandomState(123)
+    signal = signals.Signal1D(rng.uniform(size=(11, 5, 7)))
     signal.decomposition()
     signal.cluster_analysis("signal", n_clusters=2)
     signal.unfold()
     cl = signal.get_cluster_labels(merged=True)
     np.testing.assert_array_equal(
         cl.data,
-        (signal.learning_results.cluster_labels * np.arange(2)[:, np.newaxis]).sum(0))
+        (signal.learning_results.cluster_labels * np.arange(2)[:, np.newaxis]).sum(0),
+    )
 
     cl = signal.get_cluster_labels(merged=False)
-    np.testing.assert_array_equal(cl.data,
-                                  signal.learning_results.cluster_labels)
+    np.testing.assert_array_equal(cl.data, signal.learning_results.cluster_labels)
 
     cl = signal.get_cluster_signals(signal="sum")
-    np.testing.assert_array_equal(cl.data,
-                                  signal.learning_results.cluster_sum_signals)
+    np.testing.assert_array_equal(cl.data, signal.learning_results.cluster_sum_signals)
 
     cl = signal.get_cluster_signals(signal="centroid")
-    np.testing.assert_array_equal(cl.data,
-                                  signal.learning_results.cluster_centroid_signals)
+    np.testing.assert_array_equal(
+        cl.data, signal.learning_results.cluster_centroid_signals
+    )
     cl = signal.get_cluster_signals(signal="mean")
     np.testing.assert_array_equal(
         cl.data,
-        signal.learning_results.cluster_sum_signals /
-        signal.learning_results.cluster_labels.sum(1, keepdims=True))
+        signal.learning_results.cluster_sum_signals
+        / signal.learning_results.cluster_labels.sum(1, keepdims=True),
+    )
 
     cl = signal.get_cluster_distances()
-    np.testing.assert_array_equal(cl.data,
-                                  signal.learning_results.cluster_distances)
+    np.testing.assert_array_equal(cl.data, signal.learning_results.cluster_distances)

--- a/hyperspy/tests/learn/test_cluster.py
+++ b/hyperspy/tests/learn/test_cluster.py
@@ -20,11 +20,11 @@ import numpy as np
 import pytest
 
 from hyperspy import signals
-from hyperspy.misc.machine_learning import import_sklearn
+from hyperspy.misc.machine_learning.import_sklearn import sklearn_installed
 
-pytestmark = pytest.mark.skipif(
-    not import_sklearn.sklearn_installed, reason="sklearn not installed"
-)
+pytestmark = pytest.mark.skipif(not sklearn_installed, reason="sklearn not installed")
+
+import hyperspy.misc.machine_learning.import_sklearn  as import_sklearn
 
 
 # Create the data once, since the parametrizations

--- a/hyperspy/tests/misc/test_date_time_tools.py
+++ b/hyperspy/tests/misc/test_date_time_tools.py
@@ -18,7 +18,6 @@
 
 import numpy as np
 from dateutil import parser, tz
-from numpy.testing import assert_allclose
 
 import hyperspy.misc.date_time_tools as dtt
 from hyperspy.misc.test_utils import assert_deep_almost_equal
@@ -145,17 +144,17 @@ def test_serial_date_to_ISO_format():
 def test_ISO_format_to_serial_date():
     res1 = dtt.ISO_format_to_serial_date(
         dt1.date().isoformat(), dt1.time().isoformat(), timezone=dt1.tzname())
-    assert_allclose(res1, serial1, atol=1E-5)
+    np.testing.assert_allclose(res1, serial1, atol=1E-5)
     dt = dt2.astimezone(tz.tzlocal())
     res2 = dtt.ISO_format_to_serial_date(
         dt.date().isoformat(), dt.time().isoformat(), timezone=dt.tzname())
-    assert_allclose(res2, serial2, atol=1E-5)
+    np.testing.assert_allclose(res2, serial2, atol=1E-5)
     res3 = dtt.ISO_format_to_serial_date(
         dt3.date().isoformat(), dt3.time().isoformat(), timezone=dt3.tzname())
-    assert_allclose(res3, serial3, atol=1E-5)
+    np.testing.assert_allclose(res3, serial3, atol=1E-5)
 
 
 def test_datetime_to_serial_date():
-    assert_allclose(dtt.datetime_to_serial_date(dt1), serial1, atol=1E-5)
-    assert_allclose(dtt.datetime_to_serial_date(dt2), serial2, atol=1E-5)
-    assert_allclose(dtt.datetime_to_serial_date(dt3), serial3, atol=1E-5)
+    np.testing.assert_allclose(dtt.datetime_to_serial_date(dt1), serial1, atol=1E-5)
+    np.testing.assert_allclose(dtt.datetime_to_serial_date(dt2), serial2, atol=1E-5)
+    np.testing.assert_allclose(dtt.datetime_to_serial_date(dt3), serial3, atol=1E-5)

--- a/hyperspy/tests/model/test_chi_squared.py
+++ b/hyperspy/tests/model/test_chi_squared.py
@@ -39,7 +39,7 @@ class TestChiSquared:
         g = Gaussian()
         m.append(g)
         m.fit()
-        assert np.allclose(m.chisq(), 7.78966223)
+        np.testing.assert_allclose(m.chisq(), 7.78966223)
 
     def test_dof_with_fit(self):
         m = self.model
@@ -55,7 +55,7 @@ class TestChiSquared:
         g = Gaussian()
         m.append(g)
         m.fit()
-        assert np.allclose(m.red_chisq(), 1.55793245)
+        np.testing.assert_allclose(m.red_chisq(), 1.55793245)
 
     def test_chisq(self):
         m = self.model
@@ -65,7 +65,7 @@ class TestChiSquared:
         g.centre.value = self.centre
         m.append(g)
         m._calculate_chisq()
-        assert np.allclose(m.chisq(), 7.78966223)
+        np.testing.assert_allclose(m.chisq(), 7.78966223)
 
     def test_dof_with_p0(self):
         m = self.model
@@ -87,7 +87,7 @@ class TestChiSquared:
         m._set_p0()
         m._set_current_degrees_of_freedom()
         m._calculate_chisq()
-        assert np.allclose(m.red_chisq(), 1.55793245)
+        np.testing.assert_allclose(m.red_chisq(), 1.55793245)
 
     def test_chisq_in_range(self):
         m = self.model
@@ -95,7 +95,7 @@ class TestChiSquared:
         m.append(g)
         m.set_signal_range(1, 7)
         m.fit()
-        assert np.allclose(m.red_chisq(), 2.87544335)
+        np.testing.assert_allclose(m.red_chisq(), 2.87544335)
 
     def test_chisq_with_inactive_components(self):
         m = self.model
@@ -105,7 +105,7 @@ class TestChiSquared:
         m.append(gin)
         gin.active = False
         m.fit()
-        assert np.allclose(m.chisq(), 7.78966223)
+        np.testing.assert_allclose(m.chisq(), 7.78966223)
 
     def test_dof_with_inactive_components(self):
         m = self.model

--- a/hyperspy/tests/model/test_edsmodel.py
+++ b/hyperspy/tests/model/test_edsmodel.py
@@ -26,21 +26,29 @@ from hyperspy.misc.eds import utils as utils_eds
 from hyperspy.misc.elements import elements as elements_db
 
 
+# Create this outside the test class to
+# reduce computation in test suite by ~10seconds
+s = utils_eds.xray_lines_model(
+    elements=["Fe", "Cr", "Zn"],
+    beam_energy=200,
+    weight_percents=[20, 50, 30],
+    energy_resolution_MnKa=130,
+    energy_axis={
+        "units": "keV",
+        "size": 400,
+        "scale": 0.01,
+        "name": "E",
+        "offset": 5.0,
+    },
+)
+s = s + 0.002
+
+
 @lazifyTestClass
 class TestlineFit:
 
     def setup_method(self, method):
-        s = utils_eds.xray_lines_model(elements=['Fe', 'Cr', 'Zn'],
-                                       beam_energy=200,
-                                       weight_percents=[20, 50, 30],
-                                       energy_resolution_MnKa=130,
-                                       energy_axis={'units': 'keV',
-                                                    'size': 400,
-                                                    'scale': 0.01,
-                                                    'name': 'E',
-                                                    'offset': 5.})
-        s = s + 0.002
-        self.s = s
+        self.s = s.deepcopy()
 
     def test_fit(self):
         s = self.s

--- a/hyperspy/tests/model/test_eelsmodel.py
+++ b/hyperspy/tests/model/test_eelsmodel.py
@@ -18,7 +18,6 @@
 
 import numpy as np
 import pytest
-from numpy.testing import assert_allclose
 
 import hyperspy.api as hs
 from hyperspy.decorators import lazifyTestClass
@@ -140,10 +139,10 @@ class TestEELSModel:
         self.m.signal.data = 2. * self.m.axis.axis ** (-3)  # A= 2, r=3
         self.m.signal.metadata.Signal.binned = False
         self.m.two_area_background_estimation()
-        assert_allclose(
+        np.testing.assert_allclose(
             self.m._background_components[0].A.value,
             2.1451237089380295)
-        assert_allclose(
+        np.testing.assert_allclose(
             self.m._background_components[0].r.value,
             3.0118980767392736)
 
@@ -152,10 +151,10 @@ class TestEELSModel:
         self.m.signal.data = 2. * self.m.axis.axis ** (-3)  # A= 2, r=3
         self.m.signal.metadata.Signal.binned = False
         self.m.two_area_background_estimation()
-        assert_allclose(
+        np.testing.assert_allclose(
             self.m._background_components[0].A.value,
             2.3978438900878087)
-        assert_allclose(
+        np.testing.assert_allclose(
             self.m._background_components[0].r.value,
             3.031884021065014)
 
@@ -165,10 +164,10 @@ class TestEELSModel:
         self.m.signal.data = 2. * self.m.axis.axis ** (-3)  # A= 2, r=3
         self.m.signal.metadata.Signal.binned = False
         self.m.two_area_background_estimation()
-        assert_allclose(
+        np.testing.assert_allclose(
             self.m._background_components[0].A.value,
             2.6598803469440986)
-        assert_allclose(
+        np.testing.assert_allclose(
             self.m._background_components[0].r.value,
             3.0494030409062058)
 
@@ -202,7 +201,7 @@ class TestFitBackground:
 
     def test_fit_background_B_C(self):
         self.m.fit_background()
-        assert_allclose(self.m["Offset"].offset.value,
+        np.testing.assert_allclose(self.m["Offset"].offset.value,
                         1)
         assert self.m["B_K"].active
         assert self.m["C_K"].active
@@ -210,7 +209,7 @@ class TestFitBackground:
     def test_fit_background_C(self):
         self.m["B_K"].active = False
         self.m.fit_background()
-        assert_allclose(self.m["Offset"].offset.value,
+        np.testing.assert_allclose(self.m["Offset"].offset.value,
                         1.71212121212)
         assert not self.m["B_K"].active
         assert self.m["C_K"].active
@@ -219,7 +218,7 @@ class TestFitBackground:
         self.m["B_K"].active = False
         self.m["C_K"].active = False
         self.m.fit_background()
-        assert_allclose(self.m["Offset"].offset.value,
+        np.testing.assert_allclose(self.m["Offset"].offset.value,
                         2.13567839196)
         assert not self.m["B_K"].active
         assert not self.m["C_K"].active

--- a/hyperspy/tests/samfire/test_samfire.py
+++ b/hyperspy/tests/samfire/test_samfire.py
@@ -223,7 +223,7 @@ class TestSamfireEmpty:
         from multiprocessing import cpu_count
         samf = m.create_samfire(setup=False)
         assert samf._workers == cpu_count() - 1
-        assert np.allclose(samf.metadata.marker, np.zeros(self.shape))
+        np.testing.assert_allclose(samf.metadata.marker, np.zeros(self.shape))
         samf.stop()
         del samf
 

--- a/hyperspy/tests/samfire/test_strategy.py
+++ b/hyperspy/tests/samfire/test_strategy.py
@@ -18,7 +18,6 @@
 
 
 import numpy as np
-from numpy.testing import assert_allclose
 
 from hyperspy.components1d import Gaussian
 from hyperspy.misc.utils import DictionaryTreeBrowser
@@ -62,7 +61,7 @@ def compare_two_value_dicts(ans_r, ans):
             for p, pv in v.items():
                 test = test and p in ans[k]
                 if test:
-                    assert np.allclose(
+                    np.testing.assert_allclose(
                         np.array(pv),
                         np.array(
                             ans[k][p]))
@@ -144,12 +143,12 @@ class TestLocalSimple:
                          [0.00000000e+00, 0.00000000e+00, 0.00000000e+00, 0.00000000e+00]])
 
         s.refresh(True, given_pixels=None)
-        assert np.allclose(ans1, s.samf.metadata.marker[:4, :4])
+        np.testing.assert_allclose(ans1, s.samf.metadata.marker[:4, :4])
 
         given = np.ones(self.shape, dtype=bool)
         given[0, 1] = False
         s.refresh(True, given_pixels=given)
-        assert_allclose(
+        np.testing.assert_allclose(
             s.samf.metadata.marker[
                 ~given][0],
             0.011624353837970535)
@@ -176,14 +175,14 @@ class TestLocalSimple:
                          [0.00000000e+00, 0.00000000e+00, 0.00000000e+00, 0.00000000e+00]])
 
         s.refresh(False, given_pixels=None)
-        assert np.allclose(ans1, s.samf.metadata.marker[:4, :4])
+        np.testing.assert_allclose(ans1, s.samf.metadata.marker[:4, :4])
 
         s.samf.metadata.marker[0, 0] = -1
         given = np.ones(self.shape, dtype=bool)
         given[0, 0] = False
         # should stay the same, as the new point [0,0] is not in "given"
         s.refresh(False, given_pixels=given)
-        assert np.allclose(ans1, s.samf.metadata.marker[:4, :4])
+        np.testing.assert_allclose(ans1, s.samf.metadata.marker[:4, :4])
 
     def test_get_distance_array(self):
         s = self.s
@@ -204,7 +203,7 @@ class TestLocalSimple:
                           [True, False, False],
                           [False, False, False]], dtype=bool)
         assert np.all(tmp_m == mask)
-        assert np.allclose(tmp[mask], distances[mask])
+        np.testing.assert_allclose(tmp[mask], distances[mask])
         assert not s._radii_changed
         tmp_ma = np.array([[3.14884957, 2.31782464, 2.04081633, 2.31782464, 3.14884957],
                            [2.01506272,
@@ -233,7 +232,7 @@ class TestLocalSimple:
                             1.18403779,
                             2.01506272],
                            [3.14884957, 2.31782464, 2.04081633, 2.31782464, 3.14884957]])
-        assert np.allclose(s._mask_all, tmp_ma)
+        np.testing.assert_allclose(s._mask_all, tmp_ma)
         tmp_un = np.array([[3.60555128, 3.16227766, 3., 3.16227766, 3.60555128],
                            [2.82842712,
                             2.23606798,
@@ -257,7 +256,7 @@ class TestLocalSimple:
                             2.23606798,
                             2.82842712],
                            [3.60555128, 3.16227766, 3., 3.16227766, 3.60555128]])
-        assert np.allclose(s._untruncated, tmp_un)
+        np.testing.assert_allclose(s._untruncated, tmp_un)
 
         # now check that the stored values are used
         # mask:
@@ -276,7 +275,7 @@ class TestLocalSimple:
                         [np.nan, 1.41421356, 1.],
                         [np.nan, 1., 0.]])
         assert np.all(tmp_m == mask)
-        assert np.allclose(tmp[mask], distances[mask])
+        np.testing.assert_allclose(tmp[mask], distances[mask])
         assert not s._radii_changed
 
         # now mask radii changed and check that the correct result is
@@ -296,7 +295,7 @@ class TestLocalSimple:
                         [np.nan, 1.41421356, 1.],
                         [np.nan, 1., 0.]])
         assert np.all(tmp_m == mask)
-        assert np.allclose(tmp[mask], distances[mask])
+        np.testing.assert_allclose(tmp[mask], distances[mask])
         assert not s._radii_changed
 
     def test_update_marker(self):
@@ -322,7 +321,7 @@ class TestLocalSimple:
                             0.00000000e+00,
                             0.00000000e+00],
                            [0.00000000e+00, 0.00000000e+00, 0.00000000e+00, 0.00000000e+00]])
-        assert np.allclose(tmp_m1, s.samf.metadata.marker[:4, :4])
+        np.testing.assert_allclose(tmp_m1, s.samf.metadata.marker[:4, :4])
 
         ind = (1, 1)
         s.samf.running_pixels.append((1, 2))
@@ -336,7 +335,7 @@ class TestLocalSimple:
                             1.63810767e-03,
                             0.00000000e+00],
                            [0.00000000e+00, 0.00000000e+00, 0.00000000e+00, 0.00000000e+00]])
-        assert np.allclose(tmp_m2, s.samf.metadata.marker[:4, :4])
+        np.testing.assert_allclose(tmp_m2, s.samf.metadata.marker[:4, :4])
 
 
 class TestLocalWithModel:

--- a/hyperspy/tests/signal/test_1D_tools.py
+++ b/hyperspy/tests/signal/test_1D_tools.py
@@ -62,7 +62,7 @@ class TestAlignTools:
                   self.scale)
         assert m.data_changed.called
         i_zlp = s.axes_manager.signal_axes[0].value2index(0)
-        assert np.allclose(s.data[:, i_zlp], 12)
+        np.testing.assert_allclose(s.data[:, i_zlp], 12)
         # Check that at the edges of the spectrum the value == to the
         # background value. If it wasn't it'll mean that the cropping
         # code is buggy
@@ -76,7 +76,7 @@ class TestAlignTools:
         s = self.signal
         s.align1D()
         i_zlp = s.axes_manager.signal_axes[0].value2index(0)
-        assert np.allclose(s.data[:, i_zlp], 12)
+        np.testing.assert_allclose(s.data[:, i_zlp], 12)
         # Check that at the edges of the spectrum the value == to the
         # background value. If it wasn't it'll mean that the cropping
         # code is buggy
@@ -100,7 +100,7 @@ class TestAlignTools:
 
         # Check actual alignment of zlp
         i_zlp = s.axes_manager.signal_axes[0].value2index(0)
-        assert np.allclose(s.data[:, i_zlp], 12)
+        np.testing.assert_allclose(s.data[:, i_zlp], 12)
 
 
 @lazifyTestClass
@@ -142,22 +142,22 @@ class TestFindPeaks1D:
 
     def test_single_spectrum(self):
         peaks = self.signal.inav[0].find_peaks1D_ohaver()[0]
-        assert np.allclose(
+        np.testing.assert_allclose(
             peaks['position'], self.peak_positions0, rtol=1e-5, atol=1e-4)
 
     def test_two_spectra(self):
         peaks = self.signal.find_peaks1D_ohaver()[1]
-        assert np.allclose(
+        np.testing.assert_allclose(
             peaks['position'], self.peak_positions1, rtol=1e-5, atol=1e-4)
 
     def test_height(self):
         peaks = self.signal.find_peaks1D_ohaver()[1]
-        assert np.allclose(
+        np.testing.assert_allclose(
             peaks['height'], 1.0, rtol=1e-5, atol=1e-4)
 
     def test_width(self):
         peaks = self.signal.find_peaks1D_ohaver()[1]
-        assert np.allclose(peaks['width'], 3.5758, rtol=1e-4, atol=1e-4)
+        np.testing.assert_allclose(peaks['width'], 3.5758, rtol=1e-4, atol=1e-4)
 
     def test_n_peaks(self):
         peaks = self.signal.find_peaks1D_ohaver()[1]

--- a/hyperspy/tests/signal/test_2D_tools.py
+++ b/hyperspy/tests/signal/test_2D_tools.py
@@ -133,7 +133,7 @@ class TestAlignTools:
         shifts = s.estimate_shift2D()
         print(shifts)
         print(self.ishifts)
-        assert np.allclose(shifts, self.ishifts)
+        np.testing.assert_allclose(shifts, self.ishifts)
 
     def test_align_no_shift(self):
         s = self.signal

--- a/hyperspy/tests/signal/test_apodization.py
+++ b/hyperspy/tests/signal/test_apodization.py
@@ -25,7 +25,11 @@ from hyperspy.signals import BaseSignal, Signal1D, Signal2D
 
 
 def test_hann_nth_order():
-    assert np.allclose(np.hanning(1000), hann_window_nth_order(1000, order=1))
+    np.testing.assert_allclose(
+        np.hanning(1000),
+        hann_window_nth_order(1000, order=1),
+        rtol=1e-5,
+    )
     with pytest.raises(ValueError):
         hann_window_nth_order(-1000, order=1)
     with pytest.raises(ValueError):
@@ -102,26 +106,26 @@ def test_apodization(lazy, window_type, inplace):
             signal3d_a = signal3d.apply_apodization(window=window_type, inplace=inplace)
         data3_a = data3 * window3d[np.newaxis, :, :, :]
 
-        assert np.allclose(signal1d_a.data, data_a)
-        assert np.allclose(signal2d_a.data, data2_a)
-        assert np.allclose(signal3d_a.data, data3_a)
+        np.testing.assert_allclose(signal1d_a.data, data_a)
+        np.testing.assert_allclose(signal2d_a.data, data2_a)
+        np.testing.assert_allclose(signal3d_a.data, data3_a)
 
         for hann_order in 9 * (np.random.rand(5)) + 1:
             window = hann_window_nth_order(SIZE_SIG0, order=int(hann_order))
             signal1d_a = signal1d.apply_apodization(window=window_type, hann_order=int(hann_order))
             data_a = data * window[np.newaxis, np.newaxis, np.newaxis, :]
-            assert np.allclose(signal1d_a.data, data_a)
+            np.testing.assert_allclose(signal1d_a.data, data_a)
     elif window_type == 'hamming':
         window = np.hamming(SIZE_SIG0)
         signal1d_a = signal1d.apply_apodization(window=window_type)
         data_a = data * window[np.newaxis, np.newaxis, np.newaxis, :]
-        assert np.allclose(signal1d_a.data, data_a)
+        np.testing.assert_allclose(signal1d_a.data, data_a)
     elif window_type == 'tukey':
         for tukey_alpha in np.random.rand(5):
             window = tukey(SIZE_SIG0, alpha=tukey_alpha)
             signal1d_a = signal1d.apply_apodization(window=window_type, tukey_alpha=tukey_alpha)
             data_a = data * window[np.newaxis, np.newaxis, np.newaxis, :]
-            assert np.allclose(signal1d_a.data, data_a)
+            np.testing.assert_allclose(signal1d_a.data, data_a)
 
     # 2. Test raises:
     with pytest.raises(ValueError):

--- a/hyperspy/tests/signal/test_complex_signal.py
+++ b/hyperspy/tests/signal/test_complex_signal.py
@@ -19,7 +19,6 @@
 
 import numpy as np
 import pytest
-from numpy.testing import assert_allclose
 
 import hyperspy.api as hs
 from hyperspy.decorators import lazifyTestClass
@@ -40,40 +39,40 @@ class TestComplexProperties:
         self.s.axes_manager.set_signal_dimension(1)
 
     def test_get_real(self):
-        assert_allclose(self.s.real.data, self.real_ref)
+        np.testing.assert_allclose(self.s.real.data, self.real_ref)
 
     def test_set_real(self):
         real = np.random.random((3, 3))
         self.s.real = real
-        assert_allclose(self.s.real.data, real)
+        np.testing.assert_allclose(self.s.real.data, real)
 
     def test_get_imag(self):
-        assert_allclose(self.s.imag.data, self.imag_ref)
+        np.testing.assert_allclose(self.s.imag.data, self.imag_ref)
 
     def test_set_imag(self):
         imag = np.random.random((3, 3))
         self.s.imag = imag
-        assert_allclose(self.s.imag.data, imag)
+        np.testing.assert_allclose(self.s.imag.data, imag)
 
     def test_get_amplitude(self):
-        assert_allclose(self.s.amplitude.data, self.amplitude_ref)
+        np.testing.assert_allclose(self.s.amplitude.data, self.amplitude_ref)
 
     def test_set_amplitude(self):
         amplitude = np.random.random((3, 3))
         self.s.amplitude = amplitude
-        assert_allclose(self.s.amplitude, amplitude)
+        np.testing.assert_allclose(self.s.amplitude, amplitude)
 
     def test_get_phase(self):
-        assert_allclose(self.s.phase.data, self.phase_ref)
+        np.testing.assert_allclose(self.s.phase.data, self.phase_ref)
 
     def test_set_phase(self):
         phase = np.random.random((3, 3))
         self.s.phase = phase
-        assert_allclose(self.s.phase, phase)
+        np.testing.assert_allclose(self.s.phase, phase)
 
     def test_angle(self):
-        assert_allclose(self.s.angle(deg=False), self.phase_ref)
-        assert_allclose(
+        np.testing.assert_allclose(self.s.angle(deg=False), self.phase_ref)
+        np.testing.assert_allclose(
             self.s.angle(
                 deg=True),
             self.phase_ref *
@@ -94,7 +93,7 @@ def test_get_unwrapped_phase_1D(parallel, lazy):
     assert (
         phase_unwrapped.metadata.General.title ==
         'unwrapped phase(Untitled Signal)')
-    assert_allclose(phase_unwrapped.data, phase)
+    np.testing.assert_allclose(phase_unwrapped.data, phase)
 
 
 @pytest.mark.parametrize('parallel,lazy', [(True, False),
@@ -109,7 +108,7 @@ def test_get_unwrapped_phase_2D(parallel, lazy):
     assert (
         phase_unwrapped.metadata.General.title ==
         'unwrapped phase(Untitled Signal)')
-    assert_allclose(phase_unwrapped.data, phase)
+    np.testing.assert_allclose(phase_unwrapped.data, phase)
 
 
 @pytest.mark.parametrize('parallel,lazy', [(True, False),
@@ -124,7 +123,7 @@ def test_get_unwrapped_phase_3D(parallel, lazy):
     assert (
         phase_unwrapped.metadata.General.title ==
         'unwrapped phase(Untitled Signal)')
-    assert_allclose(phase_unwrapped.data, phase)
+    np.testing.assert_allclose(phase_unwrapped.data, phase)
 
 
 def test_argand_diagram():
@@ -140,7 +139,7 @@ def test_argand_diagram():
     s1d.metadata.Signal.quantity = 'Test quantity (Test units)'
     ap1d = s1d.argand_diagram(size=[7, 7])
     ap1_ref = np.histogram2d(re, im, bins=[7, 7])
-    assert np.allclose(ap1d.data, ap1_ref[0].T)
+    np.testing.assert_allclose(ap1d.data, ap1_ref[0].T)
     assert ap1d.metadata.General.title == 'Argand diagram of Test signal'
 
     # 2. Test ComplexSignal1D with specified range
@@ -154,14 +153,14 @@ def test_argand_diagram():
     x_axis = ap2d_a.axes_manager.signal_axes[0]
     y_axis = ap2d_a.axes_manager.signal_axes[1]
 
-    assert np.allclose(ap2d.data, ap2_ref[0].T)
-    assert np.allclose(ap2d_a.data, ap2_ref_a[0].T)
+    np.testing.assert_allclose(ap2d.data, ap2_ref[0].T)
+    np.testing.assert_allclose(ap2d_a.data, ap2_ref_a[0].T)
 
     assert x_axis.offset == -12.
-    assert np.allclose(x_axis.scale, np.gradient(ap2_ref_a[2]))
+    np.testing.assert_allclose(x_axis.scale, np.gradient(ap2_ref_a[2]))
 
     assert y_axis.offset == -10.
-    assert np.allclose(y_axis.scale, np.gradient(ap2_ref_a[1]))
+    np.testing.assert_allclose(y_axis.scale, np.gradient(ap2_ref_a[1]))
 
     assert x_axis.units == 'Test units'
     assert y_axis.units == 'Test units'

--- a/hyperspy/tests/signal/test_complex_signal2d.py
+++ b/hyperspy/tests/signal/test_complex_signal2d.py
@@ -18,8 +18,6 @@
 
 
 import numpy as np
-import numpy.testing as nt
-from numpy.testing import assert_allclose
 
 import hyperspy.api as hs
 
@@ -28,7 +26,7 @@ def test_add_phase_ramp():
     s = hs.signals.ComplexSignal2D(
         np.exp(1j * (np.indices((3, 3)).sum(axis=0) + 4)))
     s.add_phase_ramp(-1, -1, -4)
-    assert_allclose(s.phase.data, np.zeros_like(s.phase.data),
+    np.testing.assert_allclose(s.phase.data, np.zeros_like(s.phase.data),
                     atol=np.finfo(float).eps * 1.5)
 
 
@@ -36,4 +34,4 @@ def test_lazy_add_phase_ramp():
     s = hs.signals.ComplexSignal2D(
         np.exp(1j * (np.indices((3, 3)).sum(axis=0) + 4))).as_lazy()
     s.add_phase_ramp(-1, -1, -4)
-    nt.assert_almost_equal(s.phase.data.compute(), 0)
+    np.testing.assert_almost_equal(s.phase.data.compute(), 0)

--- a/hyperspy/tests/signal/test_eds_tem.py
+++ b/hyperspy/tests/signal/test_eds_tem.py
@@ -213,6 +213,17 @@ class Test_quantification:
             [22.70779, 22.70779],
             [22.70779, 22.70779]]), atol=1e-3)
 
+    def test_quant_lorimer_warning(self):
+        s = self.signal
+        method = 'CL'
+        kfactors = [1, 2.0009344042484134]
+        composition_units = 'weight'
+        intensities = s.get_lines_intensity()
+        with pytest.raises(ValueError, match="Thickness is required for absorption"):
+            _ = s.quantification(intensities, method, kfactors,
+                                 composition_units,
+                                 absorption_correction=True,
+                                 thickness=None)
 
     def test_quant_lorimer_ac(self):
         s = self.signal
@@ -370,6 +381,14 @@ class Test_quantification:
             [[49.4889, 49.4889],
              [49.4889, 49.4889]]), atol=1e-3)
 
+
+    def test_method_error(self):
+        s = self.signal
+        method = 'random_method'
+        factors = [3, 5]
+        intensities = s.get_lines_intensity()
+        with pytest.raises(ValueError, match="Please specify method for quantification"):
+            _ = s.quantification(intensities, method, factors)
 
     def test_quant_cross_section_ac(self):
         s = self.signal

--- a/hyperspy/tests/signal/test_eels.py
+++ b/hyperspy/tests/signal/test_eels.py
@@ -200,7 +200,7 @@ class TestAlignZLP:
         # Max value in the original spectrum is 12, but due to the aligning
         # the peak is split between two different channels. So 8 is the
         # maximum value for the aligned spectrum
-        assert np.allclose(zlp_max, 8)
+        np.testing.assert_allclose(zlp_max, 8)
 
     def test_align_zero_loss_peak_crop_false(self):
         s = self.signal

--- a/hyperspy/tests/signal/test_find_peaks2D.py
+++ b/hyperspy/tests/signal/test_find_peaks2D.py
@@ -18,7 +18,6 @@
 
 import pytest
 import numpy as np
-import numpy.testing as nt
 from scipy.stats import norm
 
 from hyperspy.signals import Signal2D, BaseSignal
@@ -125,7 +124,7 @@ class TestFindPeaks2D:
         assert not isinstance(peaks, LazySignal)
 
         # Check navigation shape
-        nt.assert_equal(dataset.axes_manager.navigation_shape,
+        np.testing.assert_equal(dataset.axes_manager.navigation_shape,
                         peaks.axes_manager.navigation_shape)
         if dataset.axes_manager.navigation_size == 0:
             shape = (1,)
@@ -139,12 +138,12 @@ class TestFindPeaks2D:
         peaks = self.sparse_nav2d_shifted.find_peaks(parallel=parallel,
                                                      interactive=False)
 
-        nt.assert_equal(peaks.inav[0, 0].data,
+        np.testing.assert_equal(peaks.inav[0, 0].data,
                         np.array([[27,  1],
                                   [10, 17],
                                   [22, 23],
                                   [33, 29]]))
-        nt.assert_equal(peaks.inav[0, 1].data,
+        np.testing.assert_equal(peaks.inav[0, 1].data,
                         np.array([[35,  3],
                                   [ 6, 13],
                                   [18, 19],
@@ -166,7 +165,7 @@ class TestFindPeaks2D:
         else:
             peaks = self.ref.find_peaks(method=method, parallel=parallel,
                                         interactive=False)
-        nt.assert_allclose(peaks.data[0], ans[0])
+        np.testing.assert_allclose(peaks.data[0], ans[0])
 
     def test_return_peaks(self):
         sig = self.sparse_nav2d_shifted
@@ -175,12 +174,12 @@ class TestFindPeaks2D:
         peaks = BaseSignal(np.empty(sig.axes_manager.navigation_shape),
                            axes=axes_dict)
         pf2D = PeaksFinder2D(sig, method='local_max', peaks=peaks)
-        nt.assert_allclose(peaks.data, np.array([[22, 23]]))
+        np.testing.assert_allclose(peaks.data, np.array([[22, 23]]))
 
         pf2D.local_max_threshold = 2
         pf2D._update_peak_finding()
         result_index0 = np.array([[10, 17], [22, 23], [33, 29]])
-        nt.assert_allclose(peaks.data, result_index0)
+        np.testing.assert_allclose(peaks.data, result_index0)
         pf2D.compute_navigation()
         pf2D.close()
 

--- a/hyperspy/tests/signal/test_image_contrast_editor_tool.py
+++ b/hyperspy/tests/signal/test_image_contrast_editor_tool.py
@@ -1,5 +1,4 @@
 import numpy as np
-from numpy.testing import assert_allclose
 
 import hyperspy.api as hs
 from hyperspy.signal_tools import ImageContrastEditor
@@ -16,15 +15,15 @@ class TestContrastEditorTool:
         s.plot(vmin='10th', vmax='99th')
         ceditor = ImageContrastEditor(s._plot.signal_plot)
 
-        assert_allclose(ceditor._vmin, 9.9)
-        assert_allclose(ceditor._vmax, 98.01)
+        np.testing.assert_allclose(ceditor._vmin, 9.9)
+        np.testing.assert_allclose(ceditor._vmax, 98.01)
 
         ceditor._vmin = 20
         ceditor._vmax = 90
         ceditor._reset_original_settings()
 
-        assert_allclose(ceditor._vmin, 9.9)
-        assert_allclose(ceditor._vmax, 98.01)
+        np.testing.assert_allclose(ceditor._vmin, 9.9)
+        np.testing.assert_allclose(ceditor._vmax, 98.01)
 
     def test_reset_span_selector(self):
         s = self.s
@@ -35,21 +34,21 @@ class TestContrastEditorTool:
         ceditor.update_span_selector()
         ax_image = s._plot.signal_plot.ax.images[0]
 
-        assert_allclose(ax_image.norm.vmin, 20)
-        assert_allclose(ax_image.norm.vmax, 90)
+        np.testing.assert_allclose(ax_image.norm.vmin, 20)
+        np.testing.assert_allclose(ax_image.norm.vmax, 90)
 
         ceditor._reset_span_selector()
 
-        assert_allclose(ax_image.norm.vmin, 9.9)
-        assert_allclose(ax_image.norm.vmax, 98.01)
+        np.testing.assert_allclose(ax_image.norm.vmin, 9.9)
+        np.testing.assert_allclose(ax_image.norm.vmax, 98.01)
 
     def test_change_navigation_coordinate(self):
         s = self.s
         s.plot(vmin='10th', vmax='99th')
         ceditor = ImageContrastEditor(s._plot.signal_plot)
 
-        assert_allclose(ceditor._vmin, 9.9)
-        assert_allclose(ceditor._vmax, 98.01)
+        np.testing.assert_allclose(ceditor._vmin, 9.9)
+        np.testing.assert_allclose(ceditor._vmax, 98.01)
         try:
             # Convenience to be able to run test on systems using backends
             # supporting blit
@@ -57,16 +56,16 @@ class TestContrastEditorTool:
         except TypeError:
             pass
 
-        assert_allclose(ceditor._vmin, 409.9)
-        assert_allclose(ceditor._vmax, 498.01)
+        np.testing.assert_allclose(ceditor._vmin, 409.9)
+        np.testing.assert_allclose(ceditor._vmax, 498.01)
 
     def test_vmin_vmax_changed(self):
         s = self.s
         s.plot(vmin='0th', vmax='100th')
         ceditor = ImageContrastEditor(s._plot.signal_plot)
 
-        assert_allclose(ceditor._vmin, 0.0)
-        assert_allclose(ceditor._vmax, 99.0)
+        np.testing.assert_allclose(ceditor._vmin, 0.0)
+        np.testing.assert_allclose(ceditor._vmax, 99.0)
         try:
             # Convenience to be able to run test on systems using backends
             # supporting blit
@@ -80,5 +79,5 @@ class TestContrastEditorTool:
         except TypeError:
             pass
 
-        assert_allclose(ceditor._vmin, 9.9)
-        assert_allclose(ceditor._vmax, 98.01)
+        np.testing.assert_allclose(ceditor._vmin, 9.9)
+        np.testing.assert_allclose(ceditor._vmax, 98.01)

--- a/hyperspy/tests/signal/test_kramers_kronig_transform.py
+++ b/hyperspy/tests/signal/test_kramers_kronig_transform.py
@@ -90,7 +90,7 @@ class Test2D:
                                              iterations=1,
                                              n=1000.)
         s = cdf.get_electron_energy_loss_spectrum(self.zlp, self.thickness)
-        assert np.allclose(s.data,
+        np.testing.assert_allclose(s.data,
                            self.s.data[..., 1:],
                            rtol=0.01)
 
@@ -104,7 +104,7 @@ class Test2D:
                                              iterations=1,
                                              t=self.thickness)
         s = cdf.get_electron_energy_loss_spectrum(self.zlp, self.thickness)
-        assert np.allclose(s.data,
+        np.testing.assert_allclose(s.data,
                            self.s.data[..., 1:],
                            rtol=0.01)
 
@@ -114,12 +114,14 @@ class Test2D:
                                             n=1000.)
         neff1, neff2 = df.get_number_of_effective_electrons(nat=50e27,
                                                             cumulative=False)
-        assert np.allclose(neff1.data,
+        np.testing.assert_allclose(neff1.data,
                            np.array([[0.91187657, 4.72490711, 3.60594653],
-                                     [3.88077047, 0.26759741, 0.19813647]]))
-        assert np.allclose(neff2.data,
+                                     [3.88077047, 0.26759741, 0.19813647]]),
+                           rtol=1e-6)
+        np.testing.assert_allclose(neff2.data,
                            np.array([[0.91299039, 4.37469112, 3.41580094],
-                                     [3.64866394, 0.15693674, 0.11146413]]))
+                                     [3.64866394, 0.15693674, 0.11146413]]),
+                           rtol=1e-6)
 
     def test_thickness_estimation(self):
         """Kramers kronig analysis gives a rough estimation of sample
@@ -131,7 +133,7 @@ class Test2D:
                                                      iterations=1,
                                                      n=1000.,
                                                      full_output=True)
-        assert np.allclose(
+        np.testing.assert_allclose(
             self.thickness.data,
             output['thickness'].data,
             rtol=0.01)
@@ -148,4 +150,4 @@ class Test2D:
         t = self.thickness.data[0, 0]
         cdf = s_in.kramers_kronig_analysis(zlp=z, iterations=1, n=1000.)
         s_out = cdf.get_electron_energy_loss_spectrum(z, t)
-        assert np.allclose(s_out.data, s_in.data[1:], rtol=0.01)
+        np.testing.assert_allclose(s_out.data, s_in.data[1:], rtol=0.01)

--- a/hyperspy/tests/signal/test_remove_background.py
+++ b/hyperspy/tests/signal/test_remove_background.py
@@ -59,11 +59,12 @@ class TestRemoveBackground1DGaussian:
         if return_model:
             s1 = out[0]
             model = out[1]
-            assert np.allclose(model.chisq.data, 0.0)
-            assert np.allclose(model.as_signal().data, signal.data)
+            np.testing.assert_allclose(model.chisq.data, 0.0, atol=1e-12)
+            np.testing.assert_allclose(model.as_signal().data, signal.data, atol=1e-12)
         else:
             s1 = out
-        assert np.allclose(s1.data, np.zeros_like(s1.data))
+
+        np.testing.assert_allclose(s1.data, 0.0, atol=1e-12)
 
     def test_background_remove_navigation(self):
         # Check it calculate the chisq
@@ -73,9 +74,9 @@ class TestRemoveBackground1DGaussian:
             background_type='Gaussian',
             fast=True,
             return_model=True)
-        assert np.allclose(model.chisq.data, np.array([0.0, 0.0]))
-        assert np.allclose(model.as_signal().data, s2.data)
-        assert np.allclose(s.data, np.zeros_like(s.data))
+        np.testing.assert_allclose(model.chisq.data, np.array([0.0, 0.0]), atol=1e-12)
+        np.testing.assert_allclose(model.as_signal().data, s2.data)
+        np.testing.assert_allclose(s.data, 0.0, atol=1e-12)
 
 
 @lazifyTestClass
@@ -96,14 +97,14 @@ class TestRemoveBackground1DLorentzian:
         s1 = self.signal.remove_background(
             signal_range=(None, None),
             background_type='Lorentzian')
-        assert np.allclose(np.zeros(len(s1.data)), s1.data, atol=0.2)
+        np.testing.assert_allclose(s1.data, 0.0, atol=0.2)
 
     def test_background_remove_lorentzian_full_fit(self):
         s1 = self.signal.remove_background(
             signal_range=(None, None),
             background_type='Lorentzian',
             fast=False)
-        assert np.allclose(s1.data, np.zeros(len(s1.data)))
+        np.testing.assert_allclose(s1.data, 0.0, atol=1e-12)
 
 
 @lazifyTestClass
@@ -127,8 +128,7 @@ class TestRemoveBackground1DPowerLaw:
         s1 = self.signal.remove_background(
             signal_range=(None, None),
             background_type='PowerLaw')
-        # since we compare to zero, rtol can't be used (see np.allclose doc)
-        assert np.allclose(s1.data, np.zeros(len(s1.data)), atol=self.atol)
+        np.testing.assert_allclose(s1.data, 0.0, atol=self.atol)
         assert s1.axes_manager.navigation_dimension == 0
 
     def test_background_remove_pl_zero(self):
@@ -136,18 +136,15 @@ class TestRemoveBackground1DPowerLaw:
             signal_range=(110.0, 190.0),
             background_type='PowerLaw',
             zero_fill=True)
-        # since we compare to zero, rtol can't be used (see np.allclose doc)
-        assert np.allclose(s1.isig[10:], np.zeros(len(s1.data[10:])),
-                           atol=self.atol_zero_fill)
-        assert np.allclose(s1.data[:10], np.zeros(10))
+        np.testing.assert_allclose(s1.isig[10:], 0.0, atol=self.atol_zero_fill)
+        np.testing.assert_allclose(s1.data[:10], np.zeros(10))
 
     def test_background_remove_pl_int(self):
         self.signal.change_dtype("int")
         s1 = self.signal.remove_background(
             signal_range=(None, None),
             background_type='PowerLaw')
-        # since we compare to zero, rtol can't be used (see np.allclose doc)
-        assert np.allclose(s1.data, np.zeros(len(s1.data)), atol=self.atol)
+        np.testing.assert_allclose(s1.data, 0.0, atol=self.atol)
 
     def test_background_remove_pl_int_zero(self):
         self.signal_noisy.change_dtype("int")
@@ -155,10 +152,8 @@ class TestRemoveBackground1DPowerLaw:
             signal_range=(110.0, 190.0),
             background_type='PowerLaw',
             zero_fill=True)
-        # since we compare to zero, rtol can't be used (see np.allclose doc)
-        assert np.allclose(s1.isig[10:], np.zeros(len(s1.data[10:])),
-                           atol=self.atol_zero_fill)
-        assert np.allclose(s1.data[:10], np.zeros(10))
+        np.testing.assert_allclose(s1.isig[10:], 0.0, atol=self.atol_zero_fill)
+        np.testing.assert_allclose(s1.data[:10], np.zeros(10))
 
 
 @lazifyTestClass
@@ -180,14 +175,14 @@ class TestRemoveBackground1DSkewNormal:
         s1 = self.signal.remove_background(
             signal_range=(None, None),
             background_type='SkewNormal')
-        assert np.allclose(np.zeros(len(s1.data)), s1.data, atol=0.2)
+        np.testing.assert_allclose(s1.data, 0.0, atol=0.2)
 
     def test_background_remove_skewnormal_full_fit(self):
         s1 = self.signal.remove_background(
             signal_range=(None, None),
             background_type='SkewNormal',
             fast=False)
-        assert np.allclose(s1.data, np.zeros(len(s1.data)))
+        np.testing.assert_allclose(s1.data, 0.0, atol=1e-12)
 
 
 @lazifyTestClass
@@ -210,14 +205,14 @@ class TestRemoveBackground1DVoigt:
             signal_range=(None, None),
             background_type='Voigt',
             fast=False)
-        assert np.allclose(np.zeros(len(s1.data)), s1.data)
+        np.testing.assert_allclose(s1.data, 0.0, atol=1e-12)
 
     def test_background_remove_voigt_full_fit(self):
         s1 = self.signal.remove_background(
             signal_range=(None, None),
             background_type='Voigt',
             fast=False)
-        assert np.allclose(s1.data, np.zeros(len(s1.data)))
+        np.testing.assert_allclose(s1.data, 0.0, atol=1e-12)
 
 
 @lazifyTestClass
@@ -238,14 +233,14 @@ class TestRemoveBackground1DExponential:
         s1 = self.signal.remove_background(
             signal_range=(None, None),
             background_type='Exponential')
-        assert np.allclose(np.zeros(len(s1.data)), s1.data, atol=self.atol)
+        np.testing.assert_allclose(s1.data, 0.0, atol=self.atol)
 
     def test_background_remove_exponential_full_fit(self):
         s1 = self.signal.remove_background(
             signal_range=(None, None),
             background_type='Exponential',
             fast=False)
-        assert np.allclose(s1.data, np.zeros(len(s1.data)))
+        np.testing.assert_allclose(s1.data, 0.0, atol=self.atol)
 
 
 def compare_axes_manager_metadata(s0, s1):

--- a/hyperspy/tests/utils/test_material.py
+++ b/hyperspy/tests/utils/test_material.py
@@ -17,7 +17,6 @@
 # along with  HyperSpy.  If not, see <http://www.gnu.org/licenses/>.
 
 import numpy as np
-from numpy.testing import assert_allclose
 
 import hyperspy.api as hs
 from hyperspy.misc.elements import elements_db
@@ -38,22 +37,22 @@ class TestWeightToFromAtomic:
 
     def test_weight_to_atomic(self):
         cwt = hs.material.weight_to_atomic(self.wt, self.elements)
-        assert_allclose(cwt[0], self.at[0])
-        assert_allclose(cwt[1], self.at[1])
+        np.testing.assert_allclose(cwt[0], self.at[0])
+        np.testing.assert_allclose(cwt[1], self.at[1])
 
     def test_atomic_to_weight(self):
         cat = hs.material.atomic_to_weight(self.at, self.elements)
-        assert_allclose(cat[0], self.wt[0])
-        assert_allclose(cat[1], self.wt[1])
+        np.testing.assert_allclose(cat[0], self.wt[0])
+        np.testing.assert_allclose(cat[1], self.wt[1])
 
     def test_multi_dim(self):
         elements = ("Cu", "Sn")
         wt = np.array([[[88] * 2] * 3, [[12] * 2] * 3])
         at = hs.material.weight_to_atomic(wt, elements)
-        assert np.allclose(
+        np.testing.assert_allclose(
             at[:, 0, 0], np.array([93.196986, 6.803013]), atol=1e-3)
         wt2 = hs.material.atomic_to_weight(at, elements)
-        assert np.allclose(wt, wt2)
+        np.testing.assert_allclose(wt, wt2)
 
 
 def test_density_of_mixture():
@@ -66,36 +65,36 @@ def test_density_of_mixture():
 
     volumes = wt * densities
     density = volumes.sum() / 100.
-    assert_allclose(
+    np.testing.assert_allclose(
         density, hs.material.density_of_mixture(wt, elements, mean='weighted'))
 
     volumes = wt / densities
     density = 100. / volumes.sum()
-    assert_allclose(
+    np.testing.assert_allclose(
         density, hs.material.density_of_mixture(wt, elements))
 
     wt = np.array([[[88] * 2] * 3, [[12] * 2] * 3])
-    assert_allclose(
+    np.testing.assert_allclose(
         density, hs.material.density_of_mixture(wt, elements)[0, 0])
 
 
 def test_mac():
-    assert_allclose(
+    np.testing.assert_allclose(
         hs.material.mass_absorption_coefficient('Al', 3.5), 506.0153356472)
-    assert np.allclose(
+    np.testing.assert_allclose(
         hs.material.mass_absorption_coefficient('Ta', [1, 3.2, 2.3]),
         [3343.7083701143229, 1540.0819991890, 3011.264941118])
-    assert_allclose(
+    np.testing.assert_allclose(
         hs.material.mass_absorption_coefficient('Zn', 'Zn_La'),
         1413.291119134)
-    assert np.allclose(
+    np.testing.assert_allclose(
         hs.material.mass_absorption_coefficient(
             'Zn', ['Cu_La', 'Nb_La']), [1704.7912903000029,
                                         1881.2081950943339])
 
 
 def test_mixture_mac():
-    assert_allclose(hs.material.mass_absorption_mixture([50, 50],
+    np.testing.assert_allclose(hs.material.mass_absorption_mixture([50, 50],
                                                         ['Al', 'Zn'],
                                                         'Al_Ka'),
                     2587.4161643905127)

--- a/hyperspy/tests/utils/test_roi.py
+++ b/hyperspy/tests/utils/test_roi.py
@@ -385,7 +385,7 @@ class TestROIs():
         s = self.s_i
         r = Line2DROI(0, 0, 4, 4, 1)
         s2 = r(s)
-        assert np.allclose(s2.data, np.array(
+        np.testing.assert_allclose(s2.data, np.array(
             [[[0.5646904, 0.83974605, 0.37688365, 0.499676],
               [0.08130241, 0.3241552, 0.91565131, 0.85345237],
               [0.5941565, 0.90536555, 0.42692772, 0.93761072],
@@ -423,7 +423,7 @@ class TestROIs():
         ))
         r.linewidth = 10
         s3 = r(s)
-        assert np.allclose(s3.data, np.array(
+        np.testing.assert_allclose(s3.data, np.array(
             [[[0., 0., 0., 0.],
               [0., 0., 0., 0.],
               [0., 0., 0., 0.],
@@ -472,9 +472,9 @@ class TestROIs():
                              -150., -135., -45., -30.,
                              150., 135., 45., 30.,
                              135., 120., 60., 45.])
-        assert np.allclose(r_angles, angles_h)
+        np.testing.assert_allclose(r_angles, angles_h)
         r_angles = np.array([rr.angle(axis='vertical') for rr in r])
-        assert np.allclose(r_angles, angles_v)
+        np.testing.assert_allclose(r_angles, angles_v)
 
         # 2. Testing unit conversation
         r = Line2DROI(np.random.rand(), np.random.rand(), np.random.rand(), np.random.rand())


### PR DESCRIPTION
### Description of the change 

Continuation of #2472, improving the test suite performance and catching a few inconsistencies along the way. Directing it at `RELEASE_next_patch` so that the improvements can be merged into `RELEASE_next_minor` as well. This shaves off a further 90 seconds from the test suite runtime locally. #2472 already improved runs by around 2 minutes.

- Speed up cluster tests
- Speed up BSS tests
- Speed up hologram tests
- Speed up EDS model tests
- Add `pragma: no cover` and `pragma: no branch` to some obvious code branches that are never hit in testing
- Replace one warning with a `ValueError` since the code immediately fails after the warning anyway, plus added test to catch it
- Replace `assert np.allclose` with `np.testing.assert_allclose`, and `import numpy.testing as nt; nt.assert.*` to `import numpy as np; np.testing.assert.*`. This is purely for consistency across the test suite - for example, it makes it much easier in future to find/replace/update all the `np.testing.assert_*` functions in one `grep`/`sed` command.

### Progress of the PR
- [x] Change implemented (can be split into several points),
- [x] update docstring (if appropriate),
- [x] update user guide (if appropriate),
- [x] add tests,
- [x] ready for review.

