### PR TITLE
Specify file reader for hs.load

### DIFF
--- a/doc/user_guide/io.rst
+++ b/doc/user_guide/io.rst
@@ -33,6 +33,15 @@ functions will return a list of the corresponding signal.
     in the :py:attr:`~.signal.BaseSignal.data` attribute, but you will not
     normally need to access it there.
 
+HyperSpy will attempt to infer the appropriate file reader to use based on
+the file extension (for example. ``.hspy``, ``.emd`` and so on). You can
+override this using the ``reader`` keyword:
+
+.. code-block:: python
+
+    # Load a .hspy file with an unknown extension
+    >>> s = hs.load("filename.some_extension", reader="hspy")
+
 HyperSpy will try to guess the most likely data type for the corresponding
 file. However, you can force it to read the data as a particular data type by
 providing the ``signal`` keyword, which has to be one of: ``spectrum``,

--- a/doc/user_guide/io.rst
+++ b/doc/user_guide/io.rst
@@ -1136,10 +1136,17 @@ Nexus uses a variety of classes to record data, values,
 units and other experimental metadata associated with an experiment.
 For specific types of experiments an Application Definition may exist which
 defines an agreed common layout that facilities can adhere to.
+
 Nexus metadata and data are stored in Hierarchical Data Format Files (HDF5) with
 a .nxs extension although standards HDF5 extensions are sometimes used.
 Files must use the ``.nxs`` file extension in order to use this io plugin.
-Using the ``.nxs`` extension will default to the Nexus loader
+Using the ``.nxs`` extension will default to the Nexus loader. If your file has
+a HDF5 extension, you can also explicitly set the Nexus file reader:
+
+.. code-block:: python
+
+    # Load a NeXus file with a .h5 extension
+    >>> s = hs.load("filename.h5", reader="nxs")
 
 The loader will follow version 3 of the
 `Nexus data rules <https://manual.nexusformat.org/datarules.html#version-3>`_.

--- a/hyperspy/io.py
+++ b/hyperspy/io.py
@@ -192,8 +192,16 @@ def load(filenames=None,
         then square brackets are escaped before wildcard matching with
         ``glob.glob()``. If False, square brackets are used to represent
         character classes (e.g. ``[a-z]`` matches lowercase letters.
-    print_info: bool
-        For SEMPER unf- and EMD (Berkeley)-files, if True (default is False)
+    reader : None or str or custom file reader object, default None
+        Specify the file reader to use when loading the file(s). If None,
+        will use the file extension to infer the file type and appropriate
+        reader. If str, will select the appropriate file reader from the
+        list of available readers in HyperSpy. If a custom reader object,
+        it should implement the ``file_reader`` function, which returns
+        a dictionary containing the data and metadata for conversion to
+        a HyperSpy signal.
+    print_info: bool, default False
+        For SEMPER unf- and EMD (Berkeley)-files, if True
         additional information read during loading is printed for a quick
         overview.
     downsample : int (1–4095)
@@ -280,6 +288,10 @@ def load(filenames=None,
     stacking:
 
     >>> s = hs.load('file*.blo', lazy=True, stack=True)
+
+    Specify the file reader to use
+
+    >>> s = hs.load('a_nexus_file.h5', reader='nxs')
 
     """
     deprecated = ['mmap_dir', 'load_to_memory']

--- a/hyperspy/io_plugins/__init__.py
+++ b/hyperspy/io_plugins/__init__.py
@@ -19,15 +19,49 @@
 
 import logging
 
-from hyperspy.io_plugins import (msa, digital_micrograph, fei, mrc, ripple,
-                                 tiff, semper_unf, blockfile, dens, emd,
-                                 protochips, edax, bruker, hspy, nexus, image,
-                                 phenom, sur, empad)
+from hyperspy.io_plugins import (
+    blockfile,
+    bruker,
+    dens,
+    digital_micrograph,
+    edax,
+    emd,
+    empad,
+    fei,
+    hspy,
+    image,
+    mrc,
+    msa,
+    nexus,
+    phenom,
+    protochips,
+    ripple,
+    semper_unf,
+    sur,
+    tiff,
+)
 
-
-io_plugins = [msa, digital_micrograph, fei, mrc, ripple, tiff, semper_unf,
-              blockfile, dens, emd, protochips, edax, bruker, hspy, nexus,
-              emd, image, nexus, phenom, sur, empad]
+io_plugins = [
+    blockfile,
+    bruker,
+    dens,
+    digital_micrograph,
+    edax,
+    emd,
+    empad,
+    fei,
+    hspy,
+    image,
+    mrc,
+    msa,
+    nexus,
+    phenom,
+    protochips,
+    ripple,
+    semper_unf,
+    sur,
+    tiff,
+]
 
 
 _logger = logging.getLogger(__name__)
@@ -35,29 +69,35 @@ _logger = logging.getLogger(__name__)
 
 try:
     from hyperspy.io_plugins import netcdf
+
     io_plugins.append(netcdf)
 except ImportError:
-    pass
     # NetCDF is obsolete and is only provided for users who have
     # old EELSLab files. Therefore, we silently ignore if missing.
+    pass
 
 try:
     from hyperspy.io_plugins import usid_hdf5
+
     io_plugins.append(usid_hdf5)
 except ImportError:
-    _logger.info('The USID IO plugin is not available because '
-                 'the pyUSID or sidpy Python package are not installed.')
+    _logger.info(
+        "The USID IO plugin is not available because "
+        "the pyUSID or sidpy packages are not installed."
+    )
 
 try:
     from hyperspy.io_plugins import mrcz
+
     io_plugins.append(mrcz)
 except ImportError:
-    _logger.info('The mrcz IO plugin is not available because '
-                 'the mrcz Python package is not installed.')
+    _logger.info(
+        "The mrcz IO plugin is not available because "
+        "the mrcz package is not installed."
+    )
 
 
 default_write_ext = set()
 for plugin in io_plugins:
     if plugin.writes:
-        default_write_ext.add(
-            plugin.file_extensions[plugin.default_extension])
+        default_write_ext.add(plugin.file_extensions[plugin.default_extension])


### PR DESCRIPTION
### Description of the change
Closes #1478.

Introduces a `reader` kwarg to `hs.load()`, so that instead of inferring the file reader automatically from the file extension, the user can explicitly pass one themselves. Can either be a function or a string, for example:

```python
import hyperspy.api as hs
import hyperspy.io
emd_reader = hyperspy.io.io_plugins[9]

s = hs.load("an_emd_file.hdf5", reader=emd_reader)
s = hs.load("an_emd_file.hdf5", reader="emd")
```

### Progress of the PR
- [x] Change implemented (can be split into several points),
- [x] update docstring (if appropriate),
- [x] update user guide (if appropriate),
- [x] add tests,
- [x] ready for review.

