### PR TITLE
Fixes `spike_removal_tool` when it is non-interactive

### DIFF
--- a/hyperspy/_signals/eels.py
+++ b/hyperspy/_signals/eels.py
@@ -515,7 +515,7 @@ class EELSSpectrum_mixin:
                                     interactive=interactive,
                                     display=display, toolkit=toolkit)
     spikes_removal_tool.__doc__ = SPIKES_REMOVAL_TOOL_DOCSTRING % (
-        SIGNAL_MASK_ARG, NAVIGATION_MASK_ARG, MASK_ZERO_LOSS_PEAK_WIDTH, DISPLAY_DT, TOOLKIT_DT, "")
+        SIGNAL_MASK_ARG, NAVIGATION_MASK_ARG, MASK_ZERO_LOSS_PEAK_WIDTH, DISPLAY_DT, TOOLKIT_DT,)
 
     def estimate_elastic_scattering_intensity(
             self, threshold, show_progressbar=None):

--- a/hyperspy/_signals/eels.py
+++ b/hyperspy/_signals/eels.py
@@ -515,7 +515,7 @@ class EELSSpectrum_mixin:
                                     interactive=interactive,
                                     display=display, toolkit=toolkit)
     spikes_removal_tool.__doc__ = SPIKES_REMOVAL_TOOL_DOCSTRING % (
-        SIGNAL_MASK_ARG, NAVIGATION_MASK_ARG, MASK_ZERO_LOSS_PEAK_WIDTH, DISPLAY_DT, TOOLKIT_DT)
+        SIGNAL_MASK_ARG, NAVIGATION_MASK_ARG, MASK_ZERO_LOSS_PEAK_WIDTH, DISPLAY_DT, TOOLKIT_DT, "")
 
     def estimate_elastic_scattering_intensity(
             self, threshold, show_progressbar=None):

--- a/hyperspy/_signals/signal1d.py
+++ b/hyperspy/_signals/signal1d.py
@@ -34,7 +34,6 @@ from hyperspy.signal_tools import SpikesRemoval, SpikesRemovalInteractive
 from hyperspy.models.model1d import Model1D
 from hyperspy.misc.lowess_smooth import lowess
 
-
 from hyperspy.defaults_parser import preferences
 from hyperspy.signal_tools import (
     Signal1DCalibration,
@@ -53,7 +52,6 @@ from hyperspy.docstrings.signal import (SHOW_PROGRESSBAR_ARG, PARALLEL_ARG, MAX_
                                         SIGNAL_MASK_ARG, NAVIGATION_MASK_ARG)
 from hyperspy.docstrings.plot import (
     BASE_PLOT_DOCSTRING, BASE_PLOT_DOCSTRING_PARAMETERS, PLOT1D_DOCSTRING)
-
 
 _logger = logging.getLogger(__name__)
 
@@ -266,7 +264,6 @@ def _shift1D(data, **kwargs):
 
 
 class Signal1D(BaseSignal, CommonSignal1D):
-
     """
     """
     _signal_dimension = 1
@@ -340,10 +337,9 @@ class Signal1D(BaseSignal, CommonSignal1D):
 
     spikes_diagnosis.__doc__ %= (SIGNAL_MASK_ARG, NAVIGATION_MASK_ARG)
 
-
     def spikes_removal_tool(self, signal_mask=None, navigation_mask=None,
                             threshold='auto', interactive=True,
-                            display=True, toolkit=None):
+                            display=True, toolkit=None, **kwargs):
         self._check_signal_dimension_equals_one()
         if interactive:
             sr = SpikesRemovalInteractive(self,
@@ -352,10 +348,12 @@ class Signal1D(BaseSignal, CommonSignal1D):
                                           threshold=threshold)
             return sr.gui(display=display, toolkit=toolkit)
         else:
-            SpikesRemoval(self,
-                          signal_mask=signal_mask,
-                          navigation_mask=navigation_mask,
-                          threshold=threshold)
+            sr = SpikesRemoval(self,
+                               signal_mask=signal_mask,
+                               navigation_mask=navigation_mask,
+                               threshold=threshold, **kwargs)
+            sr.remove_all_spikes()
+            return sr
 
     spikes_removal_tool.__doc__ = SPIKES_REMOVAL_TOOL_DOCSTRING % (
         SIGNAL_MASK_ARG, NAVIGATION_MASK_ARG, "", DISPLAY_DT, TOOLKIT_DT)

--- a/hyperspy/_signals/signal1d.py
+++ b/hyperspy/_signals/signal1d.py
@@ -356,7 +356,7 @@ class Signal1D(BaseSignal, CommonSignal1D):
             return sr
 
     spikes_removal_tool.__doc__ = SPIKES_REMOVAL_TOOL_DOCSTRING % (
-        SIGNAL_MASK_ARG, NAVIGATION_MASK_ARG, "", DISPLAY_DT, TOOLKIT_DT, "")
+        SIGNAL_MASK_ARG, NAVIGATION_MASK_ARG, "", DISPLAY_DT, TOOLKIT_DT,)
 
     def create_model(self, dictionary=None):
         """Create a model for the current data.

--- a/hyperspy/_signals/signal1d.py
+++ b/hyperspy/_signals/signal1d.py
@@ -356,7 +356,7 @@ class Signal1D(BaseSignal, CommonSignal1D):
             return sr
 
     spikes_removal_tool.__doc__ = SPIKES_REMOVAL_TOOL_DOCSTRING % (
-        SIGNAL_MASK_ARG, NAVIGATION_MASK_ARG, "", DISPLAY_DT, TOOLKIT_DT)
+        SIGNAL_MASK_ARG, NAVIGATION_MASK_ARG, "", DISPLAY_DT, TOOLKIT_DT, "")
 
     def create_model(self, dictionary=None):
         """Create a model for the current data.

--- a/hyperspy/docstrings/signal1d.py
+++ b/hyperspy/docstrings/signal1d.py
@@ -72,7 +72,6 @@ SPIKES_REMOVAL_TOOL_DOCSTRING =\
             `signal_mask` argument to mask the signal of interest.
         %s
         %s
-        %s
         **kwargs : dict
             Keyword arguments pass to
                 :py:meth:`~hyperspy.signals._signal_tools.SpikesRemoval`

--- a/hyperspy/docstrings/signal1d.py
+++ b/hyperspy/docstrings/signal1d.py
@@ -48,7 +48,8 @@ SPIKES_DIAGNOSIS_DOCSTRING = \
         """
 
 SPIKES_REMOVAL_TOOL_DOCSTRING =\
-        """Graphical interface to remove spikes from EELS spectra. 
+        """Graphical interface to remove spikes from EELS spectra or 
+        luminescence data. 
         If non-interactive, it removes all spikes and returns a
         `~hyperspy.signals._signal_tools.SpikesRemoval` object.
 
@@ -67,8 +68,8 @@ SPIKES_REMOVAL_TOOL_DOCSTRING =\
             If True, remove the spikes using the graphical user interface. 
             If False, remove all the spikes automatically, which can
             introduce artefacts if used with signal containing peak-like 
-            features. However, this can be mitigated by it in combination
-            with the `signal_mask` argument to mask the signal of interest.
+            features. However, this can be mitigated by using the 
+            `signal_mask` argument to mask the signal of interest.
         %s
         %s
         %s

--- a/hyperspy/docstrings/signal1d.py
+++ b/hyperspy/docstrings/signal1d.py
@@ -48,7 +48,9 @@ SPIKES_DIAGNOSIS_DOCSTRING = \
         """
 
 SPIKES_REMOVAL_TOOL_DOCSTRING =\
-        """Graphical interface to remove spikes from EELS spectra.
+        """Graphical interface to remove spikes from EELS spectra. 
+        If non-interactive, it removes all spikes and returns a
+        `~hyperspy.signals._signal_tools.SpikesRemoval` object.
 
         Parameters
         ----------
@@ -62,11 +64,15 @@ SPIKES_REMOVAL_TOOL_DOCSTRING =\
             method.
         %s
         interactive : bool
-            If True, remove the spikes using the graphical user interface. If False,
-            remove the spikes automatically, which could introduce artefacts if used
-            with signal containing peak-like features. However, this could be
-            mitigated by it in combination with the `signal_mask` argument to mask the
-            signal of interest.
+            If True, remove the spikes using the graphical user interface. 
+            If False, remove all the spikes automatically, which can
+            introduce artefacts if used with signal containing peak-like 
+            features. However, this can be mitigated by it in combination
+            with the `signal_mask` argument to mask the signal of interest.
+        %s
+        **kwargs : dict
+            Keyword arguments pass to
+                :py:meth:`~hyperspy.signals._signal_tools.SpikesRemoval`
         %s
         %s
 

--- a/hyperspy/docstrings/signal1d.py
+++ b/hyperspy/docstrings/signal1d.py
@@ -70,11 +70,11 @@ SPIKES_REMOVAL_TOOL_DOCSTRING =\
             features. However, this can be mitigated by it in combination
             with the `signal_mask` argument to mask the signal of interest.
         %s
+        %s
+        %s
         **kwargs : dict
             Keyword arguments pass to
                 :py:meth:`~hyperspy.signals._signal_tools.SpikesRemoval`
-        %s
-        %s
 
         See also
         --------

--- a/hyperspy/tests/signal/test_spike_removal_tool.py
+++ b/hyperspy/tests/signal/test_spike_removal_tool.py
@@ -75,12 +75,21 @@ def test_spikes_removal_tool_non_interactive():
     np.testing.assert_almost_equal(s.data[1, 2, 14], 1, decimal=5)
     assert isinstance(sr, SpikesRemoval)
 
+def test_spikes_removal_tool_non_interactive_masking():
+    s = Signal1D(np.ones((2, 3, 30)))
+    np.random.seed(1)
+    s.add_gaussian_noise(1e-5)
+    # Add three spikes
+    s.data[1, 0, 1] += 2
+    s.data[0, 2, 29] += 1
+    s.data[1, 2, 14] += 1
+
     navigation_mask = np.zeros((2,3), dtype='bool')
     navigation_mask[1,0] = True
     signal_mask = np.zeros((30,), dtype='bool')
     signal_mask[28:] = True
     sr = s.spikes_removal_tool(threshold=0.5, interactive=False, add_noise=False,
                                navigation_mask=navigation_mask, signal_mask=signal_mask)
-    np.testing.assert_almost_equal(s.data[1, 0, 1], 2,)
-    np.testing.assert_almost_equal(s.data[0, 2, 29], 1,)
+    np.testing.assert_almost_equal(s.data[1, 0, 1], 3,)
+    np.testing.assert_almost_equal(s.data[0, 2, 29], 2,)
     np.testing.assert_almost_equal(s.data[1, 2, 14], 1, decimal=5)

--- a/hyperspy/tests/signal/test_spike_removal_tool.py
+++ b/hyperspy/tests/signal/test_spike_removal_tool.py
@@ -64,28 +64,24 @@ add_noise_params = [
     [False, 5],
     [True, 1]
 ]
-def test_spikes_removal_tool_non_interactive():
-    for noise_bool, assert_decimal in add_noise_params:
-        s = Signal1D(np.ones((2, 3, 30)))
-        np.random.seed(1)
-        s.add_gaussian_noise(1e-5)
-        # Add three spikes
-        s.data[1, 0, 1] += 2
-        s.data[0, 2, 29] += 1
-        s.data[1, 2, 14] += 1
-        s.metadata.Signal.set_item("Noise_properties.variance", 1e-5)
-
-        sr = s.spikes_removal_tool(threshold=0.5, interactive=False, add_noise=noise_bool)
-        np.testing.assert_almost_equal(s.data[1, 0, 1], 1, decimal=assert_decimal)
-        np.testing.assert_almost_equal(s.data[0, 2, 29], 1, decimal=assert_decimal)
-        np.testing.assert_almost_equal(s.data[1, 2, 14], 1, decimal=assert_decimal)
-        assert isinstance(sr, SpikesRemoval)
 
 
-def test_spikes_removal_tool_non_interactive_noise():
-    @pytest.mark.parametrize("test_input, expected", [("3+5", 8), ("2+4", 6), ("6*9", 42)])
-    def test_eval(test_input, expected):
-        assert eval(test_input) == expected
+@pytest.mark.parametrize(("add_noise, decimal"), [(True, 1), (False, 5)])
+def test_spikes_removal_tool_non_interactive(add_noise, decimal):
+    s = Signal1D(np.ones((2, 3, 30)))
+    np.random.seed(1)
+    s.add_gaussian_noise(1e-5)
+    # Add three spikes
+    s.data[1, 0, 1] += 2
+    s.data[0, 2, 29] += 1
+    s.data[1, 2, 14] += 1
+    s.metadata.Signal.set_item("Noise_properties.variance", 1e-5)
+
+    sr = s.spikes_removal_tool(threshold=0.5, interactive=False, add_noise=add_noise)
+    np.testing.assert_almost_equal(s.data[1, 0, 1], 1, decimal=decimal)
+    np.testing.assert_almost_equal(s.data[0, 2, 29], 1, decimal=decimal)
+    np.testing.assert_almost_equal(s.data[1, 2, 14], 1, decimal=decimal)
+    assert isinstance(sr, SpikesRemoval)
 
 
 def test_spikes_removal_tool_non_interactive_masking():
@@ -97,8 +93,8 @@ def test_spikes_removal_tool_non_interactive_masking():
     s.data[0, 2, 29] += 1
     s.data[1, 2, 14] += 1
 
-    navigation_mask = np.zeros((2,3), dtype='bool')
-    navigation_mask[1,0] = True
+    navigation_mask = np.zeros((2, 3), dtype='bool')
+    navigation_mask[1, 0] = True
     signal_mask = np.zeros((30,), dtype='bool')
     signal_mask[28:] = True
     sr = s.spikes_removal_tool(threshold=0.5, interactive=False, add_noise=False,

--- a/hyperspy/tests/signal/test_spike_removal_tool.py
+++ b/hyperspy/tests/signal/test_spike_removal_tool.py
@@ -74,3 +74,13 @@ def test_spikes_removal_tool_non_interactive():
     np.testing.assert_almost_equal(s.data[0, 2, 29], 1, decimal=5)
     np.testing.assert_almost_equal(s.data[1, 2, 14], 1, decimal=5)
     assert isinstance(sr, SpikesRemoval)
+
+    navigation_mask = np.zeros((2,3), dtype='bool')
+    navigation_mask[1,0] = True
+    signal_mask = np.zeros((30,), dtype='bool')
+    signal_mask[28:] = True
+    sr = s.spikes_removal_tool(threshold=0.5, interactive=False, add_noise=False,
+                               navigation_mask=navigation_mask, signal_mask=signal_mask)
+    np.testing.assert_almost_equal(s.data[1, 0, 1], 2,)
+    np.testing.assert_almost_equal(s.data[0, 2, 29], 1,)
+    np.testing.assert_almost_equal(s.data[1, 2, 14], 1, decimal=5)

--- a/hyperspy/tests/signal/test_spike_removal_tool.py
+++ b/hyperspy/tests/signal/test_spike_removal_tool.py
@@ -69,6 +69,8 @@ def test_spikes_removal_tool_non_interactive():
     s.data[0, 2, 29] += 1
     s.data[1, 2, 14] += 1
 
-    sr = s.spikes_removal_tool(threshold=0.5, interactive=False)
+    sr = s.spikes_removal_tool(threshold=0.5, interactive=False, add_noise=False)
     np.testing.assert_almost_equal(s.data[1, 0, 1], 1, decimal=5)
+    np.testing.assert_almost_equal(s.data[0, 2, 29], 1, decimal=5)
+    np.testing.assert_almost_equal(s.data[1, 2, 14], 1, decimal=5)
     assert isinstance(sr, SpikesRemoval)

--- a/hyperspy/tests/signal/test_spike_removal_tool.py
+++ b/hyperspy/tests/signal/test_spike_removal_tool.py
@@ -70,6 +70,5 @@ def test_spikes_removal_tool_non_interactive():
     s.data[1, 2, 14] += 1
 
     sr = s.spikes_removal_tool(threshold=0.5, interactive=False)
-    np.testing.assert_almost_equal(s.data[0, 2, 29], 1, decimal=5)
     np.testing.assert_almost_equal(s.data[1, 0, 1], 1, decimal=5)
     assert isinstance(sr, SpikesRemoval)

--- a/hyperspy/tests/signal/test_spike_removal_tool.py
+++ b/hyperspy/tests/signal/test_spike_removal_tool.py
@@ -18,7 +18,7 @@
 
 import numpy as np
 
-from hyperspy.signal_tools import SpikesRemovalInteractive
+from hyperspy.signal_tools import SpikesRemovalInteractive, SpikesRemoval
 from hyperspy.signals import Signal1D
 
 
@@ -58,3 +58,18 @@ def test_spikes_removal_tool():
     sr.apply()
     np.testing.assert_almost_equal(s.data[1, 2, 14], 1, decimal=5)
     assert s.axes_manager.indices == (0, 0)
+
+
+def test_spikes_removal_tool_non_interactive():
+    s = Signal1D(np.ones((2, 3, 30)))
+    np.random.seed(1)
+    s.add_gaussian_noise(1e-5)
+    # Add three spikes
+    s.data[1, 0, 1] += 2
+    s.data[0, 2, 29] += 1
+    s.data[1, 2, 14] += 1
+
+    sr = s.spikes_removal_tool(threshold=0.5, interactive=False)
+    np.testing.assert_almost_equal(s.data[0, 2, 29], 1, decimal=5)
+    np.testing.assert_almost_equal(s.data[1, 0, 1], 1, decimal=5)
+    assert isinstance(sr, SpikesRemoval)


### PR DESCRIPTION
### Description of the change
This PR tries to fix the `spike_removal_tool` when it is run non-interactively:
-  When `interactive = False` the function `spike_removal_tool` calls the `remove_all_spikes`. It also returns the `SpikesRemoval` object (in case some of the spike removal parameters need to be checked post process, e.g. threshold value used)
- Added `*kwargs* to the CLI function (I prefer to control everything via commands, not GUIs).
-  Expanded docstrings
-  Expanded tests to cover the changes

### Progress of the PR
- [x] Change implemented
- [x] update docstring
- [x] add tests,
- [x] ready for review.

### Minimal example of the bug fix or the new feature
```python
from hyperspy.signals import Signal1D
s = Signal1D(np.ones((2, 3, 30)))
# Add spike
s.data[1, 0, 1] += 2
sr = s.spikes_removal_tool(threshold='auto', interactive=False)
print('Threshold calculated: {:.2f}'.format(sr.threshold))
```


