### PR TITLE
Lazily load modules to improve hyperspy import times

### DIFF
--- a/conda_environment.yml
+++ b/conda_environment.yml
@@ -8,6 +8,7 @@ dependencies:
 - h5py
 - imageio
 - ipyparallel
+- lazyasd
 - matplotlib-base
 - mrcz
 - natsort

--- a/hyperspy/_components/error_function.py
+++ b/hyperspy/_components/error_function.py
@@ -18,7 +18,7 @@
 
 from hyperspy._components.expression import Expression
 from distutils.version import LooseVersion
-import sympy
+from hyperspy.lazy_imports import sympy
 
 
 class Erf(Expression):

--- a/hyperspy/_components/exponential.py
+++ b/hyperspy/_components/exponential.py
@@ -103,7 +103,7 @@ class Exponential(Expression):
             s = signal
 
         if s._lazy:
-            import dask.array as da
+            from hyperspy.lazy_imports import dask_array as da
             exp = da.exp
             log = da.log
         else:

--- a/hyperspy/_components/expression.py
+++ b/hyperspy/_components/expression.py
@@ -18,7 +18,7 @@
 
 from functools import wraps
 import numpy as np
-import sympy
+from hyperspy.lazy_imports import sympy
 import warnings
 
 from hyperspy.component import Component
@@ -197,7 +197,7 @@ class Expression(Component):
         possible.
         Useful to recompile the function and gradient with a different module.
         """
-        import sympy
+        from hyperspy.lazy_imports import sympy
         from sympy.utilities.lambdify import lambdify
         try:  # Expression is just a constant
             float(self._str_expression)

--- a/hyperspy/_components/gaussian.py
+++ b/hyperspy/_components/gaussian.py
@@ -19,7 +19,7 @@
 import math
 
 import numpy as np
-import dask.array as da
+from hyperspy.lazy_imports import dask_array as da
 
 from hyperspy._components.expression import Expression
 

--- a/hyperspy/_components/lorentzian.py
+++ b/hyperspy/_components/lorentzian.py
@@ -17,7 +17,7 @@
 # along with  HyperSpy.  If not, see <http://www.gnu.org/licenses/>.
 
 import numpy as np
-import dask.array as da
+from hyperspy.lazy_imports import dask_array as da
 
 from hyperspy._components.expression import Expression
 

--- a/hyperspy/_components/power_law.py
+++ b/hyperspy/_components/power_law.py
@@ -127,7 +127,7 @@ class PowerLaw(Expression):
         else:
             s = signal
         if s._lazy:
-            import dask.array as da
+            from hyperspy.lazy_imports import dask_array as da
             log = da.log
             I1 = s.isig[i1:i3].integrate1D(2j).data
             I2 = s.isig[i3:i2].integrate1D(2j).data

--- a/hyperspy/_components/skew_normal.py
+++ b/hyperspy/_components/skew_normal.py
@@ -21,7 +21,7 @@ import dask.array as da
 
 from hyperspy._components.expression import Expression
 from distutils.version import LooseVersion
-import sympy
+from hyperspy.lazy_imports import sympy
 
 sqrt2pi = np.sqrt(2 * np.pi)
 

--- a/hyperspy/_components/skew_normal.py
+++ b/hyperspy/_components/skew_normal.py
@@ -17,7 +17,7 @@
 # along with  HyperSpy.  If not, see <http://www.gnu.org/licenses/>.
 
 import numpy as np
-import dask.array as da
+from hyperspy.lazy_imports import dask_array as da
 
 from hyperspy._components.expression import Expression
 from distutils.version import LooseVersion

--- a/hyperspy/_components/voigt.py
+++ b/hyperspy/_components/voigt.py
@@ -17,7 +17,7 @@
 # along with  HyperSpy.  If not, see <http://www.gnu.org/licenses/>.
 
 import math
-import sympy
+from hyperspy.lazy_imports import sympy
 
 from hyperspy._components.expression import Expression
 from hyperspy._components.gaussian import _estimate_gaussian_parameters

--- a/hyperspy/_signals/complex_signal.py
+++ b/hyperspy/_signals/complex_signal.py
@@ -19,7 +19,7 @@
 from functools import wraps
 
 import numpy as np
-import dask.array as da
+from hyperspy.lazy_imports import dask_array as da
 
 from hyperspy.signal import BaseSignal
 from hyperspy._signals.signal2d import Signal2D

--- a/hyperspy/_signals/eds_tem.py
+++ b/hyperspy/_signals/eds_tem.py
@@ -23,8 +23,7 @@ import logging
 import traits.api as t
 import numpy as np
 from scipy import constants
-import pint
-
+from hyperspy.lazy_imports import pint
 from hyperspy.signal import BaseSetMetadataItems
 from hyperspy import utils
 from hyperspy._signals.eds import (EDSSpectrum, LazyEDSSpectrum)

--- a/hyperspy/_signals/eels.py
+++ b/hyperspy/_signals/eels.py
@@ -24,7 +24,6 @@ import dask.array as da
 import traits.api as t
 from scipy import constants
 from prettytable import PrettyTable
-import pint
 
 from hyperspy.signal import BaseSetMetadataItems, BaseSignal
 from hyperspy._signals.signal1d import (Signal1D, LazySignal1D)
@@ -49,7 +48,6 @@ from hyperspy.docstrings.signal import (
 
 
 _logger = logging.getLogger(__name__)
-_ureg = pint.UnitRegistry()
 
 
 @add_gui_method(toolkey="hyperspy.microscope_parameters_EELS")

--- a/hyperspy/_signals/eels.py
+++ b/hyperspy/_signals/eels.py
@@ -20,7 +20,7 @@ import numbers
 import logging
 
 import numpy as np
-import dask.array as da
+from hyperspy.lazy_imports import dask_array as da
 import traits.api as t
 from scipy import constants
 from prettytable import PrettyTable

--- a/hyperspy/_signals/hologram_image.py
+++ b/hyperspy/_signals/hologram_image.py
@@ -21,8 +21,8 @@ from collections import OrderedDict
 import scipy.constants as constants
 import numpy as np
 from dask.array import Array as daArray
-from pint import UnitRegistry, UndefinedUnitError
-
+from hyperspy.lazy_imports import pint
+from hyperspy.axes import _ureg
 from hyperspy._signals.signal2d import Signal2D
 from hyperspy.signal import BaseSignal
 from hyperspy._signals.signal1d import Signal1D
@@ -701,11 +701,10 @@ class HologramImage(Signal2D):
                                        max_workers=max_workers)
         fringe_sampling = np.divide(1., carrier_freq_px)
 
-        ureg = UnitRegistry()
         try:
-            units = ureg.parse_expression(
+            units = _ureg.parse_expression(
                 str(self.axes_manager.signal_axes[0].units))
-        except UndefinedUnitError:
+        except pint.UndefinedUnitError:
             raise ValueError('Signal axes units should be defined.')
 
         # Calculate carrier frequency in 1/units and fringe spacing in units:
@@ -745,7 +744,7 @@ class HologramImage(Signal2D):
                     1000 / (2 * constants.m_e * constants.c ** 2))
         wavelength = constants.h / np.sqrt(momentum) * 1e9  # in nm
         carrier_freq_quantity = wavelength * \
-            ureg('nm') * carrier_freq_units / units * ureg('rad')
+            _ureg('nm') * carrier_freq_units / units * _ureg('rad')
         carrier_freq_mrad = carrier_freq_quantity.to('mrad').magnitude
 
         # Calculate fringe contrast:

--- a/hyperspy/_signals/hologram_image.py
+++ b/hyperspy/_signals/hologram_image.py
@@ -20,7 +20,7 @@ import logging
 from collections import OrderedDict
 import scipy.constants as constants
 import numpy as np
-from dask.array import Array as daArray
+from hyperspy.lazy_imports import dask_array as da
 from hyperspy.lazy_imports import pint
 from hyperspy.axes import _ureg
 from hyperspy._signals.signal2d import Signal2D
@@ -60,7 +60,7 @@ def _parse_sb_position(s, reference, sb_position, sb, high_cf, parallel):
 
         if not isinstance(sb_position, Signal1D):
             sb_position = Signal1D(sb_position)
-            if isinstance(sb_position.data, daArray):
+            if isinstance(sb_position.data, da.Array):
                 sb_position = sb_position.as_lazy()
 
         if not sb_position.axes_manager.signal_size == 2:
@@ -90,12 +90,12 @@ def _parse_sb_size(s, reference, sb_position, sb_size, parallel):
     else:
         if not isinstance(sb_size, BaseSignal):
             if isinstance(sb_size,
-                          (np.ndarray, daArray)) and sb_size.size > 1:
+                          (np.ndarray, da.Array)) and sb_size.size > 1:
                 # transpose if np.array of multiple instances
                 sb_size = BaseSignal(sb_size).T
             else:
                 sb_size = BaseSignal(sb_size)
-            if isinstance(sb_size.data, daArray):
+            if isinstance(sb_size.data, da.Array):
                 sb_size = sb_size.as_lazy()
 
     if sb_size.axes_manager.navigation_size != s.axes_manager.navigation_size:
@@ -380,7 +380,7 @@ class HologramImage(Signal2D):
                 reference.set_signal_type('hologram')
             elif reference is not None:
                 reference = HologramImage(reference)
-                if isinstance(reference.data, daArray):
+                if isinstance(reference.data, da.Array):
                     reference = reference.as_lazy()
 
         # Testing match of navigation axes of reference and self
@@ -419,11 +419,11 @@ class HologramImage(Signal2D):
             if not isinstance(sb_smoothness, BaseSignal):
                 if isinstance(
                     sb_smoothness,
-                        (np.ndarray, daArray)) and sb_smoothness.size > 1:
+                        (np.ndarray, da.Array)) and sb_smoothness.size > 1:
                     sb_smoothness = BaseSignal(sb_smoothness).T
                 else:
                     sb_smoothness = BaseSignal(sb_smoothness)
-                if isinstance(sb_smoothness.data, daArray):
+                if isinstance(sb_smoothness.data, da.Array):
                     sb_smoothness = sb_smoothness.as_lazy()
 
         if sb_smoothness.axes_manager.navigation_size != self.axes_manager.navigation_size:

--- a/hyperspy/_signals/lazy.py
+++ b/hyperspy/_signals/lazy.py
@@ -816,7 +816,7 @@ class LazySignal(BaseSignal):
             if not import_sklearn.sklearn_installed:
                 raise ImportError("algorithm='PCA' requires scikit-learn")
 
-            obj = import_sklearn.sklearn.decomposition.IncrementalPCA(n_components=output_dimension)
+            obj = import_sklearn.decomposition.IncrementalPCA(n_components=output_dimension)
             method = partial(obj.partial_fit, **kwargs)
             reproject = True
             to_print.extend(["scikit-learn estimator:", obj])

--- a/hyperspy/_signals/signal1d.py
+++ b/hyperspy/_signals/signal1d.py
@@ -22,7 +22,7 @@ import math
 
 import matplotlib.pyplot as plt
 import numpy as np
-import dask.array as da
+from hyperspy.lazy_imports import dask_array as da
 import scipy.interpolate
 import scipy as sp
 from scipy.signal import savgol_filter

--- a/hyperspy/_signals/signal2d.py
+++ b/hyperspy/_signals/signal2d.py
@@ -25,7 +25,7 @@ import logging
 import warnings
 
 from scipy import ndimage
-from hyperspy.lazy_imports import skimage_correlation as correlation
+from hyperspy.lazy_imports import skimage_correlation as skcorrelation
 
 from hyperspy.defaults_parser import preferences
 from hyperspy.external.progressbar import progressbar
@@ -249,7 +249,7 @@ def estimate_image_shift(ref, image, roi=None, sobel=True,
         normalization = (image_product.size * sub_pixel_factor ** 2)
         # Matrix multiply DFT around the current shift estimate
         sample_region_offset = dftshift - shifts * sub_pixel_factor
-        correlation = correlation._upsampled_dft(image_product.conj(),
+        correlation = skcorrelation._upsampled_dft(image_product.conj(),
                                      upsampled_region_size,
                                      sub_pixel_factor,
                                      sample_region_offset).conj()

--- a/hyperspy/_signals/signal2d.py
+++ b/hyperspy/_signals/signal2d.py
@@ -39,9 +39,7 @@ from hyperspy.docstrings.plot import (
     PLOT2D_KWARGS_DOCSTRING)
 from hyperspy.docstrings.signal import SHOW_PROGRESSBAR_ARG, PARALLEL_ARG, MAX_WORKERS_ARG
 from hyperspy.ui_registry import DISPLAY_DT, TOOLKIT_DT
-from hyperspy.utils.peakfinders2D import (
-        find_local_max, find_peaks_max, find_peaks_minmax, find_peaks_zaefferer,
-        find_peaks_stat, find_peaks_log, find_peaks_dog, find_peaks_xc)
+
 
 
 _logger = logging.getLogger(__name__)
@@ -882,6 +880,9 @@ class Signal2D(BaseSignal, CommonSignal2D):
             the `x, y` pixel coordinates of peaks found in each image sorted
             first along `y` and then along `x`.
         """
+        from hyperspy.utils.peakfinders2D import (
+            find_local_max, find_peaks_max, find_peaks_minmax, find_peaks_zaefferer,
+            find_peaks_stat, find_peaks_log, find_peaks_dog, find_peaks_xc)
         method_dict = {
             'local_max': find_local_max,
             'max': find_peaks_max,

--- a/hyperspy/_signals/signal2d.py
+++ b/hyperspy/_signals/signal2d.py
@@ -20,7 +20,7 @@ import matplotlib.pyplot as plt
 import numpy as np
 import scipy as sp
 import numpy.ma as ma
-import dask.array as da
+from hyperspy.lazy_imports import dask_array as da
 import logging
 import warnings
 
@@ -795,7 +795,7 @@ class Signal2D(BaseSignal, CommonSignal2D):
         """
         yy, xx = np.indices(self.axes_manager._signal_shape_in_array)
         if self._lazy:
-            import dask.array as da
+            from hyperspy.lazy_imports import dask_array as da
             ramp = offset * da.ones(self.data.shape, dtype=self.data.dtype,
                                     chunks=self.data.chunks)
         else:

--- a/hyperspy/_signals/signal2d.py
+++ b/hyperspy/_signals/signal2d.py
@@ -25,11 +25,7 @@ import logging
 import warnings
 
 from scipy import ndimage
-try:
-    # For scikit-image >= 0.17.0
-    from skimage.registration._phase_cross_correlation import _upsampled_dft
-except ModuleNotFoundError:
-    from skimage.feature.register_translation import _upsampled_dft
+from hyperspy.lazy_imports import skimage_correlation as correlation
 
 from hyperspy.defaults_parser import preferences
 from hyperspy.external.progressbar import progressbar
@@ -255,7 +251,7 @@ def estimate_image_shift(ref, image, roi=None, sobel=True,
         normalization = (image_product.size * sub_pixel_factor ** 2)
         # Matrix multiply DFT around the current shift estimate
         sample_region_offset = dftshift - shifts * sub_pixel_factor
-        correlation = _upsampled_dft(image_product.conj(),
+        correlation = correlation._upsampled_dft(image_product.conj(),
                                      upsampled_region_size,
                                      sub_pixel_factor,
                                      sample_region_offset).conj()

--- a/hyperspy/api.py
+++ b/hyperspy/api.py
@@ -17,24 +17,35 @@
 # along with  HyperSpy.  If not, see <http://www.gnu.org/licenses/>.
 
 from hyperspy.api_nogui import *
+import importlib
+from lazyasd import lazyobject
 import logging
 _logger = logging.getLogger(__name__)
 
 __doc__ = hyperspy.api_nogui.__doc__
 
-try:
-    # Register ipywidgets by importing the module
-    import hyperspy_gui_ipywidgets
-except ImportError:  # pragma: no cover
+# Register ipywidgets by importing the module
+module = 'hyperspy_gui_ipywidgets'
+spam_loader = importlib.util.find_spec(module)
+if spam_loader is not None:
+    @lazyobject
+    def hyperspy_gui_traitsui():
+        return importlib.import_module(module)
+else:
     from hyperspy.defaults_parser import preferences
     if preferences.GUIs.warn_if_guis_are_missing:
         _logger.warning(
             "The ipywidgets GUI elements are not available, probably because the "
             "hyperspy_gui_ipywidgets package is not installed.")
-try:
-    # Register traitui UI elements by importing the module
-    import hyperspy_gui_traitsui
-except ImportError:  # pragma: no cover
+
+# Register traitui UI elements by importing the module
+module = 'hyperspy_gui_traitsui'
+spam_loader = importlib.util.find_spec(module)
+if spam_loader is not None:
+    @lazyobject
+    def hyperspy_gui_traitsui():
+        return importlib.import_module(module)
+else:
     from hyperspy.defaults_parser import preferences
     if preferences.GUIs.warn_if_guis_are_missing:
         _logger.warning(

--- a/hyperspy/axes.py
+++ b/hyperspy/axes.py
@@ -20,7 +20,7 @@ import copy
 import math
 
 import numpy as np
-import dask.array as da
+from hyperspy.lazy_imports import dask_array as da
 import traits.api as t
 from traits.trait_errors import TraitError
 from lazyasd import lazyobject

--- a/hyperspy/axes.py
+++ b/hyperspy/axes.py
@@ -23,7 +23,8 @@ import numpy as np
 import dask.array as da
 import traits.api as t
 from traits.trait_errors import TraitError
-import pint
+from lazyasd import lazyobject
+from hyperspy.lazy_imports import pint
 import logging
 
 from hyperspy.events import Events, Event
@@ -36,7 +37,11 @@ from hyperspy.defaults_parser import preferences
 import warnings
 
 _logger = logging.getLogger(__name__)
-_ureg = pint.UnitRegistry()
+
+
+@lazyobject
+def _ureg():
+    return pint.UnitRegistry()
 
 
 FACTOR_DOCSTRING = \

--- a/hyperspy/component.py
+++ b/hyperspy/component.py
@@ -20,8 +20,8 @@ import numpy as np
 from dask.array import Array as dArray
 import traits.api as t
 from traits.trait_numeric import Array
-import sympy
-from sympy.utilities.lambdify import lambdify
+from hyperspy.lazy_imports import sympy
+from hyperspy.lazy_imports import Lambdify
 from distutils.version import LooseVersion
 from pathlib import Path
 
@@ -240,13 +240,13 @@ class Parameter(t.HasTraits):
             raise ValueError("The expression must contain one variable, "
                              "it contains none.")
         x = tuple(expr.free_symbols)[0]
-        self.twin_function = lambdify(x, expr.evalf())
+        self.twin_function = Lambdify.lambdify(x, expr.evalf())
         self._twin_function_expr = value
         if not self.twin_inverse_function:
             y = sympy.Symbol(x.name + "2")
             try:
                 inv = list(sympy.solveset(sympy.Eq(y, expr), x))
-                self._twin_inverse_sympy = lambdify(y, inv)
+                self._twin_inverse_sympy = Lambdify.lambdify(y, inv)
                 self._twin_inverse_function = None
             except BaseException:
                 # Not all may have a suitable solution.
@@ -278,7 +278,7 @@ class Parameter(t.HasTraits):
             raise ValueError("The expression must contain one variable, "
                              "it contains none.")
         x = tuple(expr.free_symbols)[0]
-        self._twin_inverse_function = lambdify(x, expr.evalf())
+        self._twin_inverse_function = Lambdify.lambdify(x, expr.evalf())
         self._twin_inverse_function_expr = value
 
     @property

--- a/hyperspy/component.py
+++ b/hyperspy/component.py
@@ -17,7 +17,7 @@
 # along with  HyperSpy.  If not, see <http://www.gnu.org/licenses/>.
 
 import numpy as np
-from dask.array import Array as dArray
+from hyperspy.lazy_imports import dask_array as da
 import traits.api as t
 from traits.trait_numeric import Array
 from hyperspy.lazy_imports import sympy
@@ -521,9 +521,9 @@ class Parameter(t.HasTraits):
         if self.map['is_set'][indices]:
             value = self.map['values'][indices]
             std = self.map['std'][indices]
-            if isinstance(value, dArray):
+            if isinstance(value, da.Array):
                 value = value.compute()
-            if isinstance(std, dArray):
+            if isinstance(std, da.Array):
                 std = std.compute()
             self.value = value
             self.std = std

--- a/hyperspy/io.py
+++ b/hyperspy/io.py
@@ -32,7 +32,7 @@ from hyperspy.misc.io.tools import ensure_directory
 from hyperspy.misc.io.tools import overwrite as overwrite_method
 from hyperspy.misc.utils import strlist2enumeration
 from hyperspy.misc.utils import stack as stack_method
-from hyperspy.io_plugins import io_plugins, default_write_ext
+from hyperspy.lazy_imports import IO_plugins
 from hyperspy.exceptions import VisibleDeprecationWarning
 from hyperspy.ui_registry import get_gui
 from hyperspy.extensions import ALL_EXTENSIONS
@@ -64,7 +64,7 @@ def _infer_file_reader(extension):
         The inferred file reader.
 
     """
-    rdrs = [rdr for rdr in io_plugins if extension.lower() in rdr.file_extensions]
+    rdrs = [rdr for rdr in IO_plugins.io_plugins if extension.lower() in rdr.file_extensions]
 
     if not rdrs:
         # Try to load it with the python imaging library
@@ -695,6 +695,8 @@ def save(filename, signal, overwrite=None, **kwds):
     None
 
     """
+    from hyperspy.io_plugins import default_write_ext
+
     filename = Path(filename).resolve()
     extension = filename.suffix
     if extension == '':
@@ -702,7 +704,7 @@ def save(filename, signal, overwrite=None, **kwds):
         filename = filename.with_suffix(extension)
 
     writer = None
-    for plugin in io_plugins:
+    for plugin in IO_plugins.io_plugins:
         # Drop the "." separator from the suffix
         if extension[1:].lower() in plugin.file_extensions:
             writer = plugin
@@ -725,7 +727,7 @@ def save(filename, signal, overwrite=None, **kwds):
         )
 
     if writer.writes is not True and (sd, nd) not in writer.writes:
-        yes_we_can = [plugin.format_name for plugin in io_plugins
+        yes_we_can = [plugin.format_name for plugin in IO_plugins.io_plugins
                       if plugin.writes is True or
                       plugin.writes is not False and
                       (sd, nd) in plugin.writes]

--- a/hyperspy/io_plugins/__init__.py
+++ b/hyperspy/io_plugins/__init__.py
@@ -16,7 +16,6 @@
 # You should have received a copy of the GNU General Public License
 # along with  HyperSpy.  If not, see <http://www.gnu.org/licenses/>.
 
-
 import logging
 
 from hyperspy.io_plugins import (

--- a/hyperspy/io_plugins/bruker.py
+++ b/hyperspy/io_plugins/bruker.py
@@ -32,8 +32,7 @@ import re
 import logging
 from zlib import decompress as unzip_block
 from struct import unpack as strct_unp
-import dask.delayed as dd
-import dask.array as da
+from hyperspy.lazy_imports import dask_array as da
 import numpy as np
 from datetime import datetime, timedelta
 from ast import literal_eval
@@ -968,6 +967,7 @@ class BCF_reader(SFS_reader):
                                                    downsample=downsample,
                                                    for_numpy=True)
         if lazy:
+            import dask.delayed as dd
             value = dd(parse_func)(vrt_file_hand, shape,
                                    dtype, downsample=downsample)
             result = da.from_delayed(value, shape=shape, dtype=dtype)

--- a/hyperspy/io_plugins/emd.py
+++ b/hyperspy/io_plugins/emd.py
@@ -37,8 +37,8 @@ import traits.api as t
 import h5py
 import numpy as np
 import dask.array as da
+from hyperspy.axes import _ureg
 from dateutil import tz
-import pint
 
 from hyperspy.misc.elements import atomic_number2name
 import hyperspy.misc.io.fei_stream_readers as stream_readers
@@ -504,9 +504,6 @@ class EMD_NCEM:
         List of dictionaries which are passed to the file_reader.
     """
 
-    def __init__(self):
-        self._ureg = pint.UnitRegistry()
-
     def read_file(self, file, lazy=None, dataset_path=None, stack_group=None):
         """
         Read the data from an emd file
@@ -763,7 +760,7 @@ class EMD_NCEM:
                 units_list = [u[1:-1].replace("_", "") for u in units_list]
                 value = ' * '.join(units_list)
                 try:
-                    units = self._ureg.parse_units(value)
+                    units = _ureg.parse_units(value)
                     value = f"{units:~}"
                 except:
                     pass
@@ -948,7 +945,6 @@ class FeiEMDReader(object):
         # Parallelise streams reading
         self.filename = filename
         self.select_type = select_type
-        self.ureg = pint.UnitRegistry()
         self.dictionaries = []
         self.first_frame = first_frame
         self.last_frame = last_frame
@@ -1480,7 +1476,7 @@ class FeiEMDReader(object):
         if units == t.Undefined:
             return value, units
         factor /= 2
-        v = np.float(value) * self.ureg(units)
+        v = np.float(value) * _ureg(units)
         converted_v = (factor * v).to_compact()
         converted_value = float(converted_v.magnitude / factor)
         converted_units = '{:~}'.format(converted_v.units)

--- a/hyperspy/io_plugins/emd.py
+++ b/hyperspy/io_plugins/emd.py
@@ -36,8 +36,8 @@ import traits.api as t
 
 import h5py
 import numpy as np
-import dask.array as da
 from hyperspy.axes import _ureg
+from hyperspy.lazy_imports import dask_array as da
 from dateutil import tz
 
 from hyperspy.misc.elements import atomic_number2name

--- a/hyperspy/io_plugins/empad.py
+++ b/hyperspy/io_plugins/empad.py
@@ -21,14 +21,13 @@ import ast
 import xml.etree.ElementTree as ET
 import numpy as np
 import logging
-import pint
+from hyperspy.axes import _ureg
 import traits.api as t
 
 from hyperspy.misc.io.tools import convert_xml_to_dict
 
 
 _logger = logging.getLogger(__name__)
-_ureg = pint.UnitRegistry()
 
 
 # Plugin characteristics

--- a/hyperspy/io_plugins/hspy.py
+++ b/hyperspy/io_plugins/hspy.py
@@ -24,7 +24,7 @@ import ast
 
 import h5py
 import numpy as np
-import dask.array as da
+from hyperspy.lazy_imports import dask_array as da
 from traits.api import Undefined
 from hyperspy.misc.utils import ensure_unicode, multiply, get_object_package_info
 from hyperspy.axes import AxesManager

--- a/hyperspy/io_plugins/nexus.py
+++ b/hyperspy/io_plugins/nexus.py
@@ -19,7 +19,7 @@
 #
 import logging
 import numpy as np
-import dask.array as da
+from hyperspy.lazy_imports import dask_array as da
 import os
 import h5py
 import pprint

--- a/hyperspy/io_plugins/tiff.py
+++ b/hyperspy/io_plugins/tiff.py
@@ -20,7 +20,6 @@ import os
 import logging
 from datetime import datetime, timedelta
 from dateutil import parser
-import pint
 from tifffile import imwrite, TiffFile, TIFF
 import tifffile
 import traits.api as t
@@ -29,6 +28,7 @@ from distutils.version import LooseVersion
 
 from hyperspy.misc import rgb_tools
 from hyperspy.misc.date_time_tools import get_date_time_from_metadata
+from hyperspy.axes import _ureg
 
 _logger = logging.getLogger(__name__)
 
@@ -66,7 +66,7 @@ axes_label_codes = {
     '_': t.Undefined}
 
 
-ureg = pint.UnitRegistry()
+
 
 
 def file_writer(filename, signal, export_scale=True, extratags=[], **kwds):
@@ -516,7 +516,7 @@ def _parse_tuple_Zeiss(tup):
 def _parse_tuple_Zeiss_with_units(tup, to_units=None):
     (value, parse_units) = tup[1:]
     if to_units is not None:
-        v = value * ureg(parse_units)
+        v = value * _ureg(parse_units)
         value = float("%.6e" % v.to(to_units).magnitude)
     return value
 

--- a/hyperspy/io_plugins/usid_hdf5.py
+++ b/hyperspy/io_plugins/usid_hdf5.py
@@ -5,7 +5,7 @@ from functools import partial
 from collections.abc import MutableMapping
 import h5py
 import numpy as np
-from hyperspy.lazy_imports import usis # import pyUSID as usid
+from hyperspy.lazy_imports import pyUSID as usid
 
 import sidpy
 

--- a/hyperspy/io_plugins/usid_hdf5.py
+++ b/hyperspy/io_plugins/usid_hdf5.py
@@ -5,7 +5,8 @@ from functools import partial
 from collections.abc import MutableMapping
 import h5py
 import numpy as np
-import pyUSID as usid
+from hyperspy.lazy_imports import usis # import pyUSID as usid
+
 import sidpy
 
 _logger = logging.getLogger(__name__)

--- a/hyperspy/lazy_imports.py
+++ b/hyperspy/lazy_imports.py
@@ -40,3 +40,11 @@ def dask_diag():
 @lazyobject
 def numba():
     return importlib.import_module('numba')
+
+@lazyobject
+def IO_plugins():
+    return importlib.import_module('hyperspy.io_plugins')
+
+@lazyobject
+def pyUSID():
+    return importlib.import_module('pyUSID')

--- a/hyperspy/lazy_imports.py
+++ b/hyperspy/lazy_imports.py
@@ -13,3 +13,14 @@ def sympy():
 def Lambdify():
     return importlib.import_module('sympy.utilities.lambdify')
 
+@lazyobject
+def skimage_feature():
+    return importlib.import_module('skimage.feature')
+
+@lazyobject
+def skimage_correlation():
+    try:
+        # For scikit-image >= 0.17.0
+        return importlib.import_module('skimage.registration._phase_cross_correlation')
+    except ModuleNotFoundError:
+        return importlib.import_module('skimage.feature.register_translation')

--- a/hyperspy/lazy_imports.py
+++ b/hyperspy/lazy_imports.py
@@ -4,3 +4,12 @@ from lazyasd import lazyobject
 @lazyobject
 def pint():
     return importlib.import_module('pint')
+
+@lazyobject
+def sympy():
+    return importlib.import_module('sympy')
+
+@lazyobject
+def Lambdify():
+    return importlib.import_module('sympy.utilities.lambdify')
+

--- a/hyperspy/lazy_imports.py
+++ b/hyperspy/lazy_imports.py
@@ -24,3 +24,16 @@ def skimage_correlation():
         return importlib.import_module('skimage.registration._phase_cross_correlation')
     except ModuleNotFoundError:
         return importlib.import_module('skimage.feature.register_translation')
+
+@lazyobject
+def dask_array():
+    return importlib.import_module('dask.array')
+
+@lazyobject
+def threaded():
+    return importlib.import_module('dask.threaded')
+
+@lazyobject
+def dask_diag():
+    return importlib.import_module('dask.diagnostics')
+

--- a/hyperspy/lazy_imports.py
+++ b/hyperspy/lazy_imports.py
@@ -37,3 +37,6 @@ def threaded():
 def dask_diag():
     return importlib.import_module('dask.diagnostics')
 
+@lazyobject
+def numba():
+    return importlib.import_module('numba')

--- a/hyperspy/lazy_imports.py
+++ b/hyperspy/lazy_imports.py
@@ -1,0 +1,6 @@
+import importlib
+from lazyasd import lazyobject
+
+@lazyobject
+def pint():
+    return importlib.import_module('pint')

--- a/hyperspy/learn/mva.py
+++ b/hyperspy/learn/mva.py
@@ -20,7 +20,7 @@
 import logging
 import types
 import warnings
-import dask.array as da
+from hyperspy.lazy_imports import dask_array as da
 import matplotlib.pyplot as plt
 import numpy as np
 from matplotlib.ticker import FuncFormatter, MaxNLocator

--- a/hyperspy/learn/svd_pca.py
+++ b/hyperspy/learn/svd_pca.py
@@ -27,7 +27,7 @@ from scipy.sparse.linalg import svds
 
 from hyperspy.exceptions import VisibleDeprecationWarning
 from hyperspy.misc.machine_learning.import_sklearn import (
-    randomized_svd,
+    extmath,
     sklearn_installed,
 )
 
@@ -149,7 +149,7 @@ def svd_solve(
             raise ImportError(
                 "svd_solver='randomized' requires scikit-learn to be installed"
             )
-        U, S, V = randomized_svd(data, n_components=output_dimension, **kwargs)
+        U, S, V = extmath.randomized_svd(data, n_components=output_dimension, **kwargs)
     elif svd_solver == "arpack":
         if LooseVersion(scipy.__version__) < LooseVersion("1.4.0"):  # pragma: no cover
             raise ValueError('`svd_solver="arpack"` requires scipy >= 1.4.0')

--- a/hyperspy/misc/array_tools.py
+++ b/hyperspy/misc/array_tools.py
@@ -197,7 +197,7 @@ def rebin(a, new_shape=None, scale=None, crop=True):
             return a.reshape(rshape).sum(axis=tuple(
                 2 * i + 1 for i in range(lenShape)))
         else:
-            import dask.array as da
+            from hyperspy.lazy_imports import dask_array as da
 
             try:
                 return da.coarsen(np.sum, a, {i: int(f)

--- a/hyperspy/misc/eels/eelsdb.py
+++ b/hyperspy/misc/eels/eelsdb.py
@@ -20,7 +20,6 @@
 import requests
 import logging
 
-from hyperspy.io_plugins.msa import parse_msa_string
 from hyperspy.io import dict2signal
 
 _logger = logging.getLogger(__name__)
@@ -230,6 +229,7 @@ def eelsdb(spectrum_type=None, title=None, author=None, element=None, formula=No
         download_link = json_spectrum['download_link']
         msa_string = requests.get(download_link, verify=verify_certificate).text
         try:
+            from hyperspy.io_plugins.msa import parse_msa_string
             s = dict2signal(parse_msa_string(msa_string)[0])
             emsa = s.original_metadata
             s.original_metadata = s.original_metadata.__class__(

--- a/hyperspy/misc/export_dictionary.py
+++ b/hyperspy/misc/export_dictionary.py
@@ -20,7 +20,7 @@ from operator import attrgetter
 from hyperspy.misc.utils import attrsetter
 from copy import deepcopy
 import dill
-from dask.array import Array
+from hyperspy.lazy_imports import dask_array as da
 
 
 def check_that_flags_make_sense(flags):
@@ -202,6 +202,6 @@ def reconstruct_object(flags, value):
             return dill.loads(thing)
         # should not be reached
         raise ValueError("The object format is not recognized")
-    if isinstance(value, Array):
+    if isinstance(value, da.Array):
         value = value.compute()
     return value

--- a/hyperspy/misc/hist_tools.py
+++ b/hyperspy/misc/hist_tools.py
@@ -19,7 +19,7 @@
 import logging
 import warnings
 
-import dask.array as da
+from hyperspy.lazy_imports import dask_array as da
 import numpy as np
 
 from hyperspy.docstrings.signal import HISTOGRAM_BIN_ARGS, HISTOGRAM_MAX_BIN_ARGS

--- a/hyperspy/misc/io/fei_stream_readers.py
+++ b/hyperspy/misc/io/fei_stream_readers.py
@@ -20,9 +20,8 @@ import numpy as np
 from hyperspy.lazy_imports import dask_array as da
 import sparse
 
-from numba import njit
-
-
+from hyperspy.lazy_imports import numba
+raise ValueError("fei")
 class DenseSliceCOO(sparse.COO):
     """Just like sparse.COO, but returning a dense array on indexing/slicing"""
 
@@ -35,7 +34,7 @@ class DenseSliceCOO(sparse.COO):
             return obj
 
 
-@njit(cache=True)
+@numba.jit(cache=True)
 def _stream_to_sparse_COO_array_sum_frames(
         stream_data,
         last_frame,
@@ -122,7 +121,7 @@ def _stream_to_sparse_COO_array_sum_frames(
     return coords, data, final_shape
 
 
-@njit(cache=True)
+@numba.jit(cache=True)
 def _stream_to_sparse_COO_array(
         stream_data,
         last_frame,
@@ -254,7 +253,7 @@ def stream_to_sparse_COO_array(
     return dask_sparse
 
 
-@njit(cache=True)
+@numba.jit(cache=True)
 def _fill_array_with_stream_sum_frames(
         spectrum_image,
         stream,
@@ -284,7 +283,7 @@ def _fill_array_with_stream_sum_frames(
             navigation_index += 1
 
 
-@njit(cache=True)
+@numba.jit(cache=True)
 def _fill_array_with_stream(
         spectrum_image,
         stream,
@@ -368,7 +367,7 @@ def stream_to_array(
     return spectrum_image
 
 
-@njit(cache=True)
+@numba.jit(cache=True)
 def array_to_stream(array):  # pragma: no cover
     """Convert an array to a FEI stream
 

--- a/hyperspy/misc/io/fei_stream_readers.py
+++ b/hyperspy/misc/io/fei_stream_readers.py
@@ -17,7 +17,7 @@
 # along with  HyperSpy.  If not, see <http://www.gnu.org/licenses/>.
 
 import numpy as np
-import dask.array as da
+from hyperspy.lazy_imports import dask_array as da
 import sparse
 
 from numba import njit

--- a/hyperspy/misc/io/fei_stream_readers.py
+++ b/hyperspy/misc/io/fei_stream_readers.py
@@ -21,7 +21,6 @@ from hyperspy.lazy_imports import dask_array as da
 import sparse
 
 from hyperspy.lazy_imports import numba
-raise ValueError("fei")
 class DenseSliceCOO(sparse.COO):
     """Just like sparse.COO, but returning a dense array on indexing/slicing"""
 

--- a/hyperspy/misc/lowess_smooth.py
+++ b/hyperspy/misc/lowess_smooth.py
@@ -18,61 +18,65 @@ Statistical Association, September 1988, volume 83, number 403, pp. 596-610.
 # https://gist.github.com/agramfort/850437
 
 import numpy as np
-from numba import njit
+from hyperspy.lazy_imports import numba
+from lazyasd import lazyobject
 
 
-@njit(cache=True, nogil=True)
-def lowess(y, x, f=2.0 / 3.0, n_iter=3):  # pragma: no cover
-    """Lowess smoother (robust locally weighted regression).
+@lazyobject
+def lowess():  # pragma: no cover
+    @numba.jit(cache=True, nogil=True)
+    def _lowess(y, x, f=2.0 / 3.0, n_iter=3):
+        """Lowess smoother (robust locally weighted regression).
 
-    Fits a nonparametric regression curve to a scatterplot.
+        Fits a nonparametric regression curve to a scatterplot.
 
-    Parameters
-    ----------
-    y, x : np.ndarrays
-        The arrays x and y contain an equal number of elements;
-        each pair (x[i], y[i]) defines a data point in the
-        scatterplot.
+        Parameters
+        ----------
+        y, x : np.ndarrays
+            The arrays x and y contain an equal number of elements;
+            each pair (x[i], y[i]) defines a data point in the
+            scatterplot.
 
-    f : float
-        The smoothing span. A larger value will result in a
-        smoother curve.
-    n_iter : int
-        The number of robustifying iteration. Thefunction will
-        run faster with a smaller number of iterations.
+        f : float
+            The smoothing span. A larger value will result in a
+            smoother curve.
+        n_iter : int
+            The number of robustifying iteration. Thefunction will
+            run faster with a smaller number of iterations.
 
-    Returns
-    -------
-    yest : np.ndarray
-        The estimated (smooth) values of y.
+        Returns
+        -------
+        yest : np.ndarray
+            The estimated (smooth) values of y.
 
-    """
-    n = len(x)
-    r = int(np.ceil(f * n))
-    h = np.array([np.sort(np.abs(x - x[i]))[r] for i in range(n)])
-    w = np.minimum(1.0, np.maximum(np.abs((x.reshape((-1, 1)) - x.reshape((1, -1))) / h), 0.0))
-    w = (1 - w ** 3) ** 3
-    yest = np.zeros(n)
-    delta = np.ones(n)
+        """
+        n = len(x)
+        r = int(np.ceil(f * n))
+        h = np.array([np.sort(np.abs(x - x[i]))[r] for i in range(n)])
+        w = np.minimum(1.0, np.maximum(np.abs((x.reshape((-1, 1)) - x.reshape((1, -1))) / h), 0.0))
+        w = (1 - w ** 3) ** 3
+        yest = np.zeros(n)
+        delta = np.ones(n)
 
-    for _ in range(n_iter):
-        for i in range(n):
-            weights = delta * w[:, i]
-            b = np.array([np.sum(weights * y), np.sum(weights * y * x)])
-            A = np.array(
-                [
-                    [np.sum(weights), np.sum(weights * x)],
-                    [np.sum(weights * x), np.sum(weights * x * x)],
-                ]
-            )
+        for _ in range(n_iter):
+            for i in range(n):
+                weights = delta * w[:, i]
+                b = np.array([np.sum(weights * y), np.sum(weights * y * x)])
+                A = np.array(
+                    [
+                        [np.sum(weights), np.sum(weights * x)],
+                        [np.sum(weights * x), np.sum(weights * x * x)],
+                    ]
+                )
 
-            beta = np.linalg.lstsq(A, b)[0]
-            yest[i] = beta[0] + beta[1] * x[i]
+                beta = np.linalg.lstsq(A, b)[0]
+                yest[i] = beta[0] + beta[1] * x[i]
 
-        residuals = y - yest
-        s = np.median(np.abs(residuals))
-        #delta = np.clip(residuals / (6.0 * s), -1.0, 1.0)
-        delta = np.minimum(1.0, np.maximum(residuals / (6.0 * s), -1.0))
-        delta = (1 - delta ** 2) ** 2
+            residuals = y - yest
+            s = np.median(np.abs(residuals))
+            #delta = np.clip(residuals / (6.0 * s), -1.0, 1.0)
+            delta = np.minimum(1.0, np.maximum(residuals / (6.0 * s), -1.0))
+            delta = (1 - delta ** 2) ** 2
 
-    return yest
+        return yest
+    return _lowess

--- a/hyperspy/misc/machine_learning/import_sklearn.py
+++ b/hyperspy/misc/machine_learning/import_sklearn.py
@@ -21,17 +21,36 @@ Import sklearn.* and randomized_svd from scikit-learn
 """
 
 import warnings
-
+import importlib
+from lazyasd import lazyobject
 
 try:
     with warnings.catch_warnings():
         warnings.simplefilter("ignore")
-        import sklearn
-        import sklearn.decomposition
-        import sklearn.cluster
-        import sklearn.preprocessing
-        import sklearn.metrics
-        from sklearn.utils.extmath import randomized_svd
+
+        @lazyobject
+        def sklearn():
+            return importlib.import_module('sklearn')
+
+        @lazyobject
+        def decomposition():
+            return importlib.import_module('sklearn.decomposition')
+
+        @lazyobject
+        def cluster():
+            return importlib.import_module('sklearn.cluster')
+
+        @lazyobject
+        def preprocessing():
+            return importlib.import_module('sklearn.preprocessing')
+
+        @lazyobject
+        def metrics():
+            return importlib.import_module('sklearn.metrics')
+
+        @lazyobject
+        def extmath():
+            return importlib.import_module('sklearn.utils.extmath')
 
         sklearn_installed = True
 

--- a/hyperspy/misc/math_tools.py
+++ b/hyperspy/misc/math_tools.py
@@ -19,7 +19,7 @@
 import math
 import numbers
 import numpy as np
-import dask.array as da
+from hyperspy.lazy_imports import dask_array as da
 
 from functools import reduce
 

--- a/hyperspy/misc/rgb_tools.py
+++ b/hyperspy/misc/rgb_tools.py
@@ -17,7 +17,7 @@
 # along with  HyperSpy.  If not, see <http://www.gnu.org/licenses/>.
 
 import numpy as np
-from dask.array import Array
+from hyperspy.lazy_imports import dask_array as da
 
 rgba8 = np.dtype({'names': ['R', 'G', 'B', 'A'],
                   'formats': ['u1', 'u1', 'u1', 'u1']})
@@ -68,7 +68,7 @@ def rgbx2regular_array(data, plot_friendly=False):
 
     """
     # Make sure that the data is contiguous
-    if isinstance(data, Array):
+    if isinstance(data, da.Array):
         from dask.diagnostics import ProgressBar
         # an expensive thing, but nothing to be done for now...
         with ProgressBar():

--- a/hyperspy/misc/signal_tools.py
+++ b/hyperspy/misc/signal_tools.py
@@ -19,7 +19,7 @@
 import logging
 from itertools import zip_longest
 
-import dask.array as da
+from hyperspy.lazy_imports import dask_array as da
 import numpy as np
 
 from hyperspy.misc.axis_tools import check_axes_calibration

--- a/hyperspy/misc/slicing.py
+++ b/hyperspy/misc/slicing.py
@@ -18,7 +18,7 @@
 
 from operator import attrgetter
 import numpy as np
-from dask.array import Array as dArray
+from hyperspy.lazy_imports import dask_array as da
 
 from hyperspy.misc.utils import attrsetter
 from hyperspy.misc.export_dictionary import parse_flag_string
@@ -55,7 +55,7 @@ def _slice_target(target, dims, both_slices, slice_nav=None, issignal=False):
         sl = tuple(array_slices[:nav_dims])
         if isinstance(target, np.ndarray):
             return np.atleast_1d(target[sl])
-        if isinstance(target, dArray):
+        if isinstance(target, da.Array):
             return target[sl]
         raise ValueError(
             'tried to slice with navigation dimensions, but was neither a '
@@ -66,7 +66,7 @@ def _slice_target(target, dims, both_slices, slice_nav=None, issignal=False):
         sl = tuple(array_slices[-sig_dims:])
         if isinstance(target, np.ndarray):
             return np.atleast_1d(target[sl])
-        if isinstance(target, dArray):
+        if isinstance(target, da.Array):
             return target[sl]
         raise ValueError(
             'tried to slice with navigation dimensions, but was neither a '
@@ -276,7 +276,7 @@ class FancySlicing(object):
         array_slices = self._get_array_slices(slices, isNavigation)
         new_data = self.data[array_slices]
         if new_data.size == 1 and new_data.dtype is np.dtype('O'):
-            if isinstance(new_data[0], (np.ndarray, dArray)):
+            if isinstance(new_data[0], (np.ndarray, da.Array)):
                 return self.__class__(new_data[0]).transpose(navigation_axes=0)
             else:
                 return new_data[0]

--- a/hyperspy/misc/utils.py
+++ b/hyperspy/misc/utils.py
@@ -907,7 +907,7 @@ def stack(signal_list, axis=None, new_axis_name="stack_element", lazy=None,
 
     """
     from hyperspy.signals import BaseSignal
-    import dask.array as da
+    from hyperspy.lazy_imports import dask_array as da
     from numbers import Number
 
     for k in [k for k in ["mmap", "mmap_dir"] if k in kwargs]:

--- a/hyperspy/roi.py
+++ b/hyperspy/roi.py
@@ -1059,7 +1059,7 @@ class CircleROI(BaseInteractiveROI):
         roi = slicer(slices, out=out)
         roi = out or roi
         if roi._lazy:
-            import dask.array as da
+            from hyperspy.lazy_imports import dask_array as da
             mask = da.from_array(mask, chunks=chunks)
             mask = da.broadcast_to(mask, tiles)
             # By default promotes dtype to float if required

--- a/hyperspy/samfire_utils/samfire_pool.py
+++ b/hyperspy/samfire_utils/samfire_pool.py
@@ -21,7 +21,7 @@ import time
 import logging
 from multiprocessing import Manager
 import numpy as np
-from dask.array import Array as dar
+from hyperspy.lazy_imports import dask_array as da
 
 from hyperspy.utils.parallel_pool import ParallelPool
 from hyperspy.samfire_utils.samfire_worker import create_worker
@@ -33,7 +33,7 @@ def _walk_compute(athing):
     if isinstance(athing, dict):
         this = {}
         for key, val in athing.items():
-            if isinstance(key, dar):
+            if isinstance(key, da.Array):
                 raise ValueError('Dask arrays should not be used as keys')
             value = _walk_compute(val)
             this[key] = value
@@ -42,7 +42,7 @@ def _walk_compute(athing):
         return [_walk_compute(val) for val in athing]
     elif isinstance(athing, tuple):
         return tuple(_walk_compute(val) for val in athing)
-    elif isinstance(athing, dar):
+    elif isinstance(athing, da.Array):
         _logger.debug('found a dask array!')
         return athing.compute()
     else:

--- a/hyperspy/signal.py
+++ b/hyperspy/signal.py
@@ -27,7 +27,7 @@ from pathlib import Path
 
 import numpy as np
 import scipy as sp
-import dask.array as da
+from hyperspy.lazy_imports import dask_array as da
 from matplotlib import pyplot as plt
 import traits.api as t
 import numbers

--- a/hyperspy/signal.py
+++ b/hyperspy/signal.py
@@ -22,7 +22,7 @@ import inspect
 from contextlib import contextmanager
 from datetime import datetime
 import logging
-from pint import UnitRegistry, UndefinedUnitError
+from hyperspy.lazy_imports import pint
 from pathlib import Path
 
 import numpy as np
@@ -32,7 +32,7 @@ from matplotlib import pyplot as plt
 import traits.api as t
 import numbers
 
-from hyperspy.axes import AxesManager
+from hyperspy.axes import AxesManager, _ureg
 from hyperspy import io
 from hyperspy.drawing import mpl_hie, mpl_hse, mpl_he
 from hyperspy.learn.mva import MVA, LearningResults
@@ -4004,14 +4004,13 @@ class BaseSignal(FancySlicing,
         if hasattr(self.metadata.Signal, 'quantity'):
             self.metadata.Signal.__delattr__('quantity')
 
-        ureg = UnitRegistry()
         for axis in im_fft.axes_manager.signal_axes:
             axis.scale = 1. / axis.size / axis.scale
             axis.offset = 0.0
             try:
-                units = ureg.parse_expression(str(axis.units))**(-1)
+                units = _ureg.parse_expression(str(axis.units))**(-1)
                 axis.units = '{:~}'.format(units.units)
-            except UndefinedUnitError:
+            except pint.UndefinedUnitError:
                 _logger.warning('Units are not set or cannot be recognized')
             if shift:
                 axis.offset = -axis.high_value / 2.
@@ -4081,13 +4080,12 @@ class BaseSignal(FancySlicing,
         if return_real:
             im_ifft = im_ifft.real
 
-        ureg = UnitRegistry()
         for axis in im_ifft.axes_manager.signal_axes:
             axis.scale = 1. / axis.size / axis.scale
             try:
-                units = ureg.parse_expression(str(axis.units)) ** (-1)
+                units = _ureg.parse_expression(str(axis.units)) ** (-1)
                 axis.units = '{:~}'.format(units.units)
-            except UndefinedUnitError:
+            except pint.UndefinedUnitError:
                 _logger.warning('Units are not set or cannot be recognized')
             axis.offset = 0.
         return im_ifft

--- a/hyperspy/tests/axes/test_conversion_units.py
+++ b/hyperspy/tests/axes/test_conversion_units.py
@@ -23,6 +23,7 @@ import traits.api as t
 from hyperspy.axes import AxesManager, DataAxis, UnitConversion, _ureg
 from hyperspy.misc.test_utils import assert_deep_almost_equal, assert_warns
 
+import pint
 
 class TestUnitConversion:
 

--- a/hyperspy/tests/learn/test_cluster.py
+++ b/hyperspy/tests/learn/test_cluster.py
@@ -103,7 +103,7 @@ class TestCluster1D:
         )
 
     def test_custom_preprocessing(self):
-        custom_method = import_sklearn.sklearn.preprocessing.Normalizer()
+        custom_method = import_sklearn.preprocessing.Normalizer()
         self.signal.cluster_analysis(
             "signal", n_clusters=3, preprocessing=custom_method, algorithm="kmeans"
         )

--- a/hyperspy/tests/utils/test_lazy_imports.py
+++ b/hyperspy/tests/utils/test_lazy_imports.py
@@ -1,0 +1,35 @@
+# -*- coding: utf-8 -*-
+# Copyright 2007-2021 The HyperSpy developers
+#
+# This file is part of  HyperSpy.
+#
+#  HyperSpy is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+#  HyperSpy is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with  HyperSpy.  If not, see <http://www.gnu.org/licenses/>.
+
+class TestLazyImports:
+
+    def test_lazy_imports(self):
+        import sys
+        lazy_modules=[
+            'pint', 'dask', 'numba', 'sklearn', 'skimage', 'sympy'
+            'hyperspy-gui-ipywidgets', 'hyperspy-gui-traitsui']
+        for module in list(sys.modules):
+            for lazy_module in lazy_modules:
+                if lazy_module in module:
+                    sys.modules.pop(module)
+
+        import hyperspy.api as hs
+
+        modules = set(sys.modules.keys())
+        for lazy_module in lazy_modules:
+            assert lazy_module not in modules

--- a/hyperspy/utils/peakfinders2D.py
+++ b/hyperspy/utils/peakfinders2D.py
@@ -20,15 +20,14 @@ import copy
 
 import numpy as np
 import scipy.ndimage as ndi
-from numba import njit
 from hyperspy.lazy_imports import skimage_feature as feature
-
+from hyperspy.lazy_imports import numba
 from hyperspy.misc.machine_learning import import_sklearn
 
 NO_PEAKS = np.array([[np.nan, np.nan]])
 
 
-@njit(cache=True)
+@numba.jit(cache=True)
 def _fast_mean(X):  # pragma: no cover
     """JIT-compiled mean of array.
 
@@ -51,7 +50,7 @@ def _fast_mean(X):  # pragma: no cover
     return np.mean(X)
 
 
-@njit(cache=True)
+@numba.jit(cache=True)
 def _fast_std(X):  # pragma: no cover
     """JIT-compiled standard deviation of array.
 

--- a/hyperspy/utils/peakfinders2D.py
+++ b/hyperspy/utils/peakfinders2D.py
@@ -21,13 +21,7 @@ import copy
 import numpy as np
 import scipy.ndimage as ndi
 from numba import njit
-from skimage.feature import (
-    blob_dog, 
-    blob_log, 
-    corner_peaks,
-    match_template,
-    peak_local_max,
-)
+from hyperspy.lazy_imports import skimage_feature as feature
 
 from hyperspy.misc.machine_learning import import_sklearn
 
@@ -124,7 +118,7 @@ def find_local_max(z, **kwargs):
         Peak pixel coordinates.
 
     """
-    peaks = peak_local_max(z, **kwargs)
+    peaks = feature.peak_local_max(z, **kwargs)
     return clean_peaks(peaks)
 
 
@@ -483,7 +477,7 @@ def find_peaks_dog(z, min_sigma=1., max_sigma=50., sigma_ratio=1.6,
 
     """
     z = z / np.max(z)
-    blobs = blob_dog(z, min_sigma=min_sigma, max_sigma=max_sigma,
+    blobs = feature.blob_dog(z, min_sigma=min_sigma, max_sigma=max_sigma,
                      sigma_ratio=sigma_ratio, threshold=threshold,
                      overlap=overlap, exclude_border=exclude_border)
     try:
@@ -528,7 +522,7 @@ def find_peaks_log(z, min_sigma=1., max_sigma=50., num_sigma=10,
     z = z / np.max(z)
     if isinstance(num_sigma, float):
         raise ValueError("`num_sigma` parameter should be an integer.")
-    blobs = blob_log(z, min_sigma=min_sigma, max_sigma=max_sigma,
+    blobs = feature.blob_log(z, min_sigma=min_sigma, max_sigma=max_sigma,
                      num_sigma=num_sigma, threshold=threshold, overlap=overlap,
                      log_scale=log_scale, exclude_border=exclude_border)
     # Attempt to return only peak positions. If no peaks exist, return an
@@ -568,7 +562,7 @@ def find_peaks_xc(z, template, distance=5, threshold=0.5, **kwargs):
         Array of peak coordinates.
     """
     pad_input = kwargs.pop('pad_input', True)
-    response_image = match_template(z, template, pad_input=pad_input, **kwargs)
+    response_image = feature.match_template(z, template, pad_input=pad_input, **kwargs)
     peaks = find_peaks_minmax(response_image,
                               distance=distance,
                               threshold=threshold)

--- a/hyperspy/utils/peakfinders2D.py
+++ b/hyperspy/utils/peakfinders2D.py
@@ -405,7 +405,7 @@ def find_peaks_stat(z, alpha=1.0, window_radius=10, convergence_ratio=0.05):
         """Identify adjacent 'on' coordinates via DBSCAN."""
         bi = binarised_image.astype("bool")
         coordinates = np.indices(bi.shape).reshape(2, -1).T[bi.flatten()]
-        db = import_sklearn.sklearn.cluster.DBSCAN(2, 3)
+        db = import_sklearn.cluster.DBSCAN(2, 3)
         peaks = []
         if coordinates.shape[0] > 0:  # we have at least some peaks
             labeled_points = db.fit_predict(coordinates)

--- a/setup.py
+++ b/setup.py
@@ -69,6 +69,7 @@ install_req = ['scipy>=1.1',
                'prettytable',
                'tifffile>=2018.10.18',
                'numba',
+               'lazyasd'
                ]
 
 extras_require = {


### PR DESCRIPTION
### Speed up `import hyperspy.api as hs`
#1480 motivates us to reduce the time required to `import hyperspy.api as hs`.

This PR aims to use `lazyasd` to lazy import a number of modules so the imports are deferred to when they are actually needed, rather than all at once. I tested these by temporarily introducing a `raise ValueError` in the `__init__.py` files of the modules below, and working through the hyperspy code until it does not raise an error on `import hyperspy.api`.

This PR reduces `hyperspy.api` import time **from 4 sec to 1.7 sec** on my computer.

### Lazily import:
- [x] pint
- [x] sympy
- [x] skimage
- [x] dask
- [x] numba
- [x] hyperspy.io_plugins
- [x] sklearn
- [x] hyperspy-guis

Most packages were straightforward. I've detailed some of the more interesting cases here:
- numba:
The @numba.jit() decorator imports numba. Having had a [chat on the numba forums](https://numba.discourse.group/t/lazily-importing-jitted-functions-without-importing-numba/487), we arrived at a simple wrapping approach (see link).
- pint:
Calling `pint.UnitRegistry()` is *slow* and should be avoided! It takes about 120ms. To generally speed things up, I call it *lazily* once in `axes.py`, and import it from there to all other uses of the function (renamed the variable everywhere to `_ureg` - happy to choose a different name).
- GUIs:
`try/except ImportError` strangely doesn't catch the ModuleNotFoundError raised when `hyperspy_gui_***` isn't present. To get around this, I check with importlib to see if it is present first.
- io_plugins:
I use the same lazy import on the io_plugins, preventing a large chunk of the hyperspy code (io) from being called until needed.

### Progress of the PR
- [x] Change implemented (can be split into several points),
- [x] update dev user guide 
- [ ] add entry to `CHANGES.rst` (if appropriate),
- [x] add tests,
- [x] ready for review.

### Minimal example of the bug fix or the new feature
To test this in the notebook, first checkout the RELEASE_next_minor branch, and then in the notebook type:
```python
%%time
import hyperspy.api as hs
```
Then switch to this PR, restart the kernel and run the above again.

### Some further thoughts
- I can try the same for scipy, but that's a bigger job, and likely earning another 200-300 ms.
- `pkg_resources` is about 180 ms, and is a dependency of at least the hyperspy extension code and `prettytable`
