### PR TITLE
Fix saving tiff file for signal with Å units

### DIFF
--- a/hyperspy/io_plugins/tiff.py
+++ b/hyperspy/io_plugins/tiff.py
@@ -95,7 +95,7 @@ def file_writer(filename, signal, export_scale=True, extratags=[], **kwds):
             "because it is incompability with the 'ImageJ' tiff format")
     if export_scale:
         kwds.update(_get_tags_dict(signal, extratags=extratags))
-        _logger.debug("kwargs passed to tifffile.py imsave: {0}".format(kwds))
+        _logger.debug(f"kwargs passed to tifffile.py imsave: {kwds}")
 
         if 'metadata' not in kwds.keys():
             # Because we write the calibration to the ImageDescription tag
@@ -491,7 +491,9 @@ def _imagej_description(version='1.11a', **kwargs):
     for key, value in list(kwargs.items()):
         if value == 'µm':
             value = 'micron'
-        append.append('%s=%s' % (key.lower(), value))
+        if value == 'Å':
+            value = 'angstrom'
+        append.append(f'{key.lower()}={value}')
 
     return '\n'.join(result + append + [''])
 

--- a/hyperspy/tests/io/test_tiff.py
+++ b/hyperspy/tests/io/test_tiff.py
@@ -621,3 +621,19 @@ def test_olympus_SIS():
         assert ima.data.shape == (101, 112)
 
     assert s[1].data.dtype is np.dtype('uint16')
+
+
+def test_save_angstrom_units():
+    s = hs.signals.Signal2D(np.arange(200*200, dtype='float32').reshape((200, 200)))
+    for axis in s.axes_manager.signal_axes:
+        axis.units = 'Å'
+        axis.scale = 0.1
+        axis.offset = 10
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        fname = os.path.join(tmpdir, 'save_angstrom_units.tif')
+        s.save(fname)
+        s2 = hs.load(fname)
+        assert s2.axes_manager[0].units == s.axes_manager[0].units
+        assert s2.axes_manager[0].scale == s.axes_manager[0].scale
+        assert s2.axes_manager[0].offset == s.axes_manager[0].offset


### PR DESCRIPTION
Fix saving as tiff for signal with `'Å'` units.

### Progress of the PR
- [x] Workaround ascii encoding error.
- [x] add tests,
- [x] ready for review.

### Minimal example of the bug fix or the new feature
```python
s = hs.signals.Signal2D(np.arange(200*200, dtype='float32').reshape((200, 200)))
for axis in s.axes_manager.signal_axes:
    axis.units = 'Å'
    axis.scale = 0.1
    axis.offset = 10

s.save('test.tif')
```
Error:
```python
Traceback (most recent call last):

  File "<ipython-input-4-6e3430f6830e>", line 1, in <module>
    s.save('test.tif')

  File "/home/eric/Dev/hyperspy/hyperspy/signal.py", line 2748, in save
    io.save(filename, self, overwrite=overwrite, **kwds)

  File "/home/eric/Dev/hyperspy/hyperspy/io.py", line 756, in save
    writer.file_writer(str(filename), signal, **kwds)

  File "/home/eric/Dev/hyperspy/hyperspy/io_plugins/tiff.py", line 112, in file_writer
    imwrite(filename,

  File "/opt/miniconda3/lib/python3.8/site-packages/tifffile/tifffile.py", line 787, in imwrite
    return tif.write(data, shape, dtype, **kwargs)

  File "/opt/miniconda3/lib/python3.8/site-packages/tifffile/tifffile.py", line 2125, in write
    addtag(*t)

  File "/opt/miniconda3/lib/python3.8/site-packages/tifffile/tifffile.py", line 1772, in addtag
    value = bytestr(value, 'ascii') + b'\0'

  File "/opt/miniconda3/lib/python3.8/site-packages/tifffile/tifffile.py", line 15622, in bytestr
    return s.encode(encoding) if isinstance(s, str) else s

UnicodeEncodeError: 'ascii' codec can't encode character '\xc5' in position 18: ordinal not in range(128)
```
