### PR TITLE
Propagate the lazy argument when loading metadata

### DIFF
--- a/hyperspy/io_plugins/nexus.py
+++ b/hyperspy/io_plugins/nexus.py
@@ -454,7 +454,7 @@ def file_reader(filename, lazy=False, dataset_keys=None,
 
     dataset_keys = _check_search_keys(dataset_keys)
     metadata_keys = _check_search_keys(metadata_keys)
-    original_metadata = _load_metadata(fin)
+    original_metadata = _load_metadata(fin, lazy=lazy)
     # some default values...
     nexus_data_paths = []
     hdf_data_paths = []

--- a/hyperspy/tests/io/test_nexus_hdf.py
+++ b/hyperspy/tests/io/test_nexus_hdf.py
@@ -340,6 +340,9 @@ def test_read_file2_metadata_keys():
                 dataset_keys=["rocks"], metadata_keys=["energy"])
     assert s.original_metadata.instrument.energy.value == 12.0
 
+def test_read_lazy_file():
+    s = hs.load(file3, nxdata_only=True, lazy=True)
+    assert s[0]._lazy and s[1]._lazy
 
 @pytest.mark.parametrize("verbose", [True, False])
 @pytest.mark.parametrize("dataset_keys", ["testdata", "nexustest"])


### PR DESCRIPTION
This is a very simple bug fix for loading NeXus file lazily correctly. The `lazy` argument needs to be read by the function that load
metadata, as the items include the actual data and if the data is big, not saving it as dask array will cause memory issue.

### Description of the change
- pass the `lazy` argument correctly to the `_load_metadata` method in nexus file reader.

### Progress of the PR
- [x]  ready for review


### Minimal example of the bug fix or the new feature
Dataset in NeXus file exceeding the memory of the system can be loaded lazily. 
