### PR TITLE
fix gradients and use numpy function for heaviside expression (patch)

### DIFF
--- a/hyperspy/_components/heaviside.py
+++ b/hyperspy/_components/heaviside.py
@@ -25,29 +25,43 @@ from hyperspy._components.expression import Expression
 class HeavisideStep(Expression):
 
     r"""The Heaviside step function.
+    
+    Based on the corresponding `numpy function 
+    <https://numpy.org/doc/stable/reference/generated/numpy.heaviside.html>`_
+    using the half maximum definition for the central point:
 
     .. math::
 
         f(x) =
-        \\begin{cases}
-        0 & x<n\\\\
-        A & x>=n
-        \\end{cases}
+        \begin{cases}
+        0 & x<n\\
+        A/2 & x=n\\
+        A & x>n
+        \end{cases}
+
+
+    ============== =============
+    Variable        Parameter
+    ============== =============
+    :math:`n`       centre
+    :math:`A`       height
+    ============== =============
+
 
     Parameters
     -----------
     n : float
         Location parameter defining the x position of the step.
     A : float
-        Height parameter for x>=n.
+        Height parameter for x>n.
     **kwargs
         Extra keyword arguments are passed to the ``Expression`` component.
     """
 
-    def __init__(self, A=1., n=0., module="numpy", compute_gradients=False,
+    def __init__(self, A=1., n=0., module="numpy", compute_gradients=True,
                  **kwargs):
         super(HeavisideStep, self).__init__(
-            expression="where(x < n, 0, A)",
+            expression="A*heaviside(x-n,0.5)",
             name="HeavisideStep",
             A=A,
             n=n,
@@ -60,13 +74,3 @@ class HeavisideStep(Expression):
         self.isbackground = True
         self.convolved = False
 
-        # Gradients
-        self.A.grad = self.grad_A
-
-    def grad_A(self, x):
-        x = np.asanyarray(x)
-        return np.ones(x.shape)
-
-    def grad_n(self, x):
-        x = np.asanyarray(x)
-        return np.where(x < self.n.value, 0, 1)

--- a/hyperspy/tests/component/test_components.py
+++ b/hyperspy/tests/component/test_components.py
@@ -500,6 +500,7 @@ class TestScalableFixedPattern:
             m.fit()
         assert abs(fp.yscale.value - 10) <= .1
 
+
 class TestHeavisideStep:
 
     def setup_method(self, method):
@@ -507,22 +508,22 @@ class TestHeavisideStep:
 
     def test_integer_values(self):
         c = self.c
-        np.testing.assert_array_almost_equal(c.function([-1, 0, 2]),
-                                             [0, 1, 1])
+        np.testing.assert_array_almost_equal(c.function(np.array([-1, 0, 2])),
+                                             np.array([0, 0.5, 1]))
 
     def test_float_values(self):
         c = self.c
-        np.testing.assert_array_almost_equal(c.function([-0.5, 0.5, 2]),
-                                             [0, 1, 1])
+        np.testing.assert_array_almost_equal(c.function(np.array([-0.5, 0.5, 2])),
+                                             np.array([0, 1, 1]))
 
     def test_not_sorted(self):
         c = self.c
-        np.testing.assert_array_almost_equal(c.function([3, -0.1, 0]),
-                                             [1, 0, 1])
+        np.testing.assert_array_almost_equal(c.function(np.array([3, -0.1, 0])),
+                                             np.array([1, 0, 0.5]))
 
     def test_gradients(self):
         c = self.c
-        np.testing.assert_array_almost_equal(c.A.grad([3, -0.1, 0]),
-                                             [1, 1, 1])
-        np.testing.assert_array_almost_equal(c.n.grad([3, -0.1, 0]),
-                                             [1, 0, 1])
+        np.testing.assert_array_almost_equal(c.A.grad(np.array([3, -0.1, 0])),
+                                             np.array([1, 0, 0.5]))
+#        np.testing.assert_array_almost_equal(c.n.grad(np.array([3, -0.1, 0])),
+#                                             np.array([1, 1, 1]))

--- a/hyperspy/tests/component/test_heaviside.py
+++ b/hyperspy/tests/component/test_heaviside.py
@@ -25,5 +25,5 @@ def test_function():
     g.A.value = 3
     g.n.value = 2
     assert g.function(1) == 0.
-    assert g.function(2) == 3.
+    assert g.function(2) == 1.5
     assert g.function(3) == 3.


### PR DESCRIPTION
### Description of the change
* Use `numpy.heaviside` instead of `numexpr.where` for definition of heaviside as in #2067
* Fixed gradients as in #2067

Should resolve  #2067.

Rebased on `RELEASE_next_patch`, replaces #2513.

### Progress of the PR
- [X] Change implemented (can be split into several points),
- [X] update docstring (if appropriate),
- [X] adapted tests,
- [X] ready for review.

### Minimal example of the bug fix or the new feature
```python
h1 = hs.model.components1D.HeavisideStep(A=3,n=2)
x = np.arange(0,5,step=0.2)
h1.function(x)
#array([0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 3., 3., 3., 3., 3., 3., 3., 3., 3., 3., 3., 3., 3., 3., 3.])
h1.A.grad(x)
#array([0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1])
```

