### PR TITLE
Test against oldest version of matploltib, numpy and scipy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,7 +37,7 @@ install:
   # manually
   - pip install --upgrade pytest
   - if [ "$MINIMUM_VERSION" == true ]; then
-      pip install matplotlib==2.2.3 numpy==1.14 scipy==1.0.1 numba==0.40;
+      pip install matplotlib==2.2.3 numpy==1.15 scipy==1.0.1 numba==0.46 imagecodecs==2018.10.10;
       pip install -e .["${PIP_SELECTOR}"];
     else
       pip install --upgrade -e .["${PIP_SELECTOR}"];

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,8 +36,10 @@ install:
   # Because of https://github.com/pypa/pip/issues/4391, we need to update pytest
   # manually
   - pip install --upgrade pytest
+  # Test against the oldest supported version of matplotlib, numpy and scipy
+  # Use old version numba and imagecodecs to work around incompatibilities
   - if [ "$MINIMUM_VERSION" == true ]; then
-      pip install matplotlib==2.2.3 numpy==1.15 scipy==1.0.1 numba==0.46 imagecodecs==2018.10.10;
+      pip install matplotlib==2.2.3 numpy==1.15 scipy==1.0.1 numba==0.40 imagecodecs==2018.10.10;
       pip install -e .["${PIP_SELECTOR}"];
     else
       pip install --upgrade -e .["${PIP_SELECTOR}"];

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ env:
     - ENV=pip
     - PIP_SELECTOR="all, tests, coverage"
     - PYTEST_ARGS="--pyargs hyperspy"
+    - MINIMUM_VERSION=false
 
 matrix:
   include:
@@ -19,6 +20,9 @@ matrix:
   - name: "Linux, 3.7, pip, minimum requirement"
     env: PIP_SELECTOR="tests"
     python: 3.7
+  - name: "Linux, 3.6, pip, mininum version"
+    env: MINIMUM_VERSION="true"
+    python: 3.7
   - name: "Linux, 3.7, pip, doc"
     env: PIP_SELECTOR="all, build-doc"
     python: 3.7
@@ -31,9 +35,13 @@ before_install:
 install:
   # Because of https://github.com/pypa/pip/issues/4391, we need to update pytest
   # manually
-  - pip install -U pytest
-  # Install the package
-  - pip install --upgrade -e .["${PIP_SELECTOR}"]
+  - pip install --upgrade pytest
+  - if [ "$MINIMUM_VERSION" == true ]; then
+      pip install matplotlib==2.2.3 numpy==1.13 scipy==1.0.1;
+      pip install -e .["${PIP_SELECTOR}"];
+    else
+      pip install --upgrade -e .["${PIP_SELECTOR}"];
+    fi
 
 script:
   - which python

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,8 +21,8 @@ matrix:
     env: PIP_SELECTOR="tests"
     python: 3.7
   - name: "Linux, 3.6, pip, mininum version"
-    env: MINIMUM_VERSION="true"
-    python: 3.7
+    env: MINIMUM_VERSION=true
+    python: 3.6
   - name: "Linux, 3.7, pip, doc"
     env: PIP_SELECTOR="all, build-doc"
     python: 3.7
@@ -37,7 +37,7 @@ install:
   # manually
   - pip install --upgrade pytest
   - if [ "$MINIMUM_VERSION" == true ]; then
-      pip install matplotlib==2.2.3 numpy==1.13 scipy==1.0.1;
+      pip install matplotlib==2.2.3 numpy==1.14 scipy==1.0.1 numba==0.40;
       pip install -e .["${PIP_SELECTOR}"];
     else
       pip install --upgrade -e .["${PIP_SELECTOR}"];
@@ -49,7 +49,7 @@ script:
   - if [[ $PIP_SELECTOR == *"build-doc"* ]]; then
       cd doc && make html;
     else
-      echo "py.test arguments $PYTEST_ARGS";
+      echo "pytest arguments $PYTEST_ARGS";
       pytest $PYTEST_ARGS;
     fi
 

--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,7 @@ setup_path = os.path.dirname(__file__)
 
 install_req = ['scipy>=1.0.1',
                'matplotlib>=2.2.3',
-               'numpy>=1.13.0',
+               'numpy>=1.15.0',
                'traits>=4.5.0',
                'natsort',
                'requests',


### PR DESCRIPTION
### Progress of the PR
- [x] add a build to travis to check the oldest supported version of matplotlib, numpy and scipy,
- [x] ready for review.

There are binaries incompatibilities issues for old version of numpy and the imagecodecs wheels on linux, which make me think we should possibly make imagecodecs an optional dependencies - at the moment imagecodecs is installed through `tifffile[all]`. This should not be an issue for more recent version and therefore it should be a fairly niche issue.