### PR TITLE
Add warning on Windows and test to guard against #2320

### DIFF
--- a/hyperspy/_signals/signal1d.py
+++ b/hyperspy/_signals/signal1d.py
@@ -1467,9 +1467,6 @@ class Signal1D(BaseSignal, CommonSignal1D):
         background must be previously substracted.
         The estimation is performed by interpolation using cubic splines.
 
-        Warning: `parallel=True` is not currently supported on
-        Windows platforms.
-
         Parameters
         ----------
         factor : 0 < float < 1
@@ -1494,6 +1491,11 @@ class Signal1D(BaseSignal, CommonSignal1D):
         width or [width, left, right], depending on the value of
         `return_interval`.
 
+        Notes
+        -----
+        Parallel operation of this function is not supported
+        on Windows platforms.
+
         """
         if show_progressbar is None:
             show_progressbar = preferences.General.show_progressbar
@@ -1503,12 +1505,16 @@ class Signal1D(BaseSignal, CommonSignal1D):
 
         from hyperspy.misc.config_dir import os_name
 
-        if parallel and os_name == "windows":  # pragma: no cover
+        if parallel != False and os_name == "windows":  # pragma: no cover
             # Due to a scipy bug where scipy.interpolate.UnivariateSpline
-            # appears to not be thread-safe on Windows, we raise a ValueError
+            # appears to not be thread-safe on Windows, we raise a warning
             # here. See https://github.com/hyperspy/hyperspy/issues/2320
-            # Until/if the scipy bug is fixed, we should raise this.
-            raise ValueError("`parallel=True` is not supported on Windows")
+            # Until/if the scipy bug is fixed, we should do this.
+            _logger.warning(
+                "Parallel operation is not supported on Windows. "
+                "Setting `parallel=False`"
+            )
+            parallel = False
 
         axis = self.axes_manager.signal_axes[0]
         # x = axis.axis

--- a/hyperspy/_signals/signal1d.py
+++ b/hyperspy/_signals/signal1d.py
@@ -1490,13 +1490,22 @@ class Signal1D(BaseSignal, CommonSignal1D):
         -------
         width or [width, left, right], depending on the value of
         `return_interval`.
-        """
 
+        """
         if show_progressbar is None:
             show_progressbar = preferences.General.show_progressbar
         self._check_signal_dimension_equals_one()
         if not 0 < factor < 1:
             raise ValueError("factor must be between 0 and 1.")
+
+        from hyperspy.misc.config_dir import os_name
+
+        if parallel and os_name == "windows":  # pragma: no cover
+            # Due to a scipy bug where scipy.interpolate.UnivariateSpline
+            # appears to not be thread-safe on Windows, we raise a ValueError
+            # here. See https://github.com/hyperspy/hyperspy/issues/2320
+            # Until/if the scipy bug is fixed, we should raise this.
+            raise ValueError("`parallel=True` is not supported on Windows")
 
         axis = self.axes_manager.signal_axes[0]
         # x = axis.axis

--- a/hyperspy/_signals/signal1d.py
+++ b/hyperspy/_signals/signal1d.py
@@ -1467,6 +1467,9 @@ class Signal1D(BaseSignal, CommonSignal1D):
         background must be previously substracted.
         The estimation is performed by interpolation using cubic splines.
 
+        Warning: `parallel=True` is not currently supported on
+        Windows platforms.
+
         Parameters
         ----------
         factor : 0 < float < 1

--- a/hyperspy/tests/signal/test_1D_tools.py
+++ b/hyperspy/tests/signal/test_1D_tools.py
@@ -257,6 +257,19 @@ class TestEstimatePeakWidth:
         assert np.isnan(left.data).all()
         assert np.isnan(right.data).all()
 
+    def test_windows_error(self):
+        from hyperspy.misc.config_dir import os_name
+
+        if os_name == "windows":
+            with pytest.raises(ValueError, match="Windows"):
+                _ = self.s.estimate_peak_width(
+                    window=0.5,
+                    return_interval=True,
+                    parallel=True,
+                )
+        else:
+            pytest.skip("Ignored on non-Windows OS")
+
     def test_two_peaks(self):
         s = self.s.deepcopy()
         s.shift1D(np.array([1.0]))

--- a/hyperspy/tests/signal/test_1D_tools.py
+++ b/hyperspy/tests/signal/test_1D_tools.py
@@ -18,6 +18,7 @@
 
 from unittest import mock
 
+import logging
 import numpy as np
 import pytest
 from scipy.signal import savgol_filter

--- a/hyperspy/tests/signal/test_1D_tools.py
+++ b/hyperspy/tests/signal/test_1D_tools.py
@@ -257,18 +257,21 @@ class TestEstimatePeakWidth:
         assert np.isnan(left.data).all()
         assert np.isnan(right.data).all()
 
-    def test_windows_error(self):
+    @pytest.mark.parametrize("parallel", [None, True])
+    def test_warnings_on_windows(self, parallel, caplog):
         from hyperspy.misc.config_dir import os_name
 
-        if os_name == "windows":
-            with pytest.raises(ValueError, match="Windows"):
-                _ = self.s.estimate_peak_width(
-                    window=0.5,
-                    return_interval=True,
-                    parallel=True,
-                )
-        else:
+        if os_name != "windows":
             pytest.skip("Ignored on non-Windows OS")
+
+        with caplog.at_level(logging.WARNING):
+            _ = self.s.estimate_peak_width(
+                window=0.5,
+                return_interval=True,
+                parallel=parallel,
+            )
+
+        assert "Parallel operation is not supported on Windows" in caplog.text
 
     def test_two_peaks(self):
         s = self.s.deepcopy()


### PR DESCRIPTION
### Description of the change
Closes #2320.

There looks to be a bug in scipy where `scipy.interpolate.UnivariateSpline` is not thread-safe on Windows, so running `s.estimate_peak_width(parallel=True)` (which uses thread-based parallelism) will return garbage, as @thomasaarholt  points out in the issue.

Short of the issue being fixed in scipy, this logs a warning on Windows when `parallel=True` or `parallel=None`, and explicitly sets `parallel=False`.

### Progress of the PR
- [x] Change implemented (can be split into several points),
- [x] update docstring (if appropriate),
- [x] update user guide (if appropriate),
- [x] add tests,
- [x] ready for review.

