### PR TITLE
added support for lazy loading DPC and FFT

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -21,6 +21,7 @@ RELEASE_next_patch (Unreleased)
 * Use dask chunking when saving lazy signal instead of rechunking and leave the user to decide what is the suitable chunking (`#2629 <https://github.com/hyperspy/hyperspy/pull/2629>`_)
 * Fix incorrect chunksize when saving EMD NCEM file and specifying chunks (`#2629 <https://github.com/hyperspy/hyperspy/pull/2629>`_)
 * Fix ``find_peaks`` GUIs call with laplacian/difference of gaussian methods (`#2622 <https://github.com/hyperspy/hyperspy/issues/2622>`_ and `#2647 <https://github.com/hyperspy/hyperspy/pull/2647>`_)
+* Added lazy reading support for FFT and DPC datasets in FEI emd datasets (`#2651 <https://github.com/hyperspy/hyperspy/pull/2651>`_).
 
 
 Changelog

--- a/doc/user_guide/io.rst
+++ b/doc/user_guide/io.rst
@@ -941,13 +941,11 @@ the data size in memory.
 
     FFTs made in Velox are loaded in as-is as a HyperSpy ComplexSignal2D object.
     The FFT is not centered and only positive frequencies are stored in the file.
-    Lazy reading of these datasets is not supported. Making FFTs with HyperSpy
-    from the respective image datasets is recommended.
+    Making FFTs with HyperSpy from the respective image datasets is recommended.
 
 .. note::
 
-    DPC data is loaded in as a HyperSpy ComplexSignal2D object. Lazy reading of these
-    datasets is not supported.
+    DPC data is loaded in as a HyperSpy ComplexSignal2D object.
 
 .. note::
 

--- a/hyperspy/io_plugins/emd.py
+++ b/hyperspy/io_plugins/emd.py
@@ -1092,15 +1092,18 @@ class FeiEMDReader(object):
                      ('imagFloat', '<f4')]
         if h5data.dtype == fft_dtype or h5data.dtype == dpc_dtype:
             _logger.debug("Found an FFT or DPC, loading as Complex2DSignal")
-            if self.lazy:
-                _logger.warning("Lazy not supported for FFT or DPC")
-            data = np.empty(h5data.shape, h5data.dtype)
-            h5data.read_direct(data)
             real = h5data.dtype.descr[0][0]
             imag = h5data.dtype.descr[1][0]
-            data = data[real] + 1j * data[imag]
-            # Set the axes in frame, y, x order
-            data = np.rollaxis(data, axis=2)
+            if self.lazy:
+                data = da.from_array(h5data)
+                data = data[real] + 1j * data[imag]
+                data = da.rollaxis(data, axis=2)
+            else:
+                data = np.empty(h5data.shape, h5data.dtype)
+                h5data.read_direct(data)
+                data = data[real] + 1j * data[imag]
+                # Set the axes in frame, y, x order
+                data = np.rollaxis(data, axis=2)
         else:
             if self.lazy:
                 data = da.transpose(

--- a/hyperspy/io_plugins/emd.py
+++ b/hyperspy/io_plugins/emd.py
@@ -1095,9 +1095,9 @@ class FeiEMDReader(object):
             real = h5data.dtype.descr[0][0]
             imag = h5data.dtype.descr[1][0]
             if self.lazy:
-                data = da.from_array(h5data)
+                data = da.from_array(h5data, chunks=h5data.chunks)
                 data = data[real] + 1j * data[imag]
-                data = da.rollaxis(data, axis=2)
+                data = da.transpose(data, axes=[2, 0, 1])
             else:
                 data = np.empty(h5data.shape, h5data.dtype)
                 h5data.read_direct(data)

--- a/hyperspy/tests/io/test_emd.py
+++ b/hyperspy/tests/io/test_emd.py
@@ -688,6 +688,9 @@ def test_fei_complex_loading():
     signal = load(os.path.join(my_path, 'emd_files', 'fei_example_complex_fft.emd'))
     assert isinstance(signal, ComplexSignal2D)
 
+def test_fei_complex_loading_lazy():
+    signal = load(os.path.join(my_path, 'emd_files', 'fei_example_complex_fft.emd'), lazy=True)
+    assert isinstance(signal, ComplexSignal2D)
 
 def test_fei_no_frametime():
     signal = load(os.path.join(my_path, 'emd_files', 'fei_example_tem_stack.emd'))


### PR DESCRIPTION
### Description of the change
in #2564 and #2567 I added support for loading DPC and FFT signals from the FEI .emd format but didn't know how to support lazy reading. It's a tiny gap but after learning a bit about Dask this should now be resolved with this PR.

### Progress of the PR
- [x] Change implemented (can be split into several points),
- [x] update docstring (if appropriate),
- [x] update user guide (if appropriate),
- [x] add entry to `CHANGES.rst` (if appropriate),
- [x] add tests,
- [x] ready for review.

