### PR TITLE
Plotting fixes

### DIFF
--- a/hyperspy/drawing/image.py
+++ b/hyperspy/drawing/image.py
@@ -557,8 +557,7 @@ class ImagePlot(BlittedFigure):
             else:
                 self.figure.canvas.draw_idle()
         else:  # no signal have been drawn yet
-            new_args = {'interpolation': 'nearest',
-                        'extent': self._extent,
+            new_args = {'extent': self._extent,
                         'aspect': self._aspect,
                         'animated': self.figure.canvas.supports_blit,
                         }

--- a/hyperspy/roi.py
+++ b/hyperspy/roi.py
@@ -491,8 +491,7 @@ class BaseInteractiveROI(BaseROI):
             # disconnect events which has been added when
             if self.update in signal.axes_manager.events.any_axis_changed.connected:
                 signal.axes_manager.events.any_axis_changed.disconnect(
-                    self.update,
-                    [])
+                    self.update)
 
 
     def remove_widget(self, signal):

--- a/hyperspy/tests/drawing/test_plot_roi_widgets.py
+++ b/hyperspy/tests/drawing/test_plot_roi_widgets.py
@@ -19,7 +19,7 @@
 import numpy as np
 import pytest
 
-from hyperspy.signals import Signal2D
+from hyperspy.signals import Signal1D, Signal2D
 from hyperspy.utils import roi
 
 BASELINE_DIR = 'plot_roi'
@@ -147,3 +147,16 @@ def test_error_message():
     p = roi.Point1DROI(0.5)
     with pytest.raises(Exception, match='does not have an active plot.'):
         p.add_widget(signal=im, axes=[0, ], color="cyan")
+
+
+def test_remove_rois():
+    s = Signal1D(np.arange(10))
+    s2 = s.deepcopy()
+    r = roi.SpanROI(2, 4)
+    s.plot()
+    s2.plot()
+
+    s_roi = r.interactive(s)
+    s2_roi = r.interactive(s2)
+
+    r.remove_widget(s)


### PR DESCRIPTION
### Description of the change
- Don't set `imshow` interpolation default to allow using matplotlib default value or the `rcParams`. Since a while the matploltib default have been `nearest` and since matploltib 3.2, it is [`antialiased`](https://matplotlib.org/3.3.0/api/_as_gen/matplotlib.axes.Axes.imshow.html#matplotlib.axes.Axes.imshow), which is an improvement.
- Fix remove widget bug when a roi has been added to several signals.

### Progress of the PR
- [x] Change implemented,
- [x] add tests,
- [x] ready for review.

### Remove widget bug fix
```python
import numpy as np
import hyperspy.api as hs

s = hs.signals.Signal1D(np.arange(10))
s2 = s.deepcopy()
r = hs.roi.SpanROI(2, 4)
s.plot()
s2.plot()

s_roi = r.interactive(s)
s2_roi = r.interactive(s2)

r.remove_widget(s)
```
Note that this example can be useful to update the user guide.

