### PR TITLE
Use the nightly merge action

### DIFF
--- a/.github/workflows/nightly-merge.yml
+++ b/.github/workflows/nightly-merge.yml
@@ -1,0 +1,24 @@
+name: 'Nightly Merge'
+
+on:
+  schedule:
+    - cron:  '0 0 * * *'
+
+jobs:
+  nightly-merge:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v1
+
+    - name: Nightly Merge
+      uses: robotology/gh-action-nightly-merge@v1.2.0
+      with:
+        stable_branch: 'RELEASE_next_patch'
+        development_branch: 'RELEASE_next_minor'
+        allow_ff: true
+        allow_forks: false
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Use https://github.com/marketplace/actions/nightly-merge to merge RnP into RnM. Fix #1711.

I have tested it in my fork (with `allow_forks` enabled) and it works fine, see:
- https://github.com/ericpre/hyperspy/actions/runs/219147454 for the CI
- https://github.com/ericpre/hyperspy/commit/2268a66687eec6c34871ea1284ce07881d6d9b63 for the commit

