### PR TITLE
Add visibility boolean for all markers, only used by text markers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,6 +46,7 @@ hyperspy/misc/etc/test_compilers.obj
 *nbc
 *nbi
 hyperspy/tests/io/edax_files.zip
+htmlcov/
 
 ### Code ###
 # Visual Studio Code - https://code.visualstudio.com/

--- a/hyperspy/drawing/_markers/text.py
+++ b/hyperspy/drawing/_markers/text.py
@@ -56,11 +56,11 @@ class Text(MarkerBase):
     >>> s.add_marker(m, permanent=True)
     """
 
-    def __init__(self, x, y, text, **kwargs):
+    def __init__(self, x, y, text, visible=None, **kwargs):
         MarkerBase.__init__(self)
         lp = {'color': 'black'}
         self.marker_properties = lp
-        self.set_data(x1=x, y1=y, text=text)
+        self.set_data(x1=x, y1=y, text=text, visible=visible)
         self.set_marker_properties(**kwargs)
         self.name = 'text'
 
@@ -81,8 +81,13 @@ class Text(MarkerBase):
         self.marker.set_position([self.get_data_position('x1'),
                                   self.get_data_position('y1')])
         self.marker.set_text(self.get_data_position('text'))
+        self.marker.set_visible(self.get_data_position('visible'))
 
     def _plot_marker(self):
         self.marker = self.ax.text(
-            self.get_data_position('x1'), self.get_data_position('y1'),
-            self.get_data_position('text'), **self.marker_properties)
+            x=self.get_data_position('x1'),
+            y=self.get_data_position('y1'),
+            s=self.get_data_position('text'),
+            visible=self.get_data_position('visible'),
+            **self.marker_properties,
+        )

--- a/hyperspy/drawing/_markers/text.py
+++ b/hyperspy/drawing/_markers/text.py
@@ -33,6 +33,10 @@ class Text(MarkerBase):
         The position of the text in y. see x arguments
     text : array or str
         The text. see x arguments
+    visible : bool, optional
+        Whether to plot the marker, default is True. This is useful when
+        adding a marker that changes with signal navigation index, but is
+        not visibile in all indices.
     kwargs :
         Keywords argument of axvline valid properties (i.e. recognized by
         mpl.plot).
@@ -56,7 +60,7 @@ class Text(MarkerBase):
     >>> s.add_marker(m, permanent=True)
     """
 
-    def __init__(self, x, y, text, visible=None, **kwargs):
+    def __init__(self, x, y, text, visible=True, **kwargs):
         MarkerBase.__init__(self)
         lp = {'color': 'black'}
         self.marker_properties = lp
@@ -73,7 +77,7 @@ class Text(MarkerBase):
             self.get_data_position('text'),
             self.marker_properties['color'],
         )
-        return(string)
+        return string
 
     def update(self):
         if self.auto_update is False:

--- a/hyperspy/drawing/marker.py
+++ b/hyperspy/drawing/marker.py
@@ -93,7 +93,7 @@ class MarkerBase(object):
             'marker_type': self.__class__.__name__,
             'plot_on_signal': self._plot_on_signal,
             'data': {k: self.data[k][()].tolist() for k in (
-                'x1', 'x2', 'y1', 'y2', 'text', 'size')}
+                'x1', 'x2', 'y1', 'y2', 'text', 'size', 'visible')}
         }
         return marker_dict
 
@@ -116,19 +116,40 @@ class MarkerBase(object):
         """
         self.marker_properties = kwargs
 
-    def set_data(self, x1=None, y1=None,
-                 x2=None, y2=None, text=None, size=None):
+    def set_data(
+        self,
+        x1=None,
+        y1=None,
+        x2=None,
+        y2=None,
+        text=None,
+        size=None,
+        visible=None,
+    ):
+        """Set data to the structured array. Each field of data should
+        have the same dimensions than the navigation axes. The other
+        fields are overwritten.
         """
-        Set data to the structured array. Each field of data should have
-        the same dimensions than the navigation axes. The other fields are
-        overwritten.
-        """
-        self.data = np.array((np.array(x1), np.array(y1),
-                              np.array(x2), np.array(y2),
-                              np.array(text), np.array(size)),
-                             dtype=[('x1', object), ('y1', object),
-                                    ('x2', object), ('y2', object),
-                                    ('text', object), ('size', object)])
+        self.data = np.array(
+            (
+                np.array(x1),
+                np.array(y1),
+                np.array(x2),
+                np.array(y2),
+                np.array(text),
+                np.array(size),
+                np.array(visible),
+            ),
+            dtype=[
+                ('x1', object),
+                ('y1', object),
+                ('x2', object),
+                ('y2', object),
+                ('text', object),
+                ('size', object),
+                ('visible', object)
+            ]
+        )
         self._is_marker_static()
 
     def add_data(self, **kwargs):

--- a/hyperspy/drawing/marker.py
+++ b/hyperspy/drawing/marker.py
@@ -124,7 +124,7 @@ class MarkerBase(object):
         y2=None,
         text=None,
         size=None,
-        visible=None,
+        visible=None,  # Or True?
     ):
         """Set data to the structured array. Each field of data should
         have the same dimensions than the navigation axes. The other

--- a/hyperspy/tests/drawing/test_plot_markers.py
+++ b/hyperspy/tests/drawing/test_plot_markers.py
@@ -494,12 +494,16 @@ def test_iterate_markers():
     index = np.array([peak_local_max(im.data, min_distance=100,
                                      num_peaks=4) for im in ims])
     # Add multiple markers
+    # Numbers "1" and "2" are not visible in the 1st and 2nd image, respectively
+    visible = [[True] * 3, [False, True, True], [True, None, True], [True] * 3]
     for i in range(4):
         xs = index[:, i, 1]
         ys = index[:, i, 0]
         m = markers.point(x=xs, y=ys, color='red')
         ims.add_marker(m, plot_marker=True, permanent=True)
-        m = markers.text(x=10 + xs, y=10 + ys, text=str(i), color='k')
+        m = markers.text(
+            x=10 + xs, y=10 + ys, text=str(i), color='k', visible=visible[i]
+        )
         ims.add_marker(m, plot_marker=True, permanent=True)
     xs = index[:, :, 1]
     ys = index[:, :, 0]
@@ -523,6 +527,13 @@ def test_iterate_markers():
             assert mo.get_data_position('text') == mi.get_data_position('text')
             assert mo.marker_properties['color'] == \
                 mi.marker_properties['color']
+            assert mo.get_data_position('visible') == mi.get_data_position('visible')
+
+    # Ensure text markers' visibility are as set above
+    for i, im in enumerate(ims):
+        mi = im.metadata.Markers
+        for j, tm in enumerate([mi.text, mi.text1, mi.text2, mi.text3]):
+            assert tm.get_data_position("visible") == visible[j][i]
 
 
 @update_close_figure


### PR DESCRIPTION
Signed-off-by: Håkon Wiik Ånes <hwaanes@gmail.com>

### Description of the change
I've added a `visible` parameter to the `MarkerBase.data` array, used by `Text` markers so that the call to `ax.draw_artist()` in `BlittedFigure._draw_animated()` for those markers with `visible=False` aren't drawn:
* Add `visible` parameter to `hyperspy.drawing._markers.text.Text.__init__()`, default to True, passed to `set_data()`. Docstring updated with a brief explanation of when it is useful.
* Add `visible` parameter to `hyperspy.drawing.marker.MarkerBase.set_data()`
* Update methods `Text._plot_marker()` and `Text.update()` to pass on the `visible` parameter to Matplotlib

Why? I'm implementing geometrical simulations of EBSD patterns, i.e. detector positions of Kikuchi bands and zone axes, in kikuchipy, and add these as markers to an EBSD signal as seen in the bottom GIF. Markers are added as iterables over the navigation shape. Not all bands/zone axes appear in all patterns, so setting `LineSegment` (bands) and `Point` (zone axes) coordinates to `np.nan` for some navigation indices ensures they are only plotted where they are present. However, setting `Text` (zone axes labels) coordinates to `np.nan` results in [`matplotlib.text.Text.draw()` writing a log warning to stdout](https://github.com/matplotlib/matplotlib/blob/master/lib/matplotlib/text.py#L677) for each marker... I therefore decided to set the `Text` coordinates of zone axes labels not present in a navigation point to (0, 0) and instead pass `visible=False` to `Text`, which [doesn't draw the marker](https://matplotlib.org/api/text_api.html#matplotlib.text.Annotation.draw), and thus solves my problem.

### Progress of the PR
- [x] Update docstring
- [x] Add to existing test `hyperspy.tests.drawing.test_plot_markers.test_iterate_markers()`.
- [x] Ready for review

### Minimal example of the bug fix or the new feature
Taken from the test `hyperspy.tests.drawing.test_plot_markers.test_iterate_markers()`:

```python
>>> import matplotlib
>>> matplotlib.rcParams["backend"] = "qt5agg"
>>> import matplotlib.pyplot as plt
>>> import numpy as np
>>> import scipy.misc
>>> from skimage.feature import peak_local_max
>>> from hyperspy.signal import BaseSignal
>>> from hyperspy.utils import markers
>>> ims = BaseSignal(scipy.misc.face()).as_signal2D([1, 2])
>>> index = np.array(
...     [peak_local_max(im.data, min_distance=100, num_peaks=4) for im in ims]
... )
# Make text markers "1" ("2") not visible in 0th (1st) image
>>> visible = [[True] * 3, [False, True, True], [True, None, True], [True] * 3]
>>> for i in range(4):
...     xs = index[:, i, 1]
...     ys = index[:, i, 0]
...     m = markers.text(
...         x=10 + xs, y=10 + ys, text=str(i), color='r', visible=visible[i], size=20
...     )
...     ims.add_marker(m, plot_marker=True, permanent=True)
>>> ims.plot()  # Observe that markers "1" ("2") are not visible in 0th (1st) image
>>> plt.show()  # Needed this in PyCharm for some reason today...
```

### Motivational GIF

![Peek 07-10-2020 22-25](https://user-images.githubusercontent.com/12139781/95383963-3f2ab680-08ec-11eb-94d1-8cd91ab003d0.gif)