### PR TITLE
Fix drawing multiple widgets

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,6 +8,7 @@ What's new
 RELEASE_next_patch (Unreleased)
 +++++++++++++++++++++++++++++++
 
+* Widgets plotting improvement and add `pick_tolerance` to plot preferences (`#2615 <https://github.com/hyperspy/hyperspy/pull/2615>`_)
 
 
 Changelog

--- a/doc/user_guide/interactive_operations_ROIs.rst
+++ b/doc/user_guide/interactive_operations_ROIs.rst
@@ -108,6 +108,14 @@ added before calling :py:meth:`~.roi.BaseInteractiveROI.interactive`.
   :align:   center
   :width:   500
 
+.. NOTE::
+
+    Depending on your screen and display settings, it can be difficult to `pick`
+    or manipulate widgets and you can try to change the pick tolerance in
+    the :ref:`HyperSpy plot preferences <configuring-hyperspy-label>`.
+    Typically, using a 4K resolution with a small scaling factor (<150 %), setting
+    the pick tolerance to 15 instead of 7.5 makes the widgets easier to manipulate.
+
 Notably, since ROIs are independent from the signals they sub-select, the widget
 can be plotted on a different signal altogether.
 
@@ -258,3 +266,6 @@ Handily, we can pass a :py:class:`~.roi.RectangularROI` ROI instead.
     >>> tuple(roi)
     (2.0, 10.0, 0.0, 5.0)
     >>> im.align2D(roi=roi)
+    
+
+

--- a/doc/user_guide/visualisation.rst
+++ b/doc/user_guide/visualisation.rst
@@ -70,17 +70,18 @@ more will disable the extra cursor:
 
 In matplotlib, left and right arrow keys are by default set to navigate the
 "zoom" history. To avoid the problem of changing zoom while navigating,
-Ctrl + arrows can be used instead. Navigating without using the modifier keys
+``Ctrl`` + arrows can be used instead. Navigating without using the modifier keys
 will be deprecated in version 2.0.
 
 To navigate navigation dimensions larger than 2, modifier keys can be used.
-The defaults are Shift + left/right and Shift + up/down, (Alt + left/right and Alt + up/down)
+The defaults are ``Shift`` + ``left``/``right`` and ``Shift`` + ``up``/``down``,
+(``Alt`` + ``left``/``right`` and ``Alt`` + ``up``/``down``)
 for navigating dimensions 2 and 3 (4 and 5) respectively. Modifier keys do not work with the numpad.
 
-Hotkeys and modifier keys for navigating the plot can be set in the ``hs.preferences.gui()``.
+Hotkeys and modifier keys for navigating the plot can be set in the
+:ref:`HyperSpy plot preferences <configuring-hyperspy-label>``.
 Note that some combinations will not work for all platforms, as some systems reserve them for
 other purposes.
-.. _second_pointer.png:
 
 .. figure::  images/second_pointer.png
    :align:   center

--- a/hyperspy/conftest.py
+++ b/hyperspy/conftest.py
@@ -35,6 +35,7 @@ matplotlib.rcParams['interactive'] = False
 hs.preferences.Plot.saturated_pixels = 0.0
 hs.preferences.Plot.cmap_navigator = 'viridis'
 hs.preferences.Plot.cmap_signal = 'viridis'
+hs.preferences.Plot.pick_tolerance = 5.0
 
 # Set parallel to False by default, so only
 # those tests with parallel=True are run in parallel

--- a/hyperspy/defaults_parser.py
+++ b/hyperspy/defaults_parser.py
@@ -170,6 +170,10 @@ class PlotConfig(t.HasTraits):
                                'ctrl+alt+shift'], label='Modifier key for 3rd and 4th dimensions')  # 0 elem is default
     modifier_dims_45 = t.Enum(['alt', 'ctrl', 'shift', 'ctrl+alt', 'ctrl+shift', 'alt+shift',
                                'ctrl+alt+shift'], label='Modifier key for 5th and 6th dimensions')  # 0 elem is default
+    pick_tolerance = t.CFloat(5.,
+                              label='Pick tolerance',
+                              desc='The pick tolerance of ROIs in screen pixels.'
+                              )
 
 
 class EDSConfig(t.HasTraits):

--- a/hyperspy/defaults_parser.py
+++ b/hyperspy/defaults_parser.py
@@ -170,7 +170,7 @@ class PlotConfig(t.HasTraits):
                                'ctrl+alt+shift'], label='Modifier key for 3rd and 4th dimensions')  # 0 elem is default
     modifier_dims_45 = t.Enum(['alt', 'ctrl', 'shift', 'ctrl+alt', 'ctrl+shift', 'alt+shift',
                                'ctrl+alt+shift'], label='Modifier key for 5th and 6th dimensions')  # 0 elem is default
-    pick_tolerance = t.CFloat(5.,
+    pick_tolerance = t.CFloat(7.5,
                               label='Pick tolerance',
                               desc='The pick tolerance of ROIs in screen pixels.'
                               )

--- a/hyperspy/drawing/_widgets/circle.py
+++ b/hyperspy/drawing/_widgets/circle.py
@@ -108,7 +108,6 @@ class CircleWidget(Widget2DBase, ResizersMixin):
         ro, ri = self.size
         self.patch = [plt.Circle(
             xy, radius=ro,
-            animated=self.blit,
             fill=False,
             lw=self.border_thickness,
             ec=self.color,
@@ -118,7 +117,6 @@ class CircleWidget(Widget2DBase, ResizersMixin):
             self.patch.append(
                 plt.Circle(
                     xy, radius=ro,
-                    animated=self.blit,
                     fill=False,
                     lw=self.border_thickness,
                     ec=self.color,

--- a/hyperspy/drawing/_widgets/horizontal_line.py
+++ b/hyperspy/drawing/_widgets/horizontal_line.py
@@ -18,6 +18,7 @@
 
 from hyperspy.drawing.widgets import Widget1DBase
 from hyperspy.drawing.utils import picker_kwargs
+from hyperspy.defaults_parser import preferences
 
 
 class HorizontalLineWidget(Widget1DBase):
@@ -32,7 +33,7 @@ class HorizontalLineWidget(Widget1DBase):
 
     def _set_patch(self):
         ax = self.ax
-        kwargs = picker_kwargs(5)
+        kwargs = picker_kwargs(preferences.Plot.pick_tolerance)
         self.patch = [ax.axhline(
             self._pos[0],
             color=self.color,

--- a/hyperspy/drawing/_widgets/label.py
+++ b/hyperspy/drawing/_widgets/label.py
@@ -102,7 +102,6 @@ class LabelWidget(Widget1DBase):
             transform=trans,
             horizontalalignment='left',
             bbox=self.bbox,
-            animated=self.blit,
             picker=True)]
 
     def _onmousemove(self, event):

--- a/hyperspy/drawing/_widgets/line2d.py
+++ b/hyperspy/drawing/_widgets/line2d.py
@@ -87,7 +87,7 @@ class Line2DWidget(ResizableDraggableWidgetBase):
     Notes
     -----
     The 'position' is now a 2D tuple: tuple(tuple(x1, x2), tuple(y1, y2))
-    
+
     Notes
     -----
     The 'size' property corresponds to line width, so it has a len() of only
@@ -263,7 +263,6 @@ class Line2DWidget(ResizableDraggableWidgetBase):
         self.patch = self.ax.plot(
             xy[:, 0], xy[:, 1],
             linestyle='-',
-            animated=self.blit,
             lw=self.linewidth,
             c=self.color,
             alpha=self.alpha,
@@ -280,9 +279,9 @@ class Line2DWidget(ResizableDraggableWidgetBase):
             wi, = self.ax.plot(
                 wc[i][0], wc[i][1],
                 linestyle=':',
-                animated=self.blit,
                 lw=self.linewidth,
                 c=self.color,
+                animated=self.blit,
                 **kwargs)
             self.patch.append(wi)
             self._width_indicator_patches.append(wi)

--- a/hyperspy/drawing/_widgets/range.py
+++ b/hyperspy/drawing/_widgets/range.py
@@ -24,6 +24,7 @@ import logging
 
 from hyperspy.drawing.widgets import ResizableDraggableWidgetBase
 from hyperspy.events import Events, Event
+from hyperspy.defaults_parser import preferences
 
 
 _logger = logging.getLogger(__name__)
@@ -85,7 +86,7 @@ class RangeWidget(ResizableDraggableWidgetBase):
         self.span.can_switch = True
         self.span.events.changed.connect(self._span_changed, {'obj': 'widget'})
         self.span.step_ax = self.axes[0]
-        self.span.tolerance = 5
+        self.span.tolerance = preferences.Plot.pick_tolerance
         self.patch = [self.span.rect]
         self.patch[0].set_color(self.color)
         self.patch[0].set_alpha(self.alpha)
@@ -285,7 +286,7 @@ class ModifiableSpanSelector(SpanSelector):
         SpanSelector.__init__(self, ax, onselect, direction=direction,
                               useblit=useblit, span_stays=False, **kwargs)
         # The tolerance in points to pick the rectangle sizes
-        self.tolerance = 2
+        self.tolerance = preferences.Plot.pick_tolerance
         self.on_move_cid = None
         self._range = None
         self.step_ax = None

--- a/hyperspy/drawing/_widgets/range.py
+++ b/hyperspy/drawing/_widgets/range.py
@@ -404,8 +404,8 @@ class ModifiableSpanSelector(SpanSelector):
         """Update the patch drawing.
         """
         try:
-            if self.useblit and hasattr(self.ax, 'hspy_fig'):
-                self.ax.hspy_fig._update_animated()
+            if hasattr(self.ax, 'hspy_fig'):
+                self.ax.hspy_fig.render_figure()
             elif self.ax.figure is not None:
                 self.ax.figure.canvas.draw_idle()
         except AttributeError:
@@ -577,7 +577,7 @@ class ModifiableSpanSelector(SpanSelector):
             return
         x_increment = self._get_mouse_position(event) - self.pressv
         if self.step_ax is not None:
-            if (self.bounds_check  
+            if (self.bounds_check
                 and self._range[0] <= self.step_ax.low_value
                 and self._get_mouse_position(event) <= self.pressv):
                 return

--- a/hyperspy/drawing/_widgets/rectangles.py
+++ b/hyperspy/drawing/_widgets/rectangles.py
@@ -48,7 +48,6 @@ class SquareWidget(Widget2DBase):
         xs, ys = self.size
         self.patch = [plt.Rectangle(
             xy, xs, ys,
-            animated=self.blit,
             fill=False,
             lw=self.border_thickness,
             ec=self.color,

--- a/hyperspy/drawing/_widgets/vertical_line.py
+++ b/hyperspy/drawing/_widgets/vertical_line.py
@@ -18,6 +18,7 @@
 
 from hyperspy.drawing.widgets import Widget1DBase
 from hyperspy.drawing.utils import picker_kwargs
+from hyperspy.defaults_parser import preferences
 
 
 class VerticalLineWidget(Widget1DBase):
@@ -32,7 +33,7 @@ class VerticalLineWidget(Widget1DBase):
 
     def _set_patch(self):
         ax = self.ax
-        kwargs = picker_kwargs(5)
+        kwargs = picker_kwargs(preferences.Plot.pick_tolerance)
         self.patch = [ax.axvline(self._pos[0],
                                  color=self.color,
                                  alpha=self.alpha,

--- a/hyperspy/drawing/figure.py
+++ b/hyperspy/drawing/figure.py
@@ -102,10 +102,7 @@ class BlittedFigure(object):
         for marker in self.ax_markers:
             marker.close(render_figure=False)
         if render_figure:
-            if self.ax.figure.canvas.supports_blit:
-                self.ax.hspy_fig._update_animated()
-            else:
-                self.ax.figure.canvas.draw_idle()
+            self.render_figure()
 
     def _on_close(self):
         _logger.debug('Closing `BlittedFigure`.')
@@ -138,3 +135,9 @@ class BlittedFigure(object):
     def title(self, value):
         # Wrap the title so that each line is not longer than 60 characters.
         self._title = textwrap.fill(value, 60)
+
+    def render_figure(self):
+        if self.figure.canvas.supports_blit:
+            self._update_animated()
+        else:
+            self.figure.canvas.draw_idle()

--- a/hyperspy/drawing/marker.py
+++ b/hyperspy/drawing/marker.py
@@ -192,10 +192,7 @@ class MarkerBase(object):
             self._render_figure()
 
     def _render_figure(self):
-        if self.ax.figure.canvas.supports_blit:
-            self.ax.hspy_fig._update_animated()
-        else:
-            self.ax.figure.canvas.draw_idle()
+        self.ax.hspy_fig.render_figure()
 
     def close(self, render_figure=True):
         """Remove and disconnect the marker.

--- a/hyperspy/drawing/signal1d.py
+++ b/hyperspy/drawing/signal1d.py
@@ -202,10 +202,7 @@ class Signal1DFigure(BlittedFigure):
         if self.right_ax is not None:
             update_lines(self.right_ax, self.right_ax_lines)
 
-        if self.ax.figure.canvas.supports_blit:
-            self.ax.hspy_fig._update_animated()
-        else:
-            self.ax.figure.canvas.draw_idle()
+        self.render_figure()
 
 
 class Signal1DLine(object):
@@ -496,10 +493,7 @@ class Signal1DLine(object):
             self.text.set_text(self.axes_manager.indices)
 
         if render_figure:
-            if self.ax.figure.canvas.supports_blit:
-                self.ax.hspy_fig._update_animated()
-            else:
-                self.ax.figure.canvas.draw_idle()
+            self.ax.hspy_fig.render_figure()
 
     def close(self):
         _logger.debug('Closing `Signal1DLine`.')

--- a/hyperspy/drawing/utils.py
+++ b/hyperspy/drawing/utils.py
@@ -1411,7 +1411,7 @@ def animate_legend(fig=None, ax=None):
     lined = dict()
     leg = ax.get_legend()
     for legline, origline in zip(leg.get_lines(), lines):
-        legline.set_pickradius(5)  # 5 pts tolerance
+        legline.set_pickradius(preferences.Plot.pick_tolerance)
         legline.set_picker(True)
         lined[legline] = origline
 

--- a/hyperspy/drawing/widget.py
+++ b/hyperspy/drawing/widget.py
@@ -60,7 +60,7 @@ class WidgetBase(object):
         self.color = color
         self.alpha = alpha
         self.cids = list()
-        self.blit = True
+        self.blit = None
         self.events = Events()
         self.events.changed = Event(doc="""
             Event that triggers when the widget has a significant change.
@@ -884,7 +884,6 @@ class ResizersMixin(object):
                         if r in container:
                             container.remove(r)
             self._resizers_on = value
-            self.draw_patch()
 
     def _get_resizer_size(self):
         """Gets the size of the resizer handles in axes coordinates. If
@@ -946,9 +945,8 @@ class ResizersMixin(object):
         rsize = self._get_resizer_size()
         pos = self._get_resizer_pos()
         for i in range(len(pos)):
-            r = plt.Rectangle(pos[i], rsize[0], rsize[1], animated=self.blit,
-                              fill=True, lw=0, fc=self.resize_color,
-                              picker=True,)
+            r = plt.Rectangle(pos[i], rsize[0], rsize[1], fill=True, lw=0,
+                              fc=self.resize_color, picker=True,)
             self._resizer_handles.append(r)
 
     def set_on(self, value):

--- a/hyperspy/drawing/widget.py
+++ b/hyperspy/drawing/widget.py
@@ -24,6 +24,7 @@ import numpy as np
 
 from hyperspy.drawing.utils import on_figure_window_close
 from hyperspy.events import Events, Event
+from hyperspy.defaults_parser import preferences
 
 
 class WidgetBase(object):
@@ -835,7 +836,8 @@ class ResizersMixin(object):
         self.resizer_picked = False
         self.pick_offset = (0, 0)
         self.resize_color = 'lime'
-        self.resize_pixel_size = (5, 5)  # Set to None to make one data pixel
+        pick_tol = preferences.Plot.pick_tolerance
+        self.resize_pixel_size = (pick_tol, pick_tol)  # Set to None to make one data pixel
         self._resizers = resizers
         self._resizer_handles = []
         self._resizers_on = False

--- a/hyperspy/drawing/widget.py
+++ b/hyperspy/drawing/widget.py
@@ -104,7 +104,7 @@ class WidgetBase(object):
         """
         return self.__is_on
 
-    def set_on(self, value):
+    def set_on(self, value, render_figure=True):
         """Change the on state of the widget. If turning off, all patches will
         be removed from the matplotlib axes and the widget will disconnect from
         all events. If turning on, the patch(es) will be added to the
@@ -129,7 +129,8 @@ class WidgetBase(object):
         if hasattr(super(WidgetBase, self), 'set_on'):
             super(WidgetBase, self).set_on(value)
         if did_something:
-            self.draw_patch()
+            if render_figure:
+                self.draw_patch()
             if value is False:
                 self.ax = None
         self.__is_on = value
@@ -246,11 +247,11 @@ class WidgetBase(object):
         if self._navigating:
             self.disconnect_navigate()
 
-    def close(self, window=None):
+    def close(self, window=None, render_figure=False):
         """Set the on state to off (removes patch and disconnects), and trigger
         events.closed.
         """
-        self.set_on(False)
+        self.set_on(False, render_figure=render_figure)
         self.events.closed.trigger(obj=self)
 
     def draw_patch(self, *args):

--- a/hyperspy/drawing/widget.py
+++ b/hyperspy/drawing/widget.py
@@ -182,11 +182,10 @@ class WidgetBase(object):
         if self.ax is not None and self.is_on():
             self.disconnect()
         self.ax = ax
-        canvas = ax.figure.canvas
         if self.is_on() is True:
             self._add_patch_to(ax)
             self.connect(ax)
-            canvas.draw_idle()
+            ax.figure.canvas.draw_idle()
             self.select()
 
     def select(self):
@@ -257,8 +256,8 @@ class WidgetBase(object):
         """Update the patch drawing.
         """
         try:
-            if self.blit and hasattr(self.ax, 'hspy_fig'):
-                self.ax.hspy_fig._update_animated()
+            if hasattr(self.ax, 'hspy_fig'):
+                self.ax.hspy_fig.render_figure()
             elif self.ax.figure is not None:
                 self.ax.figure.canvas.draw_idle()
         except AttributeError:
@@ -976,6 +975,7 @@ class ResizersMixin(object):
         elif self.picked:
             if self.resizers and not self._resizers_on:
                 self._set_resizers(True, self.ax)
+                self.ax.figure.canvas.draw_idle()
             x = event.mouseevent.xdata
             y = event.mouseevent.ydata
             self.pick_offset = (x - self._pos[0], y - self._pos[1])

--- a/hyperspy/roi.py
+++ b/hyperspy/roi.py
@@ -480,10 +480,10 @@ class BaseInteractiveROI(BaseROI):
         self.signal_map[signal] = (widget, axes)
         return widget
 
-    def _remove_widget(self, widget):
+    def _remove_widget(self, widget, render_figure=True):
         widget.events.closed.disconnect(self._remove_widget)
         widget.events.changed.disconnect(self._on_widget_change)
-        widget.close()
+        widget.close(render_figure=render_figure)
         for signal, w in self.signal_map.items():
             if w[0] == widget:
                 self.signal_map.pop(signal)
@@ -494,11 +494,30 @@ class BaseInteractiveROI(BaseROI):
                     self.update,
                     [])
 
+    def remove_widget(self, signal, render_figure=True):
+        """
+        Removing a widget from a signal consists in two tasks:
+            1. Disconnect the interactive operations associated with this ROI
+               and the specified signal `signal`.
+            2. Removing the widget from the plot.
 
-    def remove_widget(self, signal):
+        Parameters
+        ----------
+        signal : BaseSignal
+            The signal from the which the interactive operations will be
+            disconnected.
+        render_figure : bool, optional
+            If False, the figure will not be rendered after removing the widget
+            in order to save redraw events. The default is True.
+
+        Returns
+        -------
+        None.
+
+        """
         if signal in self.signal_map:
             w = self.signal_map.pop(signal)[0]
-            self._remove_widget(w)
+            self._remove_widget(w, render_figure)
 
 
 class BasePointROI(BaseInteractiveROI):

--- a/hyperspy/roi.py
+++ b/hyperspy/roi.py
@@ -460,6 +460,8 @@ class BaseInteractiveROI(BaseROI):
 
         # Set DataAxes
         widget.axes = axes
+        with widget.events.changed.suppress_callback(self._on_widget_change):
+            self._apply_roi2widget(widget)
         if widget.ax is None:
             if signal._plot is None or signal._plot.signal_plot is None:
                 raise Exception(
@@ -468,8 +470,6 @@ class BaseInteractiveROI(BaseROI):
 
             ax = _get_mpl_ax(signal._plot, axes)
             widget.set_mpl_ax(ax)
-        with widget.events.changed.suppress_callback(self._on_widget_change):
-            self._apply_roi2widget(widget)
 
         # Connect widget changes to on_widget_change
         widget.events.changed.connect(self._on_widget_change,

--- a/hyperspy/signal.py
+++ b/hyperspy/signal.py
@@ -5600,10 +5600,7 @@ class BaseSignal(FancySlicing,
         for p in plot:
             if hasattr(self._plot, p):
                 p = getattr(self._plot, p)
-                if p.figure.canvas.supports_blit:
-                    p.ax.hspy_fig._update_animated()
-                else:
-                    p.ax.hspy_fig._draw_animated()
+                p.render_figure()
 
     def _plot_permanent_markers(self):
         marker_name_list = self.metadata.Markers.keys()

--- a/hyperspy/signal_tools.py
+++ b/hyperspy/signal_tools.py
@@ -1026,10 +1026,7 @@ class ImageContrastEditor(t.HasTraits):
         if self._vmin == self._vmax:
             return
         self.line.set_data(*self._get_line())
-        if self.ax.figure.canvas.supports_blit:
-            self.hspy_fig._update_animated()
-        else:
-            self.ax.figure.canvas.draw_idle()
+        self.hspy_fig.render_figure()
 
     def apply(self):
         if self.ss_left_value == self.ss_right_value:

--- a/hyperspy/tests/drawing/test_plot_roi_widgets.py
+++ b/hyperspy/tests/drawing/test_plot_roi_widgets.py
@@ -49,10 +49,11 @@ class TestPlotROI():
 
     def setup_method(self, method):
         # Create test image 100x100 pixels:
-        self.im = Signal2D(np.arange(50000).reshape([10, 50, 100]))
-        self.im.axes_manager[0].scale = 1e-1
-        self.im.axes_manager[1].scale = 1e-2
-        self.im.axes_manager[2].scale = 1e-3
+        im = Signal2D(np.arange(50000).reshape([10, 50, 100]))
+        im.axes_manager[0].scale = 1e-1
+        im.axes_manager[1].scale = 1e-2
+        im.axes_manager[2].scale = 1e-3
+        self.im = im
 
     @pytest.mark.mpl_image_compare(baseline_dir=BASELINE_DIR,
                                    tolerance=DEFAULT_TOL, style=STYLE_PYTEST_MPL)
@@ -129,6 +130,14 @@ class TestPlotROI():
         p = roi.RectangularROI(left=0.01, top=0.01, right=0.1, bottom=0.03)
         p.add_widget(signal=objs["im"], axes=objs["axes"], color="cyan")
         return objs["figure"]
+
+    @pytest.mark.parametrize("render_figure", [True, False])
+    def test_plot_rectangular_roi_remove(self, render_figure):
+        im = self.im
+        im.plot()
+        p = roi.RectangularROI(left=0.01, top=0.01, right=0.1, bottom=0.03)
+        p.add_widget(signal=im)
+        p.remove_widget(im, render_figure=render_figure)
 
     @pytest.mark.parametrize("space", ("signal", "navigation"))
     @pytest.mark.mpl_image_compare(baseline_dir=BASELINE_DIR,


### PR DESCRIPTION
### Description of the change
- Fix a bug with unnecessary drawing event, which makes the widgets "sticky" when picking it (only noticeable on matplotlib backend supporting blitting)
- Speed up adding widgets for matplotlib backend supporting blitting. Before this PR, there was an unnecessary full redraw event when adding a widget, now it draw only the added widget
- Add option not to render figure when removing a widget, so that it is possible to remove many widgets without rendering. This was slow for matplotlib backend supporting blitting because of similar reason as in the previous point
- Add `pick_tolerance` to plot preferences: at the moment, this is hardcoded and the tolerance is too small on 4K screen and this is a pain!

### Progress of the PR
- [x] Fix various unnecessary drawing event 
- [x] update docstring (if appropriate),
- [x] add entry to `CHANGES.rst` (if appropriate),
- [x] add tests,
- [x] ready for review.

### Minimal example of the bug fix or the new feature
```python
import numpy as np
import hyperspy.api as hs

size = 1024
s = hs.signals.Signal2D(np.arange(size**2).reshape([size]*2))
s.plot()

offset, width = 20, 25
number = 50
position_list = [offset*i for i in range(number)]

def add_roi(s, position_list):
    roi_list = []
    for pos in position_list:
        roi = hs.roi.RectangularROI(pos, pos, pos+width, pos+width)
        roi.add_widget(s)
        roi_list.append(roi)
    return roi_list

def remove_roi(s, roi_list, render_figure=False):
    for roi in roi_list:
        roi.remove_widget(s, render_figure=render_figure)

roi_list = add_roi(s, position_list)

remove_roi(s, roi_list, render_figure=True)

```
Note that this example can be useful to update the user guide.

