### PR TITLE
Set reading mode hdf5 file

### DIFF
--- a/doc/user_guide/io.rst
+++ b/doc/user_guide/io.rst
@@ -1059,13 +1059,13 @@ If multiple datasets are present within the h5USID file and you try the same com
     [<Signal2D, title: HAADF, dimensions: (|128, 128)>,
     <Signal1D, title: EELS, dimensions: (|64, 64, 1024)>]
 
-We can load a specific dataset using the ``dset_path`` keyword argument. setting it to the
+We can load a specific dataset using the ``dataset_path`` keyword argument. setting it to the
 absolute path of the desired dataset will cause the single dataset to be loaded.
 
 .. code-block:: python
 
     >>> # Loading a specific dataset
-    >>> hs.load("sample.h5", dset_path='/Measurement_004/Channel_003/Main_Data')
+    >>> hs.load("sample.h5", dataset_path='/Measurement_004/Channel_003/Main_Data')
     <Signal2D, title: HAADF, dimensions: (|128, 128)>
 
 h5USID files support the storage of HDF5 dataset with

--- a/hyperspy/io_plugins/emd.py
+++ b/hyperspy/io_plugins/emd.py
@@ -356,7 +356,7 @@ class EMD(object):
         """
         cls._log.debug('Calling load_from_emd')
         # Read in file:
-        emd_file = h5py.File(filename, 'r')
+        emd_file = h5py.File(filename, 'r+' if lazy else 'r')
         # Creat empty EMD instance:
         emd = cls()
         # Extract user:
@@ -1690,7 +1690,7 @@ def file_reader(filename, lazy=False, **kwds):
         Keyword argument pass to the EMD NCEM or EMD Velox reader. See user
         guide or the docstring of the `load` function for more information.
     """
-    file = h5py.File(filename, 'r')
+    file = h5py.File(filename, 'r+' if lazy else 'r')
     dictionaries = []
     try:
         if is_EMD_Velox(file):

--- a/hyperspy/io_plugins/hspy.py
+++ b/hyperspy/io_plugins/hspy.py
@@ -116,7 +116,7 @@ def get_hspy_format_version(f):
 
 def file_reader(filename, backing_store=False,
                 lazy=False, **kwds):
-    mode = kwds.pop('mode', 'r+')
+    mode = kwds.pop('mode', 'r+' if lazy else 'r')
     f = h5py.File(filename, mode=mode, **kwds)
     # Getting the format version here also checks if it is a valid HSpy
     # hdf5 file, so the following two lines must not be deleted or moved

--- a/hyperspy/io_plugins/nexus.py
+++ b/hyperspy/io_plugins/nexus.py
@@ -449,7 +449,7 @@ def file_reader(filename, lazy=False, dataset_keys=None,
     mapping = kwds.get('mapping', {})
     original_metadata = {}
     learning = {}
-    fin = h5py.File(filename, "r+")
+    fin = h5py.File(filename, "r+" if lazy else "r")
     signal_dict_list = []
 
     dataset_keys = _check_search_keys(dataset_keys)

--- a/hyperspy/io_plugins/usid_hdf5.py
+++ b/hyperspy/io_plugins/usid_hdf5.py
@@ -384,7 +384,7 @@ def _axes_list_to_dimensions(axes_list, data_shape, is_spec):
 
 
 def file_reader(filename, dataset_path=None, ignore_non_linear_dims=True,
-                **kwds):
+                lazy=False, **kwds):
     """
     Reads a USID Main dataset present in an HDF5 file into a HyperSpy Signal
 
@@ -416,14 +416,8 @@ def file_reader(filename, dataset_path=None, ignore_non_linear_dims=True,
 
     # Need to keep h5 file handle open indefinitely if lazy
     # Using "with" will cause the file to be closed
-    # with h5py.File(filename, mode='r') as h5_f:
-    h5_f = h5py.File(filename, mode='r')
+    h5_f = h5py.File(filename, mode='r+' if lazy else 'r')
     if dataset_path is None:
-        """
-        if not kwds.get('lazy', True):
-            warn('In order to safely load multiple large datasets to memory, '
-                 'please consider setting the kwarg lazy=True')
-        """
         all_main_dsets = usid.hdf_utils.get_all_main(h5_f)
         signals = []
         for h5_dset in all_main_dsets:
@@ -431,7 +425,8 @@ def file_reader(filename, dataset_path=None, ignore_non_linear_dims=True,
             # Should not append
             signals += _usidataset_to_signal(h5_dset,
                                              ignore_non_linear_dims=
-                                             ignore_non_linear_dims, **kwds)
+                                             ignore_non_linear_dims,
+                                             lazy=lazy, **kwds)
         return signals
     else:
         if not isinstance(dataset_path, str):
@@ -439,10 +434,11 @@ def file_reader(filename, dataset_path=None, ignore_non_linear_dims=True,
         h5_dset = h5_f[dataset_path]
         return _usidataset_to_signal(h5_dset,
                                      ignore_non_linear_dims=
-                                     ignore_non_linear_dims, **kwds)
+                                     ignore_non_linear_dims,
+                                     lazy=lazy, **kwds)
 
     # At least close the file handle if not lazy load
-    if not kwds.get('lazy', True):
+    if not lazy:
         h5_f.close()
 
 

--- a/hyperspy/tests/io/test_usid.py
+++ b/hyperspy/tests/io/test_usid.py
@@ -326,7 +326,7 @@ class TestHS2USIDlazy:
     def test_base_nd(self):
         sig = hs.signals.Signal2D(da.random.randint(0, high=100,
                                                     size=(2, 3, 5, 7),
-                                                    chunks='auto'))
+                                                    chunks='auto')).as_lazy()
         with tempfile.TemporaryDirectory() as tmp_dir:
             file_path = tmp_dir + 'usid_n_pos_n_spec_dask.h5'
         sig.save(file_path)
@@ -434,7 +434,8 @@ class TestUSID2HSbase:
                                  sig_type=hs.signals.BaseSignal,
                                  axes_to_spec=[])
 
-    def base_n_pos_m_spec(self, lazy, slow_to_fast=True):
+    @pytest.mark.parametrize('lazy', [True, False])
+    def test_base_n_pos_m_spec(self, lazy, slow_to_fast=True):
         phy_quant = 'Current'
         phy_unit = 'nA'
         ret_vals = gen_2pos_2spec(s2f_aux=slow_to_fast)
@@ -449,12 +450,6 @@ class TestUSID2HSbase:
         compare_signal_from_usid(file_path, ndata, new_sig,
                                  sig_type=hs.signals.BaseSignal,
                                  axes_to_spec=['Frequency', 'Bias'])
-
-    def test_n_pos_m_spec(self):
-        self.base_n_pos_m_spec(False)
-
-    def test_lazy_load(self):
-        self.base_n_pos_m_spec(True)
 
 
 @pytest.mark.filterwarnings("ignore:This dataset does not have an N-dimensional form:UserWarning")


### PR DESCRIPTION
Use `"r"` in favor of `"r+"` when possible because using `"r+"` change the "last modified" timestamp of the file and only reading a file shouldn't it.

### Progress of the PR
- [x] Use `mode="r"` in favor of `"r+"` in `hdf5.File` when possible,
- [x] fix wrong argument in user guide,
- [x] ready for review.


