### PR TITLE
Remove reference to googlegroup

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -2,8 +2,6 @@
 
 For discussions on the use of HyperSpy, please use the [gitter chat](https://gitter.im/hyperspy/hyperspy): useful to ask quick questions, discuss use cases of HyperSpy and ask about specific applications.
 
-Alternatively, there is the HyperSpy [mailing list](http://groups.google.com/group/hyperspy-users). It predates the gitter chat and is now less frequently used. But please do not double post on gitter and the mailing list!
-
 ## Issues
 
 The [issue tracker](https://github.com/hyperspy/hyperspy/issues) can be used to report bugs or propose new features. When reporting a bug, the following is useful:

--- a/doc/user_guide/install.rst
+++ b/doc/user_guide/install.rst
@@ -14,6 +14,12 @@ see the :ref:`anaconda-install` section.
 To enable context-menu (right-click) shortcut in a chosen folder, use the
 `start_jupyter_cm <https://github.com/hyperspy/start_jupyter_cm>`_ library.
 
+.. note::
+
+    If you want to be notified about new releases, please *Watch (Releases only)* 
+    the `hyperspy repositorium on GitHub <https://github.com/hyperspy/hyperspy/>`_ 
+    (requires a `GitHub account <https://github.com/login>`_).
+
 .. warning::
 
     Since version 0.8.4 HyperSpy only supports Python 3. If you need to install

--- a/doc/user_guide/install.rst
+++ b/doc/user_guide/install.rst
@@ -17,7 +17,7 @@ To enable context-menu (right-click) shortcut in a chosen folder, use the
 .. note::
 
     If you want to be notified about new releases, please *Watch (Releases only)* 
-    the `hyperspy repositorium on GitHub <https://github.com/hyperspy/hyperspy/>`_ 
+    the `hyperspy repository on GitHub <https://github.com/hyperspy/hyperspy/>`_ 
     (requires a `GitHub account <https://github.com/login>`_).
 
 .. warning::


### PR DESCRIPTION
Removes reference to google group based on the discussion at:
hyperspy/hyperspy#2252

[X] Remove googlegroup from `CONTRIBUTING`
[X] Add note on 'watching' GitHub releases to user guide