### PR TITLE
Fix to make sure example signals are loaded read-only

### DIFF
--- a/hyperspy/misc/example_signals_loading.py
+++ b/hyperspy/misc/example_signals_loading.py
@@ -80,7 +80,8 @@ def load_object_hologram():
     """
     from hyperspy.io import load
     file_path = os.sep.join([os.path.dirname(__file__), 'holography',
-                             'example_signals', '01_holo_Vbp_130V_0V_bin2_crop.hdf5'])
+                             'example_signals', 
+                             '01_holo_Vbp_130V_0V_bin2_crop.hdf5'])
     return load(file_path, signal_type='hologram', mode='r')
 
 
@@ -109,5 +110,6 @@ def load_reference_hologram():
     """
     from hyperspy.io import load
     file_path = os.sep.join([os.path.dirname(__file__), 'holography',
-                             'example_signals', '00_ref_Vbp_130V_0V_bin2_crop.hdf5'])
+                             'example_signals', 
+                             '00_ref_Vbp_130V_0V_bin2_crop.hdf5'])
     return load(file_path, signal_type='hologram', mode='r')

--- a/hyperspy/misc/example_signals_loading.py
+++ b/hyperspy/misc/example_signals_loading.py
@@ -28,11 +28,13 @@ def load_1D_EDS_SEM_spectrum():
     - Sample: EDS-TM002 provided by BAM (www.webshop.bam.de)
     - SEM Microscope: Nvision40 Carl Zeiss
     - EDS Detector: X-max 80 from Oxford Instrument
+    - Signal is loaded "read-only" to ensure data access regardless of 
+      install location
     """
     from hyperspy.io import load
     file_path = os.sep.join([os.path.dirname(__file__), 'eds',
                              'example_signals', '1D_EDS_SEM_Spectrum.hspy'])
-    return load(file_path)
+    return load(file_path, mode='r')
 
 
 def load_1D_EDS_TEM_spectrum():
@@ -44,11 +46,13 @@ def load_1D_EDS_TEM_spectrum():
     - Sample: FePt bimetallic nanoparticles
     - SEM Microscope: Tecnai Osiris 200 kV D658 AnalyticalTwin
     - EDS Detector: Super-X 4 detectors Brucker
+    - Signal is loaded "read-only" to ensure data access regardless of 
+      install location
     """
     from hyperspy.io import load
     file_path = os.sep.join([os.path.dirname(__file__), 'eds',
                              'example_signals', '1D_EDS_TEM_Spectrum.hspy'])
-    return load(file_path)
+    return load(file_path, mode='r')
 
 
 def load_object_hologram():
@@ -71,11 +75,13 @@ def load_object_hologram():
         research facilities JLSRF 2, 44 (2016).
         https://doi.org/10.17815/jlsrf-2-70
 
+    Signal is loaded "read-only" to ensure data access regardless of 
+    install location
     """
     from hyperspy.io import load
     file_path = os.sep.join([os.path.dirname(__file__), 'holography',
                              'example_signals', '01_holo_Vbp_130V_0V_bin2_crop.hdf5'])
-    return load(file_path, signal_type='hologram')
+    return load(file_path, signal_type='hologram', mode='r')
 
 
 def load_reference_hologram():
@@ -98,8 +104,10 @@ def load_reference_hologram():
         research facilities JLSRF 2, 44 (2016).
         https://doi.org/10.17815/jlsrf-2-70
 
+    Signal is loaded "read-only" to ensure data access regardless of 
+    install location
     """
     from hyperspy.io import load
     file_path = os.sep.join([os.path.dirname(__file__), 'holography',
                              'example_signals', '00_ref_Vbp_130V_0V_bin2_crop.hdf5'])
-    return load(file_path, signal_type='hologram')
+    return load(file_path, signal_type='hologram', mode='r')


### PR DESCRIPTION
Resolves #2522 by changing file loading mode to read-only, since the default is "append mode", which does not work if the files are installed to a system-wide python installation.

@tjof2, sent to the correct branch this time :wink: 