### PR TITLE
Fix for #2452 - index-dependent plot error in non-uniform-axis branch

### DIFF
--- a/hyperspy/drawing/widget.py
+++ b/hyperspy/drawing/widget.py
@@ -576,7 +576,7 @@ class ResizableDraggableWidgetBase(DraggableWidgetBase):
         """ Use to determine the size of the widget with support for non 
         uniform axis.
         """
-        if axis.index == axis.size - 1:
+        if axis.index >= axis.size - 1:
             return axis.index2value(axis.index) - axis.index2value(axis.index - 1)
         else:
             return axis.index2value(axis.index + 1) - axis.index2value(axis.index)

--- a/hyperspy/drawing/widget.py
+++ b/hyperspy/drawing/widget.py
@@ -576,7 +576,10 @@ class ResizableDraggableWidgetBase(DraggableWidgetBase):
         """ Use to determine the size of the widget with support for non 
         uniform axis.
         """
-        return axis.index2value(axis.index + 1) - axis.index2value(axis.index)
+        if axis.index == axis.size - 1:
+            return axis.index2value(axis.index) - axis.index2value(axis.index - 1)
+        else:
+            return axis.index2value(axis.index + 1) - axis.index2value(axis.index)
 
     def _get_size(self):
         """Getter for 'size' property. Returns the size as a tuple (to prevent

--- a/hyperspy/tests/drawing/test_widget.py
+++ b/hyperspy/tests/drawing/test_widget.py
@@ -1,0 +1,32 @@
+# Copyright 2007-2020 The HyperSpy developers
+#
+# This file is part of  HyperSpy.
+#
+#  HyperSpy is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+#  HyperSpy is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with  HyperSpy.  If not, see <http://www.gnu.org/licenses/>.
+
+import numpy as np
+import pytest
+from hyperspy.drawing import widget
+from hyperspy.signals import Signal1D
+
+def test_get_step():
+    s = Signal1D(np.zeros((4, 4)))
+    axis = s.axes_manager.navigation_axes[0]
+    step = widget.ResizableDraggableWidgetBase._get_step(s,s.axes_manager.navigation_axes[0])
+    assert(step == 1)
+    axis.index = 3
+    step = widget.ResizableDraggableWidgetBase._get_step(s,s.axes_manager.navigation_axes[0])
+    assert(step == 1)
+    
+    


### PR DESCRIPTION
### Description of the change
Workaround for #2452. The `_get_step` function failed if index was on the last value of a navigation axis, because `index + 1` is then undefined. Instead now uses `index - 1` in this specific case.

### Progress of the PR
- [X] Change implemented (can be split into several points),
- [X] ready for review.
- [X] Add test