### PR TITLE
Fix oldest versions build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,9 @@ matrix:
     env: PIP_SELECTOR="tests"
     python: 3.7
   - name: "Linux, 3.6, pip, mininum version"
-    env: MINIMUM_VERSION=true
+    env:
+      - MINIMUM_VERSION=true
+      - PIP_SELECTOR="tests"
     python: 3.6
   - name: "Linux, 3.7, pip, doc"
     env: PIP_SELECTOR="all, build-doc"
@@ -39,7 +41,7 @@ install:
   # Test against the oldest supported version of matplotlib, numpy and scipy
   # Use old version numba and imagecodecs to work around incompatibilities
   - if [ "$MINIMUM_VERSION" == true ]; then
-      pip install matplotlib==2.2.3 numpy==1.15 scipy==1.0.1 numba==0.40 imagecodecs==2018.10.10;
+      pip install matplotlib==2.2.3 numpy==1.15 scipy==1.0.1 numba==0.40;
       pip install -e .["${PIP_SELECTOR}"];
     else
       pip install --upgrade -e .["${PIP_SELECTOR}"];

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,10 +3,14 @@ language: python
 
 env:
   global:
+    # The default environment variable are defined here and overwritten
+    # in the matrix when necessary
     - ENV=pip
+    - PIP_ARGS="--upgrade --use-feature=2020-resolver -e"
     - PIP_SELECTOR="all, tests, coverage"
     - PYTEST_ARGS="--pyargs hyperspy"
-    - MINIMUM_VERSION=false
+    - OLDEST_SUPPORTED_VERSION=false
+    - MPLBACKEND="agg"
 
 matrix:
   include:
@@ -20,9 +24,10 @@ matrix:
   - name: "Linux, 3.7, pip, minimum requirement"
     env: PIP_SELECTOR="tests"
     python: 3.7
-  - name: "Linux, 3.6, pip, mininum version"
+  - name: "Linux, 3.6, pip, oldest supported versions"
     env:
-      - MINIMUM_VERSION=true
+      - OLDEST_SUPPORTED_VERSION=true
+      - PIP_ARGS="-e"
       - PIP_SELECTOR="tests"
     python: 3.6
   - name: "Linux, 3.7, pip, doc"
@@ -39,13 +44,10 @@ install:
   # manually
   - pip install --upgrade pytest
   # Test against the oldest supported version of matplotlib, numpy and scipy
-  # Use old version numba and imagecodecs to work around incompatibilities
-  - if [ "$MINIMUM_VERSION" == true ]; then
-      pip install matplotlib==2.2.3 numpy==1.15 scipy==1.0.1 numba==0.40;
-      pip install -e .["${PIP_SELECTOR}"];
-    else
-      pip install --upgrade -e .["${PIP_SELECTOR}"];
+  - if [ "$OLDEST_SUPPORTED_VERSION" == true ]; then
+      pip install matplotlib==2.2.3 numpy==1.15.4 scipy==1.1;
     fi
+  - pip install $PIP_ARGS .["${PIP_SELECTOR}"];
 
 script:
   - which python

--- a/doc/dev_guide/testing.rst
+++ b/doc/dev_guide/testing.rst
@@ -59,10 +59,10 @@ First ensure pytest and its plugins are installed by:
 .. code:: bash
 
    # If using a standard hyperspy install
-   pip install hyperspy[test]
+   pip install hyperspy[tests]
 
    # Or, from a hyperspy local development directory
-   pip install -e .[test]
+   pip install -e .[tests]
 
    # Or just installing the dependencies using conda
    conda install -c conda-forge pytest pytest-mpl

--- a/doc/user_guide/install.rst
+++ b/doc/user_guide/install.rst
@@ -148,7 +148,6 @@ dependencies required by specific functionalities:
 * ``mrcz`` to read mrcz file,
 * ``speed`` to speed up some functionalities,
 * ``usid`` to read usid file,
-* ``lowess-smoothing`` to perform lowess smoothing,
 * ``tests`` to install required libraries to run HyperSpy's unit tests,
 * ``build-doc`` to install required libraries to build HyperSpy's documentation,
 * ``dev`` to install all the above,

--- a/doc/user_guide/install.rst
+++ b/doc/user_guide/install.rst
@@ -47,7 +47,7 @@ manager:
    If you are not familiar with Anaconda please refer to their
    `User Guide <https://docs.continuum.io/anaconda/>`_ for details.
 
-#. Then install HyperSpy executing the following 
+#. Then install HyperSpy executing the following
    `conda <https://docs.conda.io/en/latest/>`_ commands in the
    Anaconda Prompt, Linux/Mac Terminal or Microsoft Windows Command Prompt.
    This depends on your OS and how you have installed Anaconda, see the
@@ -69,7 +69,7 @@ and ``hyperspy_gui_traitsui``. To install hyperspy without the GUI packages, use
 .. note::
 
     Using ``-c conda-forge`` is only necessary when the conda-forge is not
-    already added to the conda configuration, see the 
+    already added to the conda configuration, see the
     `conda-forge documentation <https://conda-forge.org/docs/user/introduction.html>`_
     for more details.
 
@@ -141,14 +141,14 @@ use:
 See the following list of selectors to select the installation of optional
 dependencies required by specific functionalities:
 
-* ``learning`` to install required libraries for some machine learning features,
-* ``gui-jupyter`` to install required libraries to use the
-  `Jupyter widgets <http://ipywidgets.readthedocs.io/en/stable/>`_
-  GUI elementsm
-* ``gui-traitsui`` to install required libraries to use the GUI elements based
-  on `traitsui <http://docs.enthought.com/traitsui/>`_,
-* ``mrcz`` to install the mrcz plugin,
-* ``speed`` install optional libraries that speed up some functionalities,
+* ``learning`` for some machine learning features,
+* ``gui-jupyter`` to use the `Jupyter widgets <http://ipywidgets.readthedocs.io/en/stable/>`_
+  GUI elements,
+* ``gui-traitsui`` to use the GUI elements based on `traitsui <http://docs.enthought.com/traitsui/>`_,
+* ``mrcz`` to read mrcz file,
+* ``speed`` to speed up some functionalities,
+* ``usid`` to read usid file,
+* ``lowess-smoothing`` to perform lowess smoothing,
 * ``tests`` to install required libraries to run HyperSpy's unit tests,
 * ``build-doc`` to install required libraries to build HyperSpy's documentation,
 * ``dev`` to install all the above,
@@ -161,7 +161,7 @@ For example:
 
     $ pip install hyperspy[learning, gui-jupyter]
 
-Finally, be aware that HyperSpy depends on a number of libraries that usually 
+Finally, be aware that HyperSpy depends on a number of libraries that usually
 need to be compiled and therefore installing HyperSpy may require development
 tools installed in the system. If the above does not work for you remember that
 the easiest way to install HyperSpy is
@@ -203,7 +203,7 @@ Install the runtime and development dependencies requirements using conda:
 The package ``hyperspy-dev`` will install the development dependencies required
 for testing and building the documentation.
 
-From the root folder of your hyperspy repository (folder containing the 
+From the root folder of your hyperspy repository (folder containing the
 ``setup.py`` file) run `pip <http://www.pip-installer.org>`_ in development mode:
 
 .. code-block:: bash
@@ -213,7 +213,7 @@ From the root folder of your hyperspy repository (folder containing the
 Installation in other (non-system) Python distribution
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-From the root folder of your hyperspy repository (folder containing the 
+From the root folder of your hyperspy repository (folder containing the
 ``setup.py`` file) run `pip <http://www.pip-installer.org>`_ in development mode:
 
 .. code-block:: bash
@@ -237,7 +237,7 @@ Installation in a system Python distribution
 When using a system Python distribution, it is recommanded to install the
 dependencies using your system package manager.
 
-From the root folder of your hyperspy repository (folder containing the 
+From the root folder of your hyperspy repository (folder containing the
 ``setup.py`` file) run `pip <http://www.pip-installer.org>`_ in development mode.
 
 .. code-block:: bash

--- a/hyperspy/_signals/signal1d.py
+++ b/hyperspy/_signals/signal1d.py
@@ -26,16 +26,12 @@ import scipy.interpolate
 import scipy as sp
 from scipy.signal import savgol_filter
 from scipy.ndimage.filters import gaussian_filter1d
-try:
-    from statsmodels.nonparametric.smoothers_lowess import lowess
-    statsmodels_installed = True
-except BaseException:
-    statsmodels_installed = False
 
 from hyperspy.signal import BaseSignal
 from hyperspy._signals.common_signal1d import CommonSignal1D
 from hyperspy.signal_tools import SpikesRemoval
 from hyperspy.models.model1d import Model1D
+from hyperspy.misc.lowess_smooth import lowess
 
 
 from hyperspy.defaults_parser import preferences
@@ -971,17 +967,8 @@ class Signal1D(BaseSignal, CommonSignal1D):
         ------
         SignalDimensionError
             If the signal dimension is not 1.
-        ImportError
-            If statsmodels is not installed.
 
-        Notes
-        -----
-        This method uses the lowess algorithm from the `statsmodels` library,
-        which needs to be installed to use this method.
         """
-        if not statsmodels_installed:
-            raise ImportError("statsmodels is not installed. This package is "
-                              "required for this feature.")
         self._check_signal_dimension_equals_one()
         if smoothing_parameter is None or number_of_iterations is None:
             smoother = SmoothingLowess(self)
@@ -992,11 +979,9 @@ class Signal1D(BaseSignal, CommonSignal1D):
             return smoother.gui(display=display, toolkit=toolkit)
         else:
             self.map(lowess,
-                     exog=self.axes_manager[-1].axis,
-                     frac=smoothing_parameter,
-                     it=number_of_iterations,
-                     is_sorted=True,
-                     return_sorted=False,
+                     x=self.axes_manager[-1].axis,
+                     f=smoothing_parameter,
+                     iter=number_of_iterations,
                      show_progressbar=show_progressbar,
                      ragged=False,
                      parallel=parallel,

--- a/hyperspy/_signals/signal1d.py
+++ b/hyperspy/_signals/signal1d.py
@@ -981,7 +981,7 @@ class Signal1D(BaseSignal, CommonSignal1D):
             self.map(lowess,
                      x=self.axes_manager[-1].axis,
                      f=smoothing_parameter,
-                     iter=number_of_iterations,
+                     n_iter=number_of_iterations,
                      show_progressbar=show_progressbar,
                      ragged=False,
                      parallel=parallel,

--- a/hyperspy/misc/lowess_smooth.py
+++ b/hyperspy/misc/lowess_smooth.py
@@ -1,0 +1,56 @@
+"""
+This module implements the Lowess function for nonparametric regression.
+Functions:
+lowess Fit a smooth nonparametric regression curve to a scatterplot.
+For more information, see
+William S. Cleveland: "Robust locally weighted regression and smoothing
+scatterplots", Journal of the American Statistical Association, December 1979,
+volume 74, number 368, pp. 829-836.
+William S. Cleveland and Susan J. Devlin: "Locally weighted regression: An
+approach to regression analysis by local fitting", Journal of the American
+Statistical Association, September 1988, volume 83, number 403, pp. 596-610.
+"""
+
+# Authors: Alexandre Gramfort <alexandre.gramfort@telecom-paristech.fr>
+#
+# License: BSD (3-clause)
+#
+# https://gist.github.com/agramfort/850437
+
+from math import ceil
+import numpy as np
+
+
+def lowess(y, x, f=2. / 3., iter=3):
+    """lowess(x, y, f=2./3., iter=3) -> yest
+    Lowess smoother: Robust locally weighted regression.
+    The lowess function fits a nonparametric regression curve to a scatterplot.
+    The arrays x and y contain an equal number of elements; each pair
+    (x[i], y[i]) defines a data point in the scatterplot. The function returns
+    the estimated (smooth) values of y.
+    The smoothing span is given by f. A larger value for f will result in a
+    smoother curve. The number of robustifying iterations is given by iter. The
+    function will run faster with a smaller number of iterations.
+    """
+    n = len(x)
+    r = int(ceil(f * n))
+    h = [np.sort(np.abs(x - x[i]))[r] for i in range(n)]
+    w = np.clip(np.abs((x[:, None] - x[None, :]) / h), 0.0, 1.0)
+    w = (1 - w ** 3) ** 3
+    yest = np.zeros(n)
+    delta = np.ones(n)
+    for iteration in range(iter):
+        for i in range(n):
+            weights = delta * w[:, i]
+            b = np.array([np.sum(weights * y), np.sum(weights * y * x)])
+            A = np.array([[np.sum(weights), np.sum(weights * x)],
+                          [np.sum(weights * x), np.sum(weights * x * x)]])
+            beta = np.linalg.solve(A, b)
+            yest[i] = beta[0] + beta[1] * x[i]
+
+        residuals = y - yest
+        s = np.median(np.abs(residuals))
+        delta = np.clip(residuals / (6.0 * s), -1, 1)
+        delta = (1 - delta ** 2) ** 2
+
+    return yest

--- a/hyperspy/misc/lowess_smooth.py
+++ b/hyperspy/misc/lowess_smooth.py
@@ -17,40 +17,58 @@ Statistical Association, September 1988, volume 83, number 403, pp. 596-610.
 #
 # https://gist.github.com/agramfort/850437
 
-from math import ceil
 import numpy as np
+from scipy.linalg import lstsq
 
+def lowess(y, x, f=2.0 / 3.0, n_iter=3):
+    """Lowess smoother (robust locally weighted regression).
 
-def lowess(y, x, f=2. / 3., iter=3):
-    """lowess(x, y, f=2./3., iter=3) -> yest
-    Lowess smoother: Robust locally weighted regression.
-    The lowess function fits a nonparametric regression curve to a scatterplot.
-    The arrays x and y contain an equal number of elements; each pair
-    (x[i], y[i]) defines a data point in the scatterplot. The function returns
-    the estimated (smooth) values of y.
-    The smoothing span is given by f. A larger value for f will result in a
-    smoother curve. The number of robustifying iterations is given by iter. The
-    function will run faster with a smaller number of iterations.
+    Fits a nonparametric regression curve to a scatterplot.
+
+    Parameters
+    ----------
+    y, x : np.ndarrays
+        The arrays x and y contain an equal number of elements;
+        each pair (x[i], y[i]) defines a data point in the
+        scatterplot.
+
+    f : float
+        The smoothing span. A larger value will result in a
+        smoother curve.
+    n_iter : int
+        The number of robustifying iteration. Thefunction will
+        run faster with a smaller number of iterations.
+
+    Returns
+    -------
+    yest : np.ndarray
+        The estimated (smooth) values of y.
+
     """
     n = len(x)
-    r = int(ceil(f * n))
+    r = int(np.ceil(f * n))
     h = [np.sort(np.abs(x - x[i]))[r] for i in range(n)]
     w = np.clip(np.abs((x[:, None] - x[None, :]) / h), 0.0, 1.0)
     w = (1 - w ** 3) ** 3
     yest = np.zeros(n)
     delta = np.ones(n)
-    for iteration in range(iter):
+    for _ in range(n_iter):
         for i in range(n):
             weights = delta * w[:, i]
             b = np.array([np.sum(weights * y), np.sum(weights * y * x)])
-            A = np.array([[np.sum(weights), np.sum(weights * x)],
-                          [np.sum(weights * x), np.sum(weights * x * x)]])
-            beta = np.linalg.solve(A, b)
+            A = np.array(
+                [
+                    [np.sum(weights), np.sum(weights * x)],
+                    [np.sum(weights * x), np.sum(weights * x * x)],
+                ]
+            )
+
+            beta = lstsq(A, b)[0]
             yest[i] = beta[0] + beta[1] * x[i]
 
         residuals = y - yest
         s = np.median(np.abs(residuals))
-        delta = np.clip(residuals / (6.0 * s), -1, 1)
+        delta = np.clip(residuals / (6.0 * s), -1.0, 1.0)
         delta = (1 - delta ** 2) ** 2
 
     return yest

--- a/hyperspy/signal_tools.py
+++ b/hyperspy/signal_tools.py
@@ -660,9 +660,9 @@ class SmoothingSavitzkyGolay(Smoothing):
 
 @add_gui_method(toolkey="hyperspy.Signal1D.smooth_lowess")
 class SmoothingLowess(Smoothing):
-    smoothing_parameter = t.Range(low=0.,
-                                  high=1.,
-                                  value=0.5,
+    smoothing_parameter = t.Range(low=0.001,
+                                  high=0.99,
+                                  value=0.1,
                                   )
     number_of_iterations = t.Range(low=1,
                                    value=1)

--- a/hyperspy/tests/signal/test_1D_tools.py
+++ b/hyperspy/tests/signal/test_1D_tools.py
@@ -290,17 +290,17 @@ class TestSmoothing:
     def test_lowess(self, parallel):
         from hyperspy.misc.lowess_smooth import lowess
         f = 0.5
-        iter = 1
+        n_iter = 1
         data = np.asanyarray(self.s.data, dtype='float')
         for i in range(data.shape[0]):
             data[i, :] = lowess(
                 x=self.s.axes_manager[-1].axis,
                 y=data[i, :],
                 f=f,
-                iter=iter,
+                n_iter=n_iter,
                 )
         self.s.smooth_lowess(smoothing_parameter=f,
-                             number_of_iterations=iter,
+                             number_of_iterations=n_iter,
                              parallel=parallel)
         np.testing.assert_allclose(self.s.data, data,
                                    rtol=self.rtol, atol=self.atol)

--- a/hyperspy/tests/signal/test_1D_tools.py
+++ b/hyperspy/tests/signal/test_1D_tools.py
@@ -288,21 +288,19 @@ class TestSmoothing:
     @pytest.mark.parametrize('parallel',
                              [pytest.param(True, marks=pytest.mark.parallel), False])
     def test_lowess(self, parallel):
-        pytest.importorskip("statsmodels")
-        from statsmodels.nonparametric.smoothers_lowess import lowess
-        frac = 0.5
-        it = 1
+        from hyperspy.misc.lowess_smooth import lowess
+        f = 0.5
+        iter = 1
         data = np.asanyarray(self.s.data, dtype='float')
         for i in range(data.shape[0]):
             data[i, :] = lowess(
-                endog=data[i, :],
-                exog=self.s.axes_manager[-1].axis,
-                frac=frac,
-                it=it,
-                is_sorted=True,
-                return_sorted=False,)
-        self.s.smooth_lowess(smoothing_parameter=frac,
-                             number_of_iterations=it,
+                x=self.s.axes_manager[-1].axis,
+                y=data[i, :],
+                f=f,
+                iter=iter,
+                )
+        self.s.smooth_lowess(smoothing_parameter=f,
+                             number_of_iterations=iter,
                              parallel=parallel)
         np.testing.assert_allclose(self.s.data, data,
                                    rtol=self.rtol, atol=self.atol)

--- a/setup.py
+++ b/setup.py
@@ -76,7 +76,6 @@ extras_require = {
     "mrcz": ["blosc>=1.5", 'mrcz>=0.3.6'],
     "speed": ["cython", "imagecodecs"],
     "usid": ["pyUSID>=0.0.7"],
-    "lowess-smoothing": ["statsmodels"],
     # bug in pip: matplotib is ignored here because it is already present in
     # install_requires.
     "tests": ["pytest>=3.6", "pytest-mpl", "matplotlib>=3.1"],

--- a/setup.py
+++ b/setup.py
@@ -66,7 +66,7 @@ install_req = ['scipy>=1.0.1',
                'imageio',
                'pyyaml',
                'PTable',
-               'tifffile[all]>=2018.10.18',
+               'tifffile>=2018.10.18',
                'numba',
                ]
 
@@ -75,7 +75,7 @@ extras_require = {
     "gui-jupyter": ["hyperspy_gui_ipywidgets>=1.1.0"],
     "gui-traitsui": ["hyperspy_gui_traitsui>=1.1.0"],
     "mrcz": ["blosc>=1.5", 'mrcz>=0.3.6'],
-    "speed": ["cython"],
+    "speed": ["cython", "imagecodecs"],
     "usid": ["pyUSID>=0.0.7"],
     # bug in pip: matplotib is ignored here because it is already present in
     # install_requires.

--- a/setup.py
+++ b/setup.py
@@ -45,9 +45,9 @@ if v[0] != 3:
 setup_path = os.path.dirname(__file__)
 
 
-install_req = ['scipy>=1.0.1',
+install_req = ['scipy>=1.1',
                'matplotlib>=2.2.3',
-               'numpy>=1.15.0',
+               'numpy>=1.15.4',
                'traits>=4.5.0',
                'natsort',
                'requests',
@@ -60,7 +60,6 @@ install_req = ['scipy>=1.0.1',
                'dask[array]>2.0',
                'scikit-image>=0.15',
                'pint>=0.10',
-               'statsmodels',
                'numexpr',
                'sparse',
                'imageio',
@@ -77,6 +76,7 @@ extras_require = {
     "mrcz": ["blosc>=1.5", 'mrcz>=0.3.6'],
     "speed": ["cython", "imagecodecs"],
     "usid": ["pyUSID>=0.0.7"],
+    "lowess-smoothing": ["statsmodels"],
     # bug in pip: matplotib is ignored here because it is already present in
     # install_requires.
     "tests": ["pytest>=3.6", "pytest-mpl", "matplotlib>=3.1"],


### PR DESCRIPTION
The oldest version build introduced in #2485 wasn't working because pip was upgrading the libraries set at specific versions...

### Progress of the PR
- [x] Increase minimum version requirements for `numpy` and `scipy` to avoid pip upgrading them,
- [x] use the coming next-generation dependency resolver of pip (`--use-feature=2020-resolver`), which is be enabled from October 2020, see https://blog.python.org/2020/07/upgrade-pip-20-2-changes-20-3.html for all build except for the "oldest supported version" build,
- [x] set `imagecodecs` as optional dependencies (both have marginally used in hyperspy and come with compiled code which can caused binaries incompatibility),
- [x] remove `statsmodels` from dependencies and adapt a version of https://gist.github.com/agramfort/850437 for lowess smoothing, 
- [x] update user guide (if appropriate),
- [x] ready for review.

