### PR TITLE
Bugfix for a channel_switches issue with 2d models fits

### DIFF
--- a/hyperspy/models/model2d.py
+++ b/hyperspy/models/model2d.py
@@ -164,7 +164,7 @@ class Model2D(BaseModel):
             for component in self:  # Cut the parameters list
                 np.add(sum_, component.function(self.xaxis, self.yaxis),
                        sum_)
-        return sum_
+        return sum_[self.channel_switches]
 
     def _errfunc(self, param, y, weights=None):
         if weights is None:

--- a/hyperspy/tests/model/test_model2d.py
+++ b/hyperspy/tests/model/test_model2d.py
@@ -159,3 +159,34 @@ def test_Model2D_NotImplementedError_plot():
     for member_f in ["_plot_component", "_connect_component_line"]:
         with pytest.raises(NotImplementedError):
             _ = getattr(m, member_f)(None)
+
+def test_channelswitches_mask():
+    g = hs.model.components2D.Gaussian2D(
+        A=1, centre_x=-5.0, centre_y=-5.0, sigma_x=1.0, sigma_y=2.0
+    )
+
+    scale = 0.1
+    x = np.arange(-10, 10, scale)
+    y = np.arange(-10, 10, scale)
+    X, Y = np.meshgrid(x, y)
+
+    im = hs.signals.Signal2D(g.function(X, Y))
+    im.axes_manager[0].scale = scale
+    im.axes_manager[0].offset = -10
+    im.axes_manager[1].scale = scale
+    im.axes_manager[1].offset = -10
+
+    mask = (im<0.01).data
+
+    m = im.create_model()
+    gt = hs.model.components2D.Gaussian2D(centre_x=-4.5,
+                                          centre_y=-4.5,
+                                          sigma_x=0.5,
+                                          sigma_y=1.5)
+    m.append(gt)
+    m.fit()
+
+    np.testing.assert_allclose(gt.centre_x.value, -5.)
+    np.testing.assert_allclose(gt.centre_y.value, -5.)
+    np.testing.assert_allclose(gt.sigma_x.value, 1.)
+    np.testing.assert_allclose(gt.sigma_y.value, 2.)


### PR DESCRIPTION
### Description of the change
2dmodel.py is not taking into account the channel_switches when evaluating components on the axes, resulting in an error.
Doing what @ericpre is describing here was raising an error: 

>If I understand correctly, your aim is to able to use arbitrary mask to define the fitting ranges. `channel_switches` is actually the >mask, so you can simply do:
>```python
>m.channel_switches = your_mask
>```
>The only thing missing really is to document it in the user guide and in a couple of docstrings!
>
_Originally posted by @ericpre in https://github.com/hyperspy/hyperspy/issues/2454#issuecomment-683442074_

This PR fixes this. Example code below

### Progress of the PR
- [x] Change implemented (can be split into several points),
- [ ] update docstring (if appropriate),
- [ ] update user guide (if appropriate),
- [x] add tests,
- [x] ready for review.

### Minimal example of the bug fix or the new feature
```python
g = hs.model.components2D.Gaussian2D(A=1,
                                     centre_x=-5.0, 
                                     centre_y=-5.0, 
                                     sigma_x=1.0, 
                                     sigma_y=2.0
                                    )
scale = 0.1
x = np.arange(-10, 10, scale)
y = np.arange(-10, 10, scale)
X, Y = np.meshgrid(x, y)

im = hs.signals.Signal2D(g.function(X, Y))
im.axes_manager[0].scale = scale
im.axes_manager[0].offset = -10
im.axes_manager[1].scale = scale
im.axes_manager[1].offset = -10

m = im.create_model()
gt = hs.model.components2D.Gaussian2D()
m.append(gt)

mask = im<0.01
m.channel_switches = ~mask.data

m.fit()
---------------------------------------------------------------------------
ValueError                                Traceback (most recent call last)
<ipython-input-2-e19ac3d78e8f> in <module>
     30 m.channel_switches = ~mask.data
     31 
---> 32 m.fit()

~\Miniconda3\envs\hs\lib\site-packages\hyperspy\model.py in fit(self, optimizer, loss_function, grad, bounded, update_plot, print_info, return_info, fd_scheme, **kwargs)
   1396                         args=args,
   1397                         full_output=True,
-> 1398                         **kwargs,
   1399                     )
   1400 

~\Miniconda3\envs\hs\lib\site-packages\scipy\optimize\minpack.py in leastsq(func, x0, args, Dfun, full_output, col_deriv, ftol, xtol, gtol, maxfev, epsfcn, factor, diag)
    408     if not isinstance(args, tuple):
    409         args = (args,)
--> 410     shape, dtype = _check_func('leastsq', 'func', func, x0, args, n)
    411     m = shape[0]
    412 

~\Miniconda3\envs\hs\lib\site-packages\scipy\optimize\minpack.py in _check_func(checker, argname, thefunc, x0, args, numinputs, output_shape)
     22 def _check_func(checker, argname, thefunc, x0, args, numinputs,
     23                 output_shape=None):
---> 24     res = atleast_1d(thefunc(*((x0[:numinputs],) + args)))
     25     if (output_shape is not None) and (shape(res) != output_shape):
     26         if (output_shape[0] != 1):

~\Miniconda3\envs\hs\lib\site-packages\hyperspy\models\model2d.py in _errfunc(self, param, y, weights)
    170         if weights is None:
    171             weights = 1.
--> 172         errfunc = self._model_function(param).ravel() - y
    173         return errfunc * weights
    174 

ValueError: operands could not be broadcast together with shapes (40000,) (2609,) 
```
With this PR, this code runs correctly and outputs a nicely masked fitted gaussian
 <img src="https://user-images.githubusercontent.com/37581871/94516515-4683fd00-0226-11eb-8de7-bded3b34c1ad.png" width="400" height="400">

