### PR TITLE
Fix navigation mask issue with quantification of single spectrum

### DIFF
--- a/hyperspy/_signals/eds_tem.py
+++ b/hyperspy/_signals/eds_tem.py
@@ -391,7 +391,10 @@ class EDSTEM_mixin:
         vacuum_mask
         """
         if isinstance(navigation_mask, float):
-            navigation_mask = self.vacuum_mask(navigation_mask, closing)
+            if self.axes_manager.navigation_dimension > 0:
+                navigation_mask = self.vacuum_mask(navigation_mask, closing)
+            else:
+                navigation_mask = None
 
         xray_lines = [intensity.metadata.Sample.xray_lines[0] for intensity in intensities]
         it = 0
@@ -596,6 +599,9 @@ class EDSTEM_mixin:
         >>> si.vacuum_mask().data
         array([False, False, False,  True], dtype=bool)
         """
+        if self.axes_manager.navigation_dimension == 0:
+            raise RuntimeError('Navigation dimenstion must be higher than 0 '
+                               'to estimate a vacuum mask.')
         from scipy.ndimage.morphology import binary_dilation, binary_erosion
         mask = (self.max(-1) <= threshold)
         if closing:

--- a/hyperspy/_signals/eels.py
+++ b/hyperspy/_signals/eels.py
@@ -1816,6 +1816,9 @@ collection_angle : float
         mask: signal
             The mask of the region.
         """
+        if self.axes_manager.navigation_dimension == 0:
+            raise RuntimeError('Navigation dimenstion must be higher than 0 '
+                               'to estimate a vacuum mask.')
         signal_axis = self.axes_manager.signal_axes[0]
         if start_energy is None:
             start_energy = 0.75 * signal_axis.high_value

--- a/hyperspy/tests/signal/test_eds_tem.py
+++ b/hyperspy/tests/signal/test_eds_tem.py
@@ -210,11 +210,13 @@ class Test_quantification:
         intensities = s.get_lines_intensity()
         res = s.quantification(intensities, method, kfactors,
                                composition_units)
-        s2 = s.rebin(new_shape=(1,1,1024)).squeeze().squeeze()
-        s2.quantification(intensities, method, kfactors,
-                               composition_units, plot_result=True)
         np.testing.assert_allclose(res[0].data, np.ones((2, 2)) * 22.70779,
             atol=1e-3)
+
+        # Test plot_results
+        s2 = s.sum()
+        s2.quantification(intensities, method, kfactors,
+                          composition_units, plot_result=True)
 
     def test_quant_lorimer_mask(self):
         s = self.signal
@@ -486,6 +488,12 @@ class Test_vacum_mask:
         s = self.signal
         assert s.vacuum_mask().data[0]
         assert not s.vacuum_mask().data[-1]
+
+    def test_vacuum_mask_navigation_dimension_0(self):
+        s = self.signal
+        s2 = s.sum()
+        with pytest.raises(RuntimeError):
+            s2.vacuum_mask()
 
 
 @pytest.mark.parametrize('normalise_poissonian_noise', [True, False])

--- a/hyperspy/tests/signal/test_eds_tem.py
+++ b/hyperspy/tests/signal/test_eds_tem.py
@@ -477,7 +477,7 @@ class Test_quantification:
 
 
 @lazifyTestClass
-class Test_vacum_mask:
+class Test_vacuum_mask:
 
     def setup_method(self, method):
         s = EDSTEMSpectrum(np.array([np.linspace(0.001, 0.5, 20)] * 100).T)

--- a/hyperspy/tests/signal/test_eels.py
+++ b/hyperspy/tests/signal/test_eels.py
@@ -599,3 +599,9 @@ class TestVacuumMask:
         assert not mask.data[9]
         assert mask.data[10]
         assert mask.data[-1]
+
+    def test_vacuum_mask_navigation_dimension_0(self):
+        s = self.signal
+        s2 = s.sum()
+        with pytest.raises(RuntimeError):
+            s2.vacuum_mask()


### PR DESCRIPTION
One test added in https://github.com/hyperspy/hyperspy/pull/2602 failed on `RELEASE_next_minor` because when doing the quantification of a single spectrum, a navigation mask is computed automatically and clearly it shouldn't!

### Progress of the PR
- [x] Fix setting `navigation_mask` for the quantification of single spectrum
- [x] add tests,
- [x] ready for review.


