### PR TITLE
Keep edax zip test file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,6 +45,7 @@ hyperspy/misc/etc/test_compilers.obj
 /.spyproject/
 *nbc
 *nbi
+hyperspy/tests/io/edax_files.zip
 
 ### Code ###
 # Visual Studio Code - https://code.visualstudio.com/

--- a/hyperspy/tests/io/test_edax.py
+++ b/hyperspy/tests/io/test_edax.py
@@ -31,7 +31,6 @@ if not TEST_FILES_OK:
 
         SHA256SUM_GOT = hashlib.sha256(r.content).hexdigest()
         if SHA256SUM_GOT == SHA256SUM:
-            ZIPF = os.path.join(TMP_DIR.name, "edax_files.zip")
             with open(ZIPF, 'wb') as f:
                 f.write(r.content)
             TEST_FILES_OK = True


### PR DESCRIPTION
Running the whole test suite always download the `edax_files.zip` which is 36 MB large which can be annoying sometime.This is fixed by keeping the `zip` file, which was downloaded in a temporary folder and therefore removed at the tearing down the test module. The `zip` will now be kept in its original place, the `hyperspy/tests/io` folder.
