### PR TITLE
Improve error message initialisation SpanROI

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -13,6 +13,8 @@ RELEASE_next_patch (Unreleased)
 * Pass keyword argument to the image IO plugins (`#2627 <https://github.com/hyperspy/hyperspy/pull/2627>`_)
 * Drop support for numpy<1.16, in line with NEP 29 and fix protochip reader for numpy 1.20 (`#2616 <https://github.com/hyperspy/hyperspy/pull/2616>`_)
 * Run test suite against upstream dependencies (numpy, scipy, scikit-learn and scikit-image) (`#2616 <https://github.com/hyperspy/hyperspy/pull/2616>`_)
+* Improve error message when initialising SpanROI with left >= right (`#2604 <https://github.com/hyperspy/hyperspy/pull/2604>`_)
+
 
 Changelog
 *********

--- a/hyperspy/misc/label_position.py
+++ b/hyperspy/misc/label_position.py
@@ -219,9 +219,8 @@ class SpectrumLabelPosition():
         element, subshell = text_edge.split('_')
 
         if subshell[-1].isdigit():
-            formatted = element+' '+'$\mathregular{'+subshell[0]+'_'+\
-                subshell[-1]+'}$'
+            formatted = f"{element} {subshell[0]}$_{subshell[-1]}$"
         else:
-            formatted = element+' '+'$\mathregular{'+subshell[0]+'}$'
+            formatted = f"{element} {subshell[0]}"
 
         return formatted

--- a/hyperspy/roi.py
+++ b/hyperspy/roi.py
@@ -703,9 +703,9 @@ class SpanROI(BaseInteractiveROI):
 
     def __init__(self, left, right):
         super().__init__()
-        self._bounds_check = True   # Use reponsibly!
+        self._bounds_check = True   # Use responsibly!
         if left >= right:
-            raise ValueError("`left` must be smaller than `right`.")
+            raise ValueError(f"`left` ({left}) must be smaller than `right` ({right}).")
         self.left, self.right = left, right
 
     def __getitem__(self, *args, **kwargs):

--- a/hyperspy/roi.py
+++ b/hyperspy/roi.py
@@ -702,15 +702,15 @@ class SpanROI(BaseInteractiveROI):
     _ndim = 1
 
     def __init__(self, left, right):
-        super(SpanROI, self).__init__()
+        super().__init__()
         self._bounds_check = True   # Use reponsibly!
+        if left >= right:
+            raise ValueError("`left` must be smaller than `right`.")
         self.left, self.right = left, right
 
     def __getitem__(self, *args, **kwargs):
         _tuple = (self.left, self.right)
         return _tuple.__getitem__(*args, **kwargs)
-
-
 
     def is_valid(self):
         return (t.Undefined not in (self.left, self.right) and

--- a/hyperspy/tests/utils/test_roi.py
+++ b/hyperspy/tests/utils/test_roi.py
@@ -104,6 +104,12 @@ class TestROIs():
         r = Point2DROI(1, 2)
         assert tuple(r) == (1, 2)
 
+    def test_span_roi_init(self):
+        with pytest.raises(ValueError):
+            SpanROI(30, 15)
+        with pytest.raises(ValueError):
+            SpanROI(15, 15)
+
     def test_span_spectrum_nav(self):
         s = self.s_s
         r = SpanROI(15, 30)

--- a/hyperspy/ui_registry.py
+++ b/hyperspy/ui_registry.py
@@ -18,7 +18,7 @@
 
 """Registry of user interface widgets.
 
-Format {"tool_key" : {"toolkit" : <function(obj, display, \*\*kwargs)>}}
+Format {"tool_key" : {"toolkit" : <function(obj, display, **kwargs)>}}
 
 The ``tool_key`` is defined by the "model function" to which the widget provides
 and user interface. That function gets the widget function from this registry

--- a/hyperspy/utils/__init__.py
+++ b/hyperspy/utils/__init__.py
@@ -48,7 +48,7 @@ from hyperspy.misc.utils import stack, transpose
 
 
 def print_known_signal_types():
-    """Print all known `signal_type`\s
+    r"""Print all known `signal_type`\s
 
     This includes `signal_type`\s from all installed packages that
     extend HyperSpy.


### PR DESCRIPTION
### Progress of the PR
- [x] Improve error message when initialising ROI with left >= right.
- [x] add tests,
- [x] update changelog, 
- [x] ready for review.

### Minimal example of the bug fix or the new feature
```python
import hyperspy.api as hs
hs.roi.SpanROI(30, 15)
```
raises an confusing message: 
```python
Traceback (most recent call last):

  File "<ipython-input-1-1e344269bc12>", line 2, in <module>
    hs.roi.SpanROI(30, 15)

  File "/home/eric/Dev/hyperspy/hyperspy/roi.py", line 688, in __init__
    self.left, self.right = left, right

  File "/opt/miniconda3/lib/python3.8/site-packages/traits/trait_notifiers.py", line 346, in __call__
    handle_exception(object, trait_name, old, new)

  File "/opt/miniconda3/lib/python3.8/site-packages/traits/trait_notifiers.py", line 148, in _handle_exception
    raise excp

  File "/opt/miniconda3/lib/python3.8/site-packages/traits/trait_notifiers.py", line 340, in __call__
    self.handler(*args)

  File "/home/eric/Dev/hyperspy/hyperspy/roi.py", line 703, in _right_changed
    self.right = old

  File "/opt/miniconda3/lib/python3.8/site-packages/traits/trait_notifiers.py", line 346, in __call__
    handle_exception(object, trait_name, old, new)

  File "/opt/miniconda3/lib/python3.8/site-packages/traits/trait_notifiers.py", line 148, in _handle_exception
    raise excp

  File "/opt/miniconda3/lib/python3.8/site-packages/traits/trait_notifiers.py", line 340, in __call__
    self.handler(*args)

  File "/home/eric/Dev/hyperspy/hyperspy/roi.py", line 702, in _right_changed
    self.left is not t.Undefined and new <= self.left:

TypeError: '<=' not supported between instances of '_Undefined' and 'float'
```
With this PR:
```python
Traceback (most recent call last):

  File "<ipython-input-1-1e344269bc12>", line 2, in <module>
    hs.roi.SpanROI(30, 15)

  File "/home/eric/Dev/hyperspy/hyperspy/roi.py", line 689, in __init__
    raise ValueError("`left` must be smaller than `right`.")

ValueError: `left` must be smaller than `right`.
```

