### PR TITLE
Histogram warning fix

### DIFF
--- a/hyperspy/misc/hist_tools.py
+++ b/hyperspy/misc/hist_tools.py
@@ -74,7 +74,7 @@ def histogram(a, bins="fd", range=None, max_num_bins=250, weights=None, **kwargs
     if isinstance(a, da.Array):
         return histogram_dask(a, bins=bins, max_num_bins=max_num_bins, **kwargs)
 
-    if isinstance(bins,str):
+    if isinstance(bins, str):
         _deprecated_bins = {"scotts": "scott", "freedman": "fd"}
         new_bins = _deprecated_bins.get(bins, None)
         if new_bins:
@@ -87,7 +87,7 @@ def histogram(a, bins="fd", range=None, max_num_bins=250, weights=None, **kwargs
 
     _old_bins = bins
 
-    if bins in ["knuth", "blocks"]:
+    if isinstance(bins, str) and bins in ["knuth", "blocks"]:
         # if range is specified, we need to truncate
         # the data for these bin-finding routines
         if range is not None:
@@ -169,7 +169,7 @@ def histogram_dask(a, bins="fd", max_num_bins=250, **kwargs):
     if a.ndim != 1:
         a = a.flatten()
 
-    if isinstance(bins,str):
+    if isinstance(bins, str):
         _deprecated_bins = {"scotts": "scott", "freedman": "fd"}
         new_bins = _deprecated_bins.get(bins, None)
         if new_bins:
@@ -182,12 +182,13 @@ def histogram_dask(a, bins="fd", max_num_bins=250, **kwargs):
 
     _old_bins = bins
 
-    if bins == "scott":
-        _, bins = _scott_bw_dask(a, True)
-    elif bins == "fd":
-        _, bins = _freedman_bw_dask(a, True)
-    elif isinstance(bins, str):
-        raise ValueError(f"Unrecognized 'bins' argument: got {bins}")
+    if isinstance(bins, str):
+        if bins == "scott":
+            _, bins = _scott_bw_dask(a, True)
+        elif bins == "fd":
+            _, bins = _freedman_bw_dask(a, True)
+        else:
+            raise ValueError(f"Unrecognized 'bins' argument: got {bins}")
     elif not np.iterable(bins):
         kwargs["range"] = da.compute(a.min(), a.max())
 

--- a/hyperspy/signal.py
+++ b/hyperspy/signal.py
@@ -4354,7 +4354,7 @@ class BaseSignal(FancySlicing,
             else:
                 hist_spec.data = hist
 
-        if bins == 'blocks':
+        if isinstance(bins, str) and bins == 'blocks':
             hist_spec.axes_manager.signal_axes[0].axis = bin_edges[:-1]
             warnings.warn(
                 "The option `bins='blocks'` is not fully supported in this "


### PR DESCRIPTION
### Description of the change
Small extension to #2482 - avoids numpy `FutureWarning`:
```
FutureWarning: elementwise comparison failed; returning scalar instead, but in the future will perform elementwise comparison
```
@pc494  can you confirm this doesn't break your changes?

### Progress of the PR
- [x] Change implemented (can be split into several points),
- [x] ~update docstring (if appropriate),~
- [x] ~update user guide (if appropriate),~
- [x] ~add tests,~
- [x] ready for review.

