### PR TITLE
Correct typo in zeta_factor_quantification : Take 2

### DIFF
--- a/hyperspy/_signals/eds_tem.py
+++ b/hyperspy/_signals/eds_tem.py
@@ -481,11 +481,12 @@ class EDSTEM_mixin:
                 number_of_atoms = composition._deepcopy_with_new_data(results[1])
 
             if method == 'cross_section':
-                abs_corr_factor = utils_eds.get_abs_corr_cross_section(composition.split(),
+                if absorption_correction:
+                    abs_corr_factor = utils_eds.get_abs_corr_cross_section(composition.split(),
                                                        number_of_atoms.split(),
                                                        toa,
                                                        probe_area)
-                kwargs["absorption_correction"] = abs_corr_factor
+                    kwargs["absorption_correction"] = abs_corr_factor
             else:
                 if absorption_correction:
                     abs_corr_factor = utils_eds.get_abs_corr_zeta(composition.split(),

--- a/hyperspy/_signals/eds_tem.py
+++ b/hyperspy/_signals/eds_tem.py
@@ -531,7 +531,7 @@ class EDSTEM_mixin:
             composition[i].metadata.set_item(
                 "Sample.xray_lines", ([xray_line]))
             if plot_result and composition[i].axes_manager.navigation_size == 1:
-                c = composition[i].data
+                c = np.float(composition[i].data)
                 print(f"{element} ({xray_line}): Composition = {c:.2f} percent")
         #For the cross section method this is repeated for the number of atom maps
         if method == 'cross_section':

--- a/hyperspy/misc/eds/utils.py
+++ b/hyperspy/misc/eds/utils.py
@@ -654,7 +654,7 @@ def get_abs_corr_cross_section(composition, number_of_atoms, take_off_angle,
     #calculate the total_mass in kg/m^2, or mass thickness.
     total_mass = np.zeros_like(number_of_atoms[0], dtype = 'float')
     for i, (weight) in enumerate(atomic_weights):
-        total_mass += (number_of_atoms[i] * weight / Av / 1E-3 / probe_area / 1E-18)
+        total_mass += (number_of_atoms[i] * weight / Av / 1E3 / probe_area / 1E-18)
     # determine mass absorption coefficients and convert from cm^2/g to m^2/kg.
     to_stack = material.mass_absorption_mixture(
         weight_percent=material.atomic_to_weight(composition)

--- a/hyperspy/misc/eds/utils.py
+++ b/hyperspy/misc/eds/utils.py
@@ -547,10 +547,10 @@ def quantification_zeta_factor(intensities,
 
     sumzi = np.zeros_like(intensities[0], dtype='float')
     composition = np.zeros_like(intensities, dtype='float')
-    for intensity, zfactor, absorption_correction in zip(intensities, zfactors, absorption_correction):
-        sumzi = sumzi + intensity * zfactor * absorption_correction
-    for i, (intensity, zfactor, absorption_correction) in enumerate(zip(intensities, zfactors, absorption_correction)):
-        composition[i] = intensity * zfactor * absorption_correction / sumzi
+    for intensity, zfactor, acf in zip(intensities, zfactors, absorption_correction):
+        sumzi = sumzi + (intensity * zfactor * acf)
+    for i, (intensity, zfactor, acf) in enumerate(zip(intensities, zfactors, absorption_correction)):
+        composition[i] = intensity * zfactor * acf / sumzi
     mass_thickness = sumzi / dose
     return composition, mass_thickness
 
@@ -577,9 +577,8 @@ def get_abs_corr_zeta(weight_percent, mass_thickness, take_off_angle): # take_of
         material.mass_absorption_mixture(weight_percent=weight_percent),
         show_progressbar=False
         ) * 0.1
-    acf = mac.data * mass_thickness.data * csc_toa
-    acf = acf/(1.0 - np.exp(-(acf)))
-
+    expo = mac.data * mass_thickness.data * csc_toa
+    acf = expo/(1.0 - np.exp(-(expo)))
     return acf
 
 def quantification_cross_section(intensities,
@@ -652,25 +651,21 @@ def get_abs_corr_cross_section(composition, number_of_atoms, take_off_angle,
 
     number_of_atoms = stack(number_of_atoms, show_progressbar=False).data
 
-    #calculate the total_mass per pixel, or mass thicknessself.
+    #calculate the total_mass in kg/m^2, or mass thickness.
     total_mass = np.zeros_like(number_of_atoms[0], dtype = 'float')
     for i, (weight) in enumerate(atomic_weights):
-        total_mass += (number_of_atoms[i] * weight / Av / probe_area / 1E-15)
-
-    # determine mass absorption coefficients and convert from cm^2/g to m^2/atom.
+        total_mass += (number_of_atoms[i] * weight / Av / 1E-3 / probe_area / 1E-18)
+    # determine mass absorption coefficients and convert from cm^2/g to m^2/kg.
     to_stack = material.mass_absorption_mixture(
         weight_percent=material.atomic_to_weight(composition)
         )
     mac = stack(to_stack, show_progressbar=False) * 0.1
-
     acf = np.zeros_like(number_of_atoms)
-    constant = 1/(Av * math.sin(toa_rad) * probe_area * 1E-16)
-
-    #determine an absorption coeficcient per element per pixel.
+    csc_toa = 1/math.sin(toa_rad)
+    #determine an absorption coeficient per element per pixel.
     for i, (weight) in enumerate(atomic_weights):
-        expo = (mac.data[i] * total_mass * constant)
-        acf[i] = expo/(1 - math.e**(-expo))
-
+        expo = (mac.data[i] * total_mass * csc_toa)
+        acf[i] = expo/(1 - np.exp(-expo))
     return acf
 
 

--- a/hyperspy/tests/signal/test_eds_tem.py
+++ b/hyperspy/tests/signal/test_eds_tem.py
@@ -390,17 +390,17 @@ class Test_quantification:
     def test_quant_cross_section_ac(self):
         s = self.signal
         method = 'cross_section'
-        factors = [3, 5]
+        zfactors = [20, 50]
         intensities = s.get_lines_intensity()
         res = s.quantification(intensities, method, factors,
                                absorption_correction=True)
-        zfactors = utils_eds.edx_cross_section_to_zeta(factors, ['Al', 'Zn'])
+        factors = utils_eds.zeta_to_edx_cross_section(zfactors, ['Al', 'Zn'])
         res2 = s.quantification(intensities, method='zeta',
                                 factors=zfactors,
                                 absorption_correction=True)
         np.testing.assert_allclose(res[0][0].data, np.array(
-            [[49.4889, 49.4889],
-             [49.4889, 49.4889]]), atol=1e-3)
+            [[44.02534, 44.02534],
+             [44.02534, 44.02534]]), atol=1e-3)
         np.testing.assert_allclose(res2[0][0].data, res[0][0].data, atol=1e-3)
 
     def eros(self):

--- a/hyperspy/tests/signal/test_eds_tem.py
+++ b/hyperspy/tests/signal/test_eds_tem.py
@@ -397,7 +397,7 @@ class Test_quantification:
                                    atol=1e-3)
         np.testing.assert_allclose(res2[0][0].data, res[0][0].data, atol=1e-3)
 
-    def eros(self):
+    def test_quant_zeros(self):
         intens = np.array([[0.5, 0.5, 0.5],
                            [0.0, 0.5, 0.5],
                            [0.5, 0.0, 0.5],

--- a/hyperspy/tests/signal/test_eds_tem.py
+++ b/hyperspy/tests/signal/test_eds_tem.py
@@ -391,14 +391,14 @@ class Test_quantification:
         s = self.signal
         method = 'cross_section'
         zfactors = [20, 50]
+        factors = utils_eds.zeta_to_edx_cross_section(zfactors, ['Al', 'Zn'])
         intensities = s.get_lines_intensity()
         res = s.quantification(intensities, method, factors,
                                absorption_correction=True)
-        factors = utils_eds.zeta_to_edx_cross_section(zfactors, ['Al', 'Zn'])
         res2 = s.quantification(intensities, method='zeta',
                                 factors=zfactors,
                                 absorption_correction=True)
-        np.testing.assert_allclose(res[0][0].data, np.array(
+        np.testing.assert_allclose(res[0][1].data, np.array(
             [[44.02534, 44.02534],
              [44.02534, 44.02534]]), atol=1e-3)
         np.testing.assert_allclose(res2[0][0].data, res[0][0].data, atol=1e-3)

--- a/hyperspy/tests/signal/test_eds_tem.py
+++ b/hyperspy/tests/signal/test_eds_tem.py
@@ -210,9 +210,11 @@ class Test_quantification:
         intensities = s.get_lines_intensity()
         res = s.quantification(intensities, method, kfactors,
                                composition_units)
-        np.testing.assert_allclose(res[0].data, np.array([
-            [22.70779, 22.70779],
-            [22.70779, 22.70779]]), atol=1e-3)
+        s2 = s.rebin(new_shape=(1,1,1024)).squeeze().squeeze()
+        s2.quantification(intensities, method, kfactors,
+                               composition_units, plot_result=True)
+        np.testing.assert_allclose(res[0].data, np.ones((2, 2)) * 22.70779,
+            atol=1e-3)
 
     def test_quant_lorimer_warning(self):
         s = self.signal
@@ -263,12 +265,10 @@ class Test_quantification:
         intensities = s.get_lines_intensity()
         res = s.quantification(intensities, method, factors,
                                composition_units)
-        np.testing.assert_allclose(res[1].data, np.array(
-            [[2.7125736e-03, 2.7125736e-03],
-             [2.7125736e-03, 2.7125736e-03]]), atol=1e-3)
-        np.testing.assert_allclose(res[0][1].data, np.array(
-            [[80.962287987, 80.962287987],
-             [80.962287987, 80.962287987]]), atol=1e-3)
+        np.testing.assert_allclose(res[1].data, np.ones((2, 2)) * 2.7125736e-03,
+                                   atol=1e-3)
+        np.testing.assert_allclose(res[0][1].data,
+                                   np.ones((2, 2)) * 80.962287987, atol=1e-3)
         res2 = s.quantification(intensities, method, factors,
                                composition_units,
                                absorption_correction=True,
@@ -278,9 +278,8 @@ class Test_quantification:
                                absorption_correction=True,
                                thickness=100.)
         assert res2 == res3
-        np.testing.assert_allclose(res2[0][1].data, np.array([
-            [65.5867, 65.5867],
-            [65.5867, 65.5867]]), atol=1e-3)
+        np.testing.assert_allclose(res2[0][1].data, np.ones((2, 2)) * 65.5867,
+                                   atol=1e-3)
 
     def test_quant_cross_section_units(self):
         s = self.signal.deepcopy()
@@ -357,26 +356,22 @@ class Test_quantification:
                                 method='cross_section',
                                 factors=[22.402, 21.7132])
         np.testing.assert_allclose(res[0][0].data, res2[0][0].data, atol=1e-3)
-        np.testing.assert_allclose(res[0][0].data, np.array(
-            [[36.2969, 36.2969],
-             [36.2969, 36.2969]]), atol=1e-3)
+        np.testing.assert_allclose(res[0][0].data, np.ones((2, 2)) * 36.2969,
+                                   atol=1e-3)
 
 
-    def nt_cross_section(self):
+    def test_quant_cross_section(self):
         s = self.signal
         method = 'cross_section'
         factors = [3, 5]
         intensities = s.get_lines_intensity()
         res = s.quantification(intensities, method, factors)
-        np.testing.assert_allclose(res[1][0].data, np.array(
-            [[21517.1647074, 21517.1647074],
-                [21517.1647074, 21517.1647074]]), atol=1e-3)
-        np.testing.assert_allclose(res[1][1].data, np.array(
-            [[21961.616621, 21961.616621],
-             [21961.616621, 21961.616621]]), atol=1e-3)
-        np.testing.assert_allclose(res[0][0].data, np.array(
-            [[49.4889, 49.4889],
-             [49.4889, 49.4889]]), atol=1e-3)
+        np.testing.assert_allclose(res[1][0].data, np.ones((2, 2)) * 21517.1647,
+                                   atol=1e-3)
+        np.testing.assert_allclose(res[1][1].data, np.ones((2, 2)) * 21961.6166,
+                                   atol=1e-3)
+        np.testing.assert_allclose(res[0][0].data, np.ones((2, 2)) * 49.4889,
+                                   atol=1e-3)
 
 
     def test_method_error(self):
@@ -398,9 +393,8 @@ class Test_quantification:
         res2 = s.quantification(intensities, method='zeta',
                                 factors=zfactors,
                                 absorption_correction=True)
-        np.testing.assert_allclose(res[0][1].data, np.array(
-            [[44.02534, 44.02534],
-             [44.02534, 44.02534]]), atol=1e-3)
+        np.testing.assert_allclose(res[0][1].data, np.ones((2, 2)) * 44.02534,
+                                   atol=1e-3)
         np.testing.assert_allclose(res2[0][0].data, res[0][0].data, atol=1e-3)
 
     def eros(self):
@@ -444,9 +438,8 @@ class Test_quantification:
                                composition_units='weight')
         assert res[0].metadata.Sample.xray_lines[0] == 'Zn_Ka'
         assert res[1].metadata.Sample.xray_lines[0] == 'Al_Ka'
-        np.testing.assert_allclose(res[1].data, np.array([
-            [22.70779, 22.70779],
-            [22.70779, 22.70779]]), atol=1e-3)
+        np.testing.assert_allclose(res[1].data, np.ones((2, 2)) * 22.70779,
+                                   atol=1e-3)
 
     def test_CL_get_mass_thickness(self):
         s = self.signal

--- a/hyperspy/tests/signal/test_eds_tem.py
+++ b/hyperspy/tests/signal/test_eds_tem.py
@@ -279,8 +279,8 @@ class Test_quantification:
                                thickness=100.)
         assert res2 == res3
         np.testing.assert_allclose(res2[0][1].data, np.array([
-            [61.6284, 61.6284],
-            [61.6284, 61.6284]]), atol=1e-3)
+            [65.5867, 65.5867],
+            [65.5867, 65.5867]]), atol=1e-3)
 
     def test_quant_cross_section_units(self):
         s = self.signal.deepcopy()
@@ -362,7 +362,7 @@ class Test_quantification:
              [36.2969, 36.2969]]), atol=1e-3)
 
 
-    def test_quant_cross_section(self):
+    def nt_cross_section(self):
         s = self.signal
         method = 'cross_section'
         factors = [3, 5]
@@ -394,7 +394,7 @@ class Test_quantification:
         intensities = s.get_lines_intensity()
         res = s.quantification(intensities, method, factors,
                                absorption_correction=True)
-        zfactors = utils_eds.zeta_to_edx_cross_section(factors, ['Al', 'Zn'])
+        zfactors = utils_eds.edx_cross_section_to_zeta(factors, ['Al', 'Zn'])
         res2 = s.quantification(intensities, method='zeta',
                                 factors=zfactors,
                                 absorption_correction=True)
@@ -403,7 +403,7 @@ class Test_quantification:
              [49.4889, 49.4889]]), atol=1e-3)
         np.testing.assert_allclose(res2[0][0].data, res[0][0].data, atol=1e-3)
 
-    def test_quant_zeros(self):
+    def eros(self):
         intens = np.array([[0.5, 0.5, 0.5],
                            [0.0, 0.5, 0.5],
                            [0.5, 0.0, 0.5],


### PR DESCRIPTION
Accidental use of the same name for two variables inside and outside a for loop in the zeta_factor quantification, meant the wrong value was take forward in the function. This has now been corrected here.

Tests have been updated and mismatch errors in notation between cross sections and zeta factors have been fixed.

I have also added the fix for plot_result=True errors.

