### PR TITLE
Read EDS frame jeol

### DIFF
--- a/doc/user_guide/io.rst
+++ b/doc/user_guide/io.rst
@@ -1577,6 +1577,11 @@ Extra loading arguments
 
 - ``rebin_energy`` : Factor used to rebin the energy dimension. It must be a
   multiple of the number of channels, typically 4096. (default 1)
+- ``sum_frames`` : If False, each individual frame (sweep in JEOL software jargon)
+  is loaded. Be aware that loading each individual will use a lot of memory,
+  however, it can be used in combination with ``rebin_energy``, ``cutoff_at_kV``
+  and ``downsample`` to reduce memory usage.
+  (default True).
 - ``SI_dtype`` : set dtype of the eds dataset. Useful to adjust memory usage
   and maximum number of X-rays per channel. (default np.unit8)
 - ``cutoff_at_kV`` : if set (can be int or float >= 0), use to crop the energy

--- a/hyperspy/io_plugins/jeol.py
+++ b/hyperspy/io_plugins/jeol.py
@@ -181,8 +181,8 @@ def read_img(filename, scale=None, **kwargs):
     return dictionary
 
 
-def read_pts(filename, scale=None, rebin_energy=1, SI_dtype=np.uint8,
-             cutoff_at_kV=None, downsample=1, **kwargs):
+def read_pts(filename, scale=None, rebin_energy=1, sum_frames=True,
+             SI_dtype=np.uint8, cutoff_at_kV=None, downsample=1, **kwargs):
     fd = open(filename, "br")
     file_magic = np.fromfile(fd, "<I", 1)[0]
 
@@ -286,10 +286,26 @@ def read_pts(filename, scale=None, rebin_energy=1, SI_dtype=np.uint8,
                 "units": "keV",
             },
         ]
+        # pixel time in milliseconds
+        pixel_time = meas_data_header["Doc"]["DwellTime(msec)"]
 
-        data = np.zeros([height, width, channel_number], dtype=SI_dtype)
-        data = readcube(rawdata, data, rebin_energy, channel_number,
-                        width_norm, height_norm)
+        data_shape = [height, width, channel_number]
+        if not sum_frames:
+            sweep = meas_data_header["Doc"]["Sweep"]
+            data_shape.insert(0, sweep)
+            axes.insert(0, {
+                "index_in_array": 0,
+                "name": "Frame",
+                "size": sweep,
+                "offset": 0,
+                "scale": pixel_time*height*width/1E3,
+                "units": 's',
+            })
+
+        data = np.zeros(data_shape, dtype=SI_dtype)
+        datacube_reader = readcube if sum_frames else readcube_frames
+        data = datacube_reader(rawdata, data, rebin_energy, channel_number,
+                               width_norm, height_norm)
 
         hv = meas_data_header["MeasCond"]["AccKV"]
         if hv <= 30.0:
@@ -421,8 +437,8 @@ def parsejeol(fd):
 
 
 @numba.njit(cache=True)
-def readcube(rawdata, hypermap, rebin_energy, channel_number,
-             width_norm, height_norm):  # pragma: no cover
+def readcube(rawdata, hypermap, rebin_energy, channel_number, width_norm,
+             height_norm):  # pragma: no cover
     for value in rawdata:
         if value >= 32768 and value < 36864:
             x = int((value - 32768) / width_norm)
@@ -432,6 +448,30 @@ def readcube(rawdata, hypermap, rebin_energy, channel_number,
             z = int((value - 45056) / rebin_energy)
             if z < channel_number:
                 hypermap[y, x, z] += 1
+    return hypermap
+
+
+@numba.njit(cache=True)
+def readcube_frames(rawdata, hypermap, rebin_energy, channel_number,
+             width_norm, height_norm):  # pragma: no cover
+    """
+    We need to create a separate function, because numba.njit doesn't play well
+    with an array having its shape depending on something else
+    """
+    frame_idx = 0
+    previous_y = 0
+    for value in rawdata:
+        if value >= 32768 and value < 36864:
+            x = int((value - 32768) / width_norm)
+        elif value >= 36864 and value < 40960:
+            y = int((value - 36864) / height_norm)
+            if y < previous_y:
+                frame_idx += 1
+            previous_y = y
+        elif value >= 45056 and value < 49152:
+            z = int((value - 45056) / rebin_energy)
+            if z < channel_number:
+                hypermap[frame_idx, y, x, z] += 1
     return hypermap
 
 

--- a/hyperspy/tests/io/test_jeol.py
+++ b/hyperspy/tests/io/test_jeol.py
@@ -178,6 +178,20 @@ def test_load_datacube_downsample():
         _ = hs.load(filename, downsample=[100, 256])[-1]
 
 
+def test_load_datacube_frames():
+    rebin_energy = 2048
+    filename = os.path.join(my_path, 'JEOL_files', 'Sample', '00_View000', test_files[-1])
+    s = hs.load(filename, sum_frames=True, rebin_energy=rebin_energy)
+    assert s.data.shape == (512, 512, 2)
+    s_frame = hs.load(filename, sum_frames=False, rebin_energy=rebin_energy)
+    assert s_frame.data.shape == (14, 512, 512, 2)
+    np.testing.assert_allclose(s_frame.sum(axis='Frame').data, s.data)
+    np.testing.assert_allclose(s_frame.sum(axis=['x', 'y', 'Energy']).data,
+                               np.array([22355, 21975, 22038, 21904, 21846,
+                                         22115, 22021, 21917, 22123, 21919,
+                                         22141, 22024, 22086, 21797]))
+
+
 def test_load_eds_file():
     filename = os.path.join(my_path, 'JEOL_files', 'met03.EDS')
     s = hs.load(filename)
@@ -202,3 +216,4 @@ def test_load_eds_file():
                                              'energy_resolution_MnKa': 138.0,
                                              'live_time': 30.0}},
                         'Stage': {'tilt_alpha': 0.0}}
+


### PR DESCRIPTION
As discussed in https://github.com/hyperspy/hyperspy/pull/2488.

### Progress of the PR
- [x] Add support for reading individual frame of EDS spectrum image
- [x] update user guide (if appropriate),
- [x] add tests,
- [x] ready for review.

### Minimal example of the bug fix or the new feature
```python
import os
filename = os.path.join(os.path.dirname(hs.__file__), 'tests', 'io',
                        'JEOL_files', 'rawdata.ASW')

s = hs.load(filename, rebin_energy=16)
eds_SI_sum_frames = s[-1]
assert eds_SI_sum_frames.data.shape == (512, 512, 256)

s = hs.load(filename, sum_frames=False, rebin_energy=16)
eds_SI = s[-1]
assert eds_SI.data.shape == (14, 512, 512, 256)
```
