### PR TITLE
Patch for .histogram method, repull of #2477

### DIFF
--- a/hyperspy/misc/hist_tools.py
+++ b/hyperspy/misc/hist_tools.py
@@ -74,15 +74,16 @@ def histogram(a, bins="fd", range=None, max_num_bins=250, weights=None, **kwargs
     if isinstance(a, da.Array):
         return histogram_dask(a, bins=bins, max_num_bins=max_num_bins, **kwargs)
 
-    _deprecated_bins = {"scotts": "scott", "freedman": "fd"}
-    new_bins = _deprecated_bins.get(bins, None)
-    if new_bins:
-        warnings.warn(
-            f"`bins='{bins}'` has been deprecated and will be removed "
-            f"in HyperSpy 2.0. Please use `bins='{new_bins}'` instead.",
-            VisibleDeprecationWarning,
-        )
-        bins = new_bins
+    if isinstance(bins,str):
+        _deprecated_bins = {"scotts": "scott", "freedman": "fd"}
+        new_bins = _deprecated_bins.get(bins, None)
+        if new_bins:
+            warnings.warn(
+                f"`bins='{bins}'` has been deprecated and will be removed "
+                f"in HyperSpy 2.0. Please use `bins='{new_bins}'` instead.",
+                VisibleDeprecationWarning,
+                )
+            bins = new_bins
 
     _old_bins = bins
 
@@ -168,15 +169,16 @@ def histogram_dask(a, bins="fd", max_num_bins=250, **kwargs):
     if a.ndim != 1:
         a = a.flatten()
 
-    _deprecated_bins = {"scotts": "scott", "freedman": "fd"}
-    new_bins = _deprecated_bins.get(bins, None)
-    if new_bins:
-        warnings.warn(
-            f"`bins='{bins}'` has been deprecated and will be removed "
-            f"in HyperSpy 2.0. Please use `bins='{new_bins}'` instead.",
-            VisibleDeprecationWarning,
-        )
-        bins = new_bins
+    if isinstance(bins,str):
+        _deprecated_bins = {"scotts": "scott", "freedman": "fd"}
+        new_bins = _deprecated_bins.get(bins, None)
+        if new_bins:
+            warnings.warn(
+                f"`bins='{bins}'` has been deprecated and will be removed "
+                f"in HyperSpy 2.0. Please use `bins='{new_bins}'` instead.",
+                VisibleDeprecationWarning,
+                )
+            bins = new_bins
 
     _old_bins = bins
 

--- a/hyperspy/tests/misc/test_hist_tools.py
+++ b/hyperspy/tests/misc/test_hist_tools.py
@@ -42,6 +42,14 @@ def generate_bad_toy_data():
     s1.align_zero_loss_peak(also_align=[s2])
     return s1
 
+@pytest.mark.parametrize("bins",[10,np.linspace(1,20,num=11)])
+def test_types_of_bins(bins):
+    s1 = generate_bad_toy_data()
+    out = s1.get_histogram(bins)
+    assert out.data.shape == (10,)
+    s2 = generate_bad_toy_data().as_lazy()
+    out = s2.get_histogram(bins)
+    assert out.data.shape == (10,)
 
 def test_knuth_bad_data_set(caplog):
     s1 = generate_bad_toy_data()


### PR DESCRIPTION
Had been pulling to the wrong branch, details are a copy paste job from #2477. This will close #2475.

### Description of the change
As described in issue (#2475):
- Numpy's histogram functionality offers three types for bins:
`int or sequence of scalars or str`
- The wrapping in hist_tools wasn't set up to handle arrays (or `int`)
- This PR fixes that issue
- The PR also adds a barebones test to prevent regressions

### Progress of the PR
- [x] Change implemented (can be split into several points),
- [ ] update docstring ~(if appropriate)~,
- [ ] update user guide ~(if appropriate)~,
- [x] add tests,
- [x] ready for review.

### Minimal example of the bug fix or the new feature
```python
>>> import hyperspy.api as hs
>>> import numpy as np
>>> s = hs.signals.Signal1D(np.arange(10))
>>> s.get_histogram(bins=3)
```
