### PR TITLE
Fix default value autoscale

### DIFF
--- a/hyperspy/drawing/image.py
+++ b/hyperspy/drawing/image.py
@@ -69,7 +69,7 @@ class ImagePlot(BlittedFigure):
 
         # Attribute matching the arguments of
         # `hyperspy._signal.signal2d.signal2D.plot`
-        self.autoscale = "z"
+        self.autoscale = "v"
         self.saturated_pixels = None
         self.norm = "auto"
         self.vmin = None

--- a/hyperspy/drawing/mpl_he.py
+++ b/hyperspy/drawing/mpl_he.py
@@ -49,7 +49,7 @@ class MPL_HyperExplorer(object):
         self.pointer = None
         self._pointer_nav_dim = None
 
-    def plot_signal(self):
+    def plot_signal(self, **kwargs):
         # This method should be implemented by the subclasses.
         # Doing nothing is good enough for signal_dimension==0 though.
         if self.axes_manager.signal_dimension == 0:


### PR DESCRIPTION
The default value of `ImagePlot.autoscale`, which is used ony for `BaseSignal` and this is why it affects `plot_decomposition_results` and `get_decomposition_loadings().plot()` but not calling `plot()` of a `Signal2D` instance.

### Progress of the PR
- [x] Fix default value,
- [x] Match signature of `MPL_HyperExplorer.plot_signals` with others `plot_signals`, 
- [x] ready for review.

### Minimal example of the bug
from https://gitter.im/hyperspy/hyperspy?at=5f92cfa0a7e77a0ff165ebef

```python
%matplotlib qt
import hyperspy.api as hs
import numpy as np

s = hs.signals.Signal1D(np.random.random((50, 50, 200)))
s.decomposition()

#not updating intensity/scale in loading maps, factors are updated; 'autoscale='v'' can not be used here
s.plot_decomposition_results()

l = s.get_decomposition_loadings()
f = s.get_decomposition_factors()

l.plot() #not updating intensity
l.plot(autoscale='v') #updating intensity
f.plot() #updating intensity
f.plot(autoscale='v') #updating intensity
```
