### PR TITLE
Support h5py 3.0

### DIFF
--- a/hyperspy/io_plugins/emd.py
+++ b/hyperspy/io_plugins/emd.py
@@ -744,7 +744,7 @@ class EMD_NCEM:
                 value = value.decode()
             if key == 'units':
                 # Get all the units
-                units_list = re.findall("(\[.+?\])", value)
+                units_list = re.findall(r"(\[.+?\])", value)
                 units_list = [u[1:-1].replace("_", "") for u in units_list]
                 value = ' * '.join(units_list)
                 try:

--- a/hyperspy/io_plugins/hspy.py
+++ b/hyperspy/io_plugins/hspy.py
@@ -640,7 +640,7 @@ def hdfgroup2dict(group, dictionary=None, lazy=False):
                 if key.startswith("_list_"):
                     if (h5py.check_string_dtype(dat.dtype) and
                         hasattr(dat, 'asstr')):
-                        # h5py 3.0 and later
+                        # h5py 3.0 and newer
                         # https://docs.h5py.org/en/3.0.0/strings.html
                         dat = dat.asstr()[:]
                     ans = np.array(dat)

--- a/hyperspy/io_plugins/hspy.py
+++ b/hyperspy/io_plugins/hspy.py
@@ -544,6 +544,9 @@ def overwrite_dataset(group, data, key, signal_axes=None, chunks=None, **kwds):
             # Optimise the chunking to contain at least one signal per chunk
             chunks = get_signal_chunks(data.shape, data.dtype, signal_axes)
 
+    if np.issubdtype(data.dtype, np.dtype('U')):
+        # Saving numpy unicode type is not supported in h5py
+        data = data.astype(np.dtype('S'))
     if data.dtype == np.dtype('O'):
         # For saving ragged array
         # http://docs.h5py.org/en/stable/special.html#arbitrary-vlen-data
@@ -635,6 +638,11 @@ def hdfgroup2dict(group, dictionary=None, lazy=False):
                 dat = group[key]
                 kn = key
                 if key.startswith("_list_"):
+                    if (h5py.check_string_dtype(dat.dtype) and
+                        hasattr(dat, 'asstr')):
+                        # h5py 3.0 and later
+                        # https://docs.h5py.org/en/3.0.0/strings.html
+                        dat = dat.asstr()[:]
                     ans = np.array(dat)
                     ans = ans.tolist()
                     kn = key[6:]

--- a/hyperspy/io_plugins/nexus.py
+++ b/hyperspy/io_plugins/nexus.py
@@ -128,11 +128,11 @@ def _parse_to_file(value):
         toreturn = value
     if isinstance(totest, (list, tuple)):
         totest = np.array(value)
-    if isinstance(totest, (np.ndarray)) and totest.dtype.char == "U":
+    if isinstance(totest, np.ndarray) and totest.dtype.char == "U":
         toreturn = np.array(totest).astype("S")
     elif isinstance(totest, (np.ndarray, da.Array)):
         toreturn = totest
-    if isinstance(totest, (str)):
+    if isinstance(totest, str):
         toreturn = totest.encode("utf-8")
         toreturn = np.string_(toreturn)
     return toreturn
@@ -1055,12 +1055,11 @@ def _write_signal(signal, nxgroup, signal_name, **kwds):
     nxdata.attrs["signal"] = _parse_to_file("data")
     if smd.record_by:
         nxdata.attrs["interpretation"] = _parse_to_file(smd.record_by)
-    datastr = _parse_to_file("data")
-    overwrite_dataset(nxdata, signal.data, datastr, chunks=None, **kwds)
+    overwrite_dataset(nxdata, signal.data, "data", chunks=None, **kwds)
     axis_names = [_parse_to_file(".")] * len(signal.axes_manager.shape)
     for i, axis in enumerate(signal.axes_manager._axes):
         if axis.name != t.Undefined:
-            axname = _parse_to_file(axis.name)
+            axname = axis.name
             axindex = [axis.index_in_array]
             indices = _parse_to_file(axis.name + "_indices")
             nxdata.attrs[indices] = _parse_to_file(axindex)

--- a/hyperspy/tests/io/test_emd.py
+++ b/hyperspy/tests/io/test_emd.py
@@ -218,7 +218,6 @@ class TestReadSeveralDatasets:
     def test_load_file(self):
         s = load(self.hdf5_dataset_path)
         assert len(s) == len(self.group_path_list)
-        title_list = [s_temp.metadata.General.title for s_temp in s]
         for _s, path in zip(s, self.group_path_list):
             assert _s.metadata.General.title in path
 

--- a/hyperspy/tests/io/test_hdf5.py
+++ b/hyperspy/tests/io/test_hdf5.py
@@ -226,10 +226,7 @@ class TestSavingMetadataContainers:
         fname = tmp_path / 'test.hspy'
         s.save(fname)
         l = load(fname)
-        assert isinstance(l.metadata.test[0][0], float)
-        assert isinstance(l.metadata.test[0][1], float)
-        assert isinstance(l.metadata.test[1][0], str)
-        assert isinstance(l.metadata.test[1][1], str)
+        np.testing.assert_array_equal(l.metadata.test, s.metadata.test)
 
     @pytest.mark.xfail(sys.platform == 'win32',
                        reason="randomly fails in win32")

--- a/hyperspy/tests/io/test_hdf5.py
+++ b/hyperspy/tests/io/test_hdf5.py
@@ -183,52 +183,49 @@ class TestLoadingNewSavedMetadata:
         assert f(3.5) == 4.5
 
 
-@pytest.fixture()
-def tmpfilepath():
-    with tempfile.TemporaryDirectory() as tmp:
-        yield os.path.join(tmp, "test")
-        gc.collect()        # Make sure any memmaps are closed first!
-
-
 class TestSavingMetadataContainers:
 
     def setup_method(self, method):
         self.s = BaseSignal([0.1])
 
-    def test_save_unicode(self, tmpfilepath):
+    def test_save_unicode(self, tmp_path):
         s = self.s
         s.metadata.set_item('test', ['a', 'b', '\u6f22\u5b57'])
-        s.save(tmpfilepath)
-        l = load(tmpfilepath + ".hspy")
+        fname = tmp_path / 'test.hspy'
+        s.save(fname)
+        l = load(fname)
         assert isinstance(l.metadata.test[0], str)
         assert isinstance(l.metadata.test[1], str)
         assert isinstance(l.metadata.test[2], str)
         assert l.metadata.test[2] == '\u6f22\u5b57'
 
-    def test_save_long_list(self, tmpfilepath):
+    def test_save_long_list(self, tmp_path):
         s = self.s
         s.metadata.set_item('long_list', list(range(10000)))
         start = time.time()
-        s.save(tmpfilepath)
+        fname = tmp_path / 'test.hspy'
+        s.save(fname)
         end = time.time()
         assert end - start < 1.0  # It should finish in less that 1 s.
 
-    def test_numpy_only_inner_lists(self, tmpfilepath):
+    def test_numpy_only_inner_lists(self, tmp_path):
         s = self.s
         s.metadata.set_item('test', [[1., 2], ('3', 4)])
-        s.save(tmpfilepath)
-        l = load(tmpfilepath + ".hspy")
+        fname = tmp_path / 'test.hspy'
+        s.save(fname)
+        l = load(fname)
         assert isinstance(l.metadata.test, list)
         assert isinstance(l.metadata.test[0], list)
         assert isinstance(l.metadata.test[1], tuple)
 
     @pytest.mark.xfail(sys.platform == 'win32',
                        reason="randomly fails in win32")
-    def test_numpy_general_type(self, tmpfilepath):
+    def test_numpy_general_type(self, tmp_path):
         s = self.s
-        s.metadata.set_item('test', [[1., 2], ['3', 4]])
-        s.save(tmpfilepath)
-        l = load(tmpfilepath + ".hspy")
+        s.metadata.set_item('test', np.array([[1., 2], ['3', 4]]))
+        fname = tmp_path / 'test.hspy'
+        s.save(fname)
+        l = load(fname)
         assert isinstance(l.metadata.test[0][0], float)
         assert isinstance(l.metadata.test[0][1], float)
         assert isinstance(l.metadata.test[1][0], str)
@@ -236,34 +233,50 @@ class TestSavingMetadataContainers:
 
     @pytest.mark.xfail(sys.platform == 'win32',
                        reason="randomly fails in win32")
-    def test_general_type_not_working(self, tmpfilepath):
+    def test_list_general_type(self, tmp_path):
+        s = self.s
+        s.metadata.set_item('test', [[1., 2], ['3', 4]])
+        fname = tmp_path / 'test.hspy'
+        s.save(fname)
+        l = load(fname)
+        assert isinstance(l.metadata.test[0][0], float)
+        assert isinstance(l.metadata.test[0][1], float)
+        assert isinstance(l.metadata.test[1][0], str)
+        assert isinstance(l.metadata.test[1][1], str)
+
+    @pytest.mark.xfail(sys.platform == 'win32',
+                       reason="randomly fails in win32")
+    def test_general_type_not_working(self, tmp_path):
         s = self.s
         s.metadata.set_item('test', (BaseSignal([1]), 0.1, 'test_string'))
-        s.save(tmpfilepath)
-        l = load(tmpfilepath + ".hspy")
+        fname = tmp_path / 'test.hspy'
+        s.save(fname)
+        l = load(fname)
         assert isinstance(l.metadata.test, tuple)
         assert isinstance(l.metadata.test[0], Signal1D)
         assert isinstance(l.metadata.test[1], float)
         assert isinstance(l.metadata.test[2], str)
 
-    def test_unsupported_type(self, tmpfilepath):
+    def test_unsupported_type(self, tmp_path):
         s = self.s
         s.metadata.set_item('test', Point2DROI(1, 2))
-        s.save(tmpfilepath)
-        l = load(tmpfilepath + ".hspy")
+        fname = tmp_path / 'test.hspy'
+        s.save(fname)
+        l = load(fname)
         assert 'test' not in l.metadata
 
-    def test_date_time(self, tmpfilepath):
+    def test_date_time(self, tmp_path):
         s = self.s
         date, time = "2016-08-05", "15:00:00.450"
         s.metadata.General.date = date
         s.metadata.General.time = time
-        s.save(tmpfilepath)
-        l = load(tmpfilepath + ".hspy")
+        fname = tmp_path / 'test.hspy'
+        s.save(fname)
+        l = load(fname)
         assert l.metadata.General.date == date
         assert l.metadata.General.time == time
 
-    def test_general_metadata(self, tmpfilepath):
+    def test_general_metadata(self, tmp_path):
         s = self.s
         notes = "Dummy notes"
         authors = "Author 1, Author 2"
@@ -271,18 +284,20 @@ class TestSavingMetadataContainers:
         s.metadata.General.notes = notes
         s.metadata.General.authors = authors
         s.metadata.General.doi = doi
-        s.save(tmpfilepath)
-        l = load(tmpfilepath + ".hspy")
+        fname = tmp_path / 'test.hspy'
+        s.save(fname)
+        l = load(fname)
         assert l.metadata.General.notes == notes
         assert l.metadata.General.authors == authors
         assert l.metadata.General.doi == doi
 
-    def test_quantity(self, tmpfilepath):
+    def test_quantity(self, tmp_path):
         s = self.s
         quantity = "Intensity (electron)"
         s.metadata.Signal.quantity = quantity
-        s.save(tmpfilepath)
-        l = load(tmpfilepath + ".hspy")
+        fname = tmp_path / 'test.hspy'
+        s.save(fname)
+        l = load(fname)
         assert l.metadata.Signal.quantity == quantity
 
     def test_metadata_update_to_v3_0(self):
@@ -657,13 +672,13 @@ def test_strings_from_py2():
     assert isinstance(s.metadata.Sample.elements, list)
 
 
-def test_save_ragged_array(tmpfilepath):
+def test_save_ragged_array(tmp_path):
     a = np.array([0, 1])
     b = np.array([0, 1, 2])
     s = BaseSignal(np.array([a, b], dtype=object)).T
-    filename = os.path.join(tmpfilepath, "test_save_ragged_array.hspy")
-    s.save(filename)
-    s1 = load(filename)
+    fname = tmp_path / 'test_save_ragged_array.hspy'
+    s.save(fname)
+    s1 = load(fname)
     for i in range(len(s.data)):
         np.testing.assert_allclose(s.data[i], s1.data[i])
     assert s.__class__ == s1.__class__

--- a/hyperspy/tests/io/test_io.py
+++ b/hyperspy/tests/io/test_io.py
@@ -189,3 +189,14 @@ def test_file_reader_options():
         t = hs.load(Path(dirpath, "temp.hspy"), reader=hspy)
         assert len(t) == 1
         np.testing.assert_allclose(t.data, np.arange(10))
+
+
+def test_save_default_format():
+    s = Signal1D(np.arange(10))
+
+    with tempfile.TemporaryDirectory() as dirpath:
+        f = os.path.join(dirpath, "temp")
+        s.save(f)
+
+        t = hs.load(Path(dirpath, "temp.hspy"))
+        assert len(t) == 1

--- a/hyperspy/tests/io/test_nexus_hdf.py
+++ b/hyperspy/tests/io/test_nexus_hdf.py
@@ -273,35 +273,33 @@ class TestSavingMetadataContainers:
             lin.original_metadata.testarray1
 
 
-class TestSavingMultiSignals:
+def test_saving_multi_signals(tmp_path):
 
-    def setup_method(self, method):
-        data = np.zeros((15, 1, 40, 40))
-        self.sig = hs.signals.Signal2D(data)
-        self.sig.axes_manager[0].name = "stage_y_axis"
-        self.sig.original_metadata.set_item("stage_y.value", 4.0)
-        self.sig.original_metadata.set_item("stage_y.attrs.units", "mm")
-        data = np.zeros((30, 30, 10))
-        self.sig2 = hs.signals.Signal1D(data)
-        self.sig2.axes_manager[0].name = "axis1"
-        self.sig2.axes_manager[1].name = "axis2"
-        self.sig2.original_metadata.set_item("stage_x.value", 8.0)
-        self.sig2.original_metadata.set_item("stage_x.attrs.units", "mm")
+    sig = hs.signals.Signal2D(np.zeros((15, 1, 40, 40)))
+    sig.axes_manager[0].name = "stage_y_axis"
+    sig.original_metadata.set_item("stage_y.value", 4.0)
+    sig.original_metadata.set_item("stage_y.attrs.units", "mm")
 
-    def test_save_signal_list(self, tmp_path):
-        fname = tmp_path / 'test.nxs'
-        file_writer(fname, [self.sig, self.sig2])
-        lin = load(fname, nxdata_only=True)
-        assert len(lin) == 2
-        assert lin[0].original_metadata.stage_y.value == 4.0
-        assert lin[0].axes_manager[0].name == "stage_y_axis"
-        assert lin[1].original_metadata.stage_x.value == 8.0
-        assert lin[1].original_metadata.stage_x.attrs.units == "mm"
-        assert isinstance(lin[0], Signal2D) is True
-        assert isinstance(lin[1], Signal1D) is True
-        # test the metadata haven't merged
-        with pytest.raises(AttributeError):
-            lin[1].original_metadata.stage_y.value
+    sig2 = hs.signals.Signal1D(np.zeros((30, 30, 10)))
+    sig2.axes_manager[0].name = "axis1"
+    sig2.axes_manager[1].name = "axis2"
+    sig2.original_metadata.set_item("stage_x.value", 8.0)
+    sig2.original_metadata.set_item("stage_x.attrs.units", "mm")
+
+    fname = tmp_path / 'test.nxs'
+    sig.save(fname)
+    file_writer(fname, [sig, sig2])
+    lin = load(fname, nxdata_only=True)
+    assert len(lin) == 2
+    assert lin[0].original_metadata.stage_y.value == 4.0
+    assert lin[0].axes_manager[0].name == "stage_y_axis"
+    assert lin[1].original_metadata.stage_x.value == 8.0
+    assert lin[1].original_metadata.stage_x.attrs.units == "mm"
+    assert isinstance(lin[0], Signal2D)
+    assert isinstance(lin[1], Signal1D)
+    # test the metadata haven't merged
+    with pytest.raises(AttributeError):
+        lin[1].original_metadata.stage_y.value
 
 
 def test_read_file2_dataset_key_test():


### PR DESCRIPTION
h5py 3.0 breaks a few io plugins because of change in string handling. Relevant links:
- https://docs.h5py.org/en/stable/whatsnew/3.0.html
- https://docs.h5py.org/en/3.0.0/strings.html

### Progress of the PR
- [x] Fix emd io plugin.
- [x] Fix hspy io plugin.
- [x] Fix nexus io plugin.
- [x] Use pytest `tmp_path` default fixture instead of a custom one.
- [x] ready for review.

