### PR TITLE
Change rng.random to rng.random_sample

### DIFF
--- a/hyperspy/tests/learn/test_bss.py
+++ b/hyperspy/tests/learn/test_bss.py
@@ -74,7 +74,7 @@ def test_bss_FastICA_object():
     """Tests that a simple sklearn pipeline is an acceptable algorithm."""
     rng = np.random.RandomState(123)
     S = rng.laplace(size=(3, 1000))
-    A = rng.random((3, 3))
+    A = rng.random_sample(size=(3, 3))
     s = Signal1D(A @ S)
     s.decomposition()
 
@@ -92,7 +92,7 @@ def test_bss_pipeline():
     """Tests that a simple sklearn pipeline is an acceptable algorithm."""
     rng = np.random.RandomState(123)
     S = rng.laplace(size=(3, 1000))
-    A = rng.random((3, 3))
+    A = rng.random_sample(size=(3, 3))
     s = Signal1D(A @ S)
     s.decomposition()
 
@@ -113,7 +113,7 @@ def test_bss_pipeline():
 def test_orthomax(whiten_method):
     rng = np.random.RandomState(123)
     S = rng.laplace(size=(3, 500))
-    A = rng.random((3, 3))
+    A = rng.random_sample(size=(3, 3))
     s = Signal1D(A @ S)
     s.decomposition()
     s.blind_source_separation(3, algorithm="orthomax", whiten_method=whiten_method)
@@ -188,7 +188,7 @@ def test_algorithm_error():
 @pytest.mark.skipif(not sklearn_installed, reason="sklearn not installed")
 def test_normalize_components_errors():
     rng = np.random.RandomState(123)
-    s = Signal1D(rng.random((20, 100)))
+    s = Signal1D(rng.random_sample(size=(20, 100)))
     s.decomposition()
 
     with pytest.raises(ValueError, match="called after s.blind_source_separation"):
@@ -207,7 +207,7 @@ def test_sklearn_convergence_warning():
 
     rng = np.random.RandomState(123)
     ics = rng.laplace(size=(3, 1000))
-    mixing_matrix = rng.random((100, 3))
+    mixing_matrix = rng.random_sample(size=(100, 3))
     s = Signal1D(mixing_matrix @ ics)
     s.decomposition()
 
@@ -227,7 +227,7 @@ def test_sklearn_convergence_warning():
 def test_fastica_whiten_method(whiten_method):
     rng = np.random.RandomState(123)
     S = rng.laplace(size=(3, 1000))
-    A = rng.random((3, 3))
+    A = rng.random_sample(size=(3, 3))
     s = Signal1D(A @ S)
     s.decomposition()
     s.blind_source_separation(
@@ -243,7 +243,7 @@ class TestReverseBSS:
         rng = np.random.RandomState(123)
         S = rng.laplace(size=(3, 500))
         S -= 2 * S.min()  # Required to give us a positive dataset
-        A = rng.random((3, 3))
+        A = rng.random_sample(size=(3, 3))
         s = Signal1D(A @ S)
         s.decomposition()
         s.blind_source_separation(2)
@@ -272,7 +272,7 @@ class TestBSS1D:
     def setup_method(self, method):
         rng = np.random.RandomState(123)
         ics = rng.laplace(size=(3, 500))
-        mixing_matrix = rng.uniform(size=(100, 3))
+        mixing_matrix = rng.random_sample(size=(100, 3))
         s = Signal1D(mixing_matrix @ ics)
         s.decomposition()
 
@@ -322,7 +322,7 @@ class TestBSS2D:
     def setup_method(self, method):
         rng = np.random.RandomState(123)
         ics = rng.laplace(size=(3, 256))
-        mixing_matrix = rng.random((100, 3))
+        mixing_matrix = rng.random_sample(size=(100, 3))
         s = Signal2D((mixing_matrix @ ics).reshape((100, 16, 16)))
         for (axis, name) in zip(s.axes_manager._axes, ("z", "y", "x")):
             axis.name = name
@@ -442,7 +442,7 @@ class TestBSS2D:
 class TestPrintInfo:
     def setup_method(self, method):
         rng = np.random.RandomState(123)
-        self.s = Signal1D(rng.random((20, 100)))
+        self.s = Signal1D(rng.random_sample(size=(20, 100)))
         self.s.decomposition(output_dimension=2)
 
     def test_bss(self, capfd):
@@ -461,7 +461,7 @@ class TestPrintInfo:
 class TestReturnInfo:
     def setup_method(self, method):
         rng = np.random.RandomState(123)
-        self.s = Signal1D(rng.random((20, 100)))
+        self.s = Signal1D(rng.random_sample(size=(20, 100)))
         self.s.decomposition(output_dimension=2)
 
     def test_bss_not_supported(self):

--- a/hyperspy/tests/learn/test_cluster.py
+++ b/hyperspy/tests/learn/test_cluster.py
@@ -42,6 +42,7 @@ else:
     # will skip the rest of the file anyway
     pass
 
+
 class TestCluster1D:
     def setup_method(self):
         self.signal = signal1.deepcopy()
@@ -270,7 +271,7 @@ class DummyScalingAlgorithm:
 class TestClusterExceptions:
     def setup_method(self):
         self.rng = np.random.RandomState(123)
-        self.s = signals.Signal1D(self.rng.uniform(size=(20, 100)))
+        self.s = signals.Signal1D(self.rng.random_sample(size=(20, 100)))
 
     def test_cluster_source_error(self):
         with pytest.raises(
@@ -282,7 +283,7 @@ class TestClusterExceptions:
             self.s.cluster_analysis("randtest", n_clusters=2)
 
     def test_cluster_source_size_error(self):
-        x2 = self.rng.uniform(size=(10, 80))
+        x2 = self.rng.random_sample(size=(10, 80))
         s2 = signals.Signal1D(x2)
         with pytest.raises(
             ValueError,
@@ -292,7 +293,7 @@ class TestClusterExceptions:
             self.s.cluster_analysis(s2, n_clusters=2)
 
     def test_cluster_source_center_size_error(self):
-        x2 = self.rng.uniform(size=(10, 80))
+        x2 = self.rng.random_sample(size=(10, 80))
         s2 = signals.Signal1D(x2)
         with pytest.raises(
             ValueError,
@@ -424,7 +425,7 @@ class TestClusterExceptions:
 
 def test_get_methods():
     rng = np.random.RandomState(123)
-    signal = signals.Signal1D(rng.uniform(size=(11, 5, 7)))
+    signal = signals.Signal1D(rng.random_sample(size=(11, 5, 7)))
     signal.decomposition()
     signal.cluster_analysis("signal", n_clusters=2)
     signal.unfold()

--- a/hyperspy/tests/learn/test_decomposition.py
+++ b/hyperspy/tests/learn/test_decomposition.py
@@ -56,7 +56,7 @@ class TestNdAxes:
         Where s12 data is transposed in respect to s2
         """
         rng = np.random.RandomState(123)
-        dc1 = rng.random((2, 3, 4, 3, 2))
+        dc1 = rng.random_sample(size=(2, 3, 4, 3, 2))
         dc2 = np.rollaxis(np.rollaxis(dc1, -1), -1)
         s1 = signals.BaseSignal(dc1.copy())
         s2 = signals.BaseSignal(dc2)
@@ -199,7 +199,7 @@ class TestEstimateElbowPosition:
 
     def test_elbow_position_log(self):
         variance = self.s.learning_results.explained_variance_ratio
-        elbow = self.s.estimate_elbow_position(variance,log=False)
+        elbow = self.s.estimate_elbow_position(variance, log=False)
         assert elbow == 1
 
     def test_elbow_position_none(self):
@@ -492,8 +492,8 @@ class TestLoadDecompositionResults:
 class TestComplexSignalDecomposition:
     def setup_method(self, method):
         rng = np.random.RandomState(123)
-        real = rng.random((8, 8))
-        imag = rng.random((8, 8))
+        real = rng.random_sample(size=(8, 8))
+        imag = rng.random_sample(size=(8, 8))
         s_complex_dtype = signals.ComplexSignal1D(real + 1j * imag - 1j * imag)
         s_real_dtype = signals.ComplexSignal1D(real)
         s_complex_dtype.decomposition()
@@ -518,8 +518,8 @@ class TestComplexSignalDecomposition:
         m, n, r = 32, 32, 3
         rng = np.random.RandomState(123)
 
-        A = rng.random((m, r)) + 1j * rng.random((m, r))
-        B = rng.random((n, r)) + 1j * rng.random((n, r))
+        A = rng.random_sample(size=(m, r)) + 1j * rng.random_sample(size=(m, r))
+        B = rng.random_sample(size=(n, r)) + 1j * rng.random_sample(size=(n, r))
 
         s = signals.ComplexSignal1D(A @ B.T)
         s.decomposition()

--- a/hyperspy/tests/learn/test_lazy_decomposition.py
+++ b/hyperspy/tests/learn/test_lazy_decomposition.py
@@ -182,7 +182,7 @@ class TestLazyDecomposition:
 class TestPrintInfo:
     def setup_method(self, method):
         rng = np.random.RandomState(123)
-        self.s = Signal1D(rng.random((20, 100))).as_lazy()
+        self.s = Signal1D(rng.random_sample(size=(20, 100))).as_lazy()
 
     @pytest.mark.parametrize("algorithm", ["SVD", "ORPCA", "ORNMF"])
     def test_decomposition(self, algorithm, capfd):

--- a/hyperspy/tests/learn/test_learning_results.py
+++ b/hyperspy/tests/learn/test_learning_results.py
@@ -27,7 +27,7 @@ from hyperspy.signals import Signal1D
 def test_learning_results_decom():
     rng = np.random.RandomState(123)
 
-    s1 = Signal1D(rng.random((20, 100)))
+    s1 = Signal1D(rng.random_sample(size=(20, 100)))
     s1.decomposition(output_dimension=2)
 
     out = str(s1.learning_results)
@@ -41,7 +41,7 @@ def test_learning_results_decom():
 def test_learning_results_bss():
     rng = np.random.RandomState(123)
 
-    s1 = Signal1D(rng.random((20, 100)))
+    s1 = Signal1D(rng.random_sample(size=(20, 100)))
     s1.decomposition(output_dimension=2)
     s1.blind_source_separation(number_of_components=2)
 

--- a/hyperspy/tests/signal/test_fourier_transform.py
+++ b/hyperspy/tests/signal/test_fourier_transform.py
@@ -20,13 +20,18 @@ import numpy as np
 import pytest
 
 from hyperspy.decorators import lazifyTestClass
-from hyperspy.signals import (BaseSignal, ComplexSignal1D, ComplexSignal2D,
-                              Signal1D, Signal2D)
+from hyperspy.signals import (
+    BaseSignal,
+    ComplexSignal1D,
+    ComplexSignal2D,
+    Signal1D,
+    Signal2D,
+)
 
 
 def test_null_signal():
     rng = np.random.RandomState(123)
-    s = BaseSignal(rng.uniform())
+    s = BaseSignal(rng.random_sample())
     with pytest.raises(AttributeError):
         s.T.fft()
     with pytest.raises(AttributeError):
@@ -37,7 +42,7 @@ def test_null_signal():
 class TestFFTSignal2D:
     def setup_method(self, method):
         rng = np.random.RandomState(123)
-        self.im = Signal2D(rng.uniform(size=(2, 3, 4, 5)))
+        self.im = Signal2D(rng.random_sample(size=(2, 3, 4, 5)))
         self.im.axes_manager.signal_axes[0].units = "nm"
         self.im.axes_manager.signal_axes[1].units = "nm"
         self.im.axes_manager.signal_axes[0].scale = 10.0
@@ -113,7 +118,7 @@ class TestFFTSignal2D:
 class TestFFTSignal1D:
     def setup_method(self, method):
         rng = np.random.RandomState(123)
-        self.s = Signal1D(rng.uniform(size=(2, 3, 4, 5)))
+        self.s = Signal1D(rng.random_sample(size=(2, 3, 4, 5)))
         self.s.axes_manager.signal_axes[0].scale = 6.0
 
     def test_fft(self):


### PR DESCRIPTION
### Description of the change
Quite a few Travis tests failing on Rnm/Rnp - e.g. see https://travis-ci.org/github/hyperspy/hyperspy/jobs/716605308#L1706 as part of #2477, with the error below. I'm guessing this might be a numpy version issue but not looked into it.

```python
AttributeError: 'mtrand.RandomState' object has no attribute 'random'
``` 

This PR replaces it with `np.random.RandomState.random_sample`, which also draws from the half-open interval `[0.0, 1.0)`. 
Note that `np.random.RandomState.uniform` would also work, but that has the option of a different interval to `[0.0, 1.0)` so isn't necessary.

### Progress of the PR
- [x] Change implemented (can be split into several points),
- [x] ~update docstring (if appropriate),~
- [x] ~update user guide (if appropriate),~
- [x] ~add tests,~
- [x] ready for review.

