### PR TITLE
Fix warning when reading STEM images acquired with Digiscan 

### DIFF
--- a/hyperspy/io.py
+++ b/hyperspy/io.py
@@ -560,8 +560,9 @@ def assign_signal_subclass(dtype, signal_dimension, signal_type="", lazy=False):
         if signal_type not in set(valid_signal_types):
             _logger.warning(
                 f"`signal_type='{signal_type}'` not understood. "
-                f"See `hs.print_known_signal_types()` for a list of known signal types, "
-                f"and the developer guide for details on how to add new signal_types."
+                "See `hs.print_known_signal_types()` for a list of installed "
+                "signal types or https://github.com/hyperspy/hyperspy-extensions-list "
+                "for the list of all hyperspy extensions providing signals."
             )
 
         # If the following dict is not empty, only signal_dimension and dtype match.

--- a/hyperspy/io_plugins/digital_micrograph.py
+++ b/hyperspy/io_plugins/digital_micrograph.py
@@ -621,11 +621,13 @@ class ImageObject(object):
 
     @property
     def signal_type(self):
-        if 'ImageTags.Meta_Data.Signal' in self.imdict:
-            if self.imdict.ImageTags.Meta_Data.Signal == "X-ray":
-                return "EDS_TEM"
-            return self.imdict.ImageTags.Meta_Data.Signal
-        elif 'ImageTags.spim.eels' in self.imdict:  # Orsay's tag group
+        md_signal = self.imdict.get_item('ImageTags.Meta_Data.Signal', "")
+        if md_signal == 'X-ray':
+            return "EDS_TEM"
+        elif md_signal == 'CL':
+            return "CL"
+        # 'ImageTags.spim.eels' is Orsay's tag group
+        elif md_signal == 'EELS' or 'ImageTags.spim.eels' in self.imdict:
             return "EELS"
         else:
             return ""

--- a/hyperspy/tests/signal/test_assign_subclass.py
+++ b/hyperspy/tests/signal/test_assign_subclass.py
@@ -59,7 +59,7 @@ def test_assignment_class(caplog):
 
         assert new_subclass is getattr(hs.signals, case.cls)
 
-        warn_msg = "not understood. See `hs.print_known_signal_types()` for a list of known signal types"
+        warn_msg = "not understood. See `hs.print_known_signal_types()` for a list"
         if case.sig_type == "DefinitelyNotAHyperSpySignal":
             assert warn_msg in caplog.text
         else:


### PR DESCRIPTION
Set the `signal_type` to know value, instead of parsing a tag from dm3/dm4 file to avoid the following warning:
```
WARNING:hyperspy.io:`signal_type='DigiScan'` not understood. See `hs.print_known_signal_types()` for a list of known
signal types, and the developer guide for details on how to add new signal_types.
```

Close #2606.