### PR TITLE
Use mode=r for loading lazy data for hdf5 file as well

### DIFF
--- a/hyperspy/io_plugins/emd.py
+++ b/hyperspy/io_plugins/emd.py
@@ -356,7 +356,7 @@ class EMD(object):
         """
         cls._log.debug('Calling load_from_emd')
         # Read in file:
-        emd_file = h5py.File(filename, 'r+' if lazy else 'r')
+        emd_file = h5py.File(filename, 'r')
         # Creat empty EMD instance:
         emd = cls()
         # Extract user:
@@ -1787,7 +1787,7 @@ def file_reader(filename, lazy=False, **kwds):
         Keyword argument pass to the EMD NCEM or EMD Velox reader. See user
         guide or the docstring of the `load` function for more information.
     """
-    file = h5py.File(filename, 'r+' if lazy else 'r')
+    file = h5py.File(filename, 'r')
     dictionaries = []
     try:
         if is_EMD_Velox(file):

--- a/hyperspy/io_plugins/hspy.py
+++ b/hyperspy/io_plugins/hspy.py
@@ -116,7 +116,7 @@ def get_hspy_format_version(f):
 
 def file_reader(filename, backing_store=False,
                 lazy=False, **kwds):
-    mode = kwds.pop('mode', 'r+' if lazy else 'r')
+    mode = kwds.pop('mode', 'r')
     f = h5py.File(filename, mode=mode, **kwds)
     # Getting the format version here also checks if it is a valid HSpy
     # hdf5 file, so the following two lines must not be deleted or moved

--- a/hyperspy/io_plugins/nexus.py
+++ b/hyperspy/io_plugins/nexus.py
@@ -449,7 +449,7 @@ def file_reader(filename, lazy=False, dataset_keys=None,
     mapping = kwds.get('mapping', {})
     original_metadata = {}
     learning = {}
-    fin = h5py.File(filename, "r+" if lazy else "r")
+    fin = h5py.File(filename, "r")
     signal_dict_list = []
 
     dataset_keys = _check_search_keys(dataset_keys)

--- a/hyperspy/io_plugins/usid_hdf5.py
+++ b/hyperspy/io_plugins/usid_hdf5.py
@@ -413,7 +413,7 @@ def file_reader(filename, dataset_path=None, ignore_non_linear_dims=True,
 
     # Need to keep h5 file handle open indefinitely if lazy
     # Using "with" will cause the file to be closed
-    h5_f = h5py.File(filename, mode='r+' if lazy else 'r')
+    h5_f = h5py.File(filename, 'r')
     if dataset_path is None:
         all_main_dsets = usid.hdf_utils.get_all_main(h5_f)
         signals = []


### PR DESCRIPTION
### Description of the change
Related to #2555. It seems like there is no advantage of loading data lazily when the read mode for h5py is set to '`r+'`. This PR changes the mode to `'r'` for lazy data. This won't change the time stamp unnecessarily.

### Progress of the PR
- [x] ready for review.

### Minimal example of the bug fix or the new feature
Do not alter the time stamp when loading lazy data in hdf5 files.
