### PR TITLE
Non-uniform-axes - fix attributes in axes type conversion

### DIFF
--- a/hyperspy/axes.py
+++ b/hyperspy/axes.py
@@ -809,6 +809,7 @@ class FunctionalDataAxis(BaseDataAxis):
         self.__init__(**d, axis=self.axis)
         del self._expression
         del self._function
+        #del self.x
         self.remove_trait('x')
 
     def crop(self, start=None, end=None):
@@ -1086,11 +1087,11 @@ class UniformDataAxis(BaseDataAxis, UnitConversion):
         super()._init_trait_listeners()
         self.__class__ = DataAxis
         d["_type"] = 'DataAxis'
-        self.remove_trait('scale')
-        self.remove_trait('offset')
+        #self.remove_trait('scale')
+        #self.remove_trait('offset')
         self.__init__(**d, axis=self.axis)
-        #del self.scale
-        #del self.offset
+        del self.scale
+        del self.offset
 
 def _serpentine_iter(shape):
     '''Similar to np.ndindex, but yields indices

--- a/hyperspy/axes.py
+++ b/hyperspy/axes.py
@@ -723,7 +723,6 @@ class DataAxis(BaseDataAxis):
 
 
 class FunctionalDataAxis(BaseDataAxis):
-    x = t.Instance(BaseDataAxis)
     def __init__(self,
                  expression,
                  x=None,
@@ -734,6 +733,8 @@ class FunctionalDataAxis(BaseDataAxis):
                  size=t.Undefined,
                  **parameters):
         super().__init__(index_in_array, name, units, navigate, **parameters)
+        # These trait needs to added dynamically to be removed when necessary
+        self.add_trait("x", t.Instance(BaseDataAxis))
         if x is None:
             if size is t.Undefined:
                 raise ValueError("Please provide either `x` or `size`.")
@@ -809,7 +810,6 @@ class FunctionalDataAxis(BaseDataAxis):
         self.__init__(**d, axis=self.axis)
         del self._expression
         del self._function
-        #del self.x
         self.remove_trait('x')
 
     def crop(self, start=None, end=None):
@@ -861,9 +861,6 @@ class FunctionalDataAxis(BaseDataAxis):
 
 
 class UniformDataAxis(BaseDataAxis, UnitConversion):
-    scale = t.CFloat(1)
-    offset = t.CFloat(0)
-    size = t.CInt(0)
     def __init__(self,
                  index_in_array=None,
                  name=t.Undefined,
@@ -880,6 +877,9 @@ class UniformDataAxis(BaseDataAxis, UnitConversion):
             navigate=navigate,
             **kwargs
             )
+        # These traits need to added dynamically to be removed when necessary
+        self.add_trait("scale", t.CFloat)
+        self.add_trait("offset", t.CFloat)
         self.scale = scale
         self.offset = offset
         self.size = size
@@ -1075,10 +1075,10 @@ class UniformDataAxis(BaseDataAxis, UnitConversion):
             d["name"] = name
         d.update(kwargs)
         this_kwargs = self.get_axis_dictionary()
-        self.__class__ = FunctionalDataAxis
-        d["_type"] = 'FunctionalDataAxis'
         self.remove_trait('scale')
         self.remove_trait('offset')
+        self.__class__ = FunctionalDataAxis
+        d["_type"] = 'FunctionalDataAxis'
         self.__init__(expression=expression, x=UniformDataAxis(**this_kwargs), **d)
         self.axes_manager = axes_manager
 
@@ -1087,11 +1087,10 @@ class UniformDataAxis(BaseDataAxis, UnitConversion):
         super()._init_trait_listeners()
         self.__class__ = DataAxis
         d["_type"] = 'DataAxis'
-        #self.remove_trait('scale')
-        #self.remove_trait('offset')
+        self.remove_trait('scale')
+        self.remove_trait('offset')
         self.__init__(**d, axis=self.axis)
-        del self.scale
-        del self.offset
+
 
 def _serpentine_iter(shape):
     '''Similar to np.ndindex, but yields indices
@@ -1495,7 +1494,7 @@ class AxesManager(t.HasTraits):
                     assert len(first_indices) == self.navigation_dimension
             except TypeError as e:
                 raise TypeError(
-                    f"Each set of indices in the iterpath should be an iterable, e.g. `(0,)` or `(0,0,0)`. " 
+                    f"Each set of indices in the iterpath should be an iterable, e.g. `(0,)` or `(0,0,0)`. "
                     f"The first entry currently looks like: `{first_indices}`, and does not satisfy this requirement."
                     ) from e
             except AssertionError as e:
@@ -2134,9 +2133,9 @@ class AxesManager(t.HasTraits):
         %s
         """
 
-class GeneratorLen: 
+class GeneratorLen:
     """Helper class for creating a generator-like object with a known length.
-    Useful when giving a generator as input to the AxesManager iterpath, so that the 
+    Useful when giving a generator as input to the AxesManager iterpath, so that the
     length is known for the progressbar.
 
     Found at: https://stackoverflow.com/questions/7460836/how-to-lengenerator/7460986
@@ -2152,7 +2151,7 @@ class GeneratorLen:
         self.gen = gen
         self.length = length
 
-    def __len__(self): 
+    def __len__(self):
         return self.length
 
     def __iter__(self):

--- a/hyperspy/axes.py
+++ b/hyperspy/axes.py
@@ -807,6 +807,9 @@ class FunctionalDataAxis(BaseDataAxis):
         d["_type"] = 'DataAxis'
         self.__class__ = DataAxis
         self.__init__(**d, axis=self.axis)
+        del self._expression
+        del self._function
+        self.remove_trait('x')
 
     def crop(self, start=None, end=None):
         """Crop the axis in place.
@@ -1073,14 +1076,21 @@ class UniformDataAxis(BaseDataAxis, UnitConversion):
         this_kwargs = self.get_axis_dictionary()
         self.__class__ = FunctionalDataAxis
         d["_type"] = 'FunctionalDataAxis'
+        self.remove_trait('scale')
+        self.remove_trait('offset')
         self.__init__(expression=expression, x=UniformDataAxis(**this_kwargs), **d)
         self.axes_manager = axes_manager
 
     def convert_to_non_uniform_axis(self):
         d = super().get_axis_dictionary()
+        super()._init_trait_listeners()
         self.__class__ = DataAxis
         d["_type"] = 'DataAxis'
+        self.remove_trait('scale')
+        self.remove_trait('offset')
         self.__init__(**d, axis=self.axis)
+        #del self.scale
+        #del self.offset
 
 def _serpentine_iter(shape):
     '''Similar to np.ndindex, but yields indices

--- a/hyperspy/axes.py
+++ b/hyperspy/axes.py
@@ -1084,7 +1084,6 @@ class UniformDataAxis(BaseDataAxis, UnitConversion):
 
     def convert_to_non_uniform_axis(self):
         d = super().get_axis_dictionary()
-        super()._init_trait_listeners()
         self.__class__ = DataAxis
         d["_type"] = 'DataAxis'
         self.remove_trait('scale')

--- a/hyperspy/tests/axes/test_data_axis.py
+++ b/hyperspy/tests/axes/test_data_axis.py
@@ -417,6 +417,8 @@ class TestUniformDataAxis:
         assert self.axis.low_value == 10
         assert self.axis.high_value == 10 + 0.1 * 9
         np.testing.assert_allclose(self.axis.axis, axis)
+        with pytest.raises(AttributeError):
+            self.axis.scale
 
     @pytest.mark.parametrize("use_indices", (False, True))
     def test_crop(self, use_indices):

--- a/hyperspy/tests/axes/test_data_axis.py
+++ b/hyperspy/tests/axes/test_data_axis.py
@@ -211,6 +211,21 @@ class TestFunctionalDataAxis:
         np.testing.assert_almost_equal(axis.axis[0], 4.)
         np.testing.assert_almost_equal(axis.axis[-1], 64.)
 
+    def test_convert_to_non_uniform_axis(self):
+        axis = np.copy(self.axis.axis)
+        self.axis.convert_to_non_uniform_axis()
+        assert isinstance(self.axis, DataAxis)
+        assert self.axis.size == 10
+        assert self.axis.low_value == 0
+        assert self.axis.high_value == 81
+        np.testing.assert_allclose(self.axis.axis, axis)
+        with pytest.raises(AttributeError):
+            self.axis._expression
+        with pytest.raises(AttributeError):
+            self.axis._function
+        with pytest.raises(AttributeError):
+            self.axis.x
+
 
 class TestReciprocalDataAxis:
 
@@ -417,6 +432,23 @@ class TestUniformDataAxis:
         assert self.axis.low_value == 10
         assert self.axis.high_value == 10 + 0.1 * 9
         np.testing.assert_allclose(self.axis.axis, axis)
+        with pytest.raises(AttributeError):
+            self.axis.offset
+        with pytest.raises(AttributeError):
+            self.axis.scale
+
+    def test_convert_to_functional_data_axis(self):
+        axis = np.copy(self.axis.axis)
+        self.axis.convert_to_functional_data_axis(expression = 'x**2')
+        assert isinstance(self.axis, FunctionalDataAxis)
+        assert self.axis.size == 10
+        assert self.axis.low_value == 10**2
+        assert self.axis.high_value == (10 + 0.1 * 9)**2
+        assert self.axis._expression == 'x**2'
+        assert isinstance(self.axis.x, UniformDataAxis)
+        np.testing.assert_allclose(self.axis.axis, axis**2)
+        with pytest.raises(AttributeError):
+            self.axis.offset
         with pytest.raises(AttributeError):
             self.axis.scale
 


### PR DESCRIPTION
### Description of the change
I realized that the conversion function between different axes types (e.g. `convert_to_non_uniform_axis`) do not properly delete the attributes of the previous axes type. Only the dictionary is updated, but the attributes are still present.

1. uniform data axis -> functional or non-uniform data axis: `scale` and `offset` should be removed
2. functional data axis -> non-uniform data axis: `_expression`, `_function`, and `x` should be removed

Also, added missing tests for axes conversion functions.

### Progress of the PR
- [x] Change implemented for case 1,
- [x] Change implemented for case 2,
- [x] add tests,
- [x] ready for review.

### Minimal example of the bug fix or the new feature
```python
import hyperspy.api as hs
import numpy as np
s = hs.signals.Signal1D(np.arange(10))
s.axes_manager.signal_axes[0].convert_to_functional_data_axis(expression='x**2')
s.scale #should fail
s.axes_manager.signal_axes[0].convert_to_non_uniform_axis()
s._expression #should fail
s.x #should fail
```