### PR TITLE
Remove physical_constants.py and use scipy.constants instead

### DIFF
--- a/hyperspy/misc/eels/hartree_slater_gos.py
+++ b/hyperspy/misc/eels/hartree_slater_gos.py
@@ -24,13 +24,16 @@ import numpy as np
 import scipy as sp
 
 from hyperspy.defaults_parser import preferences
-from hyperspy.misc.physical_constants import R, a0
 from hyperspy.misc.eels.base_gos import GOSBase
 from hyperspy.misc.elements import elements
 from hyperspy.misc.export_dictionary import (
     export_to_dictionary, load_from_dictionary)
 
 _logger = logging.getLogger(__name__)
+
+
+R = sp.constants.value("Rydberg constant times hc in eV")
+a0 = sp.constants.value("Bohr radius")
 
 
 class HartreeSlaterGOS(GOSBase):

--- a/hyperspy/misc/eels/hydrogenic_gos.py
+++ b/hyperspy/misc/eels/hydrogenic_gos.py
@@ -24,7 +24,6 @@ import scipy as sp
 import scipy.interpolate
 
 from hyperspy.misc.eels.base_gos import GOSBase
-from hyperspy.misc.physical_constants import R
 
 _logger = logging.getLogger(__name__)
 
@@ -36,6 +35,8 @@ XU = [
 
 # IE1=[118,149,189,229,270,320,377,438,500,564,628,695,769,846,
 # 926,1008,1096,1194,1142,1248,1359,1476,1596,1727]
+
+R = sp.constants.value("Rydberg constant times hc in eV")
 
 
 class HydrogenicGOS(GOSBase):

--- a/hyperspy/misc/math_tools.py
+++ b/hyperspy/misc/math_tools.py
@@ -162,14 +162,14 @@ def optimal_fft_size(target, real=False):
 
         support_real = True
 
-    except ImportError:
+    except ImportError:  # pragma: no cover
         from scipy.fftpack import next_fast_len
 
         support_real = False
 
     if support_real:
         return next_fast_len(target, real)
-    else:
+    else:  # pragma: no cover
         return next_fast_len(target)
 
 

--- a/hyperspy/misc/physical_constants.py
+++ b/hyperspy/misc/physical_constants.py
@@ -1,9 +1,0 @@
-# Global constants
-# Fundamental constants
-
-
-R = 13.6056923  # Rydberg of energy in eV
-e = 1.602176487E-19  # electron charge in C
-m0 = 9.10938215E-31  # electron rest mass in kg
-a0 = 5.2917720859E-11  # Bohr radius in m
-c = 2997.92458E8  # speed of light in m/s

--- a/hyperspy/misc/physics_tools.py
+++ b/hyperspy/misc/physics_tools.py
@@ -36,7 +36,7 @@ def bragg_scattering_angle(d, E0=100):
 
     """
 
-    gamma = 1 + E0 / 511.
+    gamma = 1 + E0 / 511.0
     v_rel = np.sqrt(1 - 1 / gamma ** 2)
     e_lambda = 2 * np.pi / (2590e9 * (gamma * v_rel))  # m
 
@@ -59,6 +59,13 @@ def effective_Z(Z_list, exponent=2.94):
     float
 
     """
+    if not np.iterable(Z_list) or not np.iterable(Z_list[0]):
+        raise ValueError(
+            "Z_list should be a list of tuples (f,Z) "
+            "where f is the number of atoms of the element"
+            "in the molecule and Z its atomic number"
+        )
+
     exponent = float(exponent)
     temp = 0
     total_e = 0

--- a/hyperspy/tests/misc/test_physics_tools.py
+++ b/hyperspy/tests/misc/test_physics_tools.py
@@ -1,0 +1,45 @@
+# -*- coding: utf-8 -*-
+# Copyright 2007-2020 The HyperSpy developers
+#
+# This file is part of  HyperSpy.
+#
+#  HyperSpy is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+#  HyperSpy is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with  HyperSpy.  If not, see <http://www.gnu.org/licenses/>.
+
+import numpy as np
+import pytest
+
+
+from hyperspy.misc.physics_tools import bragg_scattering_angle, effective_Z
+
+
+def test_bragg_angle():
+    np.testing.assert_allclose(bragg_scattering_angle(1.0e-9), 0.00370087636)
+    np.testing.assert_allclose(bragg_scattering_angle(1.0e-9, E0=100.0), 0.00370087636)
+    np.testing.assert_allclose(bragg_scattering_angle(1.0e-9, E0=1.0), 0.0387581632)
+
+
+def test_effectiveZ():
+    np.testing.assert_allclose(effective_Z([(1, 1), (2, 2), (3, 3)]), 1.8984805)
+    np.testing.assert_allclose(
+        effective_Z([(1, 1), (2, 2), (3, 3)], exponent=1.5), 1.3616755
+    )
+
+
+def test_effectiveZ_errors():
+    with pytest.raises(ValueError, match="list of tuples"):
+        _ = effective_Z(1)
+
+    with pytest.raises(ValueError, match="list of tuples"):
+        _ = effective_Z([1, 2, 3])
+


### PR DESCRIPTION
### Description of the change
- Remove `hyperspy/misc/physical_constants.py` and use `scipy.constants` instead - this is done in other files already, these seem to be the only two places.
- Add simple tests for uncovered file
- Add pragma: no cover to branch never hit in CI

### Progress of the PR
- [x] Change implemented (can be split into several points),
- [x] ~update docstring (if appropriate),~
- [x] ~update user guide (if appropriate),~
- [x] add tests,
- [x] ready for review.
