### PR TITLE
small fix to USID writer

### DIFF
--- a/hyperspy/io_plugins/usid_hdf5.py
+++ b/hyperspy/io_plugins/usid_hdf5.py
@@ -370,7 +370,8 @@ def _axes_list_to_dimensions(axes_list, data_shape, is_spec):
                 dim_units = temp
                 # use REAL dimension size rather than what is presented in the
                 # axes manager
-        ar = np.arange(dim.size) * dim.scale + dim.offset
+        dim_size = data_shape[len(data_shape) - 1 - dim_ind]
+        ar = np.arange(dim_size) * dim.scale + dim.offset
         dim_list.append(usid.Dimension(dim_name, dim_units, ar))
     if len(dim_list) == 0:
         return usid.Dimension('Arb', 'a. u.', 1)

--- a/hyperspy/io_plugins/usid_hdf5.py
+++ b/hyperspy/io_plugins/usid_hdf5.py
@@ -356,8 +356,7 @@ def _axes_list_to_dimensions(axes_list, data_shape, is_spec):
     # for dim_ind, (dim_size, dim) in enumerate(zip(data_shape, axes_list)):
     # we are going by data_shape for order (slowest to fastest)
     # so the order in axes_list does not matter
-    for dim_ind in range(len(data_shape)):
-        dim_size = data_shape[len(data_shape) - 1 - dim_ind]
+    for dim_ind, dim in enumerate(axes_list):
         dim = axes_list[dim_ind]
         dim_name = dim_type + '_Dim_' + str(dim_ind)
         if isinstance(dim.name, str):
@@ -371,11 +370,8 @@ def _axes_list_to_dimensions(axes_list, data_shape, is_spec):
                 dim_units = temp
                 # use REAL dimension size rather than what is presented in the
                 # axes manager
-        dim_list.append(usid.Dimension(dim_name, dim_units,
-                                       np.arange(dim.offset,
-                                                 dim.offset + dim_size *
-                                                 dim.scale,
-                                                 dim.scale)))
+        ar = np.arange(dim.size) * dim.scale + dim.offset
+        dim_list.append(usid.Dimension(dim_name, dim_units, ar))
     if len(dim_list) == 0:
         return usid.Dimension('Arb', 'a. u.', 1)
     return dim_list[::-1]
@@ -501,6 +497,8 @@ def file_writer(filename, object2save, **kwds):
     phy_quant = 'Unknown Quantity'
     phy_units = 'Unknown Units'
     dset_name = 'Raw_Data'
+
+
 
     if not append:
         tran = usid.NumpyTranslator()


### PR DESCRIPTION
### Description of the change
A tiny bug fix to the USID writer

`usid.Dimension` should be passed an array exactly of length `dim.scale`.
The previous implementation using `np.arange` could result in variations of +/-1, which resulted in errors when writing out some files. 

### Example
Bug:

```python
>>> offset = -1
>>> size = 3
>>> scale = 0.1
>>> np.arange(offset, offset + size *scale, scale)
array([-1. , -0.9, -0.8, -0.7])
```
The array should have length 3

Fixed:

```python
>>> offset = -1
>>> size = 3
>>> scale = 0.1
>>> np.arange(size) * scale + offset
array([-1. , -0.9, -0.8])
```

### Progress of the PR
- [x] Change implemented (can be split into several points),
- [x] add tests,
- [x] ready for review.