### PR TITLE
Update documentation on TIFF dtype

### DIFF
--- a/doc/user_guide/io.rst
+++ b/doc/user_guide/io.rst
@@ -524,9 +524,9 @@ TIFF
 ----
 
 HyperSpy can read and write 2D and 3D TIFF files using using
-Christoph Gohlke's tifffile library. In particular it supports reading and
+Christoph Gohlke's ``tifffile`` library. In particular, it supports reading and
 writing of TIFF, BigTIFF, OME-TIFF, STK, LSM, NIH, and FluoView files. Most of
-these are uncompressed or losslessly compressed 2**(0 to 6) bit integer,16, 32
+these are uncompressed or losslessly compressed 2**(0 to 6) bit integer, 16, 32
 and 64-bit float, grayscale and RGB(A) images, which are commonly used in
 bio-scientific imaging. See `the library webpage
 <http://www.lfd.uci.edu/~gohlke/code/tifffile.py.html>`_ for more details.
@@ -536,21 +536,20 @@ bio-scientific imaging. See `the library webpage
    ImageJ or DigitalMicrograph
 
 Currently HyperSpy has limited support for reading and saving the TIFF tags.
-However, the way that HyperSpy reads and saves the scale and the units of tiff
+However, the way that HyperSpy reads and saves the scale and the units of TIFF
 files is compatible with ImageJ/Fiji and Gatan Digital Micrograph software.
-HyperSpy can also import the scale and the units from tiff files saved using
+HyperSpy can also import the scale and the units from TIFF files saved using
 FEI, Zeiss SEM and Olympus SIS software.
 
 .. code-block:: python
 
     >>> # Force read image resolution using the x_resolution, y_resolution and
-    >>> # the resolution_unit of the tiff tags. Be aware, that most of the
-    >>> # software doesn't (properly) use these tags when saving tiff files.
+    >>> # the resolution_unit of the TIFF tags. Be aware, that most of the
+    >>> # software doesn't (properly) use these tags when saving TIFF files.
     >>> s = hs.load('file.tif', force_read_resolution=True)
 
-HyperSpy can also read and save custom tags through Christoph Gohlke's tifffile
-library. See `the library webpage
-<http://www.lfd.uci.edu/~gohlke/code/tifffile.py.html>`_ for more details.
+HyperSpy can also read and save custom tags through the ``tifffile``
+library.
 
 .. code-block:: python
 
@@ -562,6 +561,24 @@ library. See `the library webpage
     >>> s2 = hs.load('file.tif')
     >>> s2.original_metadata['Number_65000']
     b'Random metadata'
+
+.. warning::
+
+    The file will be saved with the same bit depth as the signal. Since 
+    most processing operations in HyperSpy and numpy will result in 64-bit 
+    floats, this can result in 64-bit ``.tiff`` files, which are not always
+    compatible with other imaging software.
+
+    You can first change the dtype of the signal before saving:
+
+    .. code-block:: python
+
+        >>> s.data.dtype
+        dtype('float64')
+        >>> s.change_dtype('float32')
+        >>> s.data.dtype
+        dtype('float32')
+        >>> s.save('file.tif')
 
 .. _dm3-format:
 


### PR DESCRIPTION
### Description of the change
Closes #593 

The issue highlights that the TIFF files are often 64-bit since the default dtype after any kind of processing is usually `np.float64`. 64-bit TIFF files may not always be compatible with other image readers. This adds a warning to the documentation.

### Progress of the PR
- [x] Change implemented (can be split into several points),
- [x] update docstring (if appropriate),
- [x] update user guide (if appropriate),
- [x] add tests,
- [x] ready for review.

