### PR TITLE
Different outputs for EELS quantify()

### DIFF
--- a/doc/user_guide/eels.rst
+++ b/doc/user_guide/eels.rst
@@ -205,7 +205,7 @@ core-loss file
 
 .. code-block:: python
 
-    >>> s.set_microscope_parameters(beam_energy=100,
+    >>> s.set_microscope_parameters(beam_energy=300,
     ...                             convergence_angle=0.2,
     ...                             collection_angle=2.55)
 
@@ -293,7 +293,20 @@ Print the result of the fit
     B	0.045648
     N	0.048061
 
+See :py:class:`~._components.eels_cl_edge.EELSCLEdge` for more information about the intensity parameter.
+The intensity values can be used to calculate elemental concentrations and ratios:
 
+.. code-block:: python
+
+    >>> 0.045648/(0.045648+0.048061) #B concentration
+    0.4871250360157509
+    >>> 0.048061/(0.045648+0.048061) #N concentration
+    0.5128749639842491
+    >>> 0.045648/0.048061 #B/N ratio
+    0.9497929714321384
+
+This corresponds to 48.7% B and 51.3% N in the sample and a B/N ratio of 0.95. See :py:class:`~hyperspy.models.eelsmodel.EELSModel.quantify()` for more information.
+    
 Visualize the result
 
 .. code-block:: python

--- a/hyperspy/models/eelsmodel.py
+++ b/hyperspy/models/eelsmodel.py
@@ -597,13 +597,11 @@ class EELSModel(Model1D):
         print()
         if output == "absolute":
             print("Absolute quantification:")
-        elif output == "normalized":
-            print("Normalized elemental concentrations:")
-        if output == "absolute":
             print("Elem.\tIntensity")
         elif output == "normalized":
+            print("Normalized elemental concentrations:")
             print("Elem.\tConcentration")
-
+        
         for element in elements:
             if len(elements[element]) == 1:
                 for subshell in elements[element]:

--- a/hyperspy/models/eelsmodel.py
+++ b/hyperspy/models/eelsmodel.py
@@ -538,12 +538,51 @@ class EELSModel(Model1D):
         # Recover the channel_switches. Remove it or make it smarter.
         self.channel_switches = backup_channel_switches
 
-    def quantify(self):
-        """Prints the value of the intensity of all the independent
-        active EELS core loss edges defined in the model
 
+    def quantify(self, output = 'absolute'):
+        """Prints and returns the values of the intensity of all the independent
+        active EELS core loss edges defined in the model.
+        
+        Parameters
+        ----------
+        output : 'absolute', 'normalized', or None
+            If 'absolute', prints values of the intensity parameter of all EELSCLEdge components.\n
+            If 'normalized', prints intensity parameters normalized with respect to the sum of all intensities in the model. If all relevant elements are present in the analyzed spectrum this results in the elemental concentrations in atomic %.\n
+            If None, no output is printed.
+        
+        Returns
+        -------
+        dict
+            Python dictionary with element name, edge name and intensity value.
+        
+        Examples
+        -------
+        Load and fit the BN EELS example from the user guide:\n
+        >>> s = hs.datasets.eelsdb(title="Hexagonal Boron Nitride", spectrum_type="coreloss")[0]
+        >>> ll = hs.datasets.eelsdb(title="Hexagonal Boron Nitride", spectrum_type="lowloss")[0]
+        >>> s.add_elements(('B', 'N'))
+        >>> m = s.create_model(ll=ll)
+        >>> m.enable_fine_structure()
+        >>> m.smart_fit()
+        
+        Print the elemental concentrations:\n
+        >>> m.quantify(output='normalized')
+        
+        Calculate B/N ratio with the returned dictionary:\n
+        >>> q = m.quantify(output=None)
+        >>> print('B/N ratio: ', q['B']['K']/q['N']['K'])
+        
+        The intensity values can also be accessed directly from the model component:\n
+        >>> print('Intensity of B K edge: ', q['B']['K'])
+        >>> print('Intensity of B K edge: ', m.components.B_K.intensity.value)
+
+        See also
+        ---------
+        :py:class:`~._components.eels_cl_edge.EELSCLEdge`
         """
         elements = {}
+        if output == 'normalized':
+            int_sum = 0
         for edge in self._active_edges:
             if edge.active and edge.intensity.twin is None:
                 element = edge.element
@@ -551,18 +590,40 @@ class EELSModel(Model1D):
                 if element not in elements:
                     elements[element] = {}
                 elements[element][subshell] = edge.intensity.value
+                if output == 'normalized':
+                    int_sum += edge.intensity.value
+        
+        if output == None:
+            return elements
         print()
-        print("Absolute quantification:")
-        print("Elem.\tIntensity")
+        if output == 'absolute':
+            print("Absolute quantification:")
+        elif output == 'normalized':
+            print("Normalized elemental concentrations:")
+        if output == 'absolute':
+            print("Elem.\tIntensity")
+        elif output == 'normalized':
+            print("Elem.\tConcentration")
+
         for element in elements:
             if len(elements[element]) == 1:
                 for subshell in elements[element]:
-                    print("%s\t%f" % (
-                        element, elements[element][subshell]))
+                    if output == 'absolute':
+                        print("%s\t%f" % (
+                            element, elements[element][subshell]))
+                    elif output == 'normalized':
+                            print("%s\t%f" % (
+                                element, elements[element][subshell]/int_sum))
             else:
                 for subshell in elements[element]:
-                    print("%s_%s\t%f" % (element, subshell,
-                                         elements[element][subshell]))
+                    if output == 'absolute':
+                        print("%s_%s\t%f" % (element, subshell,
+                                            elements[element][subshell]))
+                    elif output == 'normalized':
+                        print("%s_%s\t%f" % (element, subshell,
+                                             elements[element][subshell]/int_sum))
+        return elements
+
 
     def remove_fine_structure_data(self, edges_list=None):
         """Remove the fine structure data from the fitting routine as

--- a/hyperspy/models/eelsmodel.py
+++ b/hyperspy/models/eelsmodel.py
@@ -32,6 +32,7 @@ _logger = logging.getLogger(__name__)
 class EELSModel(Model1D):
 
     """Build an EELS model
+
     Parameters
     ----------
     spectrum : a Signal1D (or any Signal1D subclass) instance
@@ -57,6 +58,7 @@ class EELSModel(Model1D):
     dictionary : {dict, None}
         A dictionary to be used to recreate a model. Usually generated using
         :meth:`hyperspy.model.as_dictionary`
+
     """
 
     def __init__(self, signal1D, auto_background=True,
@@ -128,12 +130,14 @@ class EELSModel(Model1D):
     def _classify_components(self):
         """Classify components between background and ionization edge
         components.
+
         This method should be called everytime that components are added and
         removed. An ionization edge becomes background when its onset falls to
         the left of the first non-masked energy channel. The ionization edges
         are stored in a list in the `edges` attribute. They are sorted by
         increasing `onset_energy`. The background components are stored in
         `_background_components`.
+
         """
         self.edges = []
         self._background_components = []
@@ -220,13 +224,16 @@ class EELSModel(Model1D):
             preedge_safe_window_width=2,
             i1=0):
         """Adjust the fine structure of all edges to avoid overlapping
+
         This function is called automatically everytime the position of an edge
         changes
+
         Parameters
         ----------
         preedge_safe_window_width : float
             minimum distance between the fine structure of an ionization edge
             and that of the following one. Default 2 (eV).
+
         """
 
         if self._suspend_auto_fine_structure_width is True:
@@ -283,7 +290,9 @@ class EELSModel(Model1D):
 
     def fit(self, kind="std", **kwargs):
         """Fits the model to the experimental data.
+
         Read more in the :ref:`User Guide <model.fitting>`.
+
         Parameters
         ----------
         kind : {"std", "smart"}, default "std"
@@ -291,14 +300,17 @@ class EELSModel(Model1D):
             performs a smart_fit - for more details see
             the :ref:`User Guide <eels.fitting>`.
         %s
+
         Returns
         -------
         None
+
         See Also
         --------
         * :py:meth:`~hyperspy.model.BaseModel.fit`
         * :py:meth:`~hyperspy.model.BaseModel.multifit`
         * :py:meth:`~hyperspy.model.EELSModel.smart_fit`
+
         """
         if kind not in ["smart", "std"]:
             raise ValueError(
@@ -313,25 +325,30 @@ class EELSModel(Model1D):
 
     def smart_fit(self, start_energy=None, **kwargs):
         """Fits EELS edges in a cascade style.
+
         The fitting procedure acts in iterative manner along
         the energy-loss-axis. First it fits only the background
         up to the first edge. It continues by deactivating all
         edges except the first one, then performs the fit. Then
         it only activates the the first two, fits, and repeats
         this until all edges are fitted simultanously.
+
         Other, non-EELSCLEdge components, are never deactivated,
         and fitted on every iteration.
+
         Parameters
         ----------
         start_energy : {float, None}
             If float, limit the range of energies from the left to the
             given value.
         %s
+
         See Also
         --------
         * :py:meth:`~hyperspy.model.BaseModel.fit`
         * :py:meth:`~hyperspy.model.BaseModel.multifit`
         * :py:meth:`~hyperspy.model.EELSModel.fit`
+
         """
         # Fit background
         self.fit_background(start_energy, **kwargs)
@@ -344,11 +361,13 @@ class EELSModel(Model1D):
 
     def _get_first_ionization_edge_energy(self, start_energy=None):
         """Calculate the first ionization edge energy.
+
         Returns
         -------
         iee : float or None
             The first ionization edge energy or None if no edge is defined in
             the model.
+
         """
         if not self._active_edges:
             return None
@@ -367,6 +386,7 @@ class EELSModel(Model1D):
     def fit_background(self, start_energy=None, only_current=True, **kwargs):
         """Fit the background to the first active ionization edge
         in the energy range.
+
         Parameters
         ----------
         start_energy : {float, None}, optional
@@ -378,6 +398,7 @@ class EELSModel(Model1D):
         **kwargs : extra key word arguments
             All extra key word arguments are passed to fit or
             multifit.
+
         """
 
         # If there is no active background compenent do nothing
@@ -403,6 +424,7 @@ class EELSModel(Model1D):
     def two_area_background_estimation(self, E1=None, E2=None, powerlaw=None):
         """Estimates the parameters of a power law background with the two
         area method.
+
         Parameters
         ----------
         E1 : float
@@ -410,6 +432,7 @@ class EELSModel(Model1D):
         powerlaw : PowerLaw component or None
             If None, it will try to guess the right component from the
             background components of the model
+
         """
         if powerlaw is None:
             for component in self._active_background_components:
@@ -608,11 +631,13 @@ class EELSModel(Model1D):
         """Remove the fine structure data from the fitting routine as
         defined in the fine_structure_width parameter of the
         component.EELSCLEdge
+
         Parameters
         ----------
         edges_list : None or  list of EELSCLEdge or list of edge names
             If None, the operation is performed on all the edges in the model.
             Otherwise, it will be performed only on the listed components.
+
         See Also
         --------
         enable_edges, disable_edges, enable_background,
@@ -621,6 +646,7 @@ class EELSModel(Model1D):
         unset_all_edges_intensities_positive, enable_free_onset_energy,
         disable_free_onset_energy, fix_edges, free_edges, fix_fine_structure,
         free_fine_structure
+
         """
         if edges_list is None:
             edges_list = self._active_edges
@@ -637,11 +663,13 @@ class EELSModel(Model1D):
         """Enable the edges listed in edges_list. If edges_list is
         None (default) all the edges with onset in the spectrum energy
         region will be enabled.
+
         Parameters
         ----------
         edges_list : None or  list of EELSCLEdge or list of edge names
             If None, the operation is performed on all the edges in the model.
             Otherwise, it will be performed only on the listed components.
+
         See Also
         --------
         enable_edges, disable_edges, enable_background,
@@ -650,6 +678,7 @@ class EELSModel(Model1D):
         unset_all_edges_intensities_positive, enable_free_onset_energy,
         disable_free_onset_energy, fix_edges, free_edges, fix_fine_structure,
         free_fine_structure
+
         """
 
         if edges_list is None:
@@ -665,11 +694,13 @@ class EELSModel(Model1D):
         """Disable the edges listed in edges_list. If edges_list is None (default)
         all the edges with onset in the spectrum energy region will be
         disabled.
+
         Parameters
         ----------
         edges_list : None or  list of EELSCLEdge or list of edge names
             If None, the operation is performed on all the edges in the model.
             Otherwise, it will be performed only on the listed components.
+
         See Also
         --------
         enable_edges, disable_edges, enable_background,
@@ -678,6 +709,7 @@ class EELSModel(Model1D):
         unset_all_edges_intensities_positive, enable_free_onset_energy,
         disable_free_onset_energy, fix_edges, free_edges, fix_fine_structure,
         free_fine_structure
+
         """
         if edges_list is None:
             edges_list = self._active_edges
@@ -690,12 +722,14 @@ class EELSModel(Model1D):
 
     def enable_background(self):
         """Enable the background componets.
+
         """
         for component in self._background_components:
             component.active = True
 
     def disable_background(self):
         """Disable the background components.
+
         """
         for component in self._active_background_components:
             component.active = False
@@ -704,11 +738,13 @@ class EELSModel(Model1D):
         """Enable the fine structure of the edges listed in edges_list.
         If edges_list is None (default) the fine structure of all the edges
         with onset in the spectrum energy region will be enabled.
+
         Parameters
         ----------
         edges_list : None or  list of EELSCLEdge or list of edge names
             If None, the operation is performed on all the edges in the model.
             Otherwise, it will be performed only on the listed components.
+
         See Also
         --------
         enable_edges, disable_edges, enable_background,
@@ -717,6 +753,7 @@ class EELSModel(Model1D):
         unset_all_edges_intensities_positive, enable_free_onset_energy,
         disable_free_onset_energy, fix_edges, free_edges, fix_fine_structure,
         free_fine_structure
+
         """
         if edges_list is None:
             edges_list = self._active_edges
@@ -732,11 +769,13 @@ class EELSModel(Model1D):
         """Disable the fine structure of the edges listed in edges_list.
         If edges_list is None (default) the fine structure of all the edges
         with onset in the spectrum energy region will be disabled.
+
         Parameters
         ----------
         edges_list : None or  list of EELSCLEdge or list of edge names
             If None, the operation is performed on all the edges in the model.
             Otherwise, it will be performed only on the listed components.
+
         See Also
         --------
         enable_edges, disable_edges, enable_background,
@@ -745,6 +784,7 @@ class EELSModel(Model1D):
         unset_all_edges_intensities_positive, enable_free_onset_energy,
         disable_free_onset_energy, fix_edges, free_edges, fix_fine_structure,
         free_fine_structure
+
         """
         if edges_list is None:
             edges_list = self._active_edges
@@ -771,11 +811,13 @@ class EELSModel(Model1D):
         smart fit for the edges listed in edges_list.
         If edges_list is None (default) the onset_energy of all the edges
         with onset in the spectrum energy region will be freeed.
+
         Parameters
         ----------
         edges_list : None or  list of EELSCLEdge or list of edge names
             If None, the operation is performed on all the edges in the model.
             Otherwise, it will be performed only on the listed components.
+
         See Also
         --------
         enable_edges, disable_edges, enable_background,
@@ -784,6 +826,7 @@ class EELSModel(Model1D):
         unset_all_edges_intensities_positive, enable_free_onset_energy,
         disable_free_onset_energy, fix_edges, free_edges, fix_fine_structure,
         free_fine_structure
+
         """
         if edges_list is None:
             edges_list = self._active_edges
@@ -800,11 +843,13 @@ class EELSModel(Model1D):
         with onset in the spectrum energy region will not be freed.
         Note that if their atribute edge.onset_energy.free is True, the
         parameter will be free during the smart fit.
+
         Parameters
         ----------
         edges_list : None or  list of EELSCLEdge or list of edge names
             If None, the operation is performed on all the edges in the model.
             Otherwise, it will be performed only on the listed components.
+
         See Also
         --------
         enable_edges, disable_edges, enable_background,
@@ -813,6 +858,7 @@ class EELSModel(Model1D):
         unset_all_edges_intensities_positive, enable_free_onset_energy,
         disable_free_onset_energy, fix_edges, free_edges, fix_fine_structure,
         free_fine_structure
+
         """
 
         if edges_list is None:
@@ -826,11 +872,13 @@ class EELSModel(Model1D):
     def fix_edges(self, edges_list=None):
         """Fixes all the parameters of the edges given in edges_list.
         If edges_list is None (default) all the edges will be fixed.
+
         Parameters
         ----------
         edges_list : None or  list of EELSCLEdge or list of edge names
             If None, the operation is performed on all the edges in the model.
             Otherwise, it will be performed only on the listed components.
+
         See Also
         --------
         enable_edges, disable_edges, enable_background,
@@ -839,6 +887,7 @@ class EELSModel(Model1D):
         unset_all_edges_intensities_positive, enable_free_onset_energy,
         disable_free_onset_energy, fix_edges, free_edges, fix_fine_structure,
         free_fine_structure
+
         """
         if edges_list is None:
             edges_list = self._active_edges
@@ -853,11 +902,13 @@ class EELSModel(Model1D):
     def free_edges(self, edges_list=None):
         """Frees all the parameters of the edges given in edges_list.
         If edges_list is None (default) all the edges will be freeed.
+
         Parameters
         ----------
         edges_list : None or  list of EELSCLEdge or list of edge names
             If None, the operation is performed on all the edges in the model.
             Otherwise, it will be performed only on the listed components.
+
         See Also
         --------
         enable_edges, disable_edges, enable_background,
@@ -866,6 +917,7 @@ class EELSModel(Model1D):
         unset_all_edges_intensities_positive, enable_free_onset_energy,
         disable_free_onset_energy, fix_edges, free_edges, fix_fine_structure,
         free_fine_structure
+
         """
 
         if edges_list is None:
@@ -879,11 +931,13 @@ class EELSModel(Model1D):
     def fix_fine_structure(self, edges_list=None):
         """Fixes all the parameters of the edges given in edges_list.
         If edges_list is None (default) all the edges will be fixed.
+
         Parameters
         ----------
         edges_list : None or  list of EELSCLEdge or list of edge names
             If None, the operation is performed on all the edges in the model.
             Otherwise, it will be performed only on the listed components.
+
         See Also
         --------
         enable_edges, disable_edges, enable_background,
@@ -892,6 +946,7 @@ class EELSModel(Model1D):
         unset_all_edges_intensities_positive, enable_free_onset_energy,
         disable_free_onset_energy, fix_edges, free_edges, fix_fine_structure,
         free_fine_structure
+
         """
         if edges_list is None:
             edges_list = self._active_edges
@@ -904,11 +959,13 @@ class EELSModel(Model1D):
     def free_fine_structure(self, edges_list=None):
         """Frees all the parameters of the edges given in edges_list.
         If edges_list is None (default) all the edges will be freeed.
+
         Parameters
         ----------
         edges_list : None or  list of EELSCLEdge or list of edge names
             If None, the operation is performed on all the edges in the model.
             Otherwise, it will be performed only on the listed components.
+
         See Also
         --------
         enable_edges, disable_edges, enable_background,
@@ -917,6 +974,7 @@ class EELSModel(Model1D):
         unset_all_edges_intensities_positive, enable_free_onset_energy,
         disable_free_onset_energy, fix_edges, free_edges, fix_fine_structure,
         free_fine_structure
+
         """
         if edges_list is None:
             edges_list = self._active_edges
@@ -929,9 +987,11 @@ class EELSModel(Model1D):
     def suspend_auto_fine_structure_width(self):
         """Disable the automatic adjustament of the core-loss edges fine
         structure width.
+
         See Also
         --------
         resume_auto_fine_structure_width
+
         """
         if self._suspend_auto_fine_structure_width is False:
             self._suspend_auto_fine_structure_width = True
@@ -941,13 +1001,17 @@ class EELSModel(Model1D):
     def resume_auto_fine_structure_width(self, update=True):
         """Enable the automatic adjustament of the core-loss edges fine
         structure width.
+
         Parameters
         ----------
         update : bool, optional
             If True, also execute the automatic adjustment (default).
+
+
         See Also
         --------
         suspend_auto_fine_structure_width
+
         """
         if self._suspend_auto_fine_structure_width is True:
             self._suspend_auto_fine_structure_width = False

--- a/hyperspy/models/eelsmodel.py
+++ b/hyperspy/models/eelsmodel.py
@@ -61,9 +61,15 @@ class EELSModel(Model1D):
 
     """
 
-    def __init__(self, signal1D, auto_background=True,
-                 auto_add_edges=True, ll=None,
-                 GOS=None, dictionary=None):
+    def __init__(
+        self,
+        signal1D,
+        auto_background=True,
+        auto_add_edges=True,
+        ll=None,
+        GOS=None,
+        dictionary=None,
+    ):
         Model1D.__init__(self, signal1D)
 
         # When automatically setting the fine structure energy regions,
@@ -103,8 +109,8 @@ class EELSModel(Model1D):
         else:
             raise ValueError(
                 "This attribute can only contain an EELSSpectrum "
-                "but an object of type %s was provided" %
-                str(type(value)))
+                "but an object of type %s was provided" % str(type(value))
+            )
 
     def append(self, component):
         super(EELSModel, self).append(component)
@@ -114,7 +120,8 @@ class EELSModel(Model1D):
                 E0=tem.beam_energy,
                 alpha=tem.convergence_angle,
                 beta=tem.Detector.EELS.collection_angle,
-                energy_scale=self.axis.scale)
+                energy_scale=self.axis.scale,
+            )
             component.energy_scale = self.axis.scale
             component._set_fine_structure_coeff()
         self._classify_components()
@@ -143,16 +150,17 @@ class EELSModel(Model1D):
         self._background_components = []
         for component in self:
             if isinstance(component, EELSCLEdge):
-                if component.onset_energy.value < \
-                        self.axis.axis[self.channel_switches][0]:
+                if (
+                    component.onset_energy.value
+                    < self.axis.axis[self.channel_switches][0]
+                ):
                     component.isbackground = True
                 if component.isbackground is not True:
                     self.edges.append(component)
                 else:
                     component.fine_structure_active = False
                     component.fine_structure_coeff.free = False
-            elif (isinstance(component, PowerLaw) or
-                  component.isbackground is True):
+            elif isinstance(component, PowerLaw) or component.isbackground is True:
                 self._background_components.append(component)
 
         if self.edges:
@@ -161,11 +169,9 @@ class EELSModel(Model1D):
         if len(self._background_components) > 1:
             self._backgroundtype = "mix"
         elif len(self._background_components) == 1:
-            self._backgroundtype = \
-                self._background_components[0].__repr__()
+            self._backgroundtype = self._background_components[0].__repr__()
             bg = self._background_components[0]
-            if isinstance(bg, PowerLaw) and self.edges and not \
-               bg.A.map["is_set"].any():
+            if isinstance(bg, PowerLaw) and self.edges and not bg.A.map["is_set"].any():
                 self.two_area_background_estimation()
 
     @property
@@ -198,11 +204,11 @@ class EELSModel(Model1D):
         self.append(master_edge)
         element = master_edge.element
         while len(e_shells) > 0:
-            next_element = e_shells[-1].split('_')[0]
+            next_element = e_shells[-1].split("_")[0]
             if next_element != element:
                 # New master edge
                 self._add_edges_from_subshells_names(e_shells=e_shells)
-            elif self.GOS == 'hydrogenic':
+            elif self.GOS == "hydrogenic":
                 # The hydrogenic GOS includes all the L subshells in one
                 # so we get rid of the others
                 e_shells.pop()
@@ -215,14 +221,12 @@ class EELSModel(Model1D):
                 edge.intensity.twin = master_edge.intensity
                 edge.onset_energy.twin = master_edge.onset_energy
                 edge.onset_energy.twin_function_expr = "x + {}".format(
-                    (edge.GOS.onset_energy - master_edge.GOS.onset_energy))
+                    (edge.GOS.onset_energy - master_edge.GOS.onset_energy)
+                )
                 edge.free_onset_energy = False
                 self.append(edge)
 
-    def resolve_fine_structure(
-            self,
-            preedge_safe_window_width=2,
-            i1=0):
+    def resolve_fine_structure(self, preedge_safe_window_width=2, i1=0):
         """Adjust the fine structure of all edges to avoid overlapping
 
         This function is called automatically everytime the position of an edge
@@ -242,46 +246,62 @@ class EELSModel(Model1D):
         if not self._active_edges:
             return
 
-        while (self._active_edges[i1].fine_structure_active is False and
-               i1 < len(self._active_edges) - 1):
+        while (
+            self._active_edges[i1].fine_structure_active is False
+            and i1 < len(self._active_edges) - 1
+        ):
             i1 += 1
         if i1 < len(self._active_edges) - 1:
             i2 = i1 + 1
-            while (self._active_edges[i2].fine_structure_active is False and
-                    i2 < len(self._active_edges) - 1):
+            while (
+                self._active_edges[i2].fine_structure_active is False
+                and i2 < len(self._active_edges) - 1
+            ):
                 i2 += 1
             if self._active_edges[i2].fine_structure_active is True:
                 distance_between_edges = (
-                    self._active_edges[i2].onset_energy.value -
-                    self._active_edges[i1].onset_energy.value)
-                if (self._active_edges[i1].fine_structure_width >
-                        distance_between_edges -
-                        self._preedge_safe_window_width):
+                    self._active_edges[i2].onset_energy.value
+                    - self._active_edges[i1].onset_energy.value
+                )
+                if (
+                    self._active_edges[i1].fine_structure_width
+                    > distance_between_edges - self._preedge_safe_window_width
+                ):
                     min_d = self._min_distance_between_edges_for_fine_structure
-                    if (distance_between_edges -
-                            self._preedge_safe_window_width) <= min_d:
-                        _logger.info((
-                            "Automatically deactivating the fine structure "
-                            "of edge number %d to avoid conflicts with edge "
-                            "number %d") % (i2 + 1, i1 + 1))
+                    if (
+                        distance_between_edges - self._preedge_safe_window_width
+                    ) <= min_d:
+                        _logger.info(
+                            (
+                                "Automatically deactivating the fine structure "
+                                "of edge number %d to avoid conflicts with edge "
+                                "number %d"
+                            )
+                            % (i2 + 1, i1 + 1)
+                        )
                         self._active_edges[i2].fine_structure_active = False
-                        self._active_edges[
-                            i2].fine_structure_coeff.free = False
+                        self._active_edges[i2].fine_structure_coeff.free = False
                         self.resolve_fine_structure(i1=i2)
                     else:
                         new_fine_structure_width = (
-                            distance_between_edges -
-                            self._preedge_safe_window_width)
-                        _logger.info((
-                            "Automatically changing the fine structure "
-                            "width of edge %d from %s eV to %s eV to avoid "
-                            "conflicts with edge number %d") % (
-                            i1 + 1,
-                            self._active_edges[i1].fine_structure_width,
-                            new_fine_structure_width,
-                            i2 + 1))
-                        self._active_edges[i1].fine_structure_width = \
-                            new_fine_structure_width
+                            distance_between_edges - self._preedge_safe_window_width
+                        )
+                        _logger.info(
+                            (
+                                "Automatically changing the fine structure "
+                                "width of edge %d from %s eV to %s eV to avoid "
+                                "conflicts with edge number %d"
+                            )
+                            % (
+                                i1 + 1,
+                                self._active_edges[i1].fine_structure_width,
+                                new_fine_structure_width,
+                                i2 + 1,
+                            )
+                        )
+                        self._active_edges[
+                            i1
+                        ].fine_structure_width = new_fine_structure_width
                         self.resolve_fine_structure(i1=i2)
                 else:
                     self.resolve_fine_structure(i1=i2)
@@ -313,9 +333,7 @@ class EELSModel(Model1D):
 
         """
         if kind not in ["smart", "std"]:
-            raise ValueError(
-                f"kind must be either 'std' or 'smart', not '{kind}'"
-            )
+            raise ValueError(f"kind must be either 'std' or 'smart', not '{kind}'")
         elif kind == "smart":
             return self.smart_fit(**kwargs)
         elif kind == "std":
@@ -372,8 +390,11 @@ class EELSModel(Model1D):
         if not self._active_edges:
             return None
         start_energy = self._get_start_energy(start_energy)
-        iee_list = [edge.onset_energy.value for edge in self._active_edges
-                    if edge.onset_energy.value > start_energy]
+        iee_list = [
+            edge.onset_energy.value
+            for edge in self._active_edges
+            if edge.onset_energy.value > start_energy
+        ]
         iee = min(iee_list) if iee_list else None
         return iee
 
@@ -406,8 +427,9 @@ class EELSModel(Model1D):
             return
         iee = self._get_first_ionization_edge_energy(start_energy=start_energy)
         if iee is not None:
-            to_disable = [edge for edge in self._active_edges
-                          if edge.onset_energy.value >= iee]
+            to_disable = [
+                edge for edge in self._active_edges if edge.onset_energy.value >= iee
+            ]
             E2 = iee - self._preedge_safe_window_width
             self.disable_edges(to_disable)
         else:
@@ -441,10 +463,11 @@ class EELSModel(Model1D):
                         powerlaw = component
                     else:
                         _logger.warning(
-                            'There are more than two power law '
-                            'background components defined in this model, '
-                            'please use the powerlaw keyword to specify one'
-                            ' of them')
+                            "There are more than two power law "
+                            "background components defined in this model, "
+                            "please use the powerlaw keyword to specify one"
+                            " of them"
+                        )
                         return
                 else:  # No power law component
                     return
@@ -456,15 +479,14 @@ class EELSModel(Model1D):
             if E2 is None:
                 E2 = ea[-1]
             else:
-                E2 = E2 - \
-                    self._preedge_safe_window_width
+                E2 = E2 - self._preedge_safe_window_width
 
-        if not powerlaw.estimate_parameters(
-                self.signal, E1, E2, only_current=False):
+        if not powerlaw.estimate_parameters(self.signal, E1, E2, only_current=False):
             _logger.warning(
                 "The power law background parameters could not "
                 "be estimated.\n"
-                "Try choosing a different energy range for the estimation")
+                "Try choosing a different energy range for the estimation"
+            )
             return
 
     def _fit_edge(self, edgenumber, start_energy=None, **kwargs):
@@ -475,19 +497,22 @@ class EELSModel(Model1D):
         # Declare variables
         active_edges = self._active_edges
         edge = active_edges[edgenumber]
-        if (edge.intensity.twin is not None or
-                edge.active is False or
-                edge.onset_energy.value < start_energy or
-                edge.onset_energy.value > ea[-1]):
+        if (
+            edge.intensity.twin is not None
+            or edge.active is False
+            or edge.onset_energy.value < start_energy
+            or edge.onset_energy.value > ea[-1]
+        ):
             return 1
         # Fitting edge 'edge.name'
-        last_index = len(self._active_edges) - 1    # Last edge index
+        last_index = len(self._active_edges) - 1  # Last edge index
         i = 1
         twins = []
         # find twins
         while edgenumber + i <= last_index and (
-                active_edges[edgenumber + i].intensity.twin is not None or
-                active_edges[edgenumber + i].active is False):
+            active_edges[edgenumber + i].intensity.twin is not None
+            or active_edges[edgenumber + i].active is False
+        ):
             if active_edges[edgenumber + i].intensity.twin is not None:
                 twins.append(self._active_edges[edgenumber + i])
             i += 1
@@ -495,14 +520,19 @@ class EELSModel(Model1D):
             nextedgeenergy = ea[-1]
         else:
             nextedgeenergy = (
-                active_edges[edgenumber + i].onset_energy.value -
-                self._preedge_safe_window_width)
+                active_edges[edgenumber + i].onset_energy.value
+                - self._preedge_safe_window_width
+            )
 
         # Backup the fsstate
         to_activate_fs = []
-        for edge_ in [edge, ] + twins:
-            if (edge_.fine_structure_active is True and
-                    edge_.fine_structure_coeff.free is True):
+        for edge_ in [
+            edge,
+        ] + twins:
+            if (
+                edge_.fine_structure_active is True
+                and edge_.fine_structure_coeff.free is True
+            ):
                 to_activate_fs.append(edge_)
         self.disable_fine_structure(to_activate_fs)
 
@@ -510,9 +540,8 @@ class EELSModel(Model1D):
 
         # Without fine structure to determine onset_energy
         edges_to_activate = []
-        for edge_ in self._active_edges[edgenumber + 1:]:
-            if (edge_.active is True and
-                    edge_.onset_energy.value >= nextedgeenergy):
+        for edge_ in self._active_edges[edgenumber + 1 :]:
+            if edge_.active is True and edge_.onset_energy.value >= nextedgeenergy:
                 edge_.active = False
                 edges_to_activate.append(edge_)
 
@@ -538,23 +567,22 @@ class EELSModel(Model1D):
         # Recover the channel_switches. Remove it or make it smarter.
         self.channel_switches = backup_channel_switches
 
-
-    def quantify(self, output = 'absolute'):
+    def quantify(self, output="absolute"):
         """Prints and returns the values of the intensity of all the independent
         active EELS core loss edges defined in the model.
-        
+
         Parameters
         ----------
         output : 'absolute', 'normalized', or None
             If 'absolute', prints values of the intensity parameter of all EELSCLEdge components.\n
             If 'normalized', prints intensity parameters normalized with respect to the sum of all intensities in the model. If all relevant elements are present in the analyzed spectrum this results in the elemental concentrations in atomic %.\n
             If None, no output is printed.
-        
+
         Returns
         -------
         dict
             Python dictionary with element name, edge name and intensity value.
-        
+
         Examples
         -------
         Load and fit the BN EELS example from the user guide:\n
@@ -564,14 +592,14 @@ class EELSModel(Model1D):
         >>> m = s.create_model(ll=ll)
         >>> m.enable_fine_structure()
         >>> m.smart_fit()
-        
+
         Print the elemental concentrations:\n
         >>> m.quantify(output='normalized')
-        
+
         Calculate B/N ratio with the returned dictionary:\n
         >>> q = m.quantify(output=None)
         >>> print('B/N ratio: ', q['B']['K']/q['N']['K'])
-        
+
         The intensity values can also be accessed directly from the model component:\n
         >>> print('Intensity of B K edge: ', q['B']['K'])
         >>> print('Intensity of B K edge: ', m.components.B_K.intensity.value)
@@ -581,7 +609,7 @@ class EELSModel(Model1D):
         :py:class:`~._components.eels_cl_edge.EELSCLEdge`
         """
         elements = {}
-        if output == 'normalized':
+        if output == "normalized":
             int_sum = 0
         for edge in self._active_edges:
             if edge.active and edge.intensity.twin is None:
@@ -590,40 +618,43 @@ class EELSModel(Model1D):
                 if element not in elements:
                     elements[element] = {}
                 elements[element][subshell] = edge.intensity.value
-                if output == 'normalized':
+                if output == "normalized":
                     int_sum += edge.intensity.value
-        
+
         if output == None:
             return elements
         print()
-        if output == 'absolute':
+        if output == "absolute":
             print("Absolute quantification:")
-        elif output == 'normalized':
+        elif output == "normalized":
             print("Normalized elemental concentrations:")
-        if output == 'absolute':
+        if output == "absolute":
             print("Elem.\tIntensity")
-        elif output == 'normalized':
+        elif output == "normalized":
             print("Elem.\tConcentration")
 
         for element in elements:
             if len(elements[element]) == 1:
                 for subshell in elements[element]:
-                    if output == 'absolute':
-                        print("%s\t%f" % (
-                            element, elements[element][subshell]))
-                    elif output == 'normalized':
-                            print("%s\t%f" % (
-                                element, elements[element][subshell]/int_sum))
+                    if output == "absolute":
+                        print("%s\t%f" % (element, elements[element][subshell]))
+                    elif output == "normalized":
+                        print(
+                            "%s\t%f" % (element, elements[element][subshell] / int_sum)
+                        )
             else:
                 for subshell in elements[element]:
-                    if output == 'absolute':
-                        print("%s_%s\t%f" % (element, subshell,
-                                            elements[element][subshell]))
-                    elif output == 'normalized':
-                        print("%s_%s\t%f" % (element, subshell,
-                                             elements[element][subshell]/int_sum))
+                    if output == "absolute":
+                        print(
+                            "%s_%s\t%f"
+                            % (element, subshell, elements[element][subshell])
+                        )
+                    elif output == "normalized":
+                        print(
+                            "%s_%s\t%f"
+                            % (element, subshell, elements[element][subshell] / int_sum)
+                        )
         return elements
-
 
     def remove_fine_structure_data(self, edges_list=None):
         """Remove the fine structure data from the fitting routine as
@@ -651,8 +682,7 @@ class EELSModel(Model1D):
         else:
             edges_list = [self._get_component(x) for x in edges_list]
         for edge in edges_list:
-            if (edge.isbackground is False and
-                    edge.fine_structure_active is True):
+            if edge.isbackground is False and edge.fine_structure_active is True:
                 start = edge.onset_energy.value
                 stop = start + edge.fine_structure_width
                 self.remove_signal_range(start, stop)
@@ -719,16 +749,12 @@ class EELSModel(Model1D):
         self.resolve_fine_structure()
 
     def enable_background(self):
-        """Enable the background componets.
-
-        """
+        """Enable the background componets."""
         for component in self._background_components:
             component.active = True
 
     def disable_background(self):
-        """Disable the background components.
-
-        """
+        """Disable the background components."""
         for component in self._active_background_components:
             component.active = False
 


### PR DESCRIPTION
### Added different outputs in EELS quantify()
(Disclaimer: First pull request on Github, hopefully all works out)  
This change addresses issue #2562 by giving different possiblities for printed outputs for `quantify()` for EELS model-based quantification and adds some information in the user guide and docstring. The `quantify()` function now has a parameter 'output', which can be changed to manipulate the printed output:
- 'absolute': Same as now, i.e. the intensity values of the fitted core-loss edges. It's the default value, so it should not break any existing code. (?)
- 'normalized': Sums up all intensities and uses this for normalization of each intensity value in the model. This results in the elemental concentrations (if all elements are present in the model) and mimics the functionality of Digital Micrograph.
- None: No printed output. Useful, if only the newly returned dictionary with the intensity values is relevant for further analysis.

In addition, the elements[element][subshell] dictionary is returned, which can be used as an alternative to `m.component.element_subshell.intensity.value`.  
The documentation and user guide has been updated to accomodate for the changes. Hopefully this will clarify the meaning of the 'intensity' parameter, i.e. that it can be used directly to calculate elemental concentrations/ratios and does not have to be weightened by a (partial) scattering cross-section.  
The BN example from the EELS DB has 300 keV beam energy noted in its metadata, so I changed the value in the user guide: `s.set_microscope_parameters(beam_energy=300, convergence_angle=0.2, collection_angle=2.55)`. Else, running the example with 100 keV will yield skewed quantification results for BN (around 60/40 at% instead of ~50/50 at%).

### Progress of the PR
- [x] Change quantify() method.
- [x] update docstring,
- [x] update user guide,
- [x] ready for review.

### Minimal example of the new features
```python
import hyperspy.api as hs
#Follow BN EELS model fitting example from user guide 
s = hs.datasets.eelsdb(title="Hexagonal Boron Nitride", spectrum_type="coreloss")[0]
ll = hs.datasets.eelsdb(title="Hexagonal Boron Nitride", spectrum_type="lowloss")[0]
s.add_elements(('B', 'N'))
m = s.create_model(ll=ll)
m.enable_fine_structure()
m.smart_fit()
```
```python
#New quantify() output parameters
m.quantify() #same as default value 'absolute', i.e. current version of quantify()
m.quantify(output='absolute')
m.quantify(output='normalized') #Prints elemental concentrations
m.quantify(output=None) #No printed output
```
```python
#New quantify() returns dictionary
q = m.quantify(output=None)

#The dictionary can be used alternatively to the intensity component value of the model m
print('Intensity of B K edge: ', q['B']['K'])
print('Intensity of B K edge: ', m.components.B_K.intensity.value)
print('B/N ratio: ', q['B']['K']/q['N']['K'])
```
Regarding the beam energy of the example BN spectrum (300 keV instead of 100 keV):
```python
s = hs.datasets.eelsdb(title="Hexagonal Boron Nitride", spectrum_type="coreloss")[0]
s.metadata.Acquisition_instrument.TEM.beam_energy
```