### PR TITLE
Remove signal_type='image' for velox emd and phenom

### DIFF
--- a/hyperspy/io_plugins/emd.py
+++ b/hyperspy/io_plugins/emd.py
@@ -1157,7 +1157,6 @@ class FeiEMDReader(object):
                      ])
 
         md = self._get_metadata_dict(original_metadata)
-        md['Signal']['signal_type'] = 'image'
         if self.detector_name is not None:
             original_metadata['DetectorMetadata'] = _get_detector_metadata_dict(
                 original_metadata,

--- a/hyperspy/io_plugins/phenom.py
+++ b/hyperspy/io_plugins/phenom.py
@@ -314,23 +314,24 @@ class ElidReader:
             metadata['acquisition']['scan']['detectors']['EDS'] = eds_metadata
         return (metadata, data)
 
-    def _make_metadata_dict(self, signal_type, title, datetime):
-        dict = {
+    def _make_metadata_dict(self, signal_type=None, title="", datetime=None):
+        metadata_dict = {
             'General': {
                 'original_filename': os.path.split(self._pathname)[1],
                 'title': title
-            },
-            'Signal': {
-                'signal_type': signal_type
             }
         }
+        if signal_type:
+            metadata_dict['Signal'] = {
+                'signal_type': signal_type
+                }
         if datetime:
-            dict['General'].update({
+            metadata_dict['General'].update({
                 'date': datetime[0],
                 'time': datetime[1],
                 'time_zone': self._get_local_time_zone()
             })
-        return dict
+        return metadata_dict
 
     def _get_local_time_zone(self):
         return tz.tzlocal().tzname(datetime.today())

--- a/hyperspy/io_plugins/phenom.py
+++ b/hyperspy/io_plugins/phenom.py
@@ -488,7 +488,7 @@ class ElidReader:
         dict = {
             'data': data,
             'axes': axes,
-            'metadata': self._make_metadata_dict('image', title, self._get_datetime(om)),
+            'metadata': self._make_metadata_dict('', title, self._get_datetime(om)),
             'original_metadata': om,
             'mapping': self._make_mapping()
         }

--- a/hyperspy/tests/io/test_emd.py
+++ b/hyperspy/tests/io/test_emd.py
@@ -318,7 +318,7 @@ class TestFeiEMD():
                           'time': '09:56:41',
                           'time_zone': 'BST',
                           'title': 'HAADF'},
-              'Signal': {'binned': False, 'signal_type': 'image'},
+              'Signal': {'binned': False, 'signal_type': ''},
               '_HyperSpy': {'Folding': {'original_axes_manager': None,
                                         'original_shape': None,
                                         'signal_unfolded': False,

--- a/hyperspy/tests/io/test_phenom.py
+++ b/hyperspy/tests/io/test_phenom.py
@@ -50,6 +50,7 @@ def test_elid(pathname):
     assert s[0].metadata['General']['time'] == '09:37:31'
     assert s[0].metadata['General']['title'] == 'Image 1'
     assert s[0].metadata['Signal']['binned'] == False
+    assert s[0].metadata['Signal']['signal_type'] == ''
     assert s[0].original_metadata['acquisition']['scan']['dwellTime']['value'] == '200'
     assert s[0].original_metadata['acquisition']['scan']['dwellTime']['unit'] == 'ns'
     assert s[0].original_metadata['acquisition']['scan']['fieldSize'] == 0.000019515585197840245

--- a/hyperspy/tests/io/test_phenom.py
+++ b/hyperspy/tests/io/test_phenom.py
@@ -50,7 +50,6 @@ def test_elid(pathname):
     assert s[0].metadata['General']['time'] == '09:37:31'
     assert s[0].metadata['General']['title'] == 'Image 1'
     assert s[0].metadata['Signal']['binned'] == False
-    assert s[0].metadata['Signal']['signal_type'] == 'image'
     assert s[0].original_metadata['acquisition']['scan']['dwellTime']['value'] == '200'
     assert s[0].original_metadata['acquisition']['scan']['dwellTime']['unit'] == 'ns'
     assert s[0].original_metadata['acquisition']['scan']['fieldSize'] == 0.000019515585197840245


### PR DESCRIPTION
On loading velox emd files, I noticed that I was getting a 
```python
WARNING:hyperspy.io:`signal_type='image'` not understood.
```
#2434 brought this to light, I think. 
I've removed the references to `signal_type='image'` for the emd and phenom loaders.