### PR TITLE
Initial support for pathlib

### DIFF
--- a/doc/user_guide/io.rst
+++ b/doc/user_guide/io.rst
@@ -28,10 +28,10 @@ If the loaded file contains several datasets, the :py:func:`~.io.load`
 functions will return a list of the corresponding signal.
 
 .. NOTE::
-    Note for python programmers: the data is stored in a numpy array
-    in the :py:attr:`~.signal.BaseSignal.data` attribute, but you will not
-    normally need to access it there.)
 
+    Note for Python programmers: the data is stored in a numpy array
+    in the :py:attr:`~.signal.BaseSignal.data` attribute, but you will not
+    normally need to access it there.
 
 HyperSpy will try to guess the most likely data type for the corresponding
 file. However, you can force it to read the data as a particular data type by
@@ -40,7 +40,7 @@ providing the ``signal`` keyword, which has to be one of: ``spectrum``,
 
 .. code-block:: python
 
-    >>> s = hs.load("filename", signal = "EELS")
+    >>> s = hs.load("filename", signal_type="EELS")
 
 Some file formats store some extra information about the data, which can be
 stored in "attributes". If HyperSpy manages to read some extra information
@@ -122,6 +122,22 @@ or by using `shell-style wildcards <http://docs.python.org/library/glob.html>`_:
         >>> # /home/data/afile[1x2].hspy
 
         >>> s = hs.load("/home/data/afile[*].hspy", escape_square_brackets=True)
+
+HyperSpy also supports ```pathlib.Path`` <https://docs.python.org/3/library/pathlib.html>`_
+objects, for example:
+
+.. code-block:: python
+
+    >>> import hyperspy.api as hs
+    >>> from pathlib import Path
+
+    >>> # Use pathlib.Path
+    >>> p = Path("/path/to/a/file.hspy")
+    >>> s = hs.load(p)
+
+    >>> # Use pathlib.Path.glob
+    >>> p = Path("/path/to/some/files/").glob("*.hspy")
+    >>> s = hs.load(p)
 
 By default HyperSpy will return a list of all the files loaded. Alternatively,
 HyperSpy can stack the data of the files contain data with exactly the same

--- a/hyperspy/_signals/signal1d.py
+++ b/hyperspy/_signals/signal1d.py
@@ -16,6 +16,7 @@
 # You should have received a copy of the GNU General Public License
 # along with  HyperSpy.  If not, see <http://www.gnu.org/licenses/>.
 
+import os
 import logging
 import math
 
@@ -1503,9 +1504,7 @@ class Signal1D(BaseSignal, CommonSignal1D):
         if not 0 < factor < 1:
             raise ValueError("factor must be between 0 and 1.")
 
-        from hyperspy.misc.config_dir import os_name
-
-        if parallel != False and os_name == "windows":  # pragma: no cover
+        if parallel != False and os.name in ["nt", "dos"]:  # pragma: no cover
             # Due to a scipy bug where scipy.interpolate.UnivariateSpline
             # appears to not be thread-safe on Windows, we raise a warning
             # here. See https://github.com/hyperspy/hyperspy/issues/2320

--- a/hyperspy/component.py
+++ b/hyperspy/component.py
@@ -16,8 +16,6 @@
 # You should have received a copy of the GNU General Public License
 # along with  HyperSpy.  If not, see <http://www.gnu.org/licenses/>.
 
-import os
-
 import numpy as np
 from dask.array import Array as dArray
 import traits.api as t
@@ -25,6 +23,7 @@ from traits.trait_numeric import Array
 import sympy
 from sympy.utilities.lambdify import lambdify
 from distutils.version import LooseVersion
+from pathlib import Path
 
 import hyperspy
 from hyperspy.misc.utils import slugify
@@ -671,7 +670,7 @@ class Parameter(t.HasTraits):
             name = self.component.name + '_' + self.name
         filename = incremental_filename(slugify(name) + '.' + format)
         if folder is not None:
-            filename = os.path.join(folder, filename)
+            filename = Path(folder).joinpath(filename)
         self.as_signal().save(filename)
         if save_std is True:
             self.as_signal(field='std').save(append2pathname(

--- a/hyperspy/defaults_parser.py
+++ b/hyperspy/defaults_parser.py
@@ -17,45 +17,46 @@
 # along with  HyperSpy.  If not, see <http://www.gnu.org/licenses/>.
 
 
-import os.path
+import os
 import configparser
 import logging
 
 import traits.api as t
 import matplotlib.pyplot as plt
 
-from hyperspy.misc.config_dir import config_path, os_name, data_path
+from pathlib import Path
+
+from hyperspy.misc.config_dir import config_path, data_path
 from hyperspy.misc.ipython_tools import turn_logging_on, turn_logging_off
 from hyperspy.ui_registry import add_gui_method
 
-defaults_file = os.path.join(config_path, 'hyperspyrc')
-eels_gos_files = os.path.join(data_path, 'EELS_GOS.tar.gz')
+defaults_file = Path(config_path, 'hyperspyrc')
+eels_gos_files = Path(data_path, 'EELS_GOS.tar.gz')
 
 _logger = logging.getLogger(__name__)
 
 
 def guess_gos_path():
-    if os_name == 'windows':
+    if os.name in ["nt", "dos"]:
         # If DM is installed, use the GOS tables from the default
         # installation
         # location in windows
         program_files = os.environ['PROGRAMFILES']
         gos = 'Gatan\\DigitalMicrograph\\EELS Reference Data\\H-S GOS Tables'
-        gos_path = os.path.join(program_files, gos)
+        gos_path = Path(program_files, gos)
 
         # Else, use the default location in the .hyperspy forlder
-        if os.path.isdir(gos_path) is False and \
-                'PROGRAMFILES(X86)' in os.environ:
+        if not gos_path.is_dir() and 'PROGRAMFILES(X86)' in os.environ:
             program_files = os.environ['PROGRAMFILES(X86)']
-            gos_path = os.path.join(program_files, gos)
-            if os.path.isdir(gos_path) is False:
-                gos_path = os.path.join(config_path, 'EELS_GOS')
+            gos_path = Path(program_files, gos)
+            if not gos_path.is_dir():
+                gos_path = Path(config_path, 'EELS_GOS')
     else:
-        gos_path = os.path.join(config_path, 'EELS_GOS')
+        gos_path = Path(config_path, 'EELS_GOS')
     return gos_path
 
 
-if os.path.isfile(defaults_file):
+if defaults_file.is_file():
     # Remove config file if obsolated
     with open(defaults_file) as f:
         if 'Not really' in f.readline():

--- a/hyperspy/extensions.py
+++ b/hyperspy/extensions.py
@@ -17,21 +17,19 @@
 # along with  HyperSpy.  If not, see <http://www.gnu.org/licenses/>.
 
 import logging
-import os
 import importlib
 import copy
 import pkgutil
-
-
 import pkg_resources
 import yaml
+
+from pathlib import Path
 
 import hyperspy.misc.config_dir
 
 _logger = logging.getLogger(__name__)
 
-_ext_f = os.path.join(
-    os.path.abspath(os.path.dirname(__file__)), "hyperspy_extension.yaml")
+_ext_f = Path(__file__).resolve().parent.joinpath("hyperspy_extension.yaml")
 with open(_ext_f, 'r') as stream:
     EXTENSIONS = yaml.safe_load(stream)
 EXTENSIONS["GUI"]["widgets"] = {}
@@ -46,11 +44,11 @@ _external_extensions = [
 
 for _external_extension_mod in _external_extensions:
     _logger.info("Enabling extension %s" % _external_extension_mod)
-    _path = os.path.join(
-        os.path.dirname(pkgutil.get_loader(_external_extension_mod).get_filename()),
-        "hyperspy_extension.yaml")
+    _path = Path(
+        pkgutil.get_loader(_external_extension_mod).get_filename()
+    ).resolve().parent.joinpath("hyperspy_extension.yaml")
 
-    if os.path.isfile(_path):
+    if _path.is_file():
         with open(_path, 'r') as stream:
             _external_extension = yaml.safe_load(stream)
             if "signals" in _external_extension:

--- a/hyperspy/misc/config_dir.py
+++ b/hyperspy/misc/config_dir.py
@@ -16,32 +16,21 @@
 # You should have received a copy of the GNU General Public License
 # along with  HyperSpy.  If not, see <http://www.gnu.org/licenses/>.
 
-import os
-import os.path
 import shutil
 import logging
+from pathlib import Path
 
 _logger = logging.getLogger(__name__)
 
 config_files = list()
-data_path = os.sep.join([os.path.dirname(__file__), '..', 'data'])
+config_path = Path("~/.hyperspy").expanduser()
+config_path.mkdir(parents=True, exist_ok=True)
 
-if os.name == 'posix':
-    config_path = os.path.join(os.path.expanduser('~'), '.hyperspy')
-    os_name = 'posix'
-elif os.name in ['nt', 'dos']:
-    config_path = os.path.expanduser('~/.hyperspy')
-    os_name = 'windows'
-else:
-    raise RuntimeError('Unsupported operating system: %s' % os.name)
-
-if os.path.isdir(config_path) is False:
-    _logger.info("Creating config directory: %s" % config_path)
-    os.mkdir(config_path)
+data_path = Path(__file__).resolve().parents[1].joinpath("data")
 
 for file in config_files:
-    templates_file = os.path.join(data_path, file)
-    config_file = os.path.join(config_path, file)
-    if os.path.isfile(config_file) is False:
-        _logger.info("Setting configuration file: %s" % file)
+    templates_file = data_path.joinpath(file)
+    config_file = config_path.joinpath(file)
+    if not config_file.is_file():
+        _logger.info(f"Setting configuration file: {file}")
         shutil.copy(templates_file, config_file)

--- a/hyperspy/misc/eels/hartree_slater_gos.py
+++ b/hyperspy/misc/eels/hartree_slater_gos.py
@@ -16,12 +16,13 @@
 # You should have received a copy of the GNU General Public License
 # along with  HyperSpy.  If not, see <http://www.gnu.org/licenses/>.
 
-import os
 import math
 import logging
 
 import numpy as np
 import scipy as sp
+
+from pathlib import Path
 
 from hyperspy.defaults_parser import preferences
 from hyperspy.misc.eels.base_gos import GOSBase
@@ -99,14 +100,6 @@ class HartreeSlaterGOS(GOSBase):
             self.read_elements()
             self._load_dictionary(element_subshell)
         else:
-            # Check if the Peter Rez's Hartree Slater GOS distributed by
-            # Gatan are available. Otherwise exit
-            if not os.path.isdir(preferences.EELS.eels_gos_files_path):
-                raise IOError(
-                    "The parametrized Hartree-Slater GOS files could not "
-                    "found in %s ." % preferences.EELS.eels_gos_files_path +
-                    "Please define a valid location for the files "
-                    "in the preferences.")
             self.element, self.subshell = element_subshell.split('_')
             self.read_elements()
             self.readgosfile()
@@ -123,20 +116,35 @@ class HartreeSlaterGOS(GOSBase):
         return dic
 
     def readgosfile(self):
-        info_str = (
-            "Hartree-Slater GOS\n" +
-            ("\tElement: %s " % self.element) +
-            ("\tSubshell: %s " % self.subshell) +
-            ("\tOnset Energy = %s " % self.onset_energy))
-        _logger.info(info_str)
+        _logger.info(
+            "Hartree-Slater GOS\n"
+            f"\tElement: {self.element} "
+            f"\tSubshell: {self.subshell}"
+            f"\tOnset Energy = {self.onset_energy}"
+        )
         element = self.element
         subshell = self.subshell
-        filename = os.path.join(
-            preferences.EELS.eels_gos_files_path,
-            (elements[element]['Atomic_properties']['Binding_energies']
-             [subshell]['filename']))
 
-        with open(filename) as f:
+        # Check if the Peter Rez's Hartree Slater GOS distributed by
+        # Gatan are available. Otherwise exit
+        gos_root = Path(preferences.EELS.eels_gos_files_path)
+        gos_file = gos_root.joinpath(
+            (
+                elements[element]["Atomic_properties"]["Binding_energies"][subshell][
+                    "filename"
+                ]
+            )
+        )
+
+        if not gos_root.is_dir():
+            raise FileNotFoundError(
+                "Parametrized Hartree-Slater GOS files not "
+                f"found in {gos_root}. Please define a valid "
+                "location for the files in the preferences as "
+                "`preferences.EELS.eels_gos_files_path`."
+            )
+
+        with open(gos_file) as f:
             GOS_list = f.read().replace('\r', '').split()
 
         # Map the parameters

--- a/hyperspy/misc/example_signals_loading.py
+++ b/hyperspy/misc/example_signals_loading.py
@@ -16,7 +16,12 @@
 # You should have received a copy of the GNU General Public License
 # along with  HyperSpy.  If not, see <http://www.gnu.org/licenses/>.
 
-import os
+from pathlib import Path
+
+
+def _resolve_dir():
+    """Returns the absolute path to this file's directory."""
+    return Path(__file__).resolve().parent
 
 
 def load_1D_EDS_SEM_spectrum():
@@ -32,9 +37,12 @@ def load_1D_EDS_SEM_spectrum():
       install location
     """
     from hyperspy.io import load
-    file_path = os.sep.join([os.path.dirname(__file__), 'eds',
-                             'example_signals', '1D_EDS_SEM_Spectrum.hspy'])
-    return load(file_path, mode='r')
+
+    file_path = _resolve_dir().joinpath(
+        "eds", "example_signals", "1D_EDS_SEM_Spectrum.hspy"
+    )
+
+    return load(file_path, mode="r")
 
 
 def load_1D_EDS_TEM_spectrum():
@@ -50,9 +58,12 @@ def load_1D_EDS_TEM_spectrum():
       install location
     """
     from hyperspy.io import load
-    file_path = os.sep.join([os.path.dirname(__file__), 'eds',
-                             'example_signals', '1D_EDS_TEM_Spectrum.hspy'])
-    return load(file_path, mode='r')
+
+    file_path = _resolve_dir().joinpath(
+        "eds", "example_signals", "1D_EDS_TEM_Spectrum.hspy"
+    )
+
+    return load(file_path, mode="r")
 
 
 def load_object_hologram():
@@ -79,10 +90,12 @@ def load_object_hologram():
     install location
     """
     from hyperspy.io import load
-    file_path = os.sep.join([os.path.dirname(__file__), 'holography',
-                             'example_signals', 
-                             '01_holo_Vbp_130V_0V_bin2_crop.hdf5'])
-    return load(file_path, signal_type='hologram', mode='r')
+
+    file_path = _resolve_dir().joinpath(
+        "holography", "example_signals", "01_holo_Vbp_130V_0V_bin2_crop.hdf5"
+    )
+
+    return load(file_path, signal_type="hologram", mode="r")
 
 
 def load_reference_hologram():
@@ -109,7 +122,10 @@ def load_reference_hologram():
     install location
     """
     from hyperspy.io import load
-    file_path = os.sep.join([os.path.dirname(__file__), 'holography',
-                             'example_signals', 
-                             '00_ref_Vbp_130V_0V_bin2_crop.hdf5'])
-    return load(file_path, signal_type='hologram', mode='r')
+
+    file_path = _resolve_dir().joinpath(
+        "holography", "example_signals", "00_ref_Vbp_130V_0V_bin2_crop.hdf5"
+    )
+
+    return load(file_path, signal_type="hologram", mode="r")
+

--- a/hyperspy/misc/ipython_tools.py
+++ b/hyperspy/misc/ipython_tools.py
@@ -18,8 +18,9 @@
 
 import __main__
 from distutils.version import LooseVersion
-import os
+
 from time import strftime
+from pathlib import Path
 
 
 def get_ipython():
@@ -73,8 +74,8 @@ def turn_logging_on(verbose=1):
             print("Already logging to " + ip.logger.logfname)
         return
 
-    filename = os.path.join(os.getcwd(), 'hyperspy_log.py')
-    new = not os.path.exists(filename)
+    filename = Path.cwd().joinpath('hyperspy_log.py')
+    new = not filename.is_file()
     ip.logger.logstart(logfname=filename, logmode='append')
     if new:
         ip.logger.log_write(

--- a/hyperspy/signal.py
+++ b/hyperspy/signal.py
@@ -17,13 +17,13 @@
 # along with  HyperSpy.  If not, see <http://www.gnu.org/licenses/>.
 
 import copy
-import os.path
 import warnings
 import inspect
 from contextlib import contextmanager
 from datetime import datetime
 import logging
 from pint import UnitRegistry, UndefinedUnitError
+from pathlib import Path
 
 import numpy as np
 import scipy as sp
@@ -527,7 +527,7 @@ class MVATools(object):
                 filename = '%s_%02i.%s' % (factor_prefix, comp_ids[idx],
                                            save_figures_format)
                 if folder is not None:
-                    filename = os.path.join(folder, filename)
+                    filename = Path(folder, filename)
                 ensure_directory(filename)
                 _args = {'dpi': 600,
                          'format': save_figures_format}
@@ -574,7 +574,7 @@ class MVATools(object):
                             (factor_prefix, self.metadata.General.title), }})
             filename = '%ss.%s' % (factor_prefix, factor_format)
             if folder is not None:
-                filename = os.path.join(folder, filename)
+                filename = Path(folder, filename)
             s.save(filename)
         else:  # Separate files
             if self.axes_manager.signal_dimension == 1:
@@ -594,7 +594,7 @@ class MVATools(object):
                                              dim,
                                              factor_format)
                     if folder is not None:
-                        filename = os.path.join(folder, filename)
+                        filename = Path(folder, filename)
                     s.save(filename)
 
             if self.axes_manager.signal_dimension == 2:
@@ -619,7 +619,7 @@ class MVATools(object):
                                              dim,
                                              factor_format)
                     if folder is not None:
-                        filename = os.path.join(folder, filename)
+                        filename = Path(folder, filename)
                     im.save(filename)
 
     def _export_loadings(self,
@@ -668,7 +668,7 @@ class MVATools(object):
                 filename = '%s_%02i.%s' % (loading_prefix, comp_ids[idx],
                                            save_figures_format)
                 if folder is not None:
-                    filename = os.path.join(folder, filename)
+                    filename = Path(folder, filename)
                 ensure_directory(filename)
                 _args = {'dpi': 600,
                          'format': save_figures_format}
@@ -717,7 +717,7 @@ class MVATools(object):
                                  }})
             filename = '%ss.%s' % (loading_prefix, loading_format)
             if folder is not None:
-                filename = os.path.join(folder, filename)
+                filename = Path(folder, filename)
             s.save(filename)
         else:  # Separate files
             if self.axes_manager.navigation_dimension == 1:
@@ -731,7 +731,7 @@ class MVATools(object):
                                              dim,
                                              loading_format)
                     if folder is not None:
-                        filename = os.path.join(folder, filename)
+                        filename = Path(folder, filename)
                     s.save(filename)
             elif self.axes_manager.navigation_dimension == 2:
                 axes_dicts = []
@@ -754,7 +754,7 @@ class MVATools(object):
                                              dim,
                                              loading_format)
                     if folder is not None:
-                        filename = os.path.join(folder, filename)
+                        filename = Path(folder, filename)
                     s.save(filename)
 
     def plot_decomposition_factors(self,
@@ -2731,7 +2731,7 @@ class BaseSignal(FancySlicing,
         if filename is None:
             if (self.tmp_parameters.has_item('filename') and
                     self.tmp_parameters.has_item('folder')):
-                filename = os.path.join(
+                filename = Path(
                     self.tmp_parameters.folder,
                     self.tmp_parameters.filename)
                 extension = (self.tmp_parameters.extension
@@ -2741,9 +2741,10 @@ class BaseSignal(FancySlicing,
                 filename = self.metadata.General.original_filename
             else:
                 raise ValueError('File name not defined')
+
+        filename = Path(filename)
         if extension is not None:
-            basename, ext = os.path.splitext(filename)
-            filename = basename + '.' + extension
+            filename = filename.with_suffix(f".{extension}")
         io.save(filename, self, overwrite=overwrite, **kwds)
 
     def _replot(self):

--- a/hyperspy/tests/drawing/test_plot_model.py
+++ b/hyperspy/tests/drawing/test_plot_model.py
@@ -16,16 +16,15 @@
 # You should have received a copy of the GNU General Public License
 # along with  HyperSpy.  If not, see <http://www.gnu.org/licenses/>.
 
-import os
-
 import numpy as np
 import pytest
+from pathlib import Path
 
 import hyperspy.api as hs
 from hyperspy.components1d import Gaussian
 from hyperspy.signals import EELSSpectrum, Signal1D
 
-my_path = os.path.dirname(__file__)
+my_path = Path(__file__).resolve().parent
 baseline_dir = 'plot_model'
 default_tol = 2.0
 
@@ -138,11 +137,11 @@ def test_plot_gaussian_eelsmodel(convolved, plot_component, binned):
 @pytest.mark.mpl_image_compare(
     baseline_dir=baseline_dir, tolerance=default_tol)
 def test_fit_EELS_convolved(convolved):
-    dname = os.path.join(my_path, 'data')
-    cl = hs.load(os.path.join(dname, 'Cr_L_cl.hspy'))
+    dname = my_path.joinpath('data')
+    cl = hs.load(dname.joinpath('Cr_L_cl.hspy'))
     cl.metadata.Signal.binned = False
     cl.metadata.General.title = 'Convolved: {}'.format(convolved)
-    ll = hs.load(os.path.join(dname, 'Cr_L_ll.hspy')) if convolved else None
+    ll = hs.load(dname.joinpath('Cr_L_ll.hspy')) if convolved else None
     m = cl.create_model(auto_background=False, ll=ll, GOS='hydrogenic')
     m.fit(kind='smart')
     m.plot(plot_components=True)

--- a/hyperspy/tests/drawing/test_plot_signal1d.py
+++ b/hyperspy/tests/drawing/test_plot_signal1d.py
@@ -17,6 +17,7 @@
 
 import os
 from shutil import copyfile
+from pathlib import Path
 
 import matplotlib.pyplot as plt
 import numpy as np
@@ -43,14 +44,19 @@ def mpl_generate_path_cmdopt(request):
 
 
 def _generate_filename_list(style):
-    path = os.path.dirname(__file__)
-    filename_list = ['test_plot_spectra_%s' % s for s in style] + \
-                    ['test_plot_spectra_rev_%s' % s for s in style]
+    path = Path(__file__).resolve().parent
+    baseline_path = path.joinpath(baseline_dir)
+
+    filename_list = [f'test_plot_spectra_{s}' for s in style] + \
+                    [f'test_plot_spectra_rev_{s}' for s in style]
     filename_list2 = []
+
     for filename in filename_list:
         for i in range(0, 4):
-            filename_list2.append(os.path.join(path, baseline_dir,
-                                               '%s%i.png' % (filename, i)))
+            filename_list2.append(
+                baseline_path.joinpath(f'{filename}{i}.png')
+            )
+
     return filename_list2
 
 
@@ -63,14 +69,14 @@ def setup_teardown(request, scope="class"):
     # expected images are the same.
     if mpl_generate_path_cmdopt is None:
         for filename in _generate_filename_list(style):
-            copyfile("%s.png" % filename[:-5], filename)
+            copyfile(f"{str(filename)[:-5]}.png", filename)
     yield
     # TEARDOWN
     # Create the baseline images: copy one baseline image for each test
     # and remove the other ones.
     if mpl_generate_path_cmdopt:
         for filename in _generate_filename_list(style):
-            copyfile(filename, "%s.png" % filename[:-5])
+            copyfile(filename, f"{str(filename)[:-5]}.png")
     # Delete the images that have been created in 'setup_class'
     for filename in _generate_filename_list(style):
         os.remove(filename)

--- a/hyperspy/tests/io/test_io.py
+++ b/hyperspy/tests/io/test_io.py
@@ -20,6 +20,7 @@ import hashlib
 import os
 import tempfile
 from unittest.mock import patch
+from pathlib import Path
 
 import numpy as np
 import pytest
@@ -126,6 +127,18 @@ def test_glob_wildcards():
         ):
             _ = hs.load(os.path.join(dirpath, "temp[*].hspy"))
 
+        # Test pathlib.Path
+        t = hs.load(Path(dirpath, "temp[1x0].hspy"))
+        assert len(t) == 1
+
+        t = hs.load([Path(dirpath, "temp[1x0].hspy"), Path(dirpath, "temp[1x1].hspy")])
+        assert len(t) == 2
+
+        t = hs.load(list(Path(dirpath).glob('temp*.hspy')))
+        assert len(t) == 2
+
+        t = hs.load(Path(dirpath).glob('temp*.hspy'))
+        assert len(t) == 2
 
 def test_file_not_found_error():
     with tempfile.TemporaryDirectory() as dirpath:

--- a/hyperspy/tests/learn/test_decomposition.py
+++ b/hyperspy/tests/learn/test_decomposition.py
@@ -16,8 +16,8 @@
 # You should have received a copy of the GNU General Public License
 # along with  HyperSpy.  If not, see <http://www.gnu.org/licenses/>.
 
-from os.path import join
 from tempfile import TemporaryDirectory
+from pathlib import Path
 
 import numpy as np
 import pytest
@@ -481,10 +481,10 @@ class TestLoadDecompositionResults:
         """
         with TemporaryDirectory() as tmpdir:
             self.s.decomposition()
-            fname1 = join(tmpdir, "results.npz")
+            fname1 = Path(tmpdir, "results.npz")
             self.s.learning_results.save(fname1)
             self.s.learning_results.load(fname1)
-            fname2 = join(tmpdir, "output.hspy")
+            fname2 = Path(tmpdir, "output.hspy")
             self.s.save(fname2)
             assert isinstance(self.s.learning_results.decomposition_algorithm, str)
 

--- a/hyperspy/tests/misc/test_utils.py
+++ b/hyperspy/tests/misc/test_utils.py
@@ -16,34 +16,40 @@
 # You should have received a copy of the GNU General Public License
 # along with  HyperSpy.  If not, see <http://www.gnu.org/licenses/>.
 
-from hyperspy.misc.utils import slugify, parse_quantity, is_hyperspy_signal
-from hyperspy import signals
 import numpy as np
+
+from hyperspy import signals
+from hyperspy.misc.utils import (
+    is_hyperspy_signal,
+    parse_quantity,
+    slugify,
+    strlist2enumeration,
+)
 
 
 def test_slugify():
-    assert slugify('a') == 'a'
-    assert slugify('1a') == '1a'
-    assert slugify('1') == '1'
-    assert slugify('a a') == 'a_a'
+    assert slugify("a") == "a"
+    assert slugify("1a") == "1a"
+    assert slugify("1") == "1"
+    assert slugify("a a") == "a_a"
 
-    assert slugify('a', valid_variable_name=True) == 'a'
-    assert slugify('1a', valid_variable_name=True) == 'Number_1a'
-    assert slugify('1', valid_variable_name=True) == 'Number_1'
+    assert slugify("a", valid_variable_name=True) == "a"
+    assert slugify("1a", valid_variable_name=True) == "Number_1a"
+    assert slugify("1", valid_variable_name=True) == "Number_1"
 
-    assert slugify('a', valid_variable_name=False) == 'a'
-    assert slugify('1a', valid_variable_name=False) == '1a'
-    assert slugify('1', valid_variable_name=False) == '1'
+    assert slugify("a", valid_variable_name=False) == "a"
+    assert slugify("1a", valid_variable_name=False) == "1a"
+    assert slugify("1", valid_variable_name=False) == "1"
 
 
 def test_parse_quantity():
     # From the metadata specification, the quantity is defined as
     # "name (units)" without backets in the name of the quantity
-    assert parse_quantity('a (b)') == ('a', 'b')
-    assert parse_quantity('a (b/(c))') == ('a', 'b/(c)')
-    assert parse_quantity('a (c) (b/(c))') == ('a (c)', 'b/(c)')
-    assert parse_quantity('a [b]') == ('a [b]', '')
-    assert parse_quantity('a [b]', opening = '[', closing = ']') == ('a', 'b')
+    assert parse_quantity("a (b)") == ("a", "b")
+    assert parse_quantity("a (b/(c))") == ("a", "b/(c)")
+    assert parse_quantity("a (c) (b/(c))") == ("a (c)", "b/(c)")
+    assert parse_quantity("a [b]") == ("a [b]", "")
+    assert parse_quantity("a [b]", opening="[", closing="]") == ("a", "b")
 
 
 def test_is_hyperspy_signal():
@@ -51,3 +57,11 @@ def test_is_hyperspy_signal():
     p = object()
     assert is_hyperspy_signal(s) is True
     assert is_hyperspy_signal(p) is False
+
+
+def test_strlist2enumeration():
+    assert strlist2enumeration([]) == ""
+    assert strlist2enumeration("a") == "a"
+    assert strlist2enumeration(["a"]) == "a"
+    assert strlist2enumeration(["a", "b"]) == "a and b"
+    assert strlist2enumeration(["a", "b", "c"]) == "a, b and c"

--- a/hyperspy/tests/signal/test_1D_tools.py
+++ b/hyperspy/tests/signal/test_1D_tools.py
@@ -260,9 +260,9 @@ class TestEstimatePeakWidth:
 
     @pytest.mark.parametrize("parallel", [None, True])
     def test_warnings_on_windows(self, parallel, caplog):
-        from hyperspy.misc.config_dir import os_name
+        import os
 
-        if os_name != "windows":
+        if os.name not in ["nt", "dos"]:
             pytest.skip("Ignored on non-Windows OS")
 
         with caplog.at_level(logging.WARNING):

--- a/hyperspy/tests/signal/test_eels.py
+++ b/hyperspy/tests/signal/test_eels.py
@@ -15,18 +15,17 @@
 # You should have received a copy of the GNU General Public License
 # along with  HyperSpy.  If not, see <http://www.gnu.org/licenses/>.
 
-import os
 
 import numpy as np
 import pytest
-
+from pathlib import Path
 
 from hyperspy import signals, datasets
 from hyperspy._components.gaussian import Gaussian
 from hyperspy.decorators import lazifyTestClass
 from hyperspy.io import load
 
-MYPATH = os.path.dirname(__file__)
+MYPATH = Path(__file__).resolve().parent
 
 
 @lazifyTestClass
@@ -292,12 +291,12 @@ class Test_Estimate_Thickness:
 
     def setup_method(self, method):
         # Create an empty spectrum
-        self.s = load(os.path.join(
-            MYPATH,
-            "data/EELS_LL_linescan_simulated_thickness_variation.hspy"))
-        self.zlp = load(os.path.join(
-            MYPATH,
-            "data/EELS_ZLP_linescan_simulated_thickness_variation.hspy"))
+        self.s = load(
+            MYPATH.joinpath("data/EELS_LL_linescan_simulated_thickness_variation.hspy")
+        )
+        self.zlp = load(
+            MYPATH.joinpath("data/EELS_ZLP_linescan_simulated_thickness_variation.hspy")
+        )
 
     def test_relative_thickness(self):
         t = self.s.estimate_thickness(zlp=self.zlp)

--- a/hyperspy/tests/signal/test_find_peaks1D_ohaver.py
+++ b/hyperspy/tests/signal/test_find_peaks1D_ohaver.py
@@ -16,25 +16,25 @@
 # You should have received a copy of the GNU General Public License
 # along with  HyperSpy.  If not, see <http://www.gnu.org/licenses/>.
 
-import os
+from pathlib import Path
 
 from hyperspy.api import load
 from hyperspy.decorators import lazifyTestClass
 
-my_path = os.path.dirname(__file__)
-
 
 @lazifyTestClass
-class TestFindPeaks1DOhaver():
-
+class TestFindPeaks1DOhaver:
     def setup_method(self, method):
-        self.signal = load(
-            my_path +
-            "/data/test_find_peaks1D_ohaver.hdf5")
+        filepath = (
+            Path(__file__)
+            .resolve()
+            .parent.joinpath("data/test_find_peaks1D_ohaver.hdf5")
+        )
+        self.signal = load(filepath)
 
     def test_find_peaks1D_ohaver_high_amp_thres(self):
         signal1D = self.signal
-        peak_list = signal1D.find_peaks1D_ohaver(amp_thresh=10.)[0]
+        peak_list = signal1D.find_peaks1D_ohaver(amp_thresh=10.0)[0]
         assert len(peak_list) == 0
 
     def test_find_peaks1D_ohaver_zero_value_bug(self):

--- a/setup.cfg
+++ b/setup.cfg
@@ -26,8 +26,8 @@ precision = 2
 
 [flake8]
 docstring-convention = numpy
-# See https://www.flake8rules.com/rules/
-# and http://www.pydocstyle.org/en/5.0.2/error_codes.html
+# See https://lintlyci.github.io/Flake8Rules/
+# and http://www.pydocstyle.org/en/5.1.0/error_codes.html
 ignore =
     E203  # Whitespace before ':'
     E501  # Line too long
@@ -38,6 +38,7 @@ ignore =
     D202  # No blank lines allowed after function docstring
     D401  # First line should be in imperative mood; try rephrasing
 exclude =
+    doc/
     hyperspy/external/*
     setup.py
     examples/*


### PR DESCRIPTION
### Description of the change 
First pass at #1828 (supporting pathlib in HyperSpy). 

This supports `pathlib.Path` objects everywhere **except** `hyperspy/io_plugins/*`, because that would be considerably more work given the frequent uses of `os.path.splitext` and others. Also, if the `io_plugins` are going to be split in future, it's perhaps worth leaving changing them for now. Any `os.path` instances in the `hyperspy/tests/*` folders are also untouched here.

Instead, in this PR, `hs.load()` will accept `pathlib.Path` objects, including globs, but converts them to strings internally before passing them to the various file readers to maintain backwards compatibility.

A few other locations in the core code that use `os.path` have been changed to use pathlib instead.

### Progress of the PR
- [x] Change implemented (can be split into several points),
- [x] update docstring (if appropriate),
- [x] update user guide (if appropriate),
- [x] add tests,
- [x] ready for review.

### Minimal example of the bug fix or the new feature
```python
>>> import hyperspy.api as hs
>>> from pathlib import Path

>>> # Use pathlib.Path
>>> p = Path("/path/to/a/file.hspy")
>>> s = hs.load(p)

>>> # Use pathlib.Path.glob
>>> p = Path("/path/to/some/files/").glob("*.hspy")
>>> s = hs.load(p)
```
