### PR TITLE
Add nightly merge RnM into non_uniform_axes

### DIFF
--- a/.github/workflows/nightly-merge_non_uniform.yml
+++ b/.github/workflows/nightly-merge_non_uniform.yml
@@ -1,0 +1,24 @@
+name: 'Nightly Merge'
+
+on:
+  schedule:
+    - cron:  '0 1 * * *'
+
+jobs:
+  nightly-merge:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v1
+
+    - name: Nightly Merge
+      uses: robotology/gh-action-nightly-merge@v1.2.0
+      with:
+        stable_branch: 'RELEASE_next_minor'
+        development_branch: 'non_uniform_axes'
+        allow_ff: true
+        allow_forks: false
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
To run one hour after the nightly merge of RnP into RnM.

As suggested in https://github.com/hyperspy/hyperspy/pull/2492#issuecomment-679142388.
