### PR TITLE
Plot scalebar when the axis scale have different sign

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -26,6 +26,7 @@ RELEASE_next_patch (Unreleased)
 * Improve error message when initialising SpanROI with left >= right (`#2604 <https://github.com/hyperspy/hyperspy/pull/2604>`_)
 * Fix various bugs with `CircleWidget` and `Line2DWidget` (`#2625 <https://github.com/hyperspy/hyperspy/pull/2625>`_)
 * Allow running the test suite without the pytest-mpl plugin (`#2624 <https://github.com/hyperspy/hyperspy/pull/2624>`_)
+* Plot scalebar when the axis scale have different sign, fixes `#2557 <https://github.com/hyperspy/hyperspy/issues/2557>`_ (#2657 `<https://github.com/hyperspy/hyperspy/pull/2657>`_)
 
 Changelog
 *********

--- a/hyperspy/drawing/image.py
+++ b/hyperspy/drawing/image.py
@@ -201,7 +201,8 @@ class ImagePlot(BlittedFigure):
         xaxis = self.xaxis
         yaxis = self.yaxis
 
-        if (xaxis.units == yaxis.units) and (xaxis.scale == yaxis.scale):
+        if ((xaxis.units == yaxis.units) and
+                (abs(xaxis.scale) == abs(yaxis.scale))):
             self._auto_scalebar = True
             self._auto_axes_ticks = False
             self.pixel_units = xaxis.units

--- a/hyperspy/tests/drawing/test_plot_signal2d.py
+++ b/hyperspy/tests/drawing/test_plot_signal2d.py
@@ -567,7 +567,6 @@ def test_plot_scale_different_sign():
     N = 10
     s = hs.signals.Signal2D(np.arange(N**2).reshape([10]*2))
     s2 = s.isig[:, ::-1]
-    s2.axes_manager[0]
     s2.axes_manager[0].scale = 1.0
     s2.axes_manager[1].scale = -1.0
 

--- a/hyperspy/tests/drawing/test_plot_signal2d.py
+++ b/hyperspy/tests/drawing/test_plot_signal2d.py
@@ -561,3 +561,16 @@ def test_plot_autoscale_data_changed(autoscale):
     else:
         np.testing.assert_allclose(imf._vmin, _vmin)
         np.testing.assert_allclose(imf._vmax, _vmax)
+
+
+def test_plot_scale_different_sign():
+    N = 10
+    s = hs.signals.Signal2D(np.arange(N**2).reshape([10]*2))
+    s2 = s.isig[:, ::-1]
+    s2.axes_manager[0]
+    s2.axes_manager[0].scale = 1.0
+    s2.axes_manager[1].scale = -1.0
+
+    s2.plot()
+    assert s2._plot.signal_plot.pixel_units is not None
+    assert s2._plot.signal_plot.scalebar is True


### PR DESCRIPTION
Fixes #2557.

### Progress of the PR
- [x] Plot scalebar for signals with different axis scale,
- [x] add entry to `CHANGES.rst` (if appropriate),
- [x] add tests,
- [x] ready for review.

### Minimal example of the bug fix or the new feature
```python
import hyperspy.api as hs
import numpy as np

N = 10
s = hs.signals.Signal2D(np.arange(N**2).reshape([10]*2))
s2 = s.isig[:, ::-1]
s2.plot()
```
Now the scale is displayed.

