### PR TITLE
Use hs.preferences for progress bar in LazySignal.compute()

### DIFF
--- a/hyperspy/tests/signal/test_lazy.py
+++ b/hyperspy/tests/signal/test_lazy.py
@@ -24,6 +24,7 @@ from dask.threaded import get
 import hyperspy.api as hs
 from hyperspy import _lazy_signals
 from hyperspy._signals.lazy import _reshuffle_mixed_blocks, to_array
+from hyperspy.exceptions import VisibleDeprecationWarning
 
 
 def _signal():
@@ -137,3 +138,14 @@ def test_ma_lazify():
     assert np.isnan(l.data[1].compute())
     ss = hs.stack([s, s])
     assert np.isnan(ss.data[:, 1]).all()
+
+
+def test_warning():
+    sig = _signal()
+
+    with pytest.warns(VisibleDeprecationWarning, match="progressbar"):
+        sig.compute(progressbar=False)
+
+    assert sig._lazy == False
+    thing = to_array(sig, chunks=None)
+    assert isinstance(thing, np.ndarray)


### PR DESCRIPTION
### Description of the change
In #1842 it was noted that `LazySignal.compute()` doesn't use the hs.preferences value for showing/hiding the progress bar. In #1843 some attempt at making a change was made but I believe this PR is more appropriate.

Thus here the `progressbar` argument is deprecated and replaced with `show_progressbar` for consistency with other uses. The default value is `None` in which case it takes it from the preferences. The docstring never documented `progressbar` anyway, so that's fixed also.

- Closes #1842 
- Closes #1843 (replaces it)

### Progress of the PR
- [x] Change implemented (can be split into several points),
- [x] update docstring (if appropriate),
- [x] update user guide (if appropriate),
- [x] add tests,
- [x] ready for review.

