### PR TITLE
Fix mask decomposition eds

### DIFF
--- a/hyperspy/_signals/eds_tem.py
+++ b/hyperspy/_signals/eds_tem.py
@@ -708,7 +708,7 @@ class EDSTEM_mixin:
         vacuum_mask
         """
         if isinstance(navigation_mask, float):
-            navigation_mask = self.vacuum_mask(navigation_mask, closing).data
+            navigation_mask = self.vacuum_mask(navigation_mask, closing)
         super().decomposition(
             normalize_poissonian_noise=normalize_poissonian_noise,
             navigation_mask=navigation_mask, *args, **kwargs)

--- a/hyperspy/_signals/signal1d.py
+++ b/hyperspy/_signals/signal1d.py
@@ -552,18 +552,6 @@ class Signal1D(BaseSignal, CommonSignal1D):
 
     interpolate_in_between.__doc__ %= (SHOW_PROGRESSBAR_ARG, PARALLEL_ARG, MAX_WORKERS_ARG)
 
-    def _check_navigation_mask(self, mask):
-        if mask is not None:
-            if not isinstance(mask, BaseSignal):
-                raise ValueError("mask must be a BaseSignal instance.")
-            elif mask.axes_manager.signal_dimension not in (0, 1):
-                raise ValueError("mask must be a BaseSignal "
-                                 "with signal_dimension equal to 1")
-            elif (mask.axes_manager.navigation_dimension !=
-                  self.axes_manager.navigation_dimension):
-                raise ValueError("mask must be a BaseSignal with the same "
-                                 "navigation_dimension as the current signal.")
-
     def estimate_shift1D(
         self,
         start=None,

--- a/hyperspy/learn/mva.py
+++ b/hyperspy/learn/mva.py
@@ -412,6 +412,8 @@ class MVA:
             # input masks
 
             data_ = dc[:, signal_mask][navigation_mask, :]
+            if data_.size == 0:
+                raise ValueError("All the data are masked, change the mask.")
 
             # Reset the explained_variance which is not set by all the
             # algorithms
@@ -1624,6 +1626,9 @@ class MVA:
                 signal_mask = slice(None)
             else:
                 signal_mask = ~signal_mask
+
+            if dc[:, signal_mask][navigation_mask, :].size == 0:
+                raise ValueError("All the data are masked, change the mask.")
 
             # Check non-negative
             if dc[:, signal_mask][navigation_mask, :].min() < 0.0:

--- a/hyperspy/learn/mva.py
+++ b/hyperspy/learn/mva.py
@@ -152,10 +152,10 @@ class MVA:
         auto_transpose : bool, default True
             If True, automatically transposes the data to boost performance.
             Only used by the "SVD" algorithm.
-        navigation_mask : boolean numpy array
+        navigation_mask : boolean numpy array or BaseSignal
             The navigation locations marked as True are not used in the
             decomposition.
-        signal_mask : boolean numpy array
+        signal_mask : boolean numpy array or BaseSignal
             The signal locations marked as True are not used in the
             decomposition.
         var_array : numpy array
@@ -345,6 +345,11 @@ class MVA:
             f"  centre={centre}",
         ]
 
+        from hyperspy.signal import BaseSignal
+
+        self._check_navigation_mask(navigation_mask)
+        self._check_signal_mask(signal_mask)
+
         # Backup the original data (on by default to
         # mimic previous behaviour)
         if copy:
@@ -359,9 +364,13 @@ class MVA:
         try:
             _logger.info("Performing decomposition analysis")
 
+            if isinstance(navigation_mask, BaseSignal):
+                navigation_mask = navigation_mask.data
             if hasattr(navigation_mask, "ravel"):
                 navigation_mask = navigation_mask.ravel()
 
+            if isinstance(signal_mask, BaseSignal):
+                signal_mask = signal_mask.data
             if hasattr(signal_mask, "ravel"):
                 signal_mask = signal_mask.ravel()
 
@@ -1658,13 +1667,13 @@ class MVA:
         # Deal with masks
         if hasattr(mask, 'ravel'):
             mask = mask.ravel()
-    
+
         # Transform the None masks in slices to get the right behaviour
         if mask is None:
             mask = slice(None)
         else:
             mask = ~mask
-    
+
         return mask
 
     def _scale_data_for_clustering(self,
@@ -1679,7 +1688,7 @@ class MVA:
         ----------
         cluster_signal : {"bss", "decomposition", "signal", Signal}
             If "bss" the blind source separation results are used
-            If "decomposition" the decomposition results are used 
+            If "decomposition" the decomposition results are used
             if "signal" the signal data is used (signal should be unfolded)
         preprocessing : {"standard","norm","minmax",None or scikit learn preprocessing method}
             default: 'norm'
@@ -1701,7 +1710,7 @@ class MVA:
         * :py:meth:`~.learn.mva.MVA.clusters_analysis`,
         * :py:meth:`~.learn.mva.MVA.estimate_number_of_clusters`,
         * :py:meth:`~.learn.mva.MVA.get_cluster_labels`,
-        * :py:meth:`~.learn.mva.MVA.get_cluster_signals`,        
+        * :py:meth:`~.learn.mva.MVA.get_cluster_signals`,
         * :py:meth:`~.learn.mva.MVA.plot_cluster_metric`,
         * :py:meth:`~.signal.MVATools.plot_cluster_results`
         * :py:meth:`~.signal.MVATools.plot_cluster_signals`
@@ -1716,24 +1725,24 @@ class MVA:
         """
 
 
-        preprocessing_algorithm = self._get_cluster_preprocessing_algorithm(preprocessing,**preprocessing_kwargs)                        
-            
-        
-        
+        preprocessing_algorithm = self._get_cluster_preprocessing_algorithm(preprocessing,**preprocessing_kwargs)
+
+
+
         if preprocessing_algorithm is None:
             return cluster_signal
         else:
             return preprocessing_algorithm.fit_transform(cluster_signal)
 
-        
+
     def _get_number_of_components_for_clustering(self):
         """
-        Returns the number of components 
-        """        
+        Returns the number of components
+        """
         if self.learning_results.number_significant_components is None:
             raise ValueError("A cluster source has been set to `decomposition` "
                              "or `bss` but no decomposition results are available. "
-                             "Please run a decomposition method first.")        
+                             "Please run a decomposition method first.")
         else:
             number_of_components = self.learning_results.number_significant_components
         return number_of_components
@@ -1749,22 +1758,22 @@ class MVA:
         n_clusters : int
             Number of clusters to find.
         scaled_data : numpy array - (number_of_samples,number_of_features)
-        algorithm: scikit learn clustering object 
+        algorithm: scikit learn clustering object
         **kwargs
             Additional parameters passed to the clustering algorithm.
             This may include `n_init`, the number of times the algorithm is
             restarted to optimize results.
 
-            
+
         Returns
         -------
         alg
             return the sklearn.cluster object
- 
+
         """
 
         algorithm.fit(scaled_data)
-        
+
         # We need the labels_ to proceed
         if not hasattr(algorithm, "labels_"):
             raise AttributeError(
@@ -1777,17 +1786,17 @@ class MVA:
     def plot_cluster_metric(self):
         """Plot the cluster metrics calculated
            using evaluate_number_of_clusters method
-           
+
         See Also
         --------
         * :py:meth:`~.learn.mva.MVA.estimate_number_of_clusters`,
-        * :py:meth:`~.learn.mva.MVA.cluster_analysis`,        
+        * :py:meth:`~.learn.mva.MVA.cluster_analysis`,
         * :py:meth:`~.learn.mva.MVA.get_cluster_labels`,
-        * :py:meth:`~.learn.mva.MVA.get_cluster_signals`,        
+        * :py:meth:`~.learn.mva.MVA.get_cluster_signals`,
         * :py:meth:`~.signal.MVATools.plot_cluster_results`
         * :py:meth:`~.signal.MVATools.plot_cluster_signals`
         * :py:meth:`~.signal.MVATools.plot_cluster_labels`
-           
+
 
         """
         target = self.learning_results
@@ -1840,21 +1849,21 @@ class MVA:
                             navigation_mask=None,
                             signal_mask=None,):
         """A cluster source can be an external signal, the signal data
-        or the decomposition or bss results  
+        or the decomposition or bss results
         Return a flatten version of the data, nav and signal mask
-    
+
         Parameters
         ----------
         cluster_source : str or BaseSignal
-            "decomposition", "bss", "signal" or a Signal 
+            "decomposition", "bss", "signal" or a Signal
         number_of_components : int, optional
             Number of components to use with decomposition sources.
             The default is None.
         navigation_mask : ndarray, optional
-            mask used to select regions of the cluster_source to use. 
+            mask used to select regions of the cluster_source to use.
             The default is None.
         signal_mask : ndarray, optional
-            mask used to select regions of the cluster_source signal. 
+            mask used to select regions of the cluster_source signal.
             For decomposition or bss this is not used.
             The default is None.
         reproject : bool, optional
@@ -1862,15 +1871,15 @@ class MVA:
             the loadings are returned. If True the factor @ loadings result
             is used. The default is False.
 
- 
+
         Returns
         -------
         toreturn : ndarray
-            Returns an unfolded dataset from 
+            Returns an unfolded dataset from
             the selected cluster_source
 
         """
-                
+
         toreturn=None
         # Is it a signal - i.e. BaseSignal
         if type(cluster_source) is str and cluster_source=="signal":
@@ -1880,26 +1889,26 @@ class MVA:
            if cluster_source.axes_manager.navigation_size != self.axes_manager.navigation_size:
                 raise ValueError("cluster_source does not have the same "
                                  "navigation size as the this signal")
-        else: 
+        else:
             if cluster_source not in ("bss", "decomposition", "signal"):
                 if not is_hyperspy_signal(cluster_source):
                     raise ValueError("cluster source needs to be set "
                                      "to `decomposition` , `signal` , `bss` "
                                      "or a suitable Signal")
-        
+
             if cluster_source == "decomposition":
                 if self.learning_results.factors is None:
                     raise ValueError("A cluster source has been set to decomposition "
                                      "but no decomposition results found. "
                                      "Please run decomposition method first")
-    
+
             if cluster_source == "bss":
                 if self.learning_results.bss_factors is None:
                     raise ValueError("A cluster source has been set to bss "
                                      " but no blind source separation results found. "
                                      " Please run blind source separation method first")
 
- 
+
             if cluster_source in ("decomposition","bss") and number_of_components is None:
                 number_of_components = self._get_number_of_components_for_clustering()
 
@@ -1950,18 +1959,18 @@ class MVA:
         ----------
         cluster_source : {"bss", "decomposition", "signal", BaseSignal}
             If "bss" the blind source separation results are used
-            If "decomposition" the decomposition results are used 
-            if "signal" the signal data is used 
-            Note that using the signal or BaseSignal can be memory intensive 
+            If "decomposition" the decomposition results are used
+            if "signal" the signal data is used
+            Note that using the signal or BaseSignal can be memory intensive
             and is only recommended if the Signal dimension is small
             BaseSignal must have the same navigation dimensions as the signal.
         source_for_centers : {None,"decomposition","bss","signal",BaseSignal},
             default : None
             If None the cluster_source is used
             If "bss" the blind source separation results are used
-            If "decomposition" the decomposition results are used 
-            if "signal" the signal data is used 
-            BaseSignal must have the same navigation dimensions as the signal.            
+            If "decomposition" the decomposition results are used
+            if "signal" the signal data is used
+            BaseSignal must have the same navigation dimensions as the signal.
         preprocessing : {"standard","norm","minmax",None or scikit learn preprocessing method}
             default: 'norm'
             Preprocessing the data before cluster analysis requires preprocessing
@@ -2148,7 +2157,7 @@ class MVA:
     def _get_cluster_algorithm(self,algorithm,**kwargs):
 
         """Convenience method to lookup cluster algorithm if algorithm is a string
-        and instantiates it with n_clusters or if it's an object check that 
+        and instantiates it with n_clusters or if it's an object check that
         the object has a fit method
         """
         algorithms_sklearn = list(cluster_algorithms.keys())
@@ -2247,15 +2256,15 @@ class MVA:
         ----------
         cluster_source : {"bss", "decomposition", "signal" or Signal}
             If "bss" the blind source separation results are used
-            If "decomposition" the decomposition results are used 
-            if "signal" the signal data is used 
-            Note that using the signal can be memory intensive 
+            If "decomposition" the decomposition results are used
+            if "signal" the signal data is used
+            Note that using the signal can be memory intensive
             and is only recommended if the Signal dimension is small.
             Input Signal must have the same navigation dimensions as the
             signal instance.
         max_clusters : int, default 10
             Max number of clusters to use. The method will scan from 2 to
-            max_clusters. 
+            max_clusters.
         preprocessing : {"standard","norm","minmax" or sklearn-like preprocessing object}
             default: 'norm'
             Preprocessing the data before cluster analysis requires preprocessing
@@ -2302,26 +2311,26 @@ class MVA:
         **kwargs : dict {}  default empty
             Parameters passed to the clustering algorithm.
 
-        
-        Other Parameters        
-        ----------------        
+
+        Other Parameters
+        ----------------
         n_clusters : int
             Number of clusters to find using the one of the pre-defined methods
             "kmeans","agglomerative","minibatchkmeans","spectralclustering"
-            See sklearn.cluster for details 
+            See sklearn.cluster for details
 
 
         Returns
         -------
         best_k : int
             Estimate of the best cluster size
-        
+
         See Also
         --------
         * :py:meth:`~.learn.mva.MVA.cluster_analysis`,
         * :py:meth:`~.learn.mva.MVA.get_cluster_labels`,
         * :py:meth:`~.learn.mva.MVA.get_cluster_signals`,
-        * :py:meth:`~.learn.mva.MVA.get_cluster_distances`,        
+        * :py:meth:`~.learn.mva.MVA.get_cluster_distances`,
         * :py:meth:`~.learn.mva.MVA.plot_cluster_metric`,
         * :py:meth:`~.signal.MVATools.plot_cluster_results`
         * :py:meth:`~.signal.MVATools.plot_cluster_signals`
@@ -2585,7 +2594,7 @@ class MVA:
         distance = np.nan_to_num(numer / denom)
         elbow_position = np.argmax(distance)
 
-        return elbow_position        
+        return elbow_position
 
 class LearningResults(object):
     """Stores the parameters and results from a decomposition."""
@@ -2779,4 +2788,4 @@ class LearningResults(object):
             self.bss_loadings,
             self.bss_factors,
         )
-        
+

--- a/hyperspy/misc/eds/utils.py
+++ b/hyperspy/misc/eds/utils.py
@@ -36,7 +36,7 @@ def _get_element_and_line(xray_line):
     """
     lim = xray_line.find('_')
     if lim == -1:
-        raise ValueError("Invalid xray-line: %" % xray_line)
+        raise ValueError(f"Invalid xray-line: {xray_line}")
     return xray_line[:lim], xray_line[lim + 1:]
 
 

--- a/hyperspy/signal.py
+++ b/hyperspy/signal.py
@@ -5998,15 +5998,15 @@ class BaseSignal(FancySlicing,
         """
         if isinstance(mask, BaseSignal):
             if mask.axes_manager.signal_dimension != 0:
-                raise ValueError("mask must be a BaseSignal "
-                                 "with `signal_dimension` equal to 0")
+                raise ValueError("`mask` must be a signal with "
+                                 "`signal_dimension` equal to 0")
             elif (mask.axes_manager.navigation_shape !=
                   self.axes_manager.navigation_shape):
-                raise ValueError("mask must be a BaseSignal with the same "
+                raise ValueError("`mask` must be a signal with the same "
                                  "`navigation_shape` as the current signal.")
         if isinstance(mask, np.ndarray) and (
                 mask.shape != self.axes_manager.navigation_shape):
-            raise ValueError("The shape of the mask must match the shape of "
+            raise ValueError("The shape of `mask` must match the shape of "
                              "the `navigation_shape`.")
 
     def _check_signal_mask(self, mask):
@@ -6030,15 +6030,15 @@ class BaseSignal(FancySlicing,
         """
         if isinstance(mask, BaseSignal):
             if mask.axes_manager.navigation_dimension != 0:
-                raise ValueError("mask must be a BaseSignal "
-                                 "with `navigation_dimension` equal to 0")
+                raise ValueError("`mask` must be a signal with "
+                                 "`navigation_dimension` equal to 0")
             elif (mask.axes_manager.signal_shape !=
                   self.axes_manager.signal_shape):
-                raise ValueError("mask must be a BaseSignal with the same "
+                raise ValueError("`mask` must be a signal with the same "
                                  "`signal_shape` as the current signal.")
         if isinstance(mask, np.ndarray) and (
                 mask.shape != self.axes_manager.signal_shape):
-            raise ValueError("The shape of the mask must match the shape of "
+            raise ValueError("The shape of `mask` must match the shape of "
                              "the `signal_shape`.")
 
 

--- a/hyperspy/signal.py
+++ b/hyperspy/signal.py
@@ -1276,7 +1276,7 @@ class MVATools(object):
         label_format : string
             The extension of the format that you wish to save to. default
             is "hspy". The format determines the kind of output.
-            
+
                 * For image formats (``'tif'``, ``'png'``, ``'jpg'``, etc.),
                   plots are created using the plotting flags as below, and saved
                   at 600 dpi. One plot is saved per loading.
@@ -1285,7 +1285,7 @@ class MVATools(object):
                   one file.
                 * For spectral formats (``'msa'``), each loading is saved to a
                   separate file.
-                  
+
         multiple_files : bool
             If True, on exporting a file per center will
             be created. Otherwise only two files will be created, one for
@@ -1751,16 +1751,16 @@ class MVATools(object):
 
     def get_cluster_distances(self):
         """Euclidian distances to the centroid of each cluster
-    
+
         See Also
         --------
         get_cluster_signals
-        
+
         Returns
         --------
         signal
-            Hyperspy signal of cluster distances        
-    
+            Hyperspy signal of cluster distances
+
         """
         if self.learning_results.cluster_distances is None:
             raise RuntimeError("Cluster analysis needs to be performed first.")
@@ -1847,7 +1847,7 @@ class MVATools(object):
         ----------
 
         cluster_ids : None, int, or list of ints
-            if None (default), returns maps of all components using the 
+            if None (default), returns maps of all components using the
             number_of_cluster was defined when
             executing ``cluster``. Otherwise it raises a ValueError.
             if int, returns maps of cluster labels with ids from 0 to
@@ -1941,7 +1941,7 @@ class MVATools(object):
         Parameters
         ----------
         cluster_ids : None, int, or list of ints
-            if None (default), returns maps of all components using the 
+            if None (default), returns maps of all components using the
             number_of_cluster was defined when
             executing ``cluster``. Otherwise it raises a ValueError.
             if int, returns maps of cluster labels with ids from 0 to
@@ -5976,6 +5976,70 @@ class BaseSignal(FancySlicing,
             self.events.data_changed.trigger(obj=self)
         else:
             return self * window_nd
+
+    def _check_navigation_mask(self, mask):
+        """
+        Check the shape of the navigation mask.
+
+        Parameters
+        ----------
+        mask : numpy array or BaseSignal.
+            Mask to check the shape.
+
+        Raises
+        ------
+        ValueError
+            If shape doesn't match the shape of the navigation dimension.
+
+        Returns
+        -------
+        None.
+
+        """
+        if isinstance(mask, BaseSignal):
+            if mask.axes_manager.signal_dimension != 0:
+                raise ValueError("mask must be a BaseSignal "
+                                 "with `signal_dimension` equal to 0")
+            elif (mask.axes_manager.navigation_shape !=
+                  self.axes_manager.navigation_shape):
+                raise ValueError("mask must be a BaseSignal with the same "
+                                 "`navigation_shape` as the current signal.")
+        if isinstance(mask, np.ndarray) and (
+                mask.shape != self.axes_manager.navigation_shape):
+            raise ValueError("The shape of the mask must match the shape of "
+                             "the `navigation_shape`.")
+
+    def _check_signal_mask(self, mask):
+        """
+        Check the shape of the signal mask.
+
+        Parameters
+        ----------
+        mask : numpy array or BaseSignal.
+            Mask to check the shape.
+
+        Raises
+        ------
+        ValueError
+            If shape doesn't match the shape of the signal dimension.
+
+        Returns
+        -------
+        None.
+
+        """
+        if isinstance(mask, BaseSignal):
+            if mask.axes_manager.navigation_dimension != 0:
+                raise ValueError("mask must be a BaseSignal "
+                                 "with `navigation_dimension` equal to 0")
+            elif (mask.axes_manager.signal_shape !=
+                  self.axes_manager.signal_shape):
+                raise ValueError("mask must be a BaseSignal with the same "
+                                 "`signal_shape` as the current signal.")
+        if isinstance(mask, np.ndarray) and (
+                mask.shape != self.axes_manager.signal_shape):
+            raise ValueError("The shape of the mask must match the shape of "
+                             "the `signal_shape`.")
 
 
 ARITHMETIC_OPERATORS = (

--- a/hyperspy/tests/learn/test_decomposition.py
+++ b/hyperspy/tests/learn/test_decomposition.py
@@ -680,3 +680,15 @@ def test_decomposition_signal_mask(mask_as_array):
     if mask_as_array:
         signal_mask = signal_mask.data
     s.decomposition(signal_mask=signal_mask)
+
+
+def test_decomposition_mask_all_data():
+    with pytest.raises(ValueError, match='All the data are masked'):
+        s = signals.Signal1D(generate_low_rank_matrix())
+        signal_mask = (s.sum(0) >= s.sum(0).min())
+        s.decomposition(signal_mask=signal_mask)
+
+    with pytest.raises(ValueError, match='All the data are masked'):
+        s = signals.Signal1D(generate_low_rank_matrix())
+        navigation_mask = (s.sum(-1) >= 0)
+        s.decomposition(navigation_mask=navigation_mask)

--- a/hyperspy/tests/learn/test_decomposition.py
+++ b/hyperspy/tests/learn/test_decomposition.py
@@ -662,3 +662,21 @@ def test_centering_error():
             match="centre='{}' has been deprecated".format(centre),
         ):
             s.decomposition(centre=centre)
+
+
+@pytest.mark.parametrize('mask_as_array', [True, False])
+def test_decomposition_navigation_mask(mask_as_array):
+    s = signals.Signal1D(generate_low_rank_matrix())
+    navigation_mask = (s.sum(-1) < 1.5)
+    if mask_as_array:
+        navigation_mask = navigation_mask
+    s.decomposition(navigation_mask=navigation_mask)
+
+
+@pytest.mark.parametrize('mask_as_array', [True, False])
+def test_decomposition_signal_mask(mask_as_array):
+    s = signals.Signal1D(generate_low_rank_matrix())
+    signal_mask = (s.sum(0) < 0.25)
+    if mask_as_array:
+        signal_mask = signal_mask.data
+    s.decomposition(signal_mask=signal_mask)

--- a/hyperspy/tests/learn/test_decomposition.py
+++ b/hyperspy/tests/learn/test_decomposition.py
@@ -682,13 +682,15 @@ def test_decomposition_signal_mask(mask_as_array):
     s.decomposition(signal_mask=signal_mask)
 
 
-def test_decomposition_mask_all_data():
+@pytest.mark.parametrize('normalise_poissonian_noise', [True, False])
+def test_decomposition_mask_all_data(normalise_poissonian_noise):
     with pytest.raises(ValueError, match='All the data are masked'):
         s = signals.Signal1D(generate_low_rank_matrix())
         signal_mask = (s.sum(0) >= s.sum(0).min())
-        s.decomposition(signal_mask=signal_mask)
+        s.decomposition(normalise_poissonian_noise, signal_mask=signal_mask)
 
     with pytest.raises(ValueError, match='All the data are masked'):
         s = signals.Signal1D(generate_low_rank_matrix())
         navigation_mask = (s.sum(-1) >= 0)
-        s.decomposition(navigation_mask=navigation_mask)
+        s.decomposition(normalise_poissonian_noise,
+                        navigation_mask=navigation_mask)

--- a/hyperspy/tests/misc/test_eds_utils.py
+++ b/hyperspy/tests/misc/test_eds_utils.py
@@ -1,0 +1,28 @@
+# -*- coding: utf-8 -*-
+# Copyright 2007-2020 The HyperSpy developers
+#
+# This file is part of  HyperSpy.
+#
+#  HyperSpy is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+#  HyperSpy is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with  HyperSpy.  If not, see <http://www.gnu.org/licenses/>.
+
+import pytest
+
+from hyperspy.misc.eds.utils import _get_element_and_line
+
+
+def test_get_element_and_line():
+    assert _get_element_and_line('Mn_Ka') == ('Mn', 'Ka')
+
+    with pytest.raises(ValueError):
+        _get_element_and_line('MnKa') == -1

--- a/hyperspy/tests/signal/test_check_mask.py
+++ b/hyperspy/tests/signal/test_check_mask.py
@@ -1,0 +1,71 @@
+# -*- coding: utf-8 -*-
+# Copyright 2007-2020 The HyperSpy developers
+#
+# This file is part of  HyperSpy.
+#
+#  HyperSpy is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+#  HyperSpy is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with  HyperSpy.  If not, see <http://www.gnu.org/licenses/>.
+
+import numpy as np
+import pytest
+
+import hyperspy.api as hs
+
+
+def test_check_navigation_mask():
+    s = hs.signals.Signal1D(np.ones(shape=(32, 32, 1024)))
+    s.add_gaussian_noise(0.1)
+
+    mask = (s.sum(-1) > 1)
+    assert s._check_navigation_mask(mask) is None
+
+    # wrong navigation shape
+    error_message = '`mask` must be a signal with the same `navigation_shape`'
+    with pytest.raises(ValueError, match=error_message):
+        s._check_navigation_mask(mask.inav[:-2, :])
+
+    # wrong array shape
+    error_message = 'The shape of `mask` must match the shape of the `navigation_shape`.'
+    with pytest.raises(ValueError, match=error_message):
+        s._check_navigation_mask(mask.inav[:-2, :].data)
+
+    # wrong signal dimenstion
+    mask = (s > 1)
+    error_message = '`mask` must be a signal with `signal_dimension`'
+    with pytest.raises(ValueError, match=error_message):
+        s._check_navigation_mask(mask)
+
+
+
+def test_check_signal_mask():
+    s = hs.signals.Signal1D(np.ones(shape=(32, 32, 1024)))
+    s.add_gaussian_noise(0.1)
+
+    mask = (s.inav[0, 0] > 1)
+    assert s._check_signal_mask(mask) is None
+
+    # wrong navigation shape
+    error_message = '`mask` must be a signal with the same `signal_shape`'
+    with pytest.raises(ValueError, match=error_message):
+        s._check_signal_mask(mask.isig[:-2])
+
+    # wrong array shape
+    error_message = 'The shape of `mask` must match the shape of the `signal_shape`.'
+    with pytest.raises(ValueError, match=error_message):
+        s._check_signal_mask(mask.isig[:-2].data)
+
+    # wrong signal dimenstion
+    mask = (s > 1)
+    error_message = '`mask` must be a signal with `navigation_dimension`'
+    with pytest.raises(ValueError, match=error_message):
+        s._check_signal_mask(mask)

--- a/hyperspy/tests/signal/test_eds_tem.py
+++ b/hyperspy/tests/signal/test_eds_tem.py
@@ -469,6 +469,18 @@ class Test_vacum_mask:
         assert not s.vacuum_mask().data[-1]
 
 
+@pytest.mark.parametrize('normalise_poissonian_noise', [True, False])
+def test_decomposition(normalise_poissonian_noise):
+    s = EDSTEMSpectrum(np.ones(shape=(32, 32, 1024)))
+    s.add_poissonian_noise()
+    # default uses `vacuum_mask`
+    s.decomposition(normalise_poissonian_noise)
+
+    # test with numpy array mask
+    mask = s.vacuum_mask().data
+    s.decomposition(normalise_poissonian_noise, navigation_mask=mask)
+
+
 @lazifyTestClass
 class Test_simple_model:
 


### PR DESCRIPTION
Fix issue #2550. The issue was actually that all the data were masked in this specific case:
```python
import numpy as np
import hyperspy.api as hs

s = hs.signals.Signal1D(np.ones(shape=(32, 32, 1024)))
s.set_signal_type("EDS_TEM")
# by default `navigation_mask`=1.0 and it will mask all the data, which then fails
s.decomposition()
# works
s.decomposition(navigation_mask=0.5)
```

### Progress of the PR
- [x] check shape of navigation and signal mask in decomposition,
- [x] allow the use of `BaseSignal` as mask,
- [x] raise a `ValueError` when all the data are mask,
- [x] update docstring,
- [x] add tests,
- [x] ready for review.

