### PR TITLE
Place qt navigator+signal plots side by side

### DIFF
--- a/hyperspy/drawing/mpl_he.py
+++ b/hyperspy/drawing/mpl_he.py
@@ -242,13 +242,15 @@ class MPL_HyperExplorer:
                     # Get coordinates of navigator plot
                     manager = self.navigator_plot.figure.canvas.manager
                     # Shift left
-                    left, top, width, height = manager.window.geometry().getRect()
-                    manager.window.setGeometry(left-width//2 ,top, width, height) # must take ints
+                    left1, top1, width1, height1 = manager.window.geometry().getRect()
+                    # setGeometry takes left, top, width, height
+                    # top = 0 results in hidden windows toolbar
+                    manager.window.setGeometry(0,30, width1, height1) 
 
                     # Get coordinates of signal plot
                     manager = self.signal_plot.figure.canvas.manager
                     # Shift right
-                    left, top, width, height = manager.window.geometry().getRect()
-                    manager.window.setGeometry(left+width//2 ,top, width, height) # must take ints
+                    left2, top2, width2, height2 = manager.window.geometry().getRect()
+                    manager.window.setGeometry(width1+1, 30, width2, height2) # +1 offset to left position for border
                 except:
                     pass

--- a/hyperspy/drawing/mpl_he.py
+++ b/hyperspy/drawing/mpl_he.py
@@ -23,7 +23,7 @@ from traits.api import Undefined
 
 from hyperspy.drawing import widgets, signal1d, image
 from hyperspy.defaults_parser import preferences
-
+import matplotlib.pyplot as plt
 
 _logger = logging.getLogger(__name__)
 
@@ -192,6 +192,7 @@ class MPL_HyperExplorer(object):
                 self.navigator_plot.events.closed.connect(
                     self.pointer.disconnect, [])
         self.plot_signal(**kwargs)
+        self.arrange_windows()
 
     def assign_pointer(self):
         if self.navigator_data_function is None:
@@ -229,3 +230,25 @@ class MPL_HyperExplorer(object):
             if self.signal_plot:
                 self.signal_plot.close()
             self.close_navigator_plot()
+
+    def arrange_windows(self):
+        """Attempt to offset the navigator and signal plots side-by-side
+        Only works for the non-widget/nbagg backends
+        """
+
+        if self.navigator_plot and self.signal_plot:
+            if "nbagg" not in plt.get_backend().lower(): # doesn't work for widget / nbagg backends
+                try: # Try incase some exotic backend raises an error
+                    # Get coordinates of navigator plot
+                    manager = self.navigator_plot.figure.canvas.manager
+                    # Shift left
+                    left, top, width, height = manager.window.geometry().getRect()
+                    manager.window.setGeometry(left-width//2 ,top, width, height) # must take ints
+
+                    # Get coordinates of signal plot
+                    manager = self.signal_plot.figure.canvas.manager
+                    # Shift right
+                    left, top, width, height = manager.window.geometry().getRect()
+                    manager.window.setGeometry(left+width//2 ,top, width, height) # must take ints
+                except:
+                    pass

--- a/hyperspy/drawing/mpl_he.py
+++ b/hyperspy/drawing/mpl_he.py
@@ -28,10 +28,10 @@ import matplotlib.pyplot as plt
 _logger = logging.getLogger(__name__)
 
 
-class MPL_HyperExplorer(object):
-
+class MPL_HyperExplorer:
     """
-
+    Base class for the combined navigator and signal explorer in HyperSpy
+    This class initialises the figures for navigation and plotting
     """
 
     def __init__(self):
@@ -123,7 +123,7 @@ class MPL_HyperExplorer(object):
 
             # Set all kwargs value to the image figure before passing the rest
             # of the kwargs to plot method of the image figure
-            for key, value in list(kwargs.items()):
+            for key, _ in list(kwargs.items()):
                 if hasattr(imf, key):
                     setattr(imf, key, kwargs.pop(key))
 

--- a/hyperspy/drawing/mpl_hie.py
+++ b/hyperspy/drawing/mpl_hie.py
@@ -22,6 +22,9 @@ from hyperspy.defaults_parser import preferences
 
 
 class MPL_HyperImage_Explorer(MPL_HyperExplorer):
+    """
+    Explorer for combined Navigator + Signal where the Signal is a 2D plot (image)
+    """
 
     def plot_signal(self, **kwargs):
         """

--- a/hyperspy/drawing/mpl_hse.py
+++ b/hyperspy/drawing/mpl_hse.py
@@ -28,8 +28,8 @@ from hyperspy.drawing import signal1d
 
 class MPL_HyperSignal1D_Explorer(MPL_HyperExplorer):
 
-    """Plots the current spectrum to the screen and a map with a cursor
-    to explore the SI.
+    """
+    Explorer for combined Navigator + Signal where the Signal is a 1D Signal (spectrum)
 
     """
 

--- a/hyperspy/tests/drawing/test_plot_signal2d.py
+++ b/hyperspy/tests/drawing/test_plot_signal2d.py
@@ -561,3 +561,8 @@ def test_plot_autoscale_data_changed(autoscale):
     else:
         np.testing.assert_allclose(imf._vmin, _vmin)
         np.testing.assert_allclose(imf._vmax, _vmax)
+
+def test_plot_signal_navigator_sidebyside():
+    s = hs.signals.Signal1D(np.arange(10*10*10).reshape(10, 10, 10))
+    s.plot()
+    s._plot.arrange_windows()


### PR DESCRIPTION
### Description of the change
I've offset the navigator and signal plots by half their widths left and right, so that they appear next to one another. The small annoyance of having to always drag the plots left and right has somewhat prevented me from embracing the qt backend, even though it is much, much faster than nbagg.

I'm a little unsure how this performs on other platforms - I can only test on windows. I've tried testing with the tk backend, but that seems to be acting strangely on my testing environment without the change this PR brings.

Finally, whether or not the plots appear in front of the notebook appears to be a bit ambiguous. When testing it, sometimes the plots start appearing behind the browser. A browser refresh oddly enough seems to fix this. If anyone knows why this happens, I'd appreciate it.

### Progress of the PR
- [x] Change implemented (can be split into several points),
- [x] update docstring (if appropriate),
- [x] ready for review.

### Minimal example of the bug fix or the new feature
```python
# please try with different backends if you have them
%matplotlib qt
import hyperspy.api as hs
import numpy as np
s = hs.signals.Signal1D(np.random.random((10,10,10)))
s.plot()
```