### PR TITLE
Update release github actions to fix issue when using manylinux.

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -102,7 +102,7 @@ jobs:
           python-version: 3.8
 
       - name: Build manylinux Python wheels
-        uses: RalfG/python-wheels-manylinux-build@v0.3.1-manylinux2010_x86_64
+        uses: RalfG/python-wheels-manylinux-build@v0.3.2-manylinux2010_x86_64
         with:
           build-requirements: 'cython'
 


### PR DESCRIPTION
Update version github actions to build wheels on linux (https://github.com/RalfG/python-wheels-manylinux-build/pull/28).
