### PR TITLE
copyright update 2021

### DIFF
--- a/hyperspy/Release.py
+++ b/hyperspy/Release.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2007-2020 The HyperSpy developers
+# Copyright 2007-2021 The HyperSpy developers
 #
 # This file is part of  HyperSpy.
 #

--- a/hyperspy/__init__.py
+++ b/hyperspy/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2007-2020 The HyperSpy developers
+# Copyright 2007-2021 The HyperSpy developers
 #
 # This file is part of  HyperSpy.
 #

--- a/hyperspy/_components/arctan.py
+++ b/hyperspy/_components/arctan.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2007-2020 The HyperSpy developers
+# Copyright 2007-2021 The HyperSpy developers
 #
 # This file is part of HyperSpy.
 #

--- a/hyperspy/_components/bleasdale.py
+++ b/hyperspy/_components/bleasdale.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2007-2020 The HyperSpy developers
+# Copyright 2007-2021 The HyperSpy developers
 #
 # This file is part of  HyperSpy.
 #

--- a/hyperspy/_components/doniach.py
+++ b/hyperspy/_components/doniach.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2007-2020 The HyperSpy developers
+# Copyright 2007-2021 The HyperSpy developers
 #
 # This file is part of  HyperSpy.
 #

--- a/hyperspy/_components/eels_arctan.py
+++ b/hyperspy/_components/eels_arctan.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2007-2020 The HyperSpy developers
+# Copyright 2007-2021 The HyperSpy developers
 #
 # This file is part of HyperSpy.
 #

--- a/hyperspy/_components/eels_cl_edge.py
+++ b/hyperspy/_components/eels_cl_edge.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2007-2020 The HyperSpy developers
+# Copyright 2007-2021 The HyperSpy developers
 #
 # This file is part of  HyperSpy.
 #

--- a/hyperspy/_components/eels_double_power_law.py
+++ b/hyperspy/_components/eels_double_power_law.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2007-2020 The HyperSpy developers
+# Copyright 2007-2021 The HyperSpy developers
 #
 # This file is part of  HyperSpy.
 #

--- a/hyperspy/_components/eels_vignetting.py
+++ b/hyperspy/_components/eels_vignetting.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2007-2020 The HyperSpy developers
+# Copyright 2007-2021 The HyperSpy developers
 #
 # This file is part of  HyperSpy.
 #

--- a/hyperspy/_components/error_function.py
+++ b/hyperspy/_components/error_function.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2007-2020 The HyperSpy developers
+# Copyright 2007-2021 The HyperSpy developers
 #
 # This file is part of  HyperSpy.
 #

--- a/hyperspy/_components/exponential.py
+++ b/hyperspy/_components/exponential.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2007-2020 The HyperSpy developers
+# Copyright 2007-2021 The HyperSpy developers
 #
 # This file is part of  HyperSpy.
 #

--- a/hyperspy/_components/expression.py
+++ b/hyperspy/_components/expression.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2007-2020 The HyperSpy developers
+# Copyright 2007-2021 The HyperSpy developers
 #
 # This file is part of  HyperSpy.
 #

--- a/hyperspy/_components/gaussian.py
+++ b/hyperspy/_components/gaussian.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2007-2020 The HyperSpy developers
+# Copyright 2007-2021 The HyperSpy developers
 #
 # This file is part of  HyperSpy.
 #

--- a/hyperspy/_components/gaussian2d.py
+++ b/hyperspy/_components/gaussian2d.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2007-2020 The HyperSpy developers
+# Copyright 2007-2021 The HyperSpy developers
 #
 # This file is part of  HyperSpy.
 #

--- a/hyperspy/_components/gaussianhf.py
+++ b/hyperspy/_components/gaussianhf.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2007-2020 The HyperSpy developers
+# Copyright 2007-2021 The HyperSpy developers
 #
 # This file is part of  HyperSpy.
 #

--- a/hyperspy/_components/heaviside.py
+++ b/hyperspy/_components/heaviside.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2007-2020 The HyperSpy developers
+# Copyright 2007-2021 The HyperSpy developers
 #
 # This file is part of  HyperSpy.
 #

--- a/hyperspy/_components/logistic.py
+++ b/hyperspy/_components/logistic.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2007-2020 The HyperSpy developers
+# Copyright 2007-2021 The HyperSpy developers
 #
 # This file is part of  HyperSpy.
 #

--- a/hyperspy/_components/lorentzian.py
+++ b/hyperspy/_components/lorentzian.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2007-2020 The HyperSpy developers
+# Copyright 2007-2021 The HyperSpy developers
 #
 # This file is part of  HyperSpy.
 #

--- a/hyperspy/_components/offset.py
+++ b/hyperspy/_components/offset.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2007-2020 The HyperSpy developers
+# Copyright 2007-2021 The HyperSpy developers
 #
 # This file is part of  HyperSpy.
 #

--- a/hyperspy/_components/pes_core_line_shape.py
+++ b/hyperspy/_components/pes_core_line_shape.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2007-2020 The HyperSpy developers
+# Copyright 2007-2021 The HyperSpy developers
 #
 # This file is part of  HyperSpy.
 #

--- a/hyperspy/_components/pes_see.py
+++ b/hyperspy/_components/pes_see.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2007-2020 The HyperSpy developers
+# Copyright 2007-2021 The HyperSpy developers
 #
 # This file is part of  HyperSpy.
 #

--- a/hyperspy/_components/pes_voigt.py
+++ b/hyperspy/_components/pes_voigt.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2007-2020 The HyperSpy developers
+# Copyright 2007-2021 The HyperSpy developers
 #
 # This file is part of  HyperSpy.
 #

--- a/hyperspy/_components/polynomial.py
+++ b/hyperspy/_components/polynomial.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2007-2020 The HyperSpy developers
+# Copyright 2007-2021 The HyperSpy developers
 #
 # This file is part of  HyperSpy.
 #

--- a/hyperspy/_components/polynomial_deprecated.py
+++ b/hyperspy/_components/polynomial_deprecated.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2007-2020 The HyperSpy developers
+# Copyright 2007-2021 The HyperSpy developers
 #
 # This file is part of  HyperSpy.
 #

--- a/hyperspy/_components/power_law.py
+++ b/hyperspy/_components/power_law.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2007-2020 The HyperSpy developers
+# Copyright 2007-2021 The HyperSpy developers
 #
 # This file is part of  HyperSpy.
 #

--- a/hyperspy/_components/rc.py
+++ b/hyperspy/_components/rc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2007-2020 The HyperSpy developers
+# Copyright 2007-2021 The HyperSpy developers
 #
 # This file is part of  HyperSpy.
 #

--- a/hyperspy/_components/scalable_fixed_pattern.py
+++ b/hyperspy/_components/scalable_fixed_pattern.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2007-2020 The HyperSpy developers
+# Copyright 2007-2021 The HyperSpy developers
 #
 # This file is part of  HyperSpy.
 #

--- a/hyperspy/_components/skew_normal.py
+++ b/hyperspy/_components/skew_normal.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2007-2020 The HyperSpy developers
+# Copyright 2007-2021 The HyperSpy developers
 #
 # This file is part of  HyperSpy.
 #

--- a/hyperspy/_components/split_pvoigt.py
+++ b/hyperspy/_components/split_pvoigt.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2007-2020 The HyperSpy developers
+# Copyright 2007-2021 The HyperSpy developers
 #
 # This file is part of  HyperSpy.
 #

--- a/hyperspy/_components/voigt.py
+++ b/hyperspy/_components/voigt.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2007-2020 The HyperSpy developers
+# Copyright 2007-2021 The HyperSpy developers
 #
 # This file is part of  HyperSpy.
 #

--- a/hyperspy/_components/volume_plasmon_drude.py
+++ b/hyperspy/_components/volume_plasmon_drude.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2007-2020 The HyperSpy developers
+# Copyright 2007-2021 The HyperSpy developers
 #
 # This file is part of  HyperSpy.
 #

--- a/hyperspy/_lazy_signals.py
+++ b/hyperspy/_lazy_signals.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2007-2020 The HyperSpy developers
+# Copyright 2007-2021 The HyperSpy developers
 #
 # This file is part of  HyperSpy.
 #

--- a/hyperspy/_signals/common_signal1d.py
+++ b/hyperspy/_signals/common_signal1d.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2007-2020 The HyperSpy developers
+# Copyright 2007-2021 The HyperSpy developers
 #
 # This file is part of  HyperSpy.
 #

--- a/hyperspy/_signals/common_signal2d.py
+++ b/hyperspy/_signals/common_signal2d.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2007-2020 The HyperSpy developers
+# Copyright 2007-2021 The HyperSpy developers
 #
 # This file is part of  HyperSpy.
 #

--- a/hyperspy/_signals/complex_signal.py
+++ b/hyperspy/_signals/complex_signal.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2007-2020 The HyperSpy developers
+# Copyright 2007-2021 The HyperSpy developers
 #
 # This file is part of  HyperSpy.
 #

--- a/hyperspy/_signals/complex_signal1d.py
+++ b/hyperspy/_signals/complex_signal1d.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2007-2020 The HyperSpy developers
+# Copyright 2007-2021 The HyperSpy developers
 #
 # This file is part of  HyperSpy.
 #

--- a/hyperspy/_signals/complex_signal2d.py
+++ b/hyperspy/_signals/complex_signal2d.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2007-2020 The HyperSpy developers
+# Copyright 2007-2021 The HyperSpy developers
 #
 # This file is part of  HyperSpy.
 #

--- a/hyperspy/_signals/dielectric_function.py
+++ b/hyperspy/_signals/dielectric_function.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2007-2020 The HyperSpy developers
+# Copyright 2007-2021 The HyperSpy developers
 #
 # This file is part of  HyperSpy.
 #

--- a/hyperspy/_signals/eds.py
+++ b/hyperspy/_signals/eds.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2007-2020 The HyperSpy developers
+# Copyright 2007-2021 The HyperSpy developers
 #
 # This file is part of  HyperSpy.
 #

--- a/hyperspy/_signals/eds_sem.py
+++ b/hyperspy/_signals/eds_sem.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2007-2020 The HyperSpy developers
+# Copyright 2007-2021 The HyperSpy developers
 #
 # This file is part of  HyperSpy.
 #

--- a/hyperspy/_signals/eds_tem.py
+++ b/hyperspy/_signals/eds_tem.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2007-2020 The HyperSpy developers
+# Copyright 2007-2021 The HyperSpy developers
 #
 # This file is part of  HyperSpy.
 #

--- a/hyperspy/_signals/eels.py
+++ b/hyperspy/_signals/eels.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2007-2020 The HyperSpy developers
+# Copyright 2007-2021 The HyperSpy developers
 #
 # This file is part of  HyperSpy.
 #

--- a/hyperspy/_signals/hologram_image.py
+++ b/hyperspy/_signals/hologram_image.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2007-2020 The HyperSpy developers
+# Copyright 2007-2021 The HyperSpy developers
 #
 # This file is part of  HyperSpy.
 #

--- a/hyperspy/_signals/lazy.py
+++ b/hyperspy/_signals/lazy.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2007-2020 The HyperSpy developers
+# Copyright 2007-2021 The HyperSpy developers
 #
 # This file is part of  HyperSpy.
 #

--- a/hyperspy/_signals/signal1d.py
+++ b/hyperspy/_signals/signal1d.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2007-2020 The HyperSpy developers
+# Copyright 2007-2021 The HyperSpy developers
 #
 # This file is part of  HyperSpy.
 #

--- a/hyperspy/_signals/signal2d.py
+++ b/hyperspy/_signals/signal2d.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2007-2020 The HyperSpy developers
+# Copyright 2007-2021 The HyperSpy developers
 #
 # This file is part of  HyperSpy.
 #

--- a/hyperspy/api.py
+++ b/hyperspy/api.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2007-2020 The HyperSpy developers
+# Copyright 2007-2021 The HyperSpy developers
 #
 # This file is part of  HyperSpy.
 #

--- a/hyperspy/api_nogui.py
+++ b/hyperspy/api_nogui.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2007-2020 The HyperSpy developers
+# Copyright 2007-2021 The HyperSpy developers
 #
 # This file is part of  HyperSpy.
 #

--- a/hyperspy/axes.py
+++ b/hyperspy/axes.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2007-2020 The HyperSpy developers
+# Copyright 2007-2021 The HyperSpy developers
 #
 # This file is part of  HyperSpy.
 #

--- a/hyperspy/component.py
+++ b/hyperspy/component.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2007-2020 The HyperSpy developers
+# Copyright 2007-2021 The HyperSpy developers
 #
 # This file is part of  HyperSpy.
 #

--- a/hyperspy/components1d.py
+++ b/hyperspy/components1d.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2007-2020 The HyperSpy developers
+# Copyright 2007-2021 The HyperSpy developers
 #
 # This file is part of  HyperSpy.
 #

--- a/hyperspy/components2d.py
+++ b/hyperspy/components2d.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2007-2020 The HyperSpy developers
+# Copyright 2007-2021 The HyperSpy developers
 #
 # This file is part of  HyperSpy.
 #

--- a/hyperspy/conftest.py
+++ b/hyperspy/conftest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2007-2020 The HyperSpy developers
+# Copyright 2007-2021 The HyperSpy developers
 #
 # This file is part of  HyperSpy.
 #

--- a/hyperspy/decorators.py
+++ b/hyperspy/decorators.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2007-2020 The HyperSpy developers
+# Copyright 2007-2021 The HyperSpy developers
 #
 # This file is part of  HyperSpy.
 #

--- a/hyperspy/defaults_parser.py
+++ b/hyperspy/defaults_parser.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2007-2020 The HyperSpy developers
+# Copyright 2007-2021 The HyperSpy developers
 #
 # This file is part of  HyperSpy.
 #

--- a/hyperspy/docstrings/model.py
+++ b/hyperspy/docstrings/model.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2007-2020 The HyperSpy developers
+# Copyright 2007-2021 The HyperSpy developers
 #
 # This file is part of  HyperSpy.
 #

--- a/hyperspy/docstrings/parameters.py
+++ b/hyperspy/docstrings/parameters.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2007-2020 The HyperSpy developers
+# Copyright 2007-2021 The HyperSpy developers
 #
 # This file is part of  HyperSpy.
 #

--- a/hyperspy/docstrings/plot.py
+++ b/hyperspy/docstrings/plot.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2007-2020 The HyperSpy developers
+# Copyright 2007-2021 The HyperSpy developers
 #
 # This file is part of  HyperSpy.
 #

--- a/hyperspy/docstrings/signal.py
+++ b/hyperspy/docstrings/signal.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2007-2020 The HyperSpy developers
+# Copyright 2007-2021 The HyperSpy developers
 #
 # This file is part of  HyperSpy.
 #

--- a/hyperspy/docstrings/signal1d.py
+++ b/hyperspy/docstrings/signal1d.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2007-2020 The HyperSpy developers
+# Copyright 2007-2021 The HyperSpy developers
 #
 # This file is part of  HyperSpy.
 #

--- a/hyperspy/drawing/__init__.py
+++ b/hyperspy/drawing/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2007-2020 The HyperSpy developers
+# Copyright 2007-2021 The HyperSpy developers
 #
 # This file is part of  HyperSpy.
 #

--- a/hyperspy/drawing/_markers/__init__.py
+++ b/hyperspy/drawing/_markers/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2007-2020 The HyperSpy developers
+# Copyright 2007-2021 The HyperSpy developers
 #
 # This file is part of  HyperSpy.
 #

--- a/hyperspy/drawing/_markers/horizontal_line.py
+++ b/hyperspy/drawing/_markers/horizontal_line.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2007-2020 The HyperSpy developers
+# Copyright 2007-2021 The HyperSpy developers
 #
 # This file is part of  HyperSpy.
 #

--- a/hyperspy/drawing/_markers/horizontal_line_segment.py
+++ b/hyperspy/drawing/_markers/horizontal_line_segment.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2007-2020 The HyperSpy developers
+# Copyright 2007-2021 The HyperSpy developers
 #
 # This file is part of  HyperSpy.
 #

--- a/hyperspy/drawing/_markers/line_segment.py
+++ b/hyperspy/drawing/_markers/line_segment.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2007-2020 The HyperSpy developers
+# Copyright 2007-2021 The HyperSpy developers
 #
 # This file is part of  HyperSpy.
 #

--- a/hyperspy/drawing/_markers/point.py
+++ b/hyperspy/drawing/_markers/point.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2007-2020 The HyperSpy developers
+# Copyright 2007-2021 The HyperSpy developers
 #
 # This file is part of  HyperSpy.
 #

--- a/hyperspy/drawing/_markers/rectangle.py
+++ b/hyperspy/drawing/_markers/rectangle.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2007-2020 The HyperSpy developers
+# Copyright 2007-2021 The HyperSpy developers
 #
 # This file is part of  HyperSpy.
 #

--- a/hyperspy/drawing/_markers/text.py
+++ b/hyperspy/drawing/_markers/text.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2007-2020 The HyperSpy developers
+# Copyright 2007-2021 The HyperSpy developers
 #
 # This file is part of  HyperSpy.
 #

--- a/hyperspy/drawing/_markers/vertical_line.py
+++ b/hyperspy/drawing/_markers/vertical_line.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2007-2020 The HyperSpy developers
+# Copyright 2007-2021 The HyperSpy developers
 #
 # This file is part of  HyperSpy.
 #

--- a/hyperspy/drawing/_markers/vertical_line_segment.py
+++ b/hyperspy/drawing/_markers/vertical_line_segment.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2007-2020 The HyperSpy developers
+# Copyright 2007-2021 The HyperSpy developers
 #
 # This file is part of  HyperSpy.
 #

--- a/hyperspy/drawing/_widgets/__init__.py
+++ b/hyperspy/drawing/_widgets/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2007-2020 The HyperSpy developers
+# Copyright 2007-2021 The HyperSpy developers
 #
 # This file is part of  HyperSpy.
 #

--- a/hyperspy/drawing/_widgets/circle.py
+++ b/hyperspy/drawing/_widgets/circle.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2007-2020 The HyperSpy developers
+# Copyright 2007-2021 The HyperSpy developers
 #
 # This file is part of  HyperSpy.
 #

--- a/hyperspy/drawing/_widgets/horizontal_line.py
+++ b/hyperspy/drawing/_widgets/horizontal_line.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2007-2020 The HyperSpy developers
+# Copyright 2007-2021 The HyperSpy developers
 #
 # This file is part of  HyperSpy.
 #

--- a/hyperspy/drawing/_widgets/label.py
+++ b/hyperspy/drawing/_widgets/label.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2007-2020 The HyperSpy developers
+# Copyright 2007-2021 The HyperSpy developers
 #
 # This file is part of  HyperSpy.
 #

--- a/hyperspy/drawing/_widgets/line2d.py
+++ b/hyperspy/drawing/_widgets/line2d.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2007-2020 The HyperSpy developers
+# Copyright 2007-2021 The HyperSpy developers
 #
 # This file is part of  HyperSpy.
 #

--- a/hyperspy/drawing/_widgets/range.py
+++ b/hyperspy/drawing/_widgets/range.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2007-2020 The HyperSpy developers
+# Copyright 2007-2021 The HyperSpy developers
 #
 # This file is part of  HyperSpy.
 #

--- a/hyperspy/drawing/_widgets/rectangles.py
+++ b/hyperspy/drawing/_widgets/rectangles.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2007-2020 The HyperSpy developers
+# Copyright 2007-2021 The HyperSpy developers
 #
 # This file is part of  HyperSpy.
 #

--- a/hyperspy/drawing/_widgets/scalebar.py
+++ b/hyperspy/drawing/_widgets/scalebar.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2007-2020 The HyperSpy developers
+# Copyright 2007-2021 The HyperSpy developers
 #
 # This file is part of  HyperSpy.
 #

--- a/hyperspy/drawing/_widgets/vertical_line.py
+++ b/hyperspy/drawing/_widgets/vertical_line.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2007-2020 The HyperSpy developers
+# Copyright 2007-2021 The HyperSpy developers
 #
 # This file is part of  HyperSpy.
 #

--- a/hyperspy/drawing/figure.py
+++ b/hyperspy/drawing/figure.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2007-2020 The HyperSpy developers
+# Copyright 2007-2021 The HyperSpy developers
 #
 # This file is part of  HyperSpy.
 #

--- a/hyperspy/drawing/image.py
+++ b/hyperspy/drawing/image.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2007-2020 The HyperSpy developers
+# Copyright 2007-2021 The HyperSpy developers
 #
 # This file is part of HyperSpy.
 #

--- a/hyperspy/drawing/marker.py
+++ b/hyperspy/drawing/marker.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2007-2020 The HyperSpy developers
+# Copyright 2007-2021 The HyperSpy developers
 #
 # This file is part of  HyperSpy.
 #

--- a/hyperspy/drawing/mpl_he.py
+++ b/hyperspy/drawing/mpl_he.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2007-2020 The HyperSpy developers
+# Copyright 2007-2021 The HyperSpy developers
 #
 # This file is part of  HyperSpy.
 #

--- a/hyperspy/drawing/mpl_hie.py
+++ b/hyperspy/drawing/mpl_hie.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2007-2020 The HyperSpy developers
+# Copyright 2007-2021 The HyperSpy developers
 #
 # This file is part of  HyperSpy.
 #

--- a/hyperspy/drawing/mpl_hse.py
+++ b/hyperspy/drawing/mpl_hse.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2007-2020 The HyperSpy developers
+# Copyright 2007-2021 The HyperSpy developers
 #
 # This file is part of  HyperSpy.
 #

--- a/hyperspy/drawing/signal.py
+++ b/hyperspy/drawing/signal.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2007-2020 The HyperSpy developers
+# Copyright 2007-2021 The HyperSpy developers
 #
 # This file is part of  HyperSpy.
 #

--- a/hyperspy/drawing/signal1d.py
+++ b/hyperspy/drawing/signal1d.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2007-2020 The HyperSpy developers
+# Copyright 2007-2021 The HyperSpy developers
 #
 # This file is part of  HyperSpy.
 #

--- a/hyperspy/drawing/tiles.py
+++ b/hyperspy/drawing/tiles.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2007-2020 The HyperSpy developers
+# Copyright 2007-2021 The HyperSpy developers
 #
 # This file is part of  HyperSpy.
 #

--- a/hyperspy/drawing/utils.py
+++ b/hyperspy/drawing/utils.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2007-2020 The HyperSpy developers
+# Copyright 2007-2021 The HyperSpy developers
 #
 # This file is part of  HyperSpy.
 #

--- a/hyperspy/drawing/widget.py
+++ b/hyperspy/drawing/widget.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2007-2020 The HyperSpy developers
+# Copyright 2007-2021 The HyperSpy developers
 #
 # This file is part of  HyperSpy.
 #

--- a/hyperspy/drawing/widgets.py
+++ b/hyperspy/drawing/widgets.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2007-2020 The HyperSpy developers
+# Copyright 2007-2021 The HyperSpy developers
 #
 # This file is part of  HyperSpy.
 #

--- a/hyperspy/events.py
+++ b/hyperspy/events.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2007-2020 The HyperSpy developers
+# Copyright 2007-2021 The HyperSpy developers
 #
 # This file is part of  HyperSpy.
 #

--- a/hyperspy/exceptions.py
+++ b/hyperspy/exceptions.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2007-2020 The HyperSpy developers
+# Copyright 2007-2021 The HyperSpy developers
 #
 # This file is part of  HyperSpy.
 #

--- a/hyperspy/extensions.py
+++ b/hyperspy/extensions.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2007-2020 The HyperSpy developers
+# Copyright 2007-2021 The HyperSpy developers
 #
 # This file is part of  HyperSpy.
 #

--- a/hyperspy/external/progressbar.py
+++ b/hyperspy/external/progressbar.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2007-2020 The HyperSpy developers
+# Copyright 2007-2021 The HyperSpy developers
 #
 # This file is part of  HyperSpy.
 #

--- a/hyperspy/interactive.py
+++ b/hyperspy/interactive.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2007-2020 The HyperSpy developers
+# Copyright 2007-2021 The HyperSpy developers
 #
 # This file is part of  HyperSpy.
 #

--- a/hyperspy/io.py
+++ b/hyperspy/io.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2007-2020 The HyperSpy developers
+# Copyright 2007-2021 The HyperSpy developers
 #
 # This file is part of  HyperSpy.
 #

--- a/hyperspy/io_plugins/__init__.py
+++ b/hyperspy/io_plugins/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2007-2020 The HyperSpy developers
+# Copyright 2007-2021 The HyperSpy developers
 #
 # This file is part of  HyperSpy.
 #

--- a/hyperspy/io_plugins/blockfile.py
+++ b/hyperspy/io_plugins/blockfile.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2007-2020 The HyperSpy developers
+# Copyright 2007-2021 The HyperSpy developers
 #
 # This file is part of  HyperSpy.
 #

--- a/hyperspy/io_plugins/dens.py
+++ b/hyperspy/io_plugins/dens.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2007-2020 The HyperSpy developers
+# Copyright 2007-2021 The HyperSpy developers
 #
 # This file is part of  HyperSpy.
 #

--- a/hyperspy/io_plugins/edax.py
+++ b/hyperspy/io_plugins/edax.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2007-2020 The HyperSpy developers
+# Copyright 2007-2021 The HyperSpy developers
 #
 # This file is part of  HyperSpy.
 #

--- a/hyperspy/io_plugins/emd.py
+++ b/hyperspy/io_plugins/emd.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2007-2020 The HyperSpy developers
+# Copyright 2007-2021 The HyperSpy developers
 #
 # This file is part of  HyperSpy.
 #

--- a/hyperspy/io_plugins/empad.py
+++ b/hyperspy/io_plugins/empad.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2007-2020 The HyperSpy developers
+# Copyright 2007-2021 The HyperSpy developers
 #
 # This file is part of  HyperSpy.
 #

--- a/hyperspy/io_plugins/fei.py
+++ b/hyperspy/io_plugins/fei.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2007-2020 The HyperSpy developers
+# Copyright 2007-2021 The HyperSpy developers
 #
 # This file is part of  HyperSpy.
 #

--- a/hyperspy/io_plugins/hspy.py
+++ b/hyperspy/io_plugins/hspy.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2007-2020 The HyperSpy developers
+# Copyright 2007-2021 The HyperSpy developers
 #
 # This file is part of  HyperSpy.
 #

--- a/hyperspy/io_plugins/image.py
+++ b/hyperspy/io_plugins/image.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2007-2020 The HyperSpy developers
+# Copyright 2007-2021 The HyperSpy developers
 #
 # This file is part of  HyperSpy.
 #

--- a/hyperspy/io_plugins/mrc.py
+++ b/hyperspy/io_plugins/mrc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2007-2020 The HyperSpy developers
+# Copyright 2007-2021 The HyperSpy developers
 #
 # This file is part of  HyperSpy.
 #

--- a/hyperspy/io_plugins/mrcz.py
+++ b/hyperspy/io_plugins/mrcz.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2007-2020 The HyperSpy developers
+# Copyright 2007-2021 The HyperSpy developers
 #
 # This file is part of  HyperSpy.
 #

--- a/hyperspy/io_plugins/msa.py
+++ b/hyperspy/io_plugins/msa.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2007-2020 The HyperSpy developers
+# Copyright 2007-2021 The HyperSpy developers
 #
 # This file is part of  HyperSpy.
 #

--- a/hyperspy/io_plugins/netcdf.py
+++ b/hyperspy/io_plugins/netcdf.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2007-2020 The HyperSpy developers
+# Copyright 2007-2021 The HyperSpy developers
 #
 # This file is part of  HyperSpy.
 #

--- a/hyperspy/io_plugins/nexus.py
+++ b/hyperspy/io_plugins/nexus.py
@@ -1,6 +1,6 @@
 """Nexus file reading, writing and inspection."""
 # -*- coding: utf-8 -*-
-# Copyright 2007-2020 The HyperSpy developers
+# Copyright 2007-2021 The HyperSpy developers
 #
 # This file is part of  HyperSpy.
 #

--- a/hyperspy/io_plugins/protochips.py
+++ b/hyperspy/io_plugins/protochips.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2007-2020 The HyperSpy developers
+# Copyright 2007-2021 The HyperSpy developers
 #
 # This file is part of HyperSpy.
 #

--- a/hyperspy/io_plugins/ripple.py
+++ b/hyperspy/io_plugins/ripple.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2007-2020 The HyperSpy developers
+# Copyright 2007-2021 The HyperSpy developers
 #
 # This file is part of  HyperSpy.
 #

--- a/hyperspy/io_plugins/semper_unf.py
+++ b/hyperspy/io_plugins/semper_unf.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2007-2020 The HyperSpy developers
+# Copyright 2007-2021 The HyperSpy developers
 #
 # This file is part of  HyperSpy.
 #

--- a/hyperspy/io_plugins/tiff.py
+++ b/hyperspy/io_plugins/tiff.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2007-2020 The HyperSpy developers
+# Copyright 2007-2021 The HyperSpy developers
 #
 # This file is part of  HyperSpy.
 #

--- a/hyperspy/learn/__init__.py
+++ b/hyperspy/learn/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2007-2020 The HyperSpy developers
+# Copyright 2007-2021 The HyperSpy developers
 #
 # This file is part of  HyperSpy.
 #

--- a/hyperspy/learn/mlpca.py
+++ b/hyperspy/learn/mlpca.py
@@ -6,7 +6,7 @@
 # Analytica Chimica Acta 350, no. 3 (September 19, 1997): 341-352.
 #
 # Copyright 1997 Darren T. Andrews and Peter D. Wentzell
-# Copyright 2007-2020 The HyperSpy developers
+# Copyright 2007-2021 The HyperSpy developers
 #
 # This file is part of  HyperSpy.
 #

--- a/hyperspy/learn/mva.py
+++ b/hyperspy/learn/mva.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2007-2020 The HyperSpy developers
+# Copyright 2007-2021 The HyperSpy developers
 #
 # This file is part of  HyperSpy.
 #

--- a/hyperspy/learn/ornmf.py
+++ b/hyperspy/learn/ornmf.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2007-2020 The HyperSpy developers
+# Copyright 2007-2021 The HyperSpy developers
 #
 # This file is part of  HyperSpy.
 #

--- a/hyperspy/learn/orthomax.py
+++ b/hyperspy/learn/orthomax.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2007-2020 The HyperSpy developers
+# Copyright 2007-2021 The HyperSpy developers
 #
 # This file is part of  HyperSpy.
 #

--- a/hyperspy/learn/rpca.py
+++ b/hyperspy/learn/rpca.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2007-2020 The HyperSpy developers
+# Copyright 2007-2021 The HyperSpy developers
 #
 # This file is part of  HyperSpy.
 #

--- a/hyperspy/learn/svd_pca.py
+++ b/hyperspy/learn/svd_pca.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2007-2020 The HyperSpy developers
+# Copyright 2007-2021 The HyperSpy developers
 #
 # This file is part of  HyperSpy.
 #

--- a/hyperspy/learn/whitening.py
+++ b/hyperspy/learn/whitening.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2007-2020 The HyperSpy developers
+# Copyright 2007-2021 The HyperSpy developers
 #
 # This file is part of  HyperSpy.
 #

--- a/hyperspy/logger.py
+++ b/hyperspy/logger.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2007-2020 The HyperSpy developers
+# Copyright 2007-2021 The HyperSpy developers
 #
 # This file is part of  HyperSpy.
 #

--- a/hyperspy/misc/__init__.py
+++ b/hyperspy/misc/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2007-2020 The HyperSpy developers
+# Copyright 2007-2021 The HyperSpy developers
 #
 # This file is part of  HyperSpy.
 #

--- a/hyperspy/misc/array_tools.py
+++ b/hyperspy/misc/array_tools.py
@@ -1,4 +1,4 @@
-# Copyright 2007-2020 The HyperSpy developers
+# Copyright 2007-2021 The HyperSpy developers
 #
 # This file is part of  HyperSpy.
 #

--- a/hyperspy/misc/axis_tools.py
+++ b/hyperspy/misc/axis_tools.py
@@ -1,4 +1,4 @@
-# Copyright 2007-2020 The HyperSpy developers
+# Copyright 2007-2021 The HyperSpy developers
 #
 # This file is part of  HyperSpy.
 #

--- a/hyperspy/misc/config_dir.py
+++ b/hyperspy/misc/config_dir.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2007-2020 The HyperSpy developers
+# Copyright 2007-2021 The HyperSpy developers
 #
 # This file is part of  HyperSpy.
 #

--- a/hyperspy/misc/date_time_tools.py
+++ b/hyperspy/misc/date_time_tools.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2007-2020 The HyperSpy developers
+# Copyright 2007-2021 The HyperSpy developers
 #
 # This file is part of  HyperSpy.
 #

--- a/hyperspy/misc/eds/utils.py
+++ b/hyperspy/misc/eds/utils.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2007-2020 The HyperSpy developers
+# Copyright 2007-2021 The HyperSpy developers
 #
 # This file is part of  HyperSpy.
 #

--- a/hyperspy/misc/eels/base_gos.py
+++ b/hyperspy/misc/eels/base_gos.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2007-2020 The HyperSpy developers
+# Copyright 2007-2021 The HyperSpy developers
 #
 # This file is part of  HyperSpy.
 #

--- a/hyperspy/misc/eels/eelsdb.py
+++ b/hyperspy/misc/eels/eelsdb.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2007-2020 The HyperSpy developers
+# Copyright 2007-2021 The HyperSpy developers
 #
 # This file is part of  HyperSpy.
 #

--- a/hyperspy/misc/eels/effective_angle.py
+++ b/hyperspy/misc/eels/effective_angle.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2007-2020 The HyperSpy developers
+# Copyright 2007-2021 The HyperSpy developers
 #
 # This file is part of  HyperSpy.
 #

--- a/hyperspy/misc/eels/electron_inelastic_mean_free_path.py
+++ b/hyperspy/misc/eels/electron_inelastic_mean_free_path.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2007-2020 The HyperSpy developers
+# Copyright 2007-2021 The HyperSpy developers
 #
 # This file is part of  HyperSpy.
 #

--- a/hyperspy/misc/eels/hartree_slater_gos.py
+++ b/hyperspy/misc/eels/hartree_slater_gos.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2007-2020 The HyperSpy developers
+# Copyright 2007-2021 The HyperSpy developers
 #
 # This file is part of  HyperSpy.
 #

--- a/hyperspy/misc/eels/hydrogenic_gos.py
+++ b/hyperspy/misc/eels/hydrogenic_gos.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2007-2020 The HyperSpy developers
+# Copyright 2007-2021 The HyperSpy developers
 #
 # This file is part of  HyperSpy.
 #

--- a/hyperspy/misc/eels/tools.py
+++ b/hyperspy/misc/eels/tools.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2007-2020 The HyperSpy developers
+# Copyright 2007-2021 The HyperSpy developers
 #
 # This file is part of  HyperSpy.
 #

--- a/hyperspy/misc/example_signals_loading.py
+++ b/hyperspy/misc/example_signals_loading.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2007-2020 The HyperSpy developers
+# Copyright 2007-2021 The HyperSpy developers
 #
 # This file is part of  HyperSpy.
 #

--- a/hyperspy/misc/export_dictionary.py
+++ b/hyperspy/misc/export_dictionary.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2007-2020 The HyperSpy developers
+# Copyright 2007-2021 The HyperSpy developers
 #
 # This file is part of  HyperSpy.
 #

--- a/hyperspy/misc/hist_tools.py
+++ b/hyperspy/misc/hist_tools.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2007-2020 The HyperSpy developers
+# Copyright 2007-2021 The HyperSpy developers
 #
 # This file is part of  HyperSpy.
 #

--- a/hyperspy/misc/holography/reconstruct.py
+++ b/hyperspy/misc/holography/reconstruct.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2007-2020 The HyperSpy developers
+# Copyright 2007-2021 The HyperSpy developers
 #
 # This file is part of  HyperSpy.
 #

--- a/hyperspy/misc/holography/tools.py
+++ b/hyperspy/misc/holography/tools.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2007-2020 The HyperSpy developers
+# Copyright 2007-2021 The HyperSpy developers
 #
 # This file is part of  HyperSpy.
 #

--- a/hyperspy/misc/io/fei_stream_readers.py
+++ b/hyperspy/misc/io/fei_stream_readers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2007-2020 The HyperSpy developers
+# Copyright 2007-2021 The HyperSpy developers
 #
 # This file is part of  HyperSpy.
 #

--- a/hyperspy/misc/io/tools.py
+++ b/hyperspy/misc/io/tools.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2007-2020 The HyperSpy developers
+# Copyright 2007-2021 The HyperSpy developers
 #
 # This file is part of  HyperSpy.
 #

--- a/hyperspy/misc/ipython_tools.py
+++ b/hyperspy/misc/ipython_tools.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2007-2020 The HyperSpy developers
+# Copyright 2007-2021 The HyperSpy developers
 #
 # This file is part of  HyperSpy.
 #

--- a/hyperspy/misc/label_position.py
+++ b/hyperspy/misc/label_position.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2007-2020 The HyperSpy developers
+# Copyright 2007-2021 The HyperSpy developers
 #
 # This file is part of  HyperSpy.
 #

--- a/hyperspy/misc/machine_learning/import_sklearn.py
+++ b/hyperspy/misc/machine_learning/import_sklearn.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2007-2020 The HyperSpy developers
+# Copyright 2007-2021 The HyperSpy developers
 #
 # This file is part of  HyperSpy.
 #

--- a/hyperspy/misc/machine_learning/tools.py
+++ b/hyperspy/misc/machine_learning/tools.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2007-2020 The HyperSpy developers
+# Copyright 2007-2021 The HyperSpy developers
 #
 # This file is part of  HyperSpy.
 #

--- a/hyperspy/misc/material.py
+++ b/hyperspy/misc/material.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2007-2020 The HyperSpy developers
+# Copyright 2007-2021 The HyperSpy developers
 #
 # This file is part of  HyperSpy.
 #

--- a/hyperspy/misc/math_tools.py
+++ b/hyperspy/misc/math_tools.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2007-2020 The HyperSpy developers
+# Copyright 2007-2021 The HyperSpy developers
 #
 # This file is part of  HyperSpy.
 #

--- a/hyperspy/misc/model_tools.py
+++ b/hyperspy/misc/model_tools.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2007-2020 The HyperSpy developers
+# Copyright 2007-2021 The HyperSpy developers
 #
 # This file is part of  HyperSpy.
 #

--- a/hyperspy/misc/physics_tools.py
+++ b/hyperspy/misc/physics_tools.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2007-2020 The HyperSpy developers
+# Copyright 2007-2021 The HyperSpy developers
 #
 # This file is part of  HyperSpy.
 #

--- a/hyperspy/misc/rgb_tools.py
+++ b/hyperspy/misc/rgb_tools.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2007-2020 The HyperSpy developers
+# Copyright 2007-2021 The HyperSpy developers
 #
 # This file is part of  HyperSpy.
 #

--- a/hyperspy/misc/signal_tools.py
+++ b/hyperspy/misc/signal_tools.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2007-2020 The HyperSpy developers
+# Copyright 2007-2021 The HyperSpy developers
 #
 # This file is part of  HyperSpy.
 #

--- a/hyperspy/misc/slicing.py
+++ b/hyperspy/misc/slicing.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2007-2020 The HyperSpy developers
+# Copyright 2007-2021 The HyperSpy developers
 #
 # This file is part of  HyperSpy.
 #

--- a/hyperspy/misc/test_utils.py
+++ b/hyperspy/misc/test_utils.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2007-2020 The HyperSpy developers
+# Copyright 2007-2021 The HyperSpy developers
 #
 # This file is part of  HyperSpy.
 #

--- a/hyperspy/misc/tv_denoise.py
+++ b/hyperspy/misc/tv_denoise.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2007-2020 The HyperSpy developers
+# Copyright 2007-2021 The HyperSpy developers
 #
 # This file is part of  HyperSpy.
 #

--- a/hyperspy/misc/utils.py
+++ b/hyperspy/misc/utils.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2007-2020 The HyperSpy developers
+# Copyright 2007-2021 The HyperSpy developers
 #
 # This file is part of  HyperSpy.
 #

--- a/hyperspy/model.py
+++ b/hyperspy/model.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2007-2020 The HyperSpy developers
+# Copyright 2007-2021 The HyperSpy developers
 #
 # This file is part of  HyperSpy.
 #

--- a/hyperspy/models/__init__.py
+++ b/hyperspy/models/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2007-2020 The HyperSpy developers
+# Copyright 2007-2021 The HyperSpy developers
 #
 # This file is part of  HyperSpy.
 #

--- a/hyperspy/models/edsmodel.py
+++ b/hyperspy/models/edsmodel.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2007-2020 The HyperSpy developers
+# Copyright 2007-2021 The HyperSpy developers
 #
 # This file is part of HyperSpy.
 #

--- a/hyperspy/models/edssemmodel.py
+++ b/hyperspy/models/edssemmodel.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2007-2020 The HyperSpy developers
+# Copyright 2007-2021 The HyperSpy developers
 #
 # This file is part of  HyperSpy.
 #

--- a/hyperspy/models/edstemmodel.py
+++ b/hyperspy/models/edstemmodel.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2007-2020 The HyperSpy developers
+# Copyright 2007-2021 The HyperSpy developers
 #
 # This file is part of  HyperSpy.
 #

--- a/hyperspy/models/eelsmodel.py
+++ b/hyperspy/models/eelsmodel.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2007-2020 The HyperSpy developers
+# Copyright 2007-2021 The HyperSpy developers
 #
 # This file is part of  HyperSpy.
 #

--- a/hyperspy/models/model1d.py
+++ b/hyperspy/models/model1d.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2007-2020 The HyperSpy developers
+# Copyright 2007-2021 The HyperSpy developers
 #
 # This file is part of  HyperSpy.
 #

--- a/hyperspy/models/model2d.py
+++ b/hyperspy/models/model2d.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2007-2020 The HyperSpy developers
+# Copyright 2007-2021 The HyperSpy developers
 #
 # This file is part of  HyperSpy.
 #

--- a/hyperspy/roi.py
+++ b/hyperspy/roi.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2007-2020 The HyperSpy developers
+# Copyright 2007-2021 The HyperSpy developers
 #
 # This file is part of HyperSpy.
 #

--- a/hyperspy/samfire.py
+++ b/hyperspy/samfire.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2007-2020 The HyperSpy developers
+# Copyright 2007-2021 The HyperSpy developers
 #
 # This file is part of  HyperSpy.
 #

--- a/hyperspy/samfire_utils/fit_tests.py
+++ b/hyperspy/samfire_utils/fit_tests.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2007-2020 The HyperSpy developers
+# Copyright 2007-2021 The HyperSpy developers
 #
 # This file is part of  HyperSpy.
 #

--- a/hyperspy/samfire_utils/global_strategies.py
+++ b/hyperspy/samfire_utils/global_strategies.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2007-2020 The HyperSpy developers
+# Copyright 2007-2021 The HyperSpy developers
 #
 # This file is part of  HyperSpy.
 #

--- a/hyperspy/samfire_utils/goodness_of_fit_tests/information_theory.py
+++ b/hyperspy/samfire_utils/goodness_of_fit_tests/information_theory.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2007-2020 The HyperSpy developers
+# Copyright 2007-2021 The HyperSpy developers
 #
 # This file is part of  HyperSpy.
 #

--- a/hyperspy/samfire_utils/goodness_of_fit_tests/red_chisq.py
+++ b/hyperspy/samfire_utils/goodness_of_fit_tests/red_chisq.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2007-2020 The HyperSpy developers
+# Copyright 2007-2021 The HyperSpy developers
 #
 # This file is part of  HyperSpy.
 #

--- a/hyperspy/samfire_utils/goodness_of_fit_tests/test_general.py
+++ b/hyperspy/samfire_utils/goodness_of_fit_tests/test_general.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2007-2020 The HyperSpy developers
+# Copyright 2007-2021 The HyperSpy developers
 #
 # This file is part of  HyperSpy.
 #

--- a/hyperspy/samfire_utils/local_strategies.py
+++ b/hyperspy/samfire_utils/local_strategies.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2007-2020 The HyperSpy developers
+# Copyright 2007-2021 The HyperSpy developers
 #
 # This file is part of  HyperSpy.
 #

--- a/hyperspy/samfire_utils/samfire_kernel.py
+++ b/hyperspy/samfire_utils/samfire_kernel.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2007-2020 The HyperSpy developers
+# Copyright 2007-2021 The HyperSpy developers
 #
 # This file is part of  HyperSpy.
 #

--- a/hyperspy/samfire_utils/samfire_pool.py
+++ b/hyperspy/samfire_utils/samfire_pool.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2007-2020 The HyperSpy developers
+# Copyright 2007-2021 The HyperSpy developers
 #
 # This file is part of  HyperSpy.
 #

--- a/hyperspy/samfire_utils/samfire_worker.py
+++ b/hyperspy/samfire_utils/samfire_worker.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2007-2020 The HyperSpy developers
+# Copyright 2007-2021 The HyperSpy developers
 #
 # This file is part of  HyperSpy.
 #

--- a/hyperspy/samfire_utils/segmenters/histogram.py
+++ b/hyperspy/samfire_utils/segmenters/histogram.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2007-2020 The HyperSpy developers
+# Copyright 2007-2021 The HyperSpy developers
 #
 # This file is part of  HyperSpy.
 #

--- a/hyperspy/samfire_utils/strategy.py
+++ b/hyperspy/samfire_utils/strategy.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2007-2020 The HyperSpy developers
+# Copyright 2007-2021 The HyperSpy developers
 #
 # This file is part of  HyperSpy.
 #

--- a/hyperspy/samfire_utils/weights/red_chisq.py
+++ b/hyperspy/samfire_utils/weights/red_chisq.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2007-2020 The HyperSpy developers
+# Copyright 2007-2021 The HyperSpy developers
 #
 # This file is part of  HyperSpy.
 #

--- a/hyperspy/signal.py
+++ b/hyperspy/signal.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2007-2020 The HyperSpy developers
+# Copyright 2007-2021 The HyperSpy developers
 #
 # This file is part of  HyperSpy.
 #

--- a/hyperspy/signal_tools.py
+++ b/hyperspy/signal_tools.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2007-2020 The HyperSpy developers
+# Copyright 2007-2021 The HyperSpy developers
 #
 # This file is part of  HyperSpy.
 #

--- a/hyperspy/signals.py
+++ b/hyperspy/signals.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2007-2020 The HyperSpy developers
+# Copyright 2007-2021 The HyperSpy developers
 #
 # This file is part of  HyperSpy.
 #

--- a/hyperspy/tests/__init__.py
+++ b/hyperspy/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2007-2020 The HyperSpy developers
+# Copyright 2007-2021 The HyperSpy developers
 #
 # This file is part of  HyperSpy.
 #

--- a/hyperspy/tests/axes/test_axes_manager.py
+++ b/hyperspy/tests/axes/test_axes_manager.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2007-2020 The HyperSpy developers
+# Copyright 2007-2021 The HyperSpy developers
 #
 # This file is part of  HyperSpy.
 #

--- a/hyperspy/tests/axes/test_conversion_units.py
+++ b/hyperspy/tests/axes/test_conversion_units.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2007-2020 The HyperSpy developers
+# Copyright 2007-2021 The HyperSpy developers
 #
 # This file is part of  HyperSpy.
 #

--- a/hyperspy/tests/axes/test_data_axis.py
+++ b/hyperspy/tests/axes/test_data_axis.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2007-2020 The HyperSpy developers
+# Copyright 2007-2021 The HyperSpy developers
 #
 # This file is part of  HyperSpy.
 #

--- a/hyperspy/tests/component/test_EELSarctan.py
+++ b/hyperspy/tests/component/test_EELSarctan.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2007-2020 The HyperSpy developers
+# Copyright 2007-2021 The HyperSpy developers
 #
 # This file is part of  HyperSpy.
 #

--- a/hyperspy/tests/component/test_arctan.py
+++ b/hyperspy/tests/component/test_arctan.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2007-2020 The HyperSpy developers
+# Copyright 2007-2021 The HyperSpy developers
 #
 # This file is part of  HyperSpy.
 #

--- a/hyperspy/tests/component/test_bleasdale.py
+++ b/hyperspy/tests/component/test_bleasdale.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2007-2020 The HyperSpy developers
+# Copyright 2007-2021 The HyperSpy developers
 #
 # This file is part of  HyperSpy.
 #

--- a/hyperspy/tests/component/test_component.py
+++ b/hyperspy/tests/component/test_component.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2007-2020 The HyperSpy developers
+# Copyright 2007-2021 The HyperSpy developers
 #
 # This file is part of  HyperSpy.
 #

--- a/hyperspy/tests/component/test_component_active_array.py
+++ b/hyperspy/tests/component/test_component_active_array.py
@@ -1,4 +1,4 @@
-# Copyright 2007-2020 The HyperSpy developers
+# Copyright 2007-2021 The HyperSpy developers
 #
 # This file is part of HyperSpy.
 #

--- a/hyperspy/tests/component/test_component_print_current.py
+++ b/hyperspy/tests/component/test_component_print_current.py
@@ -1,4 +1,4 @@
-# Copyright 2007-2020 The HyperSpy developers
+# Copyright 2007-2021 The HyperSpy developers
 #
 # This file is part of HyperSpy.
 #

--- a/hyperspy/tests/component/test_component_set_parameters.py
+++ b/hyperspy/tests/component/test_component_set_parameters.py
@@ -1,4 +1,4 @@
-# Copyright 2007-2020 The HyperSpy developers
+# Copyright 2007-2021 The HyperSpy developers
 #
 # This file is part of HyperSpy.
 #

--- a/hyperspy/tests/component/test_components.py
+++ b/hyperspy/tests/component/test_components.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2007-2020 The HyperSpy developers
+# Copyright 2007-2021 The HyperSpy developers
 #
 # This file is part of  HyperSpy.
 #

--- a/hyperspy/tests/component/test_components2D.py
+++ b/hyperspy/tests/component/test_components2D.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2007-2020 The HyperSpy developers
+# Copyright 2007-2021 The HyperSpy developers
 #
 # This file is part of  HyperSpy.
 #

--- a/hyperspy/tests/component/test_double_power_law.py
+++ b/hyperspy/tests/component/test_double_power_law.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2007-2020 The HyperSpy developers
+# Copyright 2007-2021 The HyperSpy developers
 #
 # This file is part of  HyperSpy.
 #

--- a/hyperspy/tests/component/test_erf.py
+++ b/hyperspy/tests/component/test_erf.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2007-2020 The HyperSpy developers
+# Copyright 2007-2021 The HyperSpy developers
 #
 # This file is part of  HyperSpy.
 #

--- a/hyperspy/tests/component/test_exponential.py
+++ b/hyperspy/tests/component/test_exponential.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2007-2020 The HyperSpy developers
+# Copyright 2007-2021 The HyperSpy developers
 #
 # This file is part of  HyperSpy.
 #

--- a/hyperspy/tests/component/test_gaussian.py
+++ b/hyperspy/tests/component/test_gaussian.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2007-2020 The HyperSpy developers
+# Copyright 2007-2021 The HyperSpy developers
 #
 # This file is part of  HyperSpy.
 #

--- a/hyperspy/tests/component/test_gaussian2d.py
+++ b/hyperspy/tests/component/test_gaussian2d.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2007-2020 The HyperSpy developers
+# Copyright 2007-2021 The HyperSpy developers
 #
 # This file is part of  HyperSpy.
 #

--- a/hyperspy/tests/component/test_gaussianhf.py
+++ b/hyperspy/tests/component/test_gaussianhf.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2007-2020 The HyperSpy developers
+# Copyright 2007-2021 The HyperSpy developers
 #
 # This file is part of  HyperSpy.
 #

--- a/hyperspy/tests/component/test_logistic.py
+++ b/hyperspy/tests/component/test_logistic.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2007-2020 The HyperSpy developers
+# Copyright 2007-2021 The HyperSpy developers
 #
 # This file is part of  HyperSpy.
 #

--- a/hyperspy/tests/component/test_lorentzian.py
+++ b/hyperspy/tests/component/test_lorentzian.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2007-2020 The HyperSpy developers
+# Copyright 2007-2021 The HyperSpy developers
 #
 # This file is part of  HyperSpy.
 #

--- a/hyperspy/tests/component/test_pes_core_line_shape.py
+++ b/hyperspy/tests/component/test_pes_core_line_shape.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2007-2020 The HyperSpy developers
+# Copyright 2007-2021 The HyperSpy developers
 #
 # This file is part of  HyperSpy.
 #

--- a/hyperspy/tests/component/test_pes_see.py
+++ b/hyperspy/tests/component/test_pes_see.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2007-2020 The HyperSpy developers
+# Copyright 2007-2021 The HyperSpy developers
 #
 # This file is part of  HyperSpy.
 #

--- a/hyperspy/tests/component/test_powerlaw.py
+++ b/hyperspy/tests/component/test_powerlaw.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2007-2020 The HyperSpy developers
+# Copyright 2007-2021 The HyperSpy developers
 #
 # This file is part of  HyperSpy.
 #

--- a/hyperspy/tests/component/test_rc.py
+++ b/hyperspy/tests/component/test_rc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2007-2020 The HyperSpy developers
+# Copyright 2007-2021 The HyperSpy developers
 #
 # This file is part of  HyperSpy.
 #

--- a/hyperspy/tests/component/test_skewnormal.py
+++ b/hyperspy/tests/component/test_skewnormal.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2007-2020 The HyperSpy developers
+# Copyright 2007-2021 The HyperSpy developers
 #
 # This file is part of  HyperSpy.
 #

--- a/hyperspy/tests/component/test_volume_plasmon_drude.py
+++ b/hyperspy/tests/component/test_volume_plasmon_drude.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2007-2020 The HyperSpy developers
+# Copyright 2007-2021 The HyperSpy developers
 #
 # This file is part of  HyperSpy.
 #

--- a/hyperspy/tests/datasets/test_artificial_data.py
+++ b/hyperspy/tests/datasets/test_artificial_data.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2007-2020 The HyperSpy developers
+# Copyright 2007-2021 The HyperSpy developers
 #
 # This file is part of  HyperSpy.
 #

--- a/hyperspy/tests/datasets/test_eelsdb.py
+++ b/hyperspy/tests/datasets/test_eelsdb.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2007-2020 The HyperSpy developers
+# Copyright 2007-2021 The HyperSpy developers
 #
 # This file is part of  HyperSpy.
 #

--- a/hyperspy/tests/drawing/test_figure.py
+++ b/hyperspy/tests/drawing/test_figure.py
@@ -1,4 +1,4 @@
-# Copyright 2007-2020 The HyperSpy developers
+# Copyright 2007-2021 The HyperSpy developers
 #
 # This file is part of  HyperSpy.
 #

--- a/hyperspy/tests/drawing/test_mpl_testing_setup.py
+++ b/hyperspy/tests/drawing/test_mpl_testing_setup.py
@@ -1,4 +1,4 @@
-# Copyright 2007-2020 The HyperSpy developers
+# Copyright 2007-2021 The HyperSpy developers
 #
 # This file is part of  HyperSpy.
 #

--- a/hyperspy/tests/drawing/test_plot_markers.py
+++ b/hyperspy/tests/drawing/test_plot_markers.py
@@ -1,4 +1,4 @@
-# Copyright 2007-2020 The HyperSpy developers
+# Copyright 2007-2021 The HyperSpy developers
 #
 # This file is part of  HyperSpy.
 #

--- a/hyperspy/tests/drawing/test_plot_model.py
+++ b/hyperspy/tests/drawing/test_plot_model.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2007-2020 The HyperSpy developers
+# Copyright 2007-2021 The HyperSpy developers
 #
 # This file is part of  HyperSpy.
 #

--- a/hyperspy/tests/drawing/test_plot_model1d.py
+++ b/hyperspy/tests/drawing/test_plot_model1d.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2007-2020 The HyperSpy developers
+# Copyright 2007-2021 The HyperSpy developers
 #
 # This file is part of  HyperSpy.
 #

--- a/hyperspy/tests/drawing/test_plot_mva.py
+++ b/hyperspy/tests/drawing/test_plot_mva.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2007-2020 The HyperSpy developers
+# Copyright 2007-2021 The HyperSpy developers
 #
 # This file is part of  HyperSpy.
 #

--- a/hyperspy/tests/drawing/test_plot_roi_widgets.py
+++ b/hyperspy/tests/drawing/test_plot_roi_widgets.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2007-2020 The HyperSpy developers
+# Copyright 2007-2021 The HyperSpy developers
 #
 # This file is part of  HyperSpy.
 #

--- a/hyperspy/tests/drawing/test_plot_signal.py
+++ b/hyperspy/tests/drawing/test_plot_signal.py
@@ -1,4 +1,4 @@
-# Copyright 2007-2020 The HyperSpy developers
+# Copyright 2007-2021 The HyperSpy developers
 #
 # This file is part of  HyperSpy.
 #

--- a/hyperspy/tests/drawing/test_plot_signal1d.py
+++ b/hyperspy/tests/drawing/test_plot_signal1d.py
@@ -1,4 +1,4 @@
-# Copyright 2007-2020 The HyperSpy developers
+# Copyright 2007-2021 The HyperSpy developers
 #
 # This file is part of  HyperSpy.
 #

--- a/hyperspy/tests/drawing/test_plot_signal2d.py
+++ b/hyperspy/tests/drawing/test_plot_signal2d.py
@@ -1,4 +1,4 @@
-# Copyright 2007-2020 The HyperSpy developers
+# Copyright 2007-2021 The HyperSpy developers
 #
 # This file is part of  HyperSpy.
 #

--- a/hyperspy/tests/drawing/test_plot_signal_tools.py
+++ b/hyperspy/tests/drawing/test_plot_signal_tools.py
@@ -1,4 +1,4 @@
-# Copyright 2007-2020 The HyperSpy developers
+# Copyright 2007-2021 The HyperSpy developers
 #
 # This file is part of  HyperSpy.
 #

--- a/hyperspy/tests/drawing/test_plot_widgets.py
+++ b/hyperspy/tests/drawing/test_plot_widgets.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2007-2020 The HyperSpy developers
+# Copyright 2007-2021 The HyperSpy developers
 #
 # This file is part of  HyperSpy.
 #

--- a/hyperspy/tests/drawing/test_utils.py
+++ b/hyperspy/tests/drawing/test_utils.py
@@ -1,4 +1,4 @@
-# Copyright 2007-2020 The HyperSpy developers
+# Copyright 2007-2021 The HyperSpy developers
 #
 # This file is part of  HyperSpy.
 #

--- a/hyperspy/tests/io/__init__.py
+++ b/hyperspy/tests/io/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2007-2020 The HyperSpy developers
+# Copyright 2007-2021 The HyperSpy developers
 #
 # This file is part of  HyperSpy.
 #

--- a/hyperspy/tests/io/generate_dm_testing_files.py
+++ b/hyperspy/tests/io/generate_dm_testing_files.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2007-2020 The HyperSpy developers
+# Copyright 2007-2021 The HyperSpy developers
 #
 # This file is part of  HyperSpy.
 #

--- a/hyperspy/tests/io/test_blockfile.py
+++ b/hyperspy/tests/io/test_blockfile.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2007-2020 The HyperSpy developers
+# Copyright 2007-2021 The HyperSpy developers
 #
 # This file is part of  HyperSpy.
 #

--- a/hyperspy/tests/io/test_dens.py
+++ b/hyperspy/tests/io/test_dens.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2007-2020 The HyperSpy developers
+# Copyright 2007-2021 The HyperSpy developers
 #
 # This file is part of  HyperSpy.
 #

--- a/hyperspy/tests/io/test_dm3.py
+++ b/hyperspy/tests/io/test_dm3.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2007-2020 The HyperSpy developers
+# Copyright 2007-2021 The HyperSpy developers
 #
 # This file is part of  HyperSpy.
 #

--- a/hyperspy/tests/io/test_dm_stackbuilder_plugin.py
+++ b/hyperspy/tests/io/test_dm_stackbuilder_plugin.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2007-2020 The HyperSpy developers
+# Copyright 2007-2021 The HyperSpy developers
 #
 # This file is part of  HyperSpy.
 #

--- a/hyperspy/tests/io/test_emd.py
+++ b/hyperspy/tests/io/test_emd.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2007-2020 The HyperSpy developers
+# Copyright 2007-2021 The HyperSpy developers
 #
 # This file is part of  HyperSpy.
 #

--- a/hyperspy/tests/io/test_emd_prismatic.py
+++ b/hyperspy/tests/io/test_emd_prismatic.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2007-2020 The HyperSpy developers
+# Copyright 2007-2021 The HyperSpy developers
 #
 # This file is part of  HyperSpy.
 #

--- a/hyperspy/tests/io/test_empad.py
+++ b/hyperspy/tests/io/test_empad.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2007-2020 The HyperSpy developers
+# Copyright 2007-2021 The HyperSpy developers
 #
 # This file is part of  HyperSpy.
 #

--- a/hyperspy/tests/io/test_fei.py
+++ b/hyperspy/tests/io/test_fei.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2007-2020 The HyperSpy developers
+# Copyright 2007-2021 The HyperSpy developers
 #
 # This file is part of  HyperSpy.
 #

--- a/hyperspy/tests/io/test_hdf5.py
+++ b/hyperspy/tests/io/test_hdf5.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2007-2020 The HyperSpy developers
+# Copyright 2007-2021 The HyperSpy developers
 #
 # This file is part of  HyperSpy.
 #

--- a/hyperspy/tests/io/test_image.py
+++ b/hyperspy/tests/io/test_image.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2007-2020 The HyperSpy developers
+# Copyright 2007-2021 The HyperSpy developers
 #
 # This file is part of  HyperSpy.
 #

--- a/hyperspy/tests/io/test_io.py
+++ b/hyperspy/tests/io/test_io.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2007-2020 The HyperSpy developers
+# Copyright 2007-2021 The HyperSpy developers
 #
 # This file is part of  HyperSpy.
 #

--- a/hyperspy/tests/io/test_mrcz.py
+++ b/hyperspy/tests/io/test_mrcz.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2007-2020 The HyperSpy developers
+# Copyright 2007-2021 The HyperSpy developers
 #
 # This file is part of  HyperSpy.
 #

--- a/hyperspy/tests/io/test_nexus_hdf.py
+++ b/hyperspy/tests/io/test_nexus_hdf.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2007-2020 The HyperSpy developers
+# Copyright 2007-2021 The HyperSpy developers
 #
 # This file is part of  HyperSpy.
 #

--- a/hyperspy/tests/io/test_protochips.py
+++ b/hyperspy/tests/io/test_protochips.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2007-2020 The HyperSpy developers
+# Copyright 2007-2021 The HyperSpy developers
 #
 # This file is part of HyperSpy.
 #

--- a/hyperspy/tests/io/test_semper_unf.py
+++ b/hyperspy/tests/io/test_semper_unf.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2007-2020 The HyperSpy developers
+# Copyright 2007-2021 The HyperSpy developers
 #
 # This file is part of  HyperSpy.
 #

--- a/hyperspy/tests/io/test_sur.py
+++ b/hyperspy/tests/io/test_sur.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2007-2020 The HyperSpy developers
+# Copyright 2007-2021 The HyperSpy developers
 #
 # This file is part of  HyperSpy.
 #

--- a/hyperspy/tests/learn/test_bss.py
+++ b/hyperspy/tests/learn/test_bss.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2007-2020 The HyperSpy developers
+# Copyright 2007-2021 The HyperSpy developers
 #
 # This file is part of  HyperSpy.
 #

--- a/hyperspy/tests/learn/test_cluster.py
+++ b/hyperspy/tests/learn/test_cluster.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2007-2020 The HyperSpy developers
+# Copyright 2007-2021 The HyperSpy developers
 #
 # This file is part of  HyperSpy.
 #

--- a/hyperspy/tests/learn/test_decomposition.py
+++ b/hyperspy/tests/learn/test_decomposition.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2007-2020 The HyperSpy developers
+# Copyright 2007-2021 The HyperSpy developers
 #
 # This file is part of  HyperSpy.
 #

--- a/hyperspy/tests/learn/test_export.py
+++ b/hyperspy/tests/learn/test_export.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2007-2020 The HyperSpy developers
+# Copyright 2007-2021 The HyperSpy developers
 #
 # This file is part of  HyperSpy.
 #

--- a/hyperspy/tests/learn/test_lazy_decomposition.py
+++ b/hyperspy/tests/learn/test_lazy_decomposition.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2007-2020 The HyperSpy developers
+# Copyright 2007-2021 The HyperSpy developers
 #
 # This file is part of  HyperSpy.
 #

--- a/hyperspy/tests/learn/test_learning_results.py
+++ b/hyperspy/tests/learn/test_learning_results.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2007-2020 The HyperSpy developers
+# Copyright 2007-2021 The HyperSpy developers
 #
 # This file is part of  HyperSpy.
 #

--- a/hyperspy/tests/learn/test_mlpca.py
+++ b/hyperspy/tests/learn/test_mlpca.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2007-2020 The HyperSpy developers
+# Copyright 2007-2021 The HyperSpy developers
 #
 # This file is part of  HyperSpy.
 #

--- a/hyperspy/tests/learn/test_rpca.py
+++ b/hyperspy/tests/learn/test_rpca.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2007-2020 The HyperSpy developers
+# Copyright 2007-2021 The HyperSpy developers
 #
 # This file is part of  HyperSpy.
 #

--- a/hyperspy/tests/learn/test_svd_pca.py
+++ b/hyperspy/tests/learn/test_svd_pca.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2007-2020 The HyperSpy developers
+# Copyright 2007-2021 The HyperSpy developers
 #
 # This file is part of  HyperSpy.
 #

--- a/hyperspy/tests/learn/test_whitening.py
+++ b/hyperspy/tests/learn/test_whitening.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2007-2020 The HyperSpy developers
+# Copyright 2007-2021 The HyperSpy developers
 #
 # This file is part of  HyperSpy.
 #

--- a/hyperspy/tests/misc/test_arraytools.py
+++ b/hyperspy/tests/misc/test_arraytools.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2007-2020 The HyperSpy developers
+# Copyright 2007-2021 The HyperSpy developers
 #
 # This file is part of  HyperSpy.
 #

--- a/hyperspy/tests/misc/test_date_time_tools.py
+++ b/hyperspy/tests/misc/test_date_time_tools.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2007-2020 The HyperSpy developers
+# Copyright 2007-2021 The HyperSpy developers
 #
 # This file is part of  HyperSpy.
 #

--- a/hyperspy/tests/misc/test_eds_utils.py
+++ b/hyperspy/tests/misc/test_eds_utils.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2007-2020 The HyperSpy developers
+# Copyright 2007-2021 The HyperSpy developers
 #
 # This file is part of  HyperSpy.
 #

--- a/hyperspy/tests/misc/test_fei_stream_readers.py
+++ b/hyperspy/tests/misc/test_fei_stream_readers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2007-2020 The HyperSpy developers
+# Copyright 2007-2021 The HyperSpy developers
 #
 # This file is part of  HyperSpy.
 #

--- a/hyperspy/tests/misc/test_hist_tools.py
+++ b/hyperspy/tests/misc/test_hist_tools.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2007-2020 The HyperSpy developers
+# Copyright 2007-2021 The HyperSpy developers
 #
 # This file is part of  HyperSpy.
 #

--- a/hyperspy/tests/misc/test_image_tools.py
+++ b/hyperspy/tests/misc/test_image_tools.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2007-2020 The HyperSpy developers
+# Copyright 2007-2021 The HyperSpy developers
 #
 # This file is part of  HyperSpy.
 #

--- a/hyperspy/tests/misc/test_math_tools.py
+++ b/hyperspy/tests/misc/test_math_tools.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2007-2020 The HyperSpy developers
+# Copyright 2007-2021 The HyperSpy developers
 #
 # This file is part of  HyperSpy.
 #

--- a/hyperspy/tests/misc/test_physics_tools.py
+++ b/hyperspy/tests/misc/test_physics_tools.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2007-2020 The HyperSpy developers
+# Copyright 2007-2021 The HyperSpy developers
 #
 # This file is part of  HyperSpy.
 #

--- a/hyperspy/tests/misc/test_rgbtools.py
+++ b/hyperspy/tests/misc/test_rgbtools.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2007-2020 The HyperSpy developers
+# Copyright 2007-2021 The HyperSpy developers
 #
 # This file is part of  HyperSpy.
 #

--- a/hyperspy/tests/misc/test_test_utils.py
+++ b/hyperspy/tests/misc/test_test_utils.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2007-2020 The HyperSpy developers
+# Copyright 2007-2021 The HyperSpy developers
 #
 # This file is part of  HyperSpy.
 #

--- a/hyperspy/tests/misc/test_tv_denoise.py
+++ b/hyperspy/tests/misc/test_tv_denoise.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2007-2020 The HyperSpy developers
+# Copyright 2007-2021 The HyperSpy developers
 #
 # This file is part of  HyperSpy.
 #

--- a/hyperspy/tests/misc/test_utils.py
+++ b/hyperspy/tests/misc/test_utils.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2007-2020 The HyperSpy developers
+# Copyright 2007-2021 The HyperSpy developers
 #
 # This file is part of  HyperSpy.
 #

--- a/hyperspy/tests/model/test_chi_squared.py
+++ b/hyperspy/tests/model/test_chi_squared.py
@@ -1,4 +1,4 @@
-# Copyright 2007-2020 The HyperSpy developers
+# Copyright 2007-2021 The HyperSpy developers
 #
 # This file is part of HyperSpy.
 #

--- a/hyperspy/tests/model/test_edsmodel.py
+++ b/hyperspy/tests/model/test_edsmodel.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2007-2020 The HyperSpy developers
+# Copyright 2007-2021 The HyperSpy developers
 #
 # This file is part of  HyperSpy.
 #

--- a/hyperspy/tests/model/test_eelsmodel.py
+++ b/hyperspy/tests/model/test_eelsmodel.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2007-2020 The HyperSpy developers
+# Copyright 2007-2021 The HyperSpy developers
 #
 # This file is part of  HyperSpy.
 #

--- a/hyperspy/tests/model/test_fancy_indexing.py
+++ b/hyperspy/tests/model/test_fancy_indexing.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2007-2020 The HyperSpy developers
+# Copyright 2007-2021 The HyperSpy developers
 #
 # This file is part of  HyperSpy.
 #

--- a/hyperspy/tests/model/test_fit_component.py
+++ b/hyperspy/tests/model/test_fit_component.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2007-2020 The HyperSpy developers
+# Copyright 2007-2021 The HyperSpy developers
 #
 # This file is part of  HyperSpy.
 #

--- a/hyperspy/tests/model/test_fitting.py
+++ b/hyperspy/tests/model/test_fitting.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2007-2020 The HyperSpy developers
+# Copyright 2007-2021 The HyperSpy developers
 #
 # This file is part of  HyperSpy.
 #

--- a/hyperspy/tests/model/test_model.py
+++ b/hyperspy/tests/model/test_model.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2007-2020 The HyperSpy developers
+# Copyright 2007-2021 The HyperSpy developers
 #
 # This file is part of  HyperSpy.
 #

--- a/hyperspy/tests/model/test_model2d.py
+++ b/hyperspy/tests/model/test_model2d.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2007-2020 The HyperSpy developers
+# Copyright 2007-2021 The HyperSpy developers
 #
 # This file is part of  HyperSpy.
 #

--- a/hyperspy/tests/model/test_model_as_dictionary.py
+++ b/hyperspy/tests/model/test_model_as_dictionary.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2007-2020 The HyperSpy developers
+# Copyright 2007-2021 The HyperSpy developers
 #
 # This file is part of  HyperSpy.
 #

--- a/hyperspy/tests/model/test_model_selection_criteria.py
+++ b/hyperspy/tests/model/test_model_selection_criteria.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2007-2020 The HyperSpy developers
+# Copyright 2007-2021 The HyperSpy developers
 #
 # This file is part of  HyperSpy.
 #

--- a/hyperspy/tests/model/test_model_storing.py
+++ b/hyperspy/tests/model/test_model_storing.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2007-2020 The HyperSpy developers
+# Copyright 2007-2021 The HyperSpy developers
 #
 # This file is part of  HyperSpy.
 #

--- a/hyperspy/tests/model/test_parameter.py
+++ b/hyperspy/tests/model/test_parameter.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2007-2020 The HyperSpy developers
+# Copyright 2007-2021 The HyperSpy developers
 #
 # This file is part of  HyperSpy.
 #

--- a/hyperspy/tests/model/test_set_parameter_state.py
+++ b/hyperspy/tests/model/test_set_parameter_state.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2007-2020 The HyperSpy developers
+# Copyright 2007-2021 The HyperSpy developers
 #
 # This file is part of  HyperSpy.
 #

--- a/hyperspy/tests/model/test_set_parameter_value.py
+++ b/hyperspy/tests/model/test_set_parameter_value.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2007-2020 The HyperSpy developers
+# Copyright 2007-2021 The HyperSpy developers
 #
 # This file is part of  HyperSpy.
 #

--- a/hyperspy/tests/samfire/test_goodness_of_fit_tests.py
+++ b/hyperspy/tests/samfire/test_goodness_of_fit_tests.py
@@ -1,4 +1,4 @@
-# Copyright 2007-2020 The HyperSpy developers
+# Copyright 2007-2021 The HyperSpy developers
 #
 # This file is part of HyperSpy.
 #

--- a/hyperspy/tests/samfire/test_histogram_segmenter.py
+++ b/hyperspy/tests/samfire/test_histogram_segmenter.py
@@ -1,4 +1,4 @@
-# Copyright 2007-2020 The HyperSpy developers
+# Copyright 2007-2021 The HyperSpy developers
 #
 # This file is part of HyperSpy.
 #

--- a/hyperspy/tests/samfire/test_red_chisq_weight.py
+++ b/hyperspy/tests/samfire/test_red_chisq_weight.py
@@ -1,4 +1,4 @@
-# Copyright 2007-2020 The HyperSpy developers
+# Copyright 2007-2021 The HyperSpy developers
 #
 # This file is part of HyperSpy.
 #

--- a/hyperspy/tests/samfire/test_samfire.py
+++ b/hyperspy/tests/samfire/test_samfire.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2007-2020 The HyperSpy developers
+# Copyright 2007-2021 The HyperSpy developers
 #
 # This file is part of  HyperSpy.
 #

--- a/hyperspy/tests/samfire/test_strategy.py
+++ b/hyperspy/tests/samfire/test_strategy.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2007-2020 The HyperSpy developers
+# Copyright 2007-2021 The HyperSpy developers
 #
 # This file is part of  HyperSpy.
 #

--- a/hyperspy/tests/samfire/test_strategy_list.py
+++ b/hyperspy/tests/samfire/test_strategy_list.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2007-2020 The HyperSpy developers
+# Copyright 2007-2021 The HyperSpy developers
 #
 # This file is part of  HyperSpy.
 #

--- a/hyperspy/tests/samfire/test_utils.py
+++ b/hyperspy/tests/samfire/test_utils.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2007-2020 The HyperSpy developers
+# Copyright 2007-2021 The HyperSpy developers
 #
 # This file is part of  HyperSpy.
 #

--- a/hyperspy/tests/signal/test_1D.py
+++ b/hyperspy/tests/signal/test_1D.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2007-2020 The HyperSpy developers
+# Copyright 2007-2021 The HyperSpy developers
 #
 # This file is part of  HyperSpy.
 #

--- a/hyperspy/tests/signal/test_1D_tools.py
+++ b/hyperspy/tests/signal/test_1D_tools.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2007-2020 The HyperSpy developers
+# Copyright 2007-2021 The HyperSpy developers
 #
 # This file is part of  HyperSpy.
 #

--- a/hyperspy/tests/signal/test_2D.py
+++ b/hyperspy/tests/signal/test_2D.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2007-2020 The HyperSpy developers
+# Copyright 2007-2021 The HyperSpy developers
 #
 # This file is part of  HyperSpy.
 #

--- a/hyperspy/tests/signal/test_2D_tools.py
+++ b/hyperspy/tests/signal/test_2D_tools.py
@@ -1,4 +1,4 @@
-# Copyright 2007-2020 The HyperSpy developers
+# Copyright 2007-2021 The HyperSpy developers
 #
 # This file is part of HyperSpy.
 #

--- a/hyperspy/tests/signal/test_3D.py
+++ b/hyperspy/tests/signal/test_3D.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2007-2020 The HyperSpy developers
+# Copyright 2007-2021 The HyperSpy developers
 #
 # This file is part of  HyperSpy.
 #

--- a/hyperspy/tests/signal/test_4D.py
+++ b/hyperspy/tests/signal/test_4D.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2007-2020 The HyperSpy developers
+# Copyright 2007-2021 The HyperSpy developers
 #
 # This file is part of  HyperSpy.
 #

--- a/hyperspy/tests/signal/test_apodization.py
+++ b/hyperspy/tests/signal/test_apodization.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2007-2020 The HyperSpy developers
+# Copyright 2007-2021 The HyperSpy developers
 #
 # This file is part of  HyperSpy.
 #

--- a/hyperspy/tests/signal/test_assign_subclass.py
+++ b/hyperspy/tests/signal/test_assign_subclass.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2007-2020 The HyperSpy developers
+# Copyright 2007-2021 The HyperSpy developers
 #
 # This file is part of  HyperSpy.
 #

--- a/hyperspy/tests/signal/test_binned.py
+++ b/hyperspy/tests/signal/test_binned.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2007-2020 The HyperSpy developers
+# Copyright 2007-2021 The HyperSpy developers
 #
 # This file is part of  HyperSpy.
 #

--- a/hyperspy/tests/signal/test_check_mask.py
+++ b/hyperspy/tests/signal/test_check_mask.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2007-2020 The HyperSpy developers
+# Copyright 2007-2021 The HyperSpy developers
 #
 # This file is part of  HyperSpy.
 #

--- a/hyperspy/tests/signal/test_complex_signal.py
+++ b/hyperspy/tests/signal/test_complex_signal.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2007-2020 The HyperSpy developers
+# Copyright 2007-2021 The HyperSpy developers
 #
 # This file is part of  HyperSpy.
 #

--- a/hyperspy/tests/signal/test_complex_signal2d.py
+++ b/hyperspy/tests/signal/test_complex_signal2d.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2007-2020 The HyperSpy developers
+# Copyright 2007-2021 The HyperSpy developers
 #
 # This file is part of  HyperSpy.
 #

--- a/hyperspy/tests/signal/test_edges_range.py
+++ b/hyperspy/tests/signal/test_edges_range.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2007-2020 The HyperSpy developers
+# Copyright 2007-2021 The HyperSpy developers
 #
 # This file is part of  HyperSpy.
 #

--- a/hyperspy/tests/signal/test_eds_sem.py
+++ b/hyperspy/tests/signal/test_eds_sem.py
@@ -1,4 +1,4 @@
-# Copyright 2007-2020 The HyperSpy developers
+# Copyright 2007-2021 The HyperSpy developers
 #
 # This file is part of  HyperSpy.
 #

--- a/hyperspy/tests/signal/test_eds_tem.py
+++ b/hyperspy/tests/signal/test_eds_tem.py
@@ -1,4 +1,4 @@
-# Copyright 2007-2020 The HyperSpy developers
+# Copyright 2007-2021 The HyperSpy developers
 #
 # This file is part of  HyperSpy.
 #

--- a/hyperspy/tests/signal/test_eels.py
+++ b/hyperspy/tests/signal/test_eels.py
@@ -1,4 +1,4 @@
-# Copyright 2007-2020 The HyperSpy developers
+# Copyright 2007-2021 The HyperSpy developers
 #
 # This file is part of  HyperSpy.
 #

--- a/hyperspy/tests/signal/test_fancy_indexing.py
+++ b/hyperspy/tests/signal/test_fancy_indexing.py
@@ -1,4 +1,4 @@
-# Copyright 2007-2020 The HyperSpy developers
+# Copyright 2007-2021 The HyperSpy developers
 #
 # This file is part of  HyperSpy.
 #

--- a/hyperspy/tests/signal/test_find_peaks1D_ohaver.py
+++ b/hyperspy/tests/signal/test_find_peaks1D_ohaver.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2007-2020 The HyperSpy developers
+# Copyright 2007-2021 The HyperSpy developers
 #
 # This file is part of  HyperSpy.
 #

--- a/hyperspy/tests/signal/test_find_peaks2D.py
+++ b/hyperspy/tests/signal/test_find_peaks2D.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2007-2020 The HyperSpy developers
+# Copyright 2007-2021 The HyperSpy developers
 #
 # This file is part of  HyperSpy.
 #

--- a/hyperspy/tests/signal/test_fourier_transform.py
+++ b/hyperspy/tests/signal/test_fourier_transform.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2007-2020 The HyperSpy developers
+# Copyright 2007-2021 The HyperSpy developers
 #
 # This file is part of  HyperSpy.
 #

--- a/hyperspy/tests/signal/test_hologram_image.py
+++ b/hyperspy/tests/signal/test_hologram_image.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2007-2020 The HyperSpy developers
+# Copyright 2007-2021 The HyperSpy developers
 #
 # This file is part of  HyperSpy.
 #

--- a/hyperspy/tests/signal/test_hologram_image_statistics.py
+++ b/hyperspy/tests/signal/test_hologram_image_statistics.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2007-2020 The HyperSpy developers
+# Copyright 2007-2021 The HyperSpy developers
 #
 # This file is part of  HyperSpy.
 #

--- a/hyperspy/tests/signal/test_image.py
+++ b/hyperspy/tests/signal/test_image.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2007-2020 The HyperSpy developers
+# Copyright 2007-2021 The HyperSpy developers
 #
 # This file is part of  HyperSpy.
 #

--- a/hyperspy/tests/signal/test_image_contrast_editor_tool.py
+++ b/hyperspy/tests/signal/test_image_contrast_editor_tool.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2007-2020 The HyperSpy developers
+# Copyright 2007-2021 The HyperSpy developers
 #
 # This file is part of  HyperSpy.
 #

--- a/hyperspy/tests/signal/test_inheritance.py
+++ b/hyperspy/tests/signal/test_inheritance.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2007-2020 The HyperSpy developers
+# Copyright 2007-2021 The HyperSpy developers
 #
 # This file is part of  HyperSpy.
 #

--- a/hyperspy/tests/signal/test_kramers_kronig_transform.py
+++ b/hyperspy/tests/signal/test_kramers_kronig_transform.py
@@ -1,4 +1,4 @@
-# Copyright 2007-2020 The HyperSpy developers
+# Copyright 2007-2021 The HyperSpy developers
 #
 # This file is part of  HyperSpy.
 #

--- a/hyperspy/tests/signal/test_lazy.py
+++ b/hyperspy/tests/signal/test_lazy.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2007-2020 The HyperSpy developers
+# Copyright 2007-2021 The HyperSpy developers
 #
 # This file is part of  HyperSpy.
 #

--- a/hyperspy/tests/signal/test_lazy_tools.py
+++ b/hyperspy/tests/signal/test_lazy_tools.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2007-2020 The HyperSpy developers
+# Copyright 2007-2021 The HyperSpy developers
 #
 # This file is part of  HyperSpy.
 #

--- a/hyperspy/tests/signal/test_linear_rebin.py
+++ b/hyperspy/tests/signal/test_linear_rebin.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2007-2020 The HyperSpy developers
+# Copyright 2007-2021 The HyperSpy developers
 #
 # This file is part of  HyperSpy.
 #

--- a/hyperspy/tests/signal/test_map_method.py
+++ b/hyperspy/tests/signal/test_map_method.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2007-2020 The HyperSpy developers
+# Copyright 2007-2021 The HyperSpy developers
 #
 # This file is part of  HyperSpy.
 #

--- a/hyperspy/tests/signal/test_remove_background.py
+++ b/hyperspy/tests/signal/test_remove_background.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2007-2020 The HyperSpy developers
+# Copyright 2007-2021 The HyperSpy developers
 #
 # This file is part of  HyperSpy.
 #

--- a/hyperspy/tests/signal/test_rgb.py
+++ b/hyperspy/tests/signal/test_rgb.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2007-2020 The HyperSpy developers
+# Copyright 2007-2021 The HyperSpy developers
 #
 # This file is part of  HyperSpy.
 #

--- a/hyperspy/tests/signal/test_signal_operators.py
+++ b/hyperspy/tests/signal/test_signal_operators.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2007-2020 The HyperSpy developers
+# Copyright 2007-2021 The HyperSpy developers
 #
 # This file is part of  HyperSpy.
 #

--- a/hyperspy/tests/signal/test_signal_subclass_conversion.py
+++ b/hyperspy/tests/signal/test_signal_subclass_conversion.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2007-2020 The HyperSpy developers
+# Copyright 2007-2021 The HyperSpy developers
 #
 # This file is part of  HyperSpy.
 #

--- a/hyperspy/tests/signal/test_spectrum.py
+++ b/hyperspy/tests/signal/test_spectrum.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2007-2020 The HyperSpy developers
+# Copyright 2007-2021 The HyperSpy developers
 #
 # This file is part of  HyperSpy.
 #

--- a/hyperspy/tests/signal/test_spike_removal_tool.py
+++ b/hyperspy/tests/signal/test_spike_removal_tool.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2007-2020 The HyperSpy developers
+# Copyright 2007-2021 The HyperSpy developers
 #
 # This file is part of  HyperSpy.
 #

--- a/hyperspy/tests/signal/test_tools.py
+++ b/hyperspy/tests/signal/test_tools.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2007-2020 The HyperSpy developers
+# Copyright 2007-2021 The HyperSpy developers
 #
 # This file is part of  HyperSpy.
 #

--- a/hyperspy/tests/signal/test_transpose.py
+++ b/hyperspy/tests/signal/test_transpose.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2007-2020 The HyperSpy developers
+# Copyright 2007-2021 The HyperSpy developers
 #
 # This file is part of  HyperSpy.
 #

--- a/hyperspy/tests/test_dictionary_tree_browser.py
+++ b/hyperspy/tests/test_dictionary_tree_browser.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2007-2020 The HyperSpy developers
+# Copyright 2007-2021 The HyperSpy developers
 #
 # This file is part of  HyperSpy.
 #

--- a/hyperspy/tests/test_events.py
+++ b/hyperspy/tests/test_events.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2007-2020 The HyperSpy developers
+# Copyright 2007-2021 The HyperSpy developers
 #
 # This file is part of  HyperSpy.
 #

--- a/hyperspy/tests/test_interactive.py
+++ b/hyperspy/tests/test_interactive.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2007-2020 The HyperSpy developers
+# Copyright 2007-2021 The HyperSpy developers
 #
 # This file is part of  HyperSpy.
 #

--- a/hyperspy/tests/utils/test_attrsetter.py
+++ b/hyperspy/tests/utils/test_attrsetter.py
@@ -1,4 +1,4 @@
-# Copyright 2007-2020 The HyperSpy developers
+# Copyright 2007-2021 The HyperSpy developers
 #
 # This file is part of  HyperSpy.
 #

--- a/hyperspy/tests/utils/test_eds.py
+++ b/hyperspy/tests/utils/test_eds.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2007-2020 The HyperSpy developers
+# Copyright 2007-2021 The HyperSpy developers
 #
 # This file is part of  HyperSpy.
 #

--- a/hyperspy/tests/utils/test_eels.py
+++ b/hyperspy/tests/utils/test_eels.py
@@ -1,4 +1,4 @@
-# Copyright 2007-2020 The HyperSpy developers
+# Copyright 2007-2021 The HyperSpy developers
 #
 # This file is part of  HyperSpy.
 #

--- a/hyperspy/tests/utils/test_material.py
+++ b/hyperspy/tests/utils/test_material.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2007-2020 The HyperSpy developers
+# Copyright 2007-2021 The HyperSpy developers
 #
 # This file is part of  HyperSpy.
 #

--- a/hyperspy/tests/utils/test_roi.py
+++ b/hyperspy/tests/utils/test_roi.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2007-2020 The HyperSpy developers
+# Copyright 2007-2021 The HyperSpy developers
 #
 # This file is part of  HyperSpy.
 #

--- a/hyperspy/tests/utils/test_slugify.py
+++ b/hyperspy/tests/utils/test_slugify.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2007-2020 The HyperSpy developers
+# Copyright 2007-2021 The HyperSpy developers
 #
 # This file is part of  HyperSpy.
 #

--- a/hyperspy/tests/utils/test_stack.py
+++ b/hyperspy/tests/utils/test_stack.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2007-2020 The HyperSpy developers
+# Copyright 2007-2021 The HyperSpy developers
 #
 # This file is part of  HyperSpy.
 #

--- a/hyperspy/tests/utils/test_stack_calibration.py
+++ b/hyperspy/tests/utils/test_stack_calibration.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2007-2020 The HyperSpy developers
+# Copyright 2007-2021 The HyperSpy developers
 #
 # This file is part of  HyperSpy.
 #

--- a/hyperspy/ui_registry.py
+++ b/hyperspy/ui_registry.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2007-2020 The HyperSpy developers
+# Copyright 2007-2021 The HyperSpy developers
 #
 # This file is part of  HyperSpy.
 #

--- a/hyperspy/utils/__init__.py
+++ b/hyperspy/utils/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2007-2020 The HyperSpy developers
+# Copyright 2007-2021 The HyperSpy developers
 #
 # This file is part of  HyperSpy.
 #

--- a/hyperspy/utils/eds.py
+++ b/hyperspy/utils/eds.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2007-2020 The HyperSpy developers
+# Copyright 2007-2021 The HyperSpy developers
 #
 # This file is part of  HyperSpy.
 #

--- a/hyperspy/utils/markers.py
+++ b/hyperspy/utils/markers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2007-2020 The HyperSpy developers
+# Copyright 2007-2021 The HyperSpy developers
 #
 # This file is part of  HyperSpy.
 #

--- a/hyperspy/utils/material.py
+++ b/hyperspy/utils/material.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2007-2020 The HyperSpy developers
+# Copyright 2007-2021 The HyperSpy developers
 #
 # This file is part of  HyperSpy.
 #

--- a/hyperspy/utils/model.py
+++ b/hyperspy/utils/model.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2007-2020 The HyperSpy developers
+# Copyright 2007-2021 The HyperSpy developers
 #
 # This file is part of  HyperSpy.
 #

--- a/hyperspy/utils/model_selection.py
+++ b/hyperspy/utils/model_selection.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2007-2020 The HyperSpy developers
+# Copyright 2007-2021 The HyperSpy developers
 #
 # This file is part of  HyperSpy.
 #

--- a/hyperspy/utils/parallel_pool.py
+++ b/hyperspy/utils/parallel_pool.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2007-2020 The HyperSpy developers
+# Copyright 2007-2021 The HyperSpy developers
 #
 # This file is part of  HyperSpy.
 #

--- a/hyperspy/utils/peakfinders2D.py
+++ b/hyperspy/utils/peakfinders2D.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2007-2020 The HyperSpy developers
+# Copyright 2007-2021 The HyperSpy developers
 #
 # This file is part of  HyperSpy.
 #

--- a/hyperspy/utils/plot.py
+++ b/hyperspy/utils/plot.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2007-2020 The HyperSpy developers
+# Copyright 2007-2021 The HyperSpy developers
 #
 # This file is part of  HyperSpy.
 #

--- a/hyperspy/utils/roi.py
+++ b/hyperspy/utils/roi.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2007-2020 The HyperSpy developers
+# Copyright 2007-2021 The HyperSpy developers
 #
 # This file is part of HyperSpy.
 #

--- a/hyperspy/utils/samfire.py
+++ b/hyperspy/utils/samfire.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2007-2020 The HyperSpy developers
+# Copyright 2007-2021 The HyperSpy developers
 #
 # This file is part of  HyperSpy.
 #


### PR DESCRIPTION
### Description of the change
Updated all Copyright notices to 2021 (using `grep -rl Copyright . | xargs sed -i 's/Copyright 2007-2020/Copyright 2007-2021/g'`)
See discussion in #2311

### Progress of the PR
- [X] Change implemented (can be split into several points),
- [X] Ready for review
