### PR TITLE
Model plotting improvement and fixes

### DIFF
--- a/hyperspy/events.py
+++ b/hyperspy/events.py
@@ -494,6 +494,7 @@ class EventSuppressor(object):
 
     def _is_tuple_target(self, candidate):
         v = (isinstance(candidate, Iterable) and
+             not isinstance(candidate, Events) and
              len(candidate) == 2 and
              isinstance(candidate[0], (Event, Events)) and
              callable(candidate[1]))
@@ -517,7 +518,8 @@ class EventSuppressor(object):
          - Any iterable collection of the above target types
         """
         # Remove useless layers of iterables:
-        while isinstance(to_suppress, Iterable) and len(to_suppress) == 1:
+        while (isinstance(to_suppress, Iterable) and
+               not isinstance(to_suppress, Events) and len(to_suppress) == 1):
             to_suppress = to_suppress[0]
         # If single target passed, add directly:
         if self._is_target(to_suppress):

--- a/hyperspy/model.py
+++ b/hyperspy/model.py
@@ -853,7 +853,7 @@ class BaseModel(list):
             if component.active:
                 component.store_current_parameters_in_map()
 
-    def fetch_stored_values(self, only_fixed=False):
+    def fetch_stored_values(self, only_fixed=False, update_on_resume=True):
         """Fetch the value of the parameters that has been previously stored.
 
         Parameters
@@ -861,15 +861,24 @@ class BaseModel(list):
         only_fixed : bool, optional
             If True, only the fixed parameters are fetched.
 
+        update_on_resume : bool, optional
+            If True, update the model plot after values are updated.
+
         See Also
         --------
         store_current_values
 
         """
         cm = self.suspend_update if self._plot_active else dummy_context_manager
-        with cm(update_on_resume=True):
+        with cm(update_on_resume=update_on_resume):
             for component in self:
                 component.fetch_stored_values(only_fixed=only_fixed)
+
+    def _on_navigating(self):
+        """Same as fetch_stored_values but without update_on_resume since
+        the model plot is updated in the figure update callback.
+        """
+        self.fetch_stored_values(only_fixed=False, update_on_resume=False)
 
     def fetch_values_from_array(self, array, array_std=None):
         """Fetch the parameter values from the given array, optionally also

--- a/hyperspy/model.py
+++ b/hyperspy/model.py
@@ -404,9 +404,9 @@ class BaseModel(list):
         thing.model = self
         setattr(self.components, slugify(name_string,
                                          valid_variable_name=True), thing)
-        if self._plot_active is True:
+        if self._plot_active:
             self._connect_parameters2update_plot(components=[thing])
-        self.update_plot(render_figure=True, update_ylimits=True)
+            self.signal._plot.signal_plot.update()
 
     def extend(self, iterable):
         for object in iterable:
@@ -453,7 +453,7 @@ class BaseModel(list):
             list.remove(self, athing)
             athing.model = None
         if self._plot_active:
-            self.update_plot(render_figure=True, update_ylimits=False)
+            self.signal._plot.signal_plot.update()
 
     def as_signal(self, component_list=None, out_of_range_to_nan=True,
                   show_progressbar=None, out=None, **kwargs):

--- a/hyperspy/model.py
+++ b/hyperspy/model.py
@@ -633,8 +633,8 @@ class BaseModel(list):
                     es.add(p.events, f)
 
         for c in self:
-            if hasattr(c, '_model_plot_line'):
-                f = c._model_plot_line._auto_update_line
+            if hasattr(c, '_component_line'):
+                f = c._component_line._auto_update_line
                 es.add(c.events, f)
                 for p in c.parameters:
                     es.add(p.events, f)
@@ -659,43 +659,11 @@ class BaseModel(list):
         self._disconnect_parameters2update_plot(components=self)
         self._model_line = None
 
-    @staticmethod
-    def _connect_component_line(component):
-        if hasattr(component, "_model_plot_line"):
-            f = component._model_plot_line._auto_update_line
-            component.events.active_changed.connect(f, [])
-            for parameter in component.parameters:
-                parameter.events.value_changed.connect(f, [])
-
-    @staticmethod
-    def _disconnect_component_line(component):
-        if hasattr(component, "_model_plot_line"):
-            f = component._model_plot_line._auto_update_line
-            component.events.active_changed.disconnect(f)
-            for parameter in component.parameters:
-                parameter.events.value_changed.disconnect(f)
-
-    def _connect_component_lines(self):
-        for component in self:
-            if component.active:
-                self._connect_component_line(component)
-
-    def _disconnect_component_lines(self):
-        for component in self:
-            if component.active:
-                self._disconnect_component_line(component)
-
-    @staticmethod
-    def _update_component_line(component):
-        if hasattr(component, "_model_plot_line"):
-            component._model_plot_line.update(render_figure=False,
-                                              update_ylimits=False)
-
     def _disable_plot_component(self, component):
         self._disconnect_component_line(component)
-        if hasattr(component, "_model_plot_line"):
-            component._model_plot_line.close()
-            del component._model_plot_line
+        if hasattr(component, "_component_line"):
+            component._component_line.close()
+            del component._component_line
         self._plot_components = False
 
     def enable_plot_components(self):

--- a/hyperspy/model.py
+++ b/hyperspy/model.py
@@ -660,26 +660,20 @@ class BaseModel(list):
         self._disconnect_parameters2update_plot(components=self)
         self._model_line = None
 
-    def _disable_plot_component(self, component):
-        self._disconnect_component_line(component)
-        if hasattr(component, "_component_line"):
-            component._component_line.close()
-            del component._component_line
-        self._plot_components = False
-
     def enable_plot_components(self):
         if self._plot is None or self._plot_components:
             return
-        self._plot_components = True
         for component in [component for component in self if
                           component.active]:
             self._plot_component(component)
+        self._plot_components = True
 
     def disable_plot_components(self):
         if self._plot is None:
             return
-        for component in self:
-            self._disable_plot_component(component)
+        if self._plot_components:
+            for component in self:
+                self._disable_plot_component(component)
         self._plot_components = False
 
     def _set_p0(self):

--- a/hyperspy/model.py
+++ b/hyperspy/model.py
@@ -627,8 +627,11 @@ class BaseModel(list):
             f = self._model_line._auto_update_line
             for c in self:
                 es.add(c.events, f)
+                if c._position:
+                    es.add(c._position.events)
                 for p in c.parameters:
                     es.add(p.events, f)
+
         for c in self:
             if hasattr(c, '_model_plot_line'):
                 f = c._model_plot_line._auto_update_line
@@ -643,6 +646,11 @@ class BaseModel(list):
         self._suspend_update = old
 
         if update_on_resume is True:
+            for c in self:
+                position = c._position
+                if position:
+                    position.events.value_changed.trigger(
+                        obj=position, value=position.value)
             self.update_plot(render_figure=True, update_ylimits=False)
 
     def _close_plot(self):

--- a/hyperspy/model.py
+++ b/hyperspy/model.py
@@ -1241,13 +1241,12 @@ class BaseModel(list):
                 # differentiation, but for consistency across all three
                 # we enforce estimation below, and raise an error here.
                 raise ValueError(
-                    f"`optimizer='{optimizer}'` does not support `grad=None`. "
-                    f"Please use `grad='auto'` instead."
+                    f"`optimizer='{optimizer}'` does not support `grad=None`."
                 )
         else:
             raise ValueError(
-                "`grad` must be one of ['auto', 'analytical', "
-                f"callable, None], not '{grad}'"
+                "`grad` must be one of ['analytical', callable, None], not "
+                f"'{grad}'."
             )
 
         with cm(update_on_resume=True):

--- a/hyperspy/model.py
+++ b/hyperspy/model.py
@@ -1628,6 +1628,9 @@ class BaseModel(list):
 
                             if autosave and i % autosave_every == 0:
                                 self.save_parameters2file(autosave_fn)
+            # Trigger the indices_changed event to update to current indices,
+            # since the callback was suppressed
+            self.axes_manager.events.indices_changed.trigger(self.axes_manager)
 
         if autosave is True:
             _logger.info(f"Deleting temporary file: {autosave_fn}.npz")

--- a/hyperspy/model.py
+++ b/hyperspy/model.py
@@ -606,9 +606,10 @@ class BaseModel(list):
                 if self._model_line is not None:
                     self._model_line.update(render_figure=render_figure,
                                             update_ylimits=update_ylimits)
-                for component in [component for component in self if
-                                  component.active is True]:
-                    self._update_component_line(component)
+                if self._plot_components:
+                    for component in [component for component in self if
+                                      component.active is True]:
+                        self._update_component_line(component)
             except BaseException:
                 self._disconnect_parameters2update_plot(components=self)
 

--- a/hyperspy/models/model1d.py
+++ b/hyperspy/models/model1d.py
@@ -780,7 +780,6 @@ class Model1D(BaseModel):
         component._component_line = line
         self._connect_component_line(component)
 
-
     def _disable_plot_component(self, component):
         self._disconnect_component_line(component)
         if hasattr(component, "_component_line"):

--- a/hyperspy/models/model1d.py
+++ b/hyperspy/models/model1d.py
@@ -89,18 +89,17 @@ class ComponentFit(SpanSelectorInSignal1D):
         only_current = self.only_current
         if self.estimate_parameters:
             if hasattr(self.component, 'estimate_parameters'):
-                if (self.signal_range != "interactive" and
-                        self.signal_range is not None):
-                    self.component.estimate_parameters(
-                        self.signal,
-                        self.signal_range[0],
-                        self.signal_range[1],
-                        only_current=only_current)
-                elif self.signal_range == "interactive":
+                if self.signal_range == "interactive":
                     self.component.estimate_parameters(
                         self.signal,
                         self.ss_left_value,
                         self.ss_right_value,
+                        only_current=only_current)
+                elif self.signal_range is not None:
+                    self.component.estimate_parameters(
+                        self.signal,
+                        self.signal_range[0],
+                        self.signal_range[1],
                         only_current=only_current)
 
         if only_current:
@@ -755,16 +754,6 @@ class Model1D(BaseModel):
             for parameter in component.parameters:
                 parameter.events.value_changed.disconnect(f)
 
-    def _connect_component_lines(self):
-        for component in self:
-            if component.active:
-                self._connect_component_line(component)
-
-    def _disconnect_component_lines(self):
-        for component in self:
-            if component.active:
-                self._disconnect_component_line(component)
-
     @staticmethod
     def _update_component_line(component):
         if hasattr(component, "_component_line"):
@@ -795,7 +784,7 @@ class Model1D(BaseModel):
         self._model_line = None
 
     def enable_plot_components(self):
-        if self._plot is None or self._plot_components:
+        if self._plot is None or self._plot_components:  # pragma: no cover
             return
         self._plot_components = True
         for component in [component for component in self if
@@ -804,7 +793,7 @@ class Model1D(BaseModel):
 
     def disable_plot_components(self):
         self._plot_components = False
-        if self._plot is None:
+        if self._plot is None:  # pragma: no cover
             return
         for component in self:
             self._disable_plot_component(component)

--- a/hyperspy/models/model1d.py
+++ b/hyperspy/models/model1d.py
@@ -264,10 +264,9 @@ class Model1D(BaseModel):
         self._plot_components = False
         self._suspend_update = False
         self._model_line = None
-        self._adjust_position_all = None
         self.axis = self.axes_manager.signal_axes[0]
         self.axes_manager.events.indices_changed.connect(
-            self.fetch_stored_values, [])
+            self._on_navigating, [])
         self.channel_switches = np.array([True] * len(self.axis.axis))
         self.chisq = signal1D._get_navigation_signal()
         self.chisq.change_dtype("float")

--- a/hyperspy/models/model1d.py
+++ b/hyperspy/models/model1d.py
@@ -782,11 +782,8 @@ class Model1D(BaseModel):
         self._plot_components = False
 
     def _close_plot(self):
-        if self._plot_components is True:
-            self.disable_plot_components()
         self.disable_adjust_position()
-        self._disconnect_parameters2update_plot(components=self)
-        self._model_line = None
+        super()._close_plot()
 
     def enable_plot_components(self):
         if self._plot is None or self._plot_components:  # pragma: no cover

--- a/hyperspy/models/model1d.py
+++ b/hyperspy/models/model1d.py
@@ -362,8 +362,8 @@ class Model1D(BaseModel):
             if parameter in self._position_widgets:
                 for pw in reversed(self._position_widgets[parameter]):
                     pw.close()
-            if hasattr(thing, '_model_plot_line'):
-                line = thing._model_plot_line
+            if hasattr(thing, '_component_line'):
+                line = thing._component_line
                 line.close()
         super(Model1D, self).remove(things)
         self._disconnect_parameters2update_plot(things)
@@ -741,16 +741,16 @@ class Model1D(BaseModel):
 
     @staticmethod
     def _connect_component_line(component):
-        if hasattr(component, "_model_plot_line"):
-            f = component._model_plot_line._auto_update_line
+        if hasattr(component, "_component_line"):
+            f = component._component_line._auto_update_line
             component.events.active_changed.connect(f, [])
             for parameter in component.parameters:
                 parameter.events.value_changed.connect(f, [])
 
     @staticmethod
     def _disconnect_component_line(component):
-        if hasattr(component, "_model_plot_line"):
-            f = component._model_plot_line._auto_update_line
+        if hasattr(component, "_component_line"):
+            f = component._component_line._auto_update_line
             component.events.active_changed.disconnect(f)
             for parameter in component.parameters:
                 parameter.events.value_changed.disconnect(f)
@@ -765,25 +765,27 @@ class Model1D(BaseModel):
             if component.active:
                 self._disconnect_component_line(component)
 
+    @staticmethod
+    def _update_component_line(component):
+        if hasattr(component, "_component_line"):
+            component._component_line.update(render_figure=False,
+                                             update_ylimits=False)
+
     def _plot_component(self, component):
         line = hyperspy.drawing.signal1d.Signal1DLine()
         line.data_function = component._component2plot
         # Add the line to the figure
         self._plot.signal_plot.add_line(line)
         line.plot()
-        component._model_plot_line = line
+        component._component_line = line
         self._connect_component_line(component)
 
-    @staticmethod
-    def _update_component_line(component):
-        if hasattr(component, "_model_plot_line"):
-            component._model_plot_line.update()
 
     def _disable_plot_component(self, component):
         self._disconnect_component_line(component)
-        if hasattr(component, "_model_plot_line"):
-            component._model_plot_line.close()
-            del component._model_plot_line
+        if hasattr(component, "_component_line"):
+            component._component_line.close()
+            del component._component_line
         self._plot_components = False
 
     def _close_plot(self):

--- a/hyperspy/models/model2d.py
+++ b/hyperspy/models/model2d.py
@@ -254,6 +254,10 @@ class Model2D(BaseModel):
     def _connect_component_line(component):
         raise NotImplementedError
 
+    @staticmethod
+    def _disconnect_component_line(component):
+        raise NotImplementedError
+
     def _plot_component(self, component):
         raise NotImplementedError
 

--- a/hyperspy/models/model2d.py
+++ b/hyperspy/models/model2d.py
@@ -95,12 +95,11 @@ class Model2D(BaseModel):
         self._plot_components = False
         self._suspend_update = False
         self._model_line = None
-        self._adjust_position_all = None
         self.xaxis, self.yaxis = np.meshgrid(
             self.axes_manager.signal_axes[0].axis,
             self.axes_manager.signal_axes[1].axis)
         self.axes_manager.events.indices_changed.connect(
-            self.fetch_stored_values, [])
+            self._on_navigating, [])
         self.channel_switches = np.ones(self.xaxis.shape, dtype=bool)
         self.chisq = signal2D._get_navigation_signal()
         self.chisq.change_dtype("float")

--- a/hyperspy/tests/component/test_components.py
+++ b/hyperspy/tests/component/test_components.py
@@ -296,10 +296,17 @@ class TestPolynomial:
 
     def test_gradient(self):
         poly = self.m[0]
-        assert poly.a2.grad(1) == 1
-        assert poly.a1.grad(1) == 1
-        assert poly.a0.grad(1) == 1
-        assert poly.a2.grad(np.arange(10)).shape == (10,)
+        np.testing.assert_allclose(poly.a2.grad(np.arange(3)), np.array([0, 1, 4]))
+        np.testing.assert_allclose(poly.a1.grad(np.arange(3)), np.array([0, 1, 2]))
+        np.testing.assert_allclose(poly.a0.grad(np.arange(3)), np.array([1, 1, 1]))
+
+    def test_fitting(self):
+        s_2d = self.m_2d.signal
+        s_2d.data += 100 * np.array([np.random.randint(50, size=10)]*100).T
+        m_2d = s_2d.create_model()
+        m_2d.append(hs.model.components1D.Polynomial(order=1, legacy=False))
+        m_2d.multifit(iterpath='serpentine', grad='analytical')
+        np.testing.assert_allclose(m_2d.red_chisq.data.sum(), 0.0, atol=1E-7)
 
     @pytest.mark.parametrize(("only_current", "binned"), TRUE_FALSE_2_TUPLE)
     def test_estimate_parameters(self,  only_current, binned):

--- a/hyperspy/tests/drawing/test_plot_model.py
+++ b/hyperspy/tests/drawing/test_plot_model.py
@@ -142,11 +142,14 @@ def test_fit_EELS_convolved(convolved):
 
 def test_plot_component():
     m = hs.signals.Signal1D(np.arange(100).reshape(2, 50)).create_model()
-    components = [hs.model.components1D.Gaussian(A=250, sigma=5, centre=20),
-                  hs.model.components1D.Offset(10)]
-    m.extend(components)
+    m.append(hs.model.components1D.Gaussian(A=250, sigma=5, centre=20))
     m.plot(plot_components=True)
-    m.multifit(iterpath='serpentine')
-    m.update_plot()
+    ax = m.signal._plot.signal_plot.ax
+    p = hs.model.components1D.Polynomial(order=1, legacy=False, a0=-10, a1=0)
+    m.append(p)
+    assert ax.get_ylim() == (-10.1, 49.0)
     m.remove(0)
+    p.estimate_parameters(m.signal, 0, 50)
+    assert ax.get_ylim() == (-10.1, 49.0)
     m.remove(0)
+    assert ax.get_ylim() == (-0.1, 49.0)

--- a/hyperspy/tests/drawing/test_plot_model.py
+++ b/hyperspy/tests/drawing/test_plot_model.py
@@ -75,17 +75,9 @@ def create_sum_of_gaussians(convolved=False):
     return s
 
 
-def _generate_parameters():
-    parameters = []
-    for convolved in [True, False]:
-        for plot_component in [True, False]:
-            for binned in [True, False]:
-                parameters.append([convolved, plot_component, binned])
-    return parameters
-
-
-@pytest.mark.parametrize(("convolved", "plot_component", "binned"),
-                         _generate_parameters())
+@pytest.mark.parametrize("convolved", [True, False])
+@pytest.mark.parametrize("plot_component", [True, False])
+@pytest.mark.parametrize("binned", [True, False])
 @pytest.mark.mpl_image_compare(
     baseline_dir=baseline_dir, tolerance=default_tol)
 def test_plot_gaussian_eelsmodel(convolved, plot_component, binned):
@@ -146,3 +138,15 @@ def test_fit_EELS_convolved(convolved):
     m.fit(kind='smart')
     m.plot(plot_components=True)
     return m._plot.signal_plot.figure
+
+
+def test_plot_component():
+    m = hs.signals.Signal1D(np.arange(100).reshape(2, 50)).create_model()
+    components = [hs.model.components1D.Gaussian(A=250, sigma=5, centre=20),
+                  hs.model.components1D.Offset(10)]
+    m.extend(components)
+    m.plot(plot_components=True)
+    m.multifit(iterpath='serpentine')
+    m.update_plot()
+    m.remove(0)
+    m.remove(0)

--- a/hyperspy/tests/drawing/test_plot_model.py
+++ b/hyperspy/tests/drawing/test_plot_model.py
@@ -153,3 +153,5 @@ def test_plot_component():
     assert ax.get_ylim() == (-10.1, 49.0)
     m.remove(0)
     assert ax.get_ylim() == (-0.1, 49.0)
+    m.append(p)
+    m.signal._plot.close()

--- a/hyperspy/tests/drawing/test_plot_model.py
+++ b/hyperspy/tests/drawing/test_plot_model.py
@@ -75,9 +75,9 @@ def create_sum_of_gaussians(convolved=False):
     return s
 
 
-@pytest.mark.parametrize("convolved", [True, False])
-@pytest.mark.parametrize("plot_component", [True, False])
 @pytest.mark.parametrize("binned", [True, False])
+@pytest.mark.parametrize("plot_component", [True, False])
+@pytest.mark.parametrize("convolved", [True, False])
 @pytest.mark.mpl_image_compare(
     baseline_dir=baseline_dir, tolerance=default_tol)
 def test_plot_gaussian_eelsmodel(convolved, plot_component, binned):

--- a/hyperspy/tests/model/test_model2d.py
+++ b/hyperspy/tests/model/test_model2d.py
@@ -156,7 +156,8 @@ def test_Model2D_NotImplementedError_plot():
         with pytest.raises(NotImplementedError):
             _ = getattr(m, member_f)()
 
-    for member_f in ["_plot_component", "_connect_component_line"]:
+    for member_f in ["_plot_component", "_connect_component_line",
+                     "_disconnect_component_line"]:
         with pytest.raises(NotImplementedError):
             _ = getattr(m, member_f)(None)
 

--- a/hyperspy/tests/test_events.py
+++ b/hyperspy/tests/test_events.py
@@ -278,6 +278,17 @@ class TestEventsSuppression(EventsBase):
         self.trigger_check(self.events.b.trigger, True)
         self.trigger_check(self.events.c.trigger, True)
 
+    def test_suppressor_events_container(self):
+        es = he.EventSuppressor()
+        es.add(self.events)
+        with es.suppress():
+            self.trigger_check(self.events.a.trigger, False)
+            self.trigger_check(self.events.b.trigger, False)
+            self.trigger_check(self.events.c.trigger, False)
+
+        self.trigger_check(self.events.a.trigger, True)
+        self.trigger_check(self.events.b.trigger, True)
+        self.trigger_check(self.events.c.trigger, True)
 
 def f_a(**kwargs): pass
 


### PR DESCRIPTION
Various fixes and speed improvement of model plotting.

### Progress of the PR
- [x] Suppress plotting callback of position widget during fit,
- [x] fix setting y limits of model line to avoid flickering,
- [x] speed improvement of model plotting by removing redundant drawing events,
- [x] add tests,
- [x] ready for review.

