### PR TITLE
Add releasing guide

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -16,6 +16,7 @@ A few sentences and/or a bulleted list to describe and motivate the change:
 - [ ] Change implemented (can be split into several points),
 - [ ] update docstring (if appropriate),
 - [ ] update user guide (if appropriate),
+- [ ] add entry to `CHANGES.rst` (if appropriate),
 - [ ] add tests,
 - [ ] ready for review.
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,15 +1,23 @@
 What's new
 **********
 
+..
+  Add a single entry in the corresponding section below.
+  See https://keepachangelog.com for details
+
+RELEASE_next_patch (Unreleased)
++++++++++++++++++++++++++++++++
+
+
+
+Changelog
+*********
+
 We only cover here the main highlights, for a detailed list of all the changes
 see `the commits in the GITHUB milestones
 <https://github.com/hyperspy/hyperspy/milestones?state=closed>`__.
 
-Current Version
-===============
-
 .. _changes_1.6.1:
-
 
 v1.6.1
 ++++++
@@ -19,15 +27,6 @@ numerous bug fixes and enhancements.
 See `the issue tracker
 <https://github.com/hyperspy/hyperspy/milestone/41?closed=1>`__
 for details.
-
-
-
-Changelog
-*********
-
-Previous Versions
-=================
-
 
 .. _changes_1.6:
 

--- a/releasing_guide.md
+++ b/releasing_guide.md
@@ -2,23 +2,30 @@
 Cut a Release
 =============
 
-Create a new PR to the `RELEASE_next_patch` and go through the following steps:
+Create a PR to the `RELEASE_next_patch` branch and go through the following steps:
+
+**Preparation**
 - Update and check changelog in `CHANGES.rst`
 - Bump version in `hyperspy/Release.py`
-- (optional) check conda-forge and wheels build
+- (optional) check conda-forge and wheels build. Pushing a tag to a fork will run the release workflow without uploading to pypi
 - Let that PR collect comments for a day to ensure that other maintainers are comfortable with releasing
-- :warning: push tag (`vx.y.z`) to https://github.com/hyperspy/hyperspy, :warning: this is a point of no return point :warning:, because the following will be triggered:
+
+**Tag and release**
+:warning: this is a point of no return point :warning:
+- push tag (`vx.y.z`) to the upstream repository and the following will be triggered:
   - creation of a zenodo record and the mining of a DOI
   - creation of a Github Release
   - build of the wheels and their upload to pypi
   - update of the current version on readthedocs to this release
+
+**Post-release action**
 - Increment the version and set it back to dev: `vx.y.z.dev0`
+- Update version in other branches when necessary
+- Prepare `CHANGES.rst` for development
 - Merge the PR
 
 Follow-up
 =========
 
-- Prepare `CHANGES.rst` to add new entry
-- Update version in other branches when necessary
 - Tidy up and close corresponding milestone
 - A PR to the conda-forge feedstock will be created by the conda-forge bot

--- a/releasing_guide.md
+++ b/releasing_guide.md
@@ -1,0 +1,24 @@
+
+Cut a Release
+=============
+
+Create a new PR to the `RELEASE_next_patch` and go through the following steps:
+- Update and check changelog in `CHANGES.rst`
+- Bump version in `hyperspy/Release.py`
+- (optional) check conda-forge and wheels build
+- Let that PR collect comments for a day to ensure that other maintainers are comfortable with releasing
+- :warning: push tag (`vx.y.z`) to https://github.com/hyperspy/hyperspy, :warning: this is a point of no return point :warning:, because the following will be triggered:
+  - creation of a zenodo record and the mining of a DOI
+  - creation of a Github Release
+  - build of the wheels and their upload to pypi
+  - update of the current version on readthedocs to this release
+- Increment the version and set it back to dev: `vx.y.z.dev0`
+- Merge the PR
+
+Follow-up
+=========
+
+- Prepare `CHANGES.rst` to add new entry
+- Update version in other branches when necessary
+- Tidy up and close corresponding milestone
+- A PR to the conda-forge feedstock will be created by the conda-forge bot


### PR DESCRIPTION
Follow up of #2490, which should help to release more often. There are still a few manual steps for preparation and post-release actions but most of the annoying bit is automated.

Another PR will be necessary to `RELEASE_next_minor` to add the `RELEASE_next_minor (Unreleased)` section to the changelog.

### Progress of the PR
- [x] Add releasing guide
- [x] update PR template
- [x] ready for review.

