### PR TITLE
Setting signal range of model with negative axis scales

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -26,6 +26,8 @@ RELEASE_next_patch (Unreleased)
 * Improve error message when initialising SpanROI with left >= right (`#2604 <https://github.com/hyperspy/hyperspy/pull/2604>`_)
 * Fix various bugs with `CircleWidget` and `Line2DWidget` (`#2625 <https://github.com/hyperspy/hyperspy/pull/2625>`_)
 * Allow running the test suite without the pytest-mpl plugin (`#2624 <https://github.com/hyperspy/hyperspy/pull/2624>`_)
+* Fix setting signal range of model with negative axis scales (`#2656 <https://github.com/hyperspy/hyperspy/pull/2656>`_)
+
 
 Changelog
 *********

--- a/hyperspy/axes.py
+++ b/hyperspy/axes.py
@@ -564,26 +564,42 @@ class DataAxis(t.HasTraits, UnitConversion):
     def value_range_to_indices(self, v1, v2):
         """Convert the given range to index range.
 
-        When an out of the axis limits, the endpoint is used instead.
+        When a value is out of the axis limits, the endpoint is used instead.
+        `v1` must be preceding `v2` in the axis values
+          - if the axis scale is positive, it means v1 < v2
+          - if the axis scale is negative, it means v1 > v2
 
         Parameters
         ----------
         v1, v2 : float
-            The end points of the interval in the axis units. v2 must be
-            greater than v1.
+            The end points of the interval in the axis units.
 
+        Returns
+        -------
+        i2, i2 : float
+            The indices corresponding to the interval [v1, v2]
         """
-        if v1 is not None and v2 is not None and v1 > v2:
-            raise ValueError("v2 must be greater than v1.")
+        i1, i2 = 0, self.size - 1
+        error_message = "Wrong order of the values: for axis with"
+        if self.scale > 0:
+            if v1 is not None and v2 is not None and v1 > v2:
+                raise ValueError(f"{error_message} positive scale, v2 ({v2}) "
+                                 f"must be greater than v1 ({v1}).")
 
-        if v1 is not None and self.low_value < v1 <= self.high_value:
-            i1 = self.value2index(v1)
+            if v1 is not None and self.low_value < v1 <= self.high_value:
+                i1 = self.value2index(v1)
+            if v2 is not None and self.high_value > v2 >= self.low_value:
+                i2 = self.value2index(v2)
         else:
-            i1 = 0
-        if v2 is not None and self.high_value > v2 >= self.low_value:
-            i2 = self.value2index(v2)
-        else:
-            i2 = self.size - 1
+            if v1 is not None and v2 is not None and v1 < v2:
+                raise ValueError(f"{error_message} negative scale: v1 ({v1}) "
+                                 f"must be greater than v2 ({v2}).")
+
+            if v1 is not None and self.high_value > v1 >= self.low_value:
+                i1 = self.value2index(v1)
+            if v2 is not None and self.low_value < v2 <= self.high_value:
+                i2 = self.value2index(v2)
+
         return i1, i2
 
     def update_from(self, axis, attributes=["scale", "offset", "units"]):

--- a/hyperspy/models/model1d.py
+++ b/hyperspy/models/model1d.py
@@ -456,6 +456,17 @@ class Model1D(BaseModel):
         self.channel_switches[i1:i2] = True
         self.update_plot()
 
+    def _parse_signal_range_values(self, x1=None, x2=None):
+        """Parse signal range values to be used by the `set_signal_range`,
+        `add_signal_range` and `remove_signal_range` and return sorted indices
+        """
+        try:
+            x1, x2 = x1
+        except TypeError:
+            # It was not a ROI, we carry on
+            pass
+        return self.axis.value_range_to_indices(x1, x2)
+
     @interactive_range_selector
     def set_signal_range(self, x1=None, x2=None):
         """Use only the selected spectral range defined in its own units in the
@@ -463,17 +474,10 @@ class Model1D(BaseModel):
 
         Parameters
         ----------
-        E1 : None or float
-        E2 : None or float
-
+        x1, x2 : None or float
         """
-        try:
-            x1, x2 = x1
-        except TypeError:
-            # It was not a ROI, we carry on
-            pass
-        i1, i2 = self.axis.value_range_to_indices(x1, x2)
-        self._set_signal_range_in_pixels(i1, i2)
+        indices = self._parse_signal_range_values(x1, x2)
+        self._set_signal_range_in_pixels(*indices)
 
     def _remove_signal_range_in_pixels(self, i1=None, i2=None):
         """Removes the data in the given range from the data range that
@@ -481,8 +485,7 @@ class Model1D(BaseModel):
 
         Parameters
         ----------
-        x1 : None or float
-        x2 : None or float
+        i1, i2 : None or integer
         """
         if i2 is not None:
             i2 += 1
@@ -496,17 +499,10 @@ class Model1D(BaseModel):
 
         Parameters
         ----------
-        x1 : None or float
-        x2 : None or float
-
+        x1, x2 : None or float
         """
-        try:
-            x1, x2 = x1
-        except TypeError:
-            # It was not a ROI, we carry on
-            pass
-        i1, i2 = self.axis.value_range_to_indices(x1, x2)
-        self._remove_signal_range_in_pixels(i1, i2)
+        indices = self._parse_signal_range_values(x1, x2)
+        self._remove_signal_range_in_pixels(*indices)
 
     def reset_signal_range(self):
         """Resets the data range"""
@@ -518,8 +514,7 @@ class Model1D(BaseModel):
 
         Parameters
         ----------
-        x1 : None or float
-        x2 : None or float
+        i1, i2 : None or integer
         """
         if i2 is not None:
             i2 += 1
@@ -533,17 +528,10 @@ class Model1D(BaseModel):
 
         Parameters
         ----------
-        x1 : None or float
-        x2 : None or float
-
+        x1, x2 : None or float
         """
-        try:
-            x1, x2 = x1
-        except TypeError:
-            # It was not a ROI, we carry on
-            pass
-        i1, i2 = self.axis.value_range_to_indices(x1, x2)
-        self._add_signal_range_in_pixels(i1, i2)
+        indices = self._parse_signal_range_values(x1, x2)
+        self._add_signal_range_in_pixels(*indices)
 
     def reset_the_signal_range(self):
         self.channel_switches[:] = True

--- a/hyperspy/tests/axes/test_data_axis.py
+++ b/hyperspy/tests/axes/test_data_axis.py
@@ -25,35 +25,54 @@ import pytest
 
 from hyperspy.axes import DataAxis
 
-
-class TestDataAxis:
+class TestDataAxisValueRangeToIndices:
 
     def setup_method(self, method):
         self.axis = DataAxis(size=10, scale=0.1, offset=10)
 
     def test_value_range_to_indices_in_range(self):
-        assert (
-            self.axis.value_range_to_indices(
-                10.1, 10.8) == (1, 8))
+        assert self.axis.value_range_to_indices(10.1, 10.8) == (1, 8)
 
     def test_value_range_to_indices_endpoints(self):
-        assert (
-            self.axis.value_range_to_indices(
-                10, 10.9) == (0, 9))
+        assert self.axis.value_range_to_indices(10, 10.9) == (0, 9)
 
     def test_value_range_to_indices_out(self):
-        assert (
-            self.axis.value_range_to_indices(
-                9, 11) == (0, 9))
+        assert self.axis.value_range_to_indices(9, 11) == (0, 9)
 
     def test_value_range_to_indices_None(self):
-        assert (
-            self.axis.value_range_to_indices(
-                None, None) == (0, 9))
+        assert self.axis.value_range_to_indices(None, None) == (0, 9)
 
     def test_value_range_to_indices_v1_greater_than_v2(self):
         with pytest.raises(ValueError):
             self.axis.value_range_to_indices(2, 1)
+
+
+class TestDataAxisValueRangeToIndicesNegativeScale:
+
+    def setup_method(self, method):
+        self.axis = DataAxis(size=10, scale=-0.1, offset=10)
+
+    def test_value_range_to_indices_in_range(self):
+        assert self.axis.value_range_to_indices(9.9, 9.2) == (1, 8)
+
+    def test_value_range_to_indices_endpoints(self):
+        assert self.axis.value_range_to_indices(10, 9.1) == (0, 9)
+
+    def test_value_range_to_indices_out(self):
+        assert self.axis.value_range_to_indices(11, 9) == (0, 9)
+
+    def test_value_range_to_indices_None(self):
+        assert self.axis.value_range_to_indices(None, None) == (0, 9)
+
+    def test_value_range_to_indices_v1_greater_than_v2(self):
+        with pytest.raises(ValueError):
+            self.axis.value_range_to_indices(1, 2)
+
+
+class TestDataAxis:
+
+    def setup_method(self, method):
+        self.axis = DataAxis(size=10, scale=0.1, offset=10)
 
     def test_deepcopy(self):
         ac = copy.deepcopy(self.axis)

--- a/hyperspy/tests/component/test_gaussian.py
+++ b/hyperspy/tests/component/test_gaussian.py
@@ -62,6 +62,23 @@ def test_estimate_parameters_binned(only_current, binned, lazy):
     assert abs(g2.sigma.value - g1.sigma.value) <= 0.1
 
 
+def test_estimate_parameters_negative_scale():
+    s = Signal1D(np.empty((100,)))
+    axis = s.axes_manager.signal_axes[0]
+    axis.scale = -1
+    axis.offset = 100
+    g1 = Gaussian(50015.156, 15/sigma2fwhm, 50)
+    s.data = g1.function(axis.axis)
+
+    g2 = Gaussian()
+    with pytest.raises(ValueError):
+        g2.estimate_parameters(s, 40, 60)
+    assert g2.estimate_parameters(s, 90, 10)
+    np.testing.assert_allclose(g1.A.value, g2.A.value)
+    assert abs(g2.centre.value - g1.centre.value) <= 1e-3
+    assert abs(g2.sigma.value - g1.sigma.value) <= 0.1
+
+
 @pytest.mark.parametrize(("lazy"), (True, False))
 @pytest.mark.parametrize(("binned"), (True, False))
 def test_function_nd(binned, lazy):

--- a/hyperspy/tests/model/test_model.py
+++ b/hyperspy/tests/model/test_model.py
@@ -826,3 +826,32 @@ def test_deprecated_private_functions():
 
     with pytest.warns(VisibleDeprecationWarning, match=r".* has been deprecated"):
         m.set_mpfit_parameters_info()
+
+
+class TestSignalRange:
+    def setup_method(self, method):
+        s = hs.signals.Signal1D(np.random.rand(10, 10, 20))
+        s.axes_manager[-1].offset = 100
+        m = s.create_model()
+        self.s = s
+        self.m = m
+
+    def test_parse_value(self):
+        m = self.m
+        assert m._parse_signal_range_values(105, 110) == (5, 10)
+        with pytest.raises(ValueError):
+            m._parse_signal_range_values(89, 85)
+
+    def test_parse_value_negative_scale(self):
+        m = self.m
+        s = self.s
+        s.axes_manager[-1].scale = -1
+        assert m._parse_signal_range_values(89, 85) == (11, 15)
+        with pytest.raises(ValueError):
+            m._parse_signal_range_values(85, 89)
+        assert m._parse_signal_range_values(89, 20) == (11, 19)
+
+    def test_parse_roi(self):
+        m = self.m
+        roi = hs.roi.SpanROI(105, 110)
+        assert m._parse_signal_range_values(roi) == (5, 10)


### PR DESCRIPTION
This PR doesn't cover the issue with ROI and negative axis scales (https://github.com/hyperspy/hyperspy/issues/887).

### Progress of the PR
- [x] Allow setting/adding/removing signal range of model with negative axis scales,
- [x] update docstring (if appropriate),
- [x] add entry to `CHANGES.rst` (if appropriate),
- [x] add tests,
- [x] ready for review.

### Minimal example of the bug fix or the new feature
```python
import hyperspy.api as hs
import numpy as np

s = hs.signals.Signal1D(np.arange(100))
axis = s.axes_manager.signal_axes[0]
axis.scale = -1
axis.offset = 100

m = s.create_model()
p = hs.model.components1D.Polynomial(legacy=False, order=1)
m.append(p)
m.plot()
m.remove_signal_range(60, 70)
```

