### PR TITLE
Use prettytable dependencies instead of ptable

### DIFF
--- a/conda_environment.yml
+++ b/conda_environment.yml
@@ -3,7 +3,7 @@ channels:
 - defaults
 - conda-forge
 dependencies:
-- dask
+- dask-core >2.0
 - dill
 - h5py
 - imageio
@@ -16,6 +16,7 @@ dependencies:
 - numpy
 - pint
 - prettytable
+- python
 - python-dateutil
 - pyusid
 - pyyaml
@@ -24,9 +25,9 @@ dependencies:
 - scikit-learn
 - scipy
 - sparse
-- statsmodels
 - sympy
 - tifffile >=2019.07.26
-- traits
+- toolz
 - tqdm
+- traits
 

--- a/conda_environment.yml
+++ b/conda_environment.yml
@@ -15,7 +15,7 @@ dependencies:
 - numexpr
 - numpy
 - pint
-- PTable
+- prettytable
 - python-dateutil
 - pyusid
 - pyyaml

--- a/setup.py
+++ b/setup.py
@@ -64,7 +64,9 @@ install_req = ['scipy>=1.1',
                'sparse',
                'imageio',
                'pyyaml',
-               'PTable',
+               # prettytable and ptable are API compatible
+               # prettytalbe is maintained and ptable is an unmaintained fork
+               'prettytable',
                'tifffile>=2018.10.18',
                'numba',
                ]

--- a/setup.py
+++ b/setup.py
@@ -65,7 +65,7 @@ install_req = ['scipy>=1.1',
                'imageio',
                'pyyaml',
                # prettytable and ptable are API compatible
-               # prettytalbe is maintained and ptable is an unmaintained fork
+               # prettytable is maintained and ptable is an unmaintained fork
                'prettytable',
                'tifffile>=2018.10.18',
                'numba',


### PR DESCRIPTION
Use prettytable dependencies instead of ptable because ptable is an unmaintained fork of prettytable. Both API are still compatible so any of the two can be used and it is better to use the one which is maintained.

### Progress of the PR
- [x] Use prettytable dependencies instead of ptable,
- [x] tidy up conda environment,
- [x] ready for review.

