### PR TITLE
Cupy support

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -63,15 +63,15 @@ jobs:
           python --version
           pip --version
 
-      - name: Install
-        shell: bash
-        run: |
-          pip install ${{ env.PIP_ARGS }} .'${{ matrix.PIP_SELECTOR }}'
-
       - name: Install oldest supported version
         if: ${{ matrix.OLDEST_SUPPORTED_VERSION }}
         run: |
           pip install ${{ matrix.DEPENDENCIES }}
+
+      - name: Install
+        shell: bash
+        run: |
+          pip install ${{ env.PIP_ARGS }} .'${{ matrix.PIP_SELECTOR }}'
 
       - name: Pip list
         run: |

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -245,7 +245,8 @@ towncrier_draft_working_directory = ".."
 
 
 # Add the hyperspy website to the intersphinx domains
-intersphinx_mapping = {'python': ('https://docs.python.org/3', None),
+intersphinx_mapping = {'cupy': ('https://docs.cupy.dev/en/stable', None),
+                       'python': ('https://docs.python.org/3', None),
                        'h5py': ('https://docs.h5py.org/en/stable', None),
                        'hyperspyweb': ('https://hyperspy.org/', None),
                        'matplotlib': ('https://matplotlib.org', None),

--- a/doc/user_guide/big_data.rst
+++ b/doc/user_guide/big_data.rst
@@ -264,6 +264,40 @@ instead:
     <LazySignal2D, title: , dimensions: (200, 200|512, 512)>
     >>> s.plot(navigator='slider')
 
+.. versionadded:: 1.7
+
+.. _big_data.gpu:
+
+GPU support
+-----------
+
+Lazy data processing using GPU requires setting the dask scheduler
+and explicitely transfering the data to the GPU.
+
+.. code-block:: python
+
+    >>> from dask_cuda import LocalCUDACluster
+    >>> from dask.distributed import Client
+    >>> import cupy as cp
+    >>> cluster = LocalCUDACluster()
+    >>> client = Client(cluster)
+    >>> # Create a dask array
+    >>> data = da.random.random(size=(20, 20, 100, 100))
+    >>> print(data)
+    ... dask.array<random_sample, shape=(20, 20, 100, 100), dtype=float64,
+    ... chunksize=(20, 20, 100, 100), chunktype=numpy.ndarray>
+    >>> # convert the dask chunks from numpy array to cupy array
+    >>> data = data.map_blocks(cp.asarray)
+    >>> print(data)
+    ... dask.array<random_sample, shape=(20, 20, 100, 100), dtype=float64,
+    ... chunksize=(20, 20, 100, 100), chunktype=cupy.ndarray>
+    >>> # Create the signal
+    >>> s = hs.signals.Signal2D(data).as_lazy()
+
+.. note::
+    See the dask blog on `Richardson Lucy (RL) deconvolution <https://blog.dask.org/2020/11/12/deconvolution>`_
+    for an example of lazy processing on GPU using dask and cupy
+
 
 .. _FitBigData-label:
 

--- a/doc/user_guide/big_data.rst
+++ b/doc/user_guide/big_data.rst
@@ -271,16 +271,27 @@ instead:
 GPU support
 -----------
 
-Lazy data processing using GPU requires setting the dask scheduler
-and explicitely transfering the data to the GPU.
+Lazy data processing on GPUs requires explicitly transferring the data to the
+GPU.
+
+On linux, it is recommended to use the
+`dask_cuda <https://docs.rapids.ai/api/dask-cuda/stable/index.html>`_ library 
+(not supported on windows) to manage the dask scheduler. As for CPU lazy
+processing, if the dask scheduler is not specified, the default scheduler
+will be used.
 
 .. code-block:: python
 
     >>> from dask_cuda import LocalCUDACluster
     >>> from dask.distributed import Client
-    >>> import cupy as cp
     >>> cluster = LocalCUDACluster()
     >>> client = Client(cluster)
+
+.. code-block:: python
+
+    >>> import hyperspy.api as hs
+    >>> import cupy as cp
+    >>> import dask.array as da
     >>> # Create a dask array
     >>> data = da.random.random(size=(20, 20, 100, 100))
     >>> print(data)
@@ -296,7 +307,7 @@ and explicitely transfering the data to the GPU.
 
 .. note::
     See the dask blog on `Richardson Lucy (RL) deconvolution <https://blog.dask.org/2020/11/12/deconvolution>`_
-    for an example of lazy processing on GPU using dask and cupy
+    for an example of lazy processing on GPUs using dask and cupy
 
 
 .. _FitBigData-label:

--- a/doc/user_guide/signal.rst
+++ b/doc/user_guide/signal.rst
@@ -1875,8 +1875,8 @@ GPU support
 GPU processing is supported thanks to the numpy dispatch mechanism of array functions
 - read `NEP-18 <https://numpy.org/neps/nep-0018-array-function-protocol.html>`_
 and `NEP-35 <https://numpy.org/neps/nep-0035-array-creation-dispatch-with-array-function.html>`_
-for more information. It means that most HyperSpy functions will work on GPU if the data is a
-:py:class:`cupy.ndarray` and that the required functions are
+for more information. It means that most HyperSpy functions will work on a GPU
+if the data is a :py:class:`cupy.ndarray` and that the required functions are
 implemented in ``cupy``.
 
 .. note::
@@ -1892,7 +1892,7 @@ implemented in ``cupy``.
     >>> type(s.data)
     ... cupy._core.core.ndarray
 
-Two convenience methods are avaiable to transfer data to or from the GPU:
+Two convenience methods are available to transfer data to or from the GPU:
 
 - :py:meth:`~.signal.BaseSignal.to_cpu`
 - :py:meth:`~.signal.BaseSignal.to_gpu`

--- a/doc/user_guide/signal.rst
+++ b/doc/user_guide/signal.rst
@@ -1886,15 +1886,16 @@ implemented in ``cupy``.
 .. code-block:: python
 
     >>> import cupy as cp
-    >>> # Create a cupy array (on GPU)
+    >>> # Create a cupy array (on GPU device)
     >>> data = cp.random.random(size=(20, 20, 100, 100))
     >>> s = hs.signals.Signal2D(data)
     >>> type(s.data)
     ... cupy._core.core.ndarray
 
-Two convenience methods are available to transfer data to or from the GPU:
+Two convenience methods are available to transfer data between the host and
+the (GPU) device memory:
 
-- :py:meth:`~.signal.BaseSignal.to_cpu`
-- :py:meth:`~.signal.BaseSignal.to_gpu`
+- :py:meth:`~.signal.BaseSignal.to_host`
+- :py:meth:`~.signal.BaseSignal.to_device`
 
 For lazy processing, see the :ref:`corresponding section<big_data.gpu>`.

--- a/doc/user_guide/signal.rst
+++ b/doc/user_guide/signal.rst
@@ -84,7 +84,7 @@ This also applies to the :py:attr:`~.signal.BaseSignal.metadata`.
     └── Signal
 	└── signal_type =
 
-Instead of using a list of *axes dictionaries* ``[dict0, dict1]`` during signal 
+Instead of using a list of *axes dictionaries* ``[dict0, dict1]`` during signal
 initialization, you can also pass a list of *axes objects*: ``[axis0, axis1]``.
 
 
@@ -292,7 +292,7 @@ For example, a numpy ragged array can be created as follow:
        >>> arr = np.array([[1, 2, 3], [1]], dtype=object)
        >>> arr
        array([list([1, 2, 3]), list([1])], dtype=object)
-       
+
 Note that the array shape is (2, ):
 
    .. code-block:: python
@@ -329,10 +329,10 @@ To create a hyperspy signal of a numpy ragged array:
 
        >>> s.axes_manager
        <Axes manager, axes: (2|ragged)>
-                   Name |   size |  index |  offset |   scale |  units 
-       ================ | ====== | ====== | ======= | ======= | ====== 
-            <undefined> |      2 |      0 |       0 |       1 | <undefined> 
-       ---------------- | ------ | ------ | ------- | ------- | ------ 
+                   Name |   size |  index |  offset |   scale |  units
+       ================ | ====== | ====== | ======= | ======= | ======
+            <undefined> |      2 |      0 |       0 |       1 | <undefined>
+       ---------------- | ------ | ------ | ------- | ------- | ------
             Ragged axis |               Variable length
 
 .. note::
@@ -345,7 +345,7 @@ To create a hyperspy signal of a numpy ragged array:
            array([[1, 2],
                   [1, 2]], dtype=object)
 
-       
+
     Unlike in the previous example, here the array is not ragged, because
     the length of the nested sequences are equal (2) and numpy will create
     an array of shape (2, 2) instead of (2, ) as in the previous example of
@@ -374,11 +374,11 @@ shape of the ragged array:
        >>> s = hs.signals.BaseSignal(arr)
        >>> s
        <BaseSignal, title: , dimensions: (|2)>
-       
+
        >>> s.ragged = True
        >>> s
-       <BaseSignal, title: , dimensions: (2|ragged)>       
-       
+       <BaseSignal, title: , dimensions: (2|ragged)>
+
 
 .. _signal.binned:
 
@@ -1211,7 +1211,7 @@ signal:
     uint8
 
     # By default `dtype=None`, the dtype is determined by the behaviour of
-    # numpy.sum, in this case, unsigned integer of the same precision as the 
+    # numpy.sum, in this case, unsigned integer of the same precision as the
     # platform interger
     >>> s4 = s.rebin(scale=(5, 2, 1))
     >>> print(s4.data.dtype)
@@ -1864,3 +1864,36 @@ and `y` direction, while the offset is determined by the ``offset`` parameter.
 The fulcrum of the linear ramp is at the origin and the slopes are given in
 units of the axis with the according scale taken into account. Both are
 available via the :py:class:`~.axes.AxesManager` of the signal.
+
+.. versionadded:: 1.7
+
+.. _gpu_processing:
+
+GPU support
+-----------
+
+GPU processing is supported thanks to the numpy dispatch mechanism of array functions
+- read `NEP-18 <https://numpy.org/neps/nep-0018-array-function-protocol.html>`_
+and `NEP-35 <https://numpy.org/neps/nep-0035-array-creation-dispatch-with-array-function.html>`_
+for more information. It means that most HyperSpy functions will work on GPU if the data is a
+:py:class:`cupy.ndarray` and that the required functions are
+implemented in ``cupy``.
+
+.. note::
+    GPU processing with hyperspy requires numpy 1.20 and dask 2021.3.0, to be
+    able to use NEP-18 and NEP-35.
+
+.. code-block:: python
+
+    >>> import cupy as cp
+    >>> # Create a cupy array (on GPU)
+    >>> data = cp.random.random(size=(20, 20, 100, 100))
+    >>> s = hs.signals.Signal2D(data)
+    >>> type(s.data)
+    ... cupy._core.core.ndarray
+
+Two convenience methods are avaiable to transfer data to or from the GPU:
+
+- :py:meth:`~.signal.BaseSignal.to_cpu`
+- :py:meth:`~.signal.BaseSignal.to_gpu`
+

--- a/doc/user_guide/signal.rst
+++ b/doc/user_guide/signal.rst
@@ -1876,11 +1876,11 @@ GPU processing is supported thanks to the numpy dispatch mechanism of array func
 - read `NEP-18 <https://numpy.org/neps/nep-0018-array-function-protocol.html>`_
 and `NEP-35 <https://numpy.org/neps/nep-0035-array-creation-dispatch-with-array-function.html>`_
 for more information. It means that most HyperSpy functions will work on a GPU
-if the data is a :py:class:`cupy.ndarray` and that the required functions are
+if the data is a :py:class:`cupy.ndarray` and the required functions are
 implemented in ``cupy``.
 
 .. note::
-    GPU processing with hyperspy requires numpy 1.20 and dask 2021.3.0, to be
+    GPU processing with hyperspy requires numpy>=1.20 and dask>=2021.3.0, to be
     able to use NEP-18 and NEP-35.
 
 .. code-block:: python
@@ -1897,3 +1897,4 @@ Two convenience methods are available to transfer data to or from the GPU:
 - :py:meth:`~.signal.BaseSignal.to_cpu`
 - :py:meth:`~.signal.BaseSignal.to_gpu`
 
+For lazy processing, see the :ref:`corresponding section<big_data.gpu>`.

--- a/hyperspy/_components/doniach.py
+++ b/hyperspy/_components/doniach.py
@@ -27,7 +27,7 @@ from hyperspy.misc.utils import is_binned # remove in v2.0
 sqrt2pi = math.sqrt(2 * math.pi)
 
 
-tiny = np.finfo(np.float64).eps
+tiny = np.finfo(float).eps
 
 
 class Doniach(Expression):

--- a/hyperspy/_components/gaussian.py
+++ b/hyperspy/_components/gaussian.py
@@ -50,7 +50,7 @@ def _estimate_gaussian_parameters(signal, x1, x2, only_current):
         centre_shape[i] = 1
 
     centre = np.sum(X.reshape(X_shape) * data, i) / np.sum(data, i)
-    sigma = np.sqrt(np.abs(np.sum((X.reshape(X_shape) - centre.reshape(
+    sigma = np.sqrt(abs(np.sum((X.reshape(X_shape) - centre.reshape(
         centre_shape)) ** 2 * data, i) / np.sum(data, i)))
     height = data.max(i)
 

--- a/hyperspy/_components/lorentzian.py
+++ b/hyperspy/_components/lorentzian.py
@@ -44,9 +44,9 @@ def _estimate_lorentzian_parameters(signal, x1, x2, only_current):
     cdf = np.cumsum(data,i)
     cdfnorm = cdf/np.max(cdf, i).reshape(centre_shape)
 
-    icentre = np.argmin(np.abs(0.5 - cdfnorm), i)
-    igamma1 = np.argmin(np.abs(0.75 - cdfnorm), i)
-    igamma2 = np.argmin(np.abs(0.25 - cdfnorm), i)
+    icentre = np.argmin(abs(0.5 - cdfnorm), i)
+    igamma1 = np.argmin(abs(0.75 - cdfnorm), i)
+    igamma2 = np.argmin(abs(0.25 - cdfnorm), i)
 
     if isinstance(data, da.Array):
         icentre, igamma1, igamma2 = da.compute(icentre, igamma1, igamma2)

--- a/hyperspy/_components/power_law.py
+++ b/hyperspy/_components/power_law.py
@@ -22,6 +22,7 @@ import numpy as np
 
 from hyperspy._components.expression import Expression
 
+from hyperspy.misc.utils import get_numpy_kwargs
 
 _logger = logging.getLogger(__name__)
 
@@ -132,24 +133,22 @@ class PowerLaw(Expression):
         else:
             s = signal
         if s._lazy:
-            import dask.array as da
-            log = da.log
             I1 = s.isig[i1:i3].integrate1D(2j).data
             I2 = s.isig[i3:i2].integrate1D(2j).data
         else:
             from hyperspy.signal import BaseSignal
             shape = s.data.shape[:-1]
-            I1_s = BaseSignal(np.empty(shape, dtype='float'))
-            I2_s = BaseSignal(np.empty(shape, dtype='float'))
+            kw = get_numpy_kwargs(s.data)
+            I1_s = BaseSignal(np.empty(shape, dtype='float', **kw))
+            I2_s = BaseSignal(np.empty(shape, dtype='float', **kw))
             # Use the `out` parameters to avoid doing the deepcopy
             s.isig[i1:i3].integrate1D(2j, out=I1_s)
             s.isig[i3:i2].integrate1D(2j, out=I2_s)
             I1 = I1_s.data
             I2 = I2_s.data
-            log = np.log
         with np.errstate(divide='raise'):
             try:
-                r = 2 * (log(I1) - log(I2)) / (log(x2) - log(x1))
+                r = 2 * (np.log(I1) - np.log(I2)) / (np.log(x2) - np.log(x1))
                 k = 1 - r
                 A = k * I2 / (x2 ** k - x3 ** k)
                 if s._lazy:
@@ -162,15 +161,15 @@ class PowerLaw(Expression):
                 _logger.warning('Power-law parameter estimation failed '
                                 'because of a "divide-by-zero" error.')
                 return False
+
         if only_current is True:
             self.r.value = r
             self.A.value = A
             return True
+
         if out:
             return A, r
         else:
-            if self.A.map is None:
-                self._create_arrays()
             self.A.map['values'][:] = A
             self.A.map['is_set'][:] = True
             self.r.map['values'][:] = r

--- a/hyperspy/_components/skew_normal.py
+++ b/hyperspy/_components/skew_normal.py
@@ -51,9 +51,9 @@ def _estimate_skewnormal_parameters(signal, x1, x2, only_current):
     a1 = np.sqrt(2 / np.pi)
     b1 = (4 / np.pi - 1) * a1
     m1 = np.sum(X.reshape(X_shape) * data, i) / np.sum(data, i)
-    m2 = np.abs(np.sum((X.reshape(X_shape) - m1.reshape(x0_shape)) ** 2 * data, i)
+    m2 = abs(np.sum((X.reshape(X_shape) - m1.reshape(x0_shape)) ** 2 * data, i)
               / np.sum(data, i))
-    m3 = np.abs(np.sum((X.reshape(X_shape) - m1.reshape(x0_shape)) ** 3 * data, i)
+    m3 = abs(np.sum((X.reshape(X_shape) - m1.reshape(x0_shape)) ** 3 * data, i)
               / np.sum(data, i))
 
     x0 = m1 - a1 * (m3 / b1) ** (1 / 3)
@@ -61,7 +61,7 @@ def _estimate_skewnormal_parameters(signal, x1, x2, only_current):
     delta = np.sqrt(1 / (a1**2 + m2 * (b1 / m3) ** (2 / 3)))
     shape = delta / np.sqrt(1 - delta**2)
 
-    iheight = np.argmin(np.abs(X.reshape(X_shape) - x0.reshape(x0_shape)), i)
+    iheight = np.argmin(abs(X.reshape(X_shape) - x0.reshape(x0_shape)), i)
     # height is the value of the function at x0, shich has to be computed
     # differently for dask array (lazy) and depending on the dimension
     if isinstance(data, da.Array):
@@ -275,5 +275,5 @@ class SkewNormal(Expression):
             return self.x0.value
         else:
             m0 = muz - self.skewness * sigmaz / 2 - np.sign(self.shape.value) \
-                / 2 * np.exp(- 2 * np.pi / np.abs(self.shape.value))
+                / 2 * np.exp(- 2 * np.pi / abs(self.shape.value))
             return self.x0.value + self.scale.value * m0

--- a/hyperspy/_signals/complex_signal.py
+++ b/hyperspy/_signals/complex_signal.py
@@ -203,9 +203,9 @@ class ComplexSignal(BaseSignal):
     unwrapped_phase.__doc__ %= (SHOW_PROGRESSBAR_ARG, PARALLEL_ARG, MAX_WORKERS_ARG)
 
     def __call__(self, axes_manager=None, power_spectrum=False,
-                 fft_shift=False):
+                 fft_shift=False, as_numpy=None):
         value = super().__call__(axes_manager=axes_manager,
-                                 fft_shift=fft_shift)
+                                 fft_shift=fft_shift, as_numpy=as_numpy)
         if power_spectrum:
             value = np.abs(value)**2
         return value

--- a/hyperspy/_signals/complex_signal.py
+++ b/hyperspy/_signals/complex_signal.py
@@ -207,7 +207,7 @@ class ComplexSignal(BaseSignal):
         value = super().__call__(axes_manager=axes_manager,
                                  fft_shift=fft_shift, as_numpy=as_numpy)
         if power_spectrum:
-            value = np.abs(value)**2
+            value = abs(value)**2
         return value
 
     def plot(self,
@@ -345,7 +345,7 @@ class ComplexSignal(BaseSignal):
             argand_diagram.axes_manager.signal_axes[0].name = 'Real'
             units_real = None
         argand_diagram.axes_manager.signal_axes[0].offset = real_edges[0]
-        argand_diagram.axes_manager.signal_axes[0].scale = np.abs(real_edges[0] - real_edges[1])
+        argand_diagram.axes_manager.signal_axes[0].scale = abs(real_edges[0] - real_edges[1])
 
         if self.imag.metadata.Signal.has_item('quantity'):
             quantity_imag, units_imag = parse_quantity(self.imag.metadata.Signal.quantity)
@@ -354,7 +354,7 @@ class ComplexSignal(BaseSignal):
             argand_diagram.axes_manager.signal_axes[1].name = 'Imaginary'
             units_imag = None
         argand_diagram.axes_manager.signal_axes[1].offset = imag_edges[0]
-        argand_diagram.axes_manager.signal_axes[1].scale = np.abs(imag_edges[0] - imag_edges[1])
+        argand_diagram.axes_manager.signal_axes[1].scale = abs(imag_edges[0] - imag_edges[1])
         if units_real:
             argand_diagram.axes_manager.signal_axes[0].units = units_real
         if units_imag:

--- a/hyperspy/_signals/eels.py
+++ b/hyperspy/_signals/eels.py
@@ -683,9 +683,9 @@ class EELSSpectrum(Signal1D):
         else:
             s = s.derivative(-1)
         if tol is None:
-            tol = np.max(np.abs(s.data).min(axis.index_in_array))
+            tol = np.max(abs(s.data).min(axis.index_in_array))
         saxis = s.axes_manager[-1]
-        inflexion = (np.abs(s.data) <= tol).argmax(saxis.index_in_array)
+        inflexion = (abs(s.data) <= tol).argmax(saxis.index_in_array)
         if isinstance(inflexion, da.Array):
             inflexion = inflexion.compute()
         threshold.data[:] = saxis.index2value(inflexion)

--- a/hyperspy/_signals/hologram_image.py
+++ b/hyperspy/_signals/hologram_image.py
@@ -104,7 +104,7 @@ def _parse_sb_size(s, reference, sb_position, sb_size, parallel):
                              'neither reference nor hologram dimensions.')
         # sb_position navdim=0, therefore map function should not iterate:
         else:
-            sb_size_temp = np.float64(sb_size.data)
+            sb_size_temp = float(sb_size.data)
     else:
         sb_size_temp = sb_size.deepcopy()
     return sb_size, sb_size_temp
@@ -462,7 +462,7 @@ class HologramImage(Signal2D):
             # sb_position navdim=0, therefore map function should not iterate
             # it:
             else:
-                sb_smoothness_temp = np.float64(sb_smoothness.data)
+                sb_smoothness_temp = float(sb_smoothness.data)
         else:
             sb_smoothness_temp = sb_smoothness.deepcopy()
 
@@ -561,7 +561,7 @@ class HologramImage(Signal2D):
             if reference.axes_manager.navigation_size == 0 and \
                sb_smoothness.axes_manager.navigation_size > 0:
                 # 1d reference, but parameters are multidimensional
-                sb_smoothness_ref = np.float64(
+                sb_smoothness_ref = float(
                     _first_nav_pixel_data(sb_smoothness_temp))
             else:
                 sb_smoothness_ref = sb_smoothness_temp

--- a/hyperspy/_signals/lazy.py
+++ b/hyperspy/_signals/lazy.py
@@ -597,10 +597,15 @@ class LazySignal(BaseSignal):
         sig_dim = self.axes_manager.signal_dimension
         chunks = self.get_chunk_size(self.axes_manager.navigation_axes)
         navigation_indices = indices[:-sig_dim]
-        chunk_slice = _get_navigation_dimension_chunk_slice(navigation_indices, chunks)
+        chunk_slice = _get_navigation_dimension_chunk_slice(
+            navigation_indices,
+            chunks
+            )
+
         if (chunk_slice != self._cache_dask_chunk_slice or
                 self._cache_dask_chunk is None):
-            self._cache_dask_chunk = np.asarray(self.data.__getitem__(chunk_slice))
+            with dummy_context_manager():
+                self._cache_dask_chunk = self.data.__getitem__(chunk_slice).compute()
             self._cache_dask_chunk_slice = chunk_slice
 
         indices = list(indices)

--- a/hyperspy/_signals/signal1d.py
+++ b/hyperspy/_signals/signal1d.py
@@ -173,7 +173,7 @@ def find_peaks_ohaver(y, x=None, slope_thresh=0., amp_thresh=None,
                         # centering and scaling
                         yynz = yy != 0
                         coef = np.polyfit(
-                            xxf[yynz], np.log10(np.abs(yy[yynz])), 2)
+                            xxf[yynz], np.log10(abs(yy[yynz])), 2)
                         c1 = coef[2]
                         c2 = coef[1]
                         c3 = coef[0]
@@ -186,7 +186,7 @@ def find_peaks_ohaver(y, x=None, slope_thresh=0., amp_thresh=None,
                         # of y in the sub-group of points near peak.
                         if peakgroup < 7:
                             height = np.max(yy)
-                            position = xx[np.argmin(np.abs(yy - height))]
+                            position = xx[np.argmin(abs(yy - height))]
                         else:
                             position = - ((stdev * c2 / (2 * c3)) - avg)
                             height = np.exp(c1 - c3 * (c2 / (2 * c3)) ** 2)
@@ -280,7 +280,7 @@ class Signal1D(BaseSignal, CommonSignal1D):
             axis = axis[~signal_mask]
         if navigation_mask is not None:
             dc = dc[~navigation_mask, :]
-        der = np.abs(np.gradient(dc, axis, axis=-1))
+        der = abs(np.gradient(dc, axis, axis=-1))
         n = ((~navigation_mask).sum() if navigation_mask else
              self.axes_manager.navigation_size)
 

--- a/hyperspy/_signals/signal2d.py
+++ b/hyperspy/_signals/signal2d.py
@@ -251,7 +251,7 @@ def estimate_image_shift(ref, image, roi=None, sobel=True,
         upsampled_region_size = np.ceil(sub_pixel_factor * 1.5)
         # Center of output array at dftshift + 1
         dftshift = np.fix(upsampled_region_size / 2.0)
-        sub_pixel_factor = np.array(sub_pixel_factor, dtype=np.float64)
+        sub_pixel_factor = np.array(sub_pixel_factor, dtype=float)
         normalization = (image_product.size * sub_pixel_factor ** 2)
         # Matrix multiply DFT around the current shift estimate
         sample_region_offset = dftshift - shifts * sub_pixel_factor
@@ -264,7 +264,7 @@ def estimate_image_shift(ref, image, roi=None, sobel=True,
         maxima = np.array(np.unravel_index(
             np.argmax(abs(correlation)),
             correlation.shape),
-            dtype=np.float64)
+            dtype=float)
         maxima -= dftshift
         shifts = shifts + maxima / sub_pixel_factor
         max_val = correlation.real.max()

--- a/hyperspy/_signals/signal2d.py
+++ b/hyperspy/_signals/signal2d.py
@@ -127,7 +127,7 @@ def fft_correlation(in1, in2, normalize=False, real_only=False):
     fprod *= fft_f(in2, fsize).conjugate()
 
     if normalize is True:
-        fprod = np.nan_to_num(fprod / np.absolute(fprod))
+        fprod = np.nan_to_num(fprod / abs(fprod))
 
     ret = ifft_f(fprod).real.copy()
 
@@ -262,7 +262,7 @@ def estimate_image_shift(ref, image, roi=None, sobel=True,
         correlation /= normalization
         # Locate maximum and map back to original pixel grid
         maxima = np.array(np.unravel_index(
-            np.argmax(np.abs(correlation)),
+            np.argmax(abs(correlation)),
             correlation.shape),
             dtype=np.float64)
         maxima -= dftshift

--- a/hyperspy/axes.py
+++ b/hyperspy/axes.py
@@ -618,7 +618,7 @@ class BaseDataAxis(t.HasTraits):
             else:
                 raise ValueError(
                     'Non-supported rounding function. Use '
-                    'round, `math.ceil` or `math.floor`'
+                    '`round`, `math.ceil` or `math.floor`.'
                     )
             #initialise the index same dimension as input, force type to int
             # index = np.empty_like(value,dtype=int)

--- a/hyperspy/conftest.py
+++ b/hyperspy/conftest.py
@@ -30,13 +30,6 @@ except ValueError:
 # 'agg' as early as we can is useless for testing.
 import matplotlib.pyplot as plt
 
-from distutils.version import LooseVersion
-from numpy.version import version as np_version
-import os
-
-if LooseVersion(np_version) < LooseVersion('1.17.0'):
-    os.environ['NUMPY_EXPERIMENTAL_ARRAY_FUNCTION'] = '1'
-
 import pytest
 import numpy as np
 import matplotlib

--- a/hyperspy/conftest.py
+++ b/hyperspy/conftest.py
@@ -30,6 +30,13 @@ except ValueError:
 # 'agg' as early as we can is useless for testing.
 import matplotlib.pyplot as plt
 
+from distutils.version import LooseVersion
+from numpy.version import version as np_version
+import os
+
+if LooseVersion(np_version) < LooseVersion('1.17.0'):
+    os.environ['NUMPY_EXPERIMENTAL_ARRAY_FUNCTION'] = '1'
+
 import pytest
 import numpy as np
 import matplotlib

--- a/hyperspy/drawing/_widgets/line2d.py
+++ b/hyperspy/drawing/_widgets/line2d.py
@@ -475,4 +475,4 @@ class Line2DWidget(ResizableDraggableWidgetBase):
         dn = 2 * np.dot(n, dx)
         if self._selected_artist is self.patch[2]:
             dn *= -1
-        self.size = np.abs(self._drag_store[1] + dn)
+        self.size = abs(self._drag_store[1] + dn)

--- a/hyperspy/drawing/image.py
+++ b/hyperspy/drawing/image.py
@@ -258,7 +258,7 @@ class ImagePlot(BlittedFigure):
                 self._auto_scalebar = False
                 self._auto_axes_ticks = True
         if xaxis.is_uniform and yaxis.is_uniform:
-            self._aspect = np.abs(factor * xaxis.scale / yaxis.scale)
+            self._aspect = abs(factor * xaxis.scale / yaxis.scale)
         else:
             self._aspect = 1.0
 

--- a/hyperspy/drawing/signal.py
+++ b/hyperspy/drawing/signal.py
@@ -24,6 +24,7 @@ from mpl_toolkits.axes_grid1 import make_axes_locatable
 from traits.api import Undefined
 
 from hyperspy.drawing.utils import set_axes_decor
+from hyperspy.misc.utils import to_numpy
 
 
 def _plot_1D_component(factors, idx, axes_manager, ax=None,
@@ -38,7 +39,7 @@ def _plot_1D_component(factors, idx, axes_manager, ax=None,
     else:
         x = np.arange(axis.size)
         plt.xlabel('Channel index')
-    ax.plot(x, factors[:, idx], label='%i' % idx)
+    ax.plot(x, to_numpy(factors[:, idx]), label='%i' % idx)
     if comp_label and not same_window:
         plt.title('%s' % comp_label)
     return ax
@@ -61,7 +62,7 @@ def _plot_2D_component(factors, idx, axes_manager,
                   axes[0].low_value)
     if comp_label:
         plt.title('%s' % idx)
-    im = ax.imshow(factors[:, idx].reshape(shape),
+    im = ax.imshow(to_numpy(factors[:, idx].reshape(shape)),
                    cmap=cmap, interpolation='nearest',
                    extent=extent)
 
@@ -78,6 +79,7 @@ def _plot_loading(loadings, idx, axes_manager, ax=None,
                   comp_label=None, no_nans=True,
                   calibrate=True, cmap=plt.cm.gray,
                   same_window=False, axes_decor='all'):
+    loadings = to_numpy(loadings)
     if ax is None:
         ax = plt.gca()
     if no_nans:
@@ -92,7 +94,7 @@ def _plot_loading(loadings, idx, axes_manager, ax=None,
                       axes[0].high_value,
                       axes[1].high_value,
                       axes[1].low_value)
-        im = ax.imshow(loadings[idx].reshape(shape),
+        im = ax.imshow(to_numpy(loadings[idx].reshape(shape)),
                        cmap=cmap, extent=extent,
                        interpolation='nearest')
         if calibrate:

--- a/hyperspy/drawing/signal.py
+++ b/hyperspy/drawing/signal.py
@@ -39,9 +39,9 @@ def _plot_1D_component(factors, idx, axes_manager, ax=None,
     else:
         x = np.arange(axis.size)
         plt.xlabel('Channel index')
-    ax.plot(x, to_numpy(factors[:, idx]), label='%i' % idx)
+    ax.plot(x, to_numpy(factors[:, idx]), label=f'{idx}')
     if comp_label and not same_window:
-        plt.title('%s' % comp_label)
+        plt.title(f'{comp_label}')
     return ax
 
 
@@ -50,10 +50,11 @@ def _plot_2D_component(factors, idx, axes_manager,
                        comp_label=None, cmap=plt.cm.gray,
                        axes_decor='all'
                        ):
+    shape = axes_manager._signal_shape_in_array
+    factors = to_numpy(factors[:, idx].reshape(shape))
     if ax is None:
         ax = plt.gca()
     axes = axes_manager.signal_axes[::-1]
-    shape = axes_manager._signal_shape_in_array
     extent = None
     if calibrate:
         extent = (axes[1].low_value,
@@ -61,10 +62,8 @@ def _plot_2D_component(factors, idx, axes_manager,
                   axes[0].high_value,
                   axes[0].low_value)
     if comp_label:
-        plt.title('%s' % idx)
-    im = ax.imshow(to_numpy(factors[:, idx].reshape(shape)),
-                   cmap=cmap, interpolation='nearest',
-                   extent=extent)
+        plt.title(f'{idx}')
+    im = ax.imshow(factors, cmap=cmap, interpolation='nearest', extent=extent)
 
     # Set axes decorations based on user input
     set_axes_decor(ax, axes_decor)
@@ -79,7 +78,7 @@ def _plot_loading(loadings, idx, axes_manager, ax=None,
                   comp_label=None, no_nans=True,
                   calibrate=True, cmap=plt.cm.gray,
                   same_window=False, axes_decor='all'):
-    loadings = to_numpy(loadings)
+    loadings = to_numpy(loadings[idx])
     if ax is None:
         ax = plt.gca()
     if no_nans:
@@ -94,7 +93,7 @@ def _plot_loading(loadings, idx, axes_manager, ax=None,
                       axes[0].high_value,
                       axes[1].high_value,
                       axes[1].low_value)
-        im = ax.imshow(to_numpy(loadings[idx].reshape(shape)),
+        im = ax.imshow(loadings.reshape(shape),
                        cmap=cmap, extent=extent,
                        interpolation='nearest')
         if calibrate:
@@ -105,9 +104,9 @@ def _plot_loading(loadings, idx, axes_manager, ax=None,
             plt.ylabel('pixels')
         if comp_label:
             if same_window:
-                plt.title('%s' % idx)
+                plt.title(f'{idx}')
             else:
-                plt.title('%s #%s' % (comp_label, idx))
+                plt.title(f'{idx} #{idx}')
 
         # Set axes decorations based on user input
         set_axes_decor(ax, axes_decor)
@@ -120,10 +119,9 @@ def _plot_loading(loadings, idx, axes_manager, ax=None,
             x = axes[0].axis
         else:
             x = np.arange(axes[0].size)
-        ax.step(x, loadings[idx],
-                label='%s' % idx)
+        ax.step(x, loadings, label=f'{idx}')
         if comp_label and not same_window:
-            plt.title('%s #%s' % (comp_label, idx))
+            plt.title(f'{comp_label} #{idx}')
         plt.ylabel('Score (a. u.)')
         if calibrate:
             if axes[0].units is not Undefined:

--- a/hyperspy/drawing/utils.py
+++ b/hyperspy/drawing/utils.py
@@ -33,6 +33,7 @@ from matplotlib.colors import LinearSegmentedColormap
 from matplotlib.colors import BASE_COLORS, to_rgba
 
 from hyperspy.defaults_parser import preferences
+from hyperspy.misc.utils import to_numpy
 
 
 _logger = logging.getLogger(__name__)
@@ -411,7 +412,7 @@ def _make_overlap_plot(spectra, ax, color, linestyle, **kwargs):
             zip(spectra, color, linestyle)):
         x_axis = spectrum.axes_manager.signal_axes[0]
         spectrum = _transpose_if_required(spectrum, 1)
-        ax.plot(x_axis.axis, spectrum.data, color=color, ls=linestyle,
+        ax.plot(x_axis.axis, to_numpy(spectrum.data), color=color,ls=linestyle,
                 **kwargs)
         set_xaxis_lims(ax, x_axis)
     _set_spectrum_xlabel(spectra, ax)
@@ -430,8 +431,8 @@ def _make_cascade_subplot(spectra, ax, color, linestyle, padding=1, **kwargs):
             zip(spectra, color, linestyle)):
         x_axis = spectrum.axes_manager.signal_axes[0]
         spectrum = _transpose_if_required(spectrum, 1)
-        data_to_plot = ((spectrum.data - spectrum.data.min()) /
-                        float(max_value) + spectrum_index * padding)
+        data_to_plot = to_numpy((spectrum.data - spectrum.data.min()) /
+                                float(max_value) + spectrum_index * padding)
         ax.plot(x_axis.axis, data_to_plot, color=color, ls=linestyle,
                 **kwargs)
         set_xaxis_lims(ax, x_axis)
@@ -442,7 +443,7 @@ def _make_cascade_subplot(spectra, ax, color, linestyle, padding=1, **kwargs):
 
 def _plot_spectrum(spectrum, ax, color="blue", linestyle='-', **kwargs):
     x_axis = spectrum.axes_manager.signal_axes[0]
-    ax.plot(x_axis.axis, spectrum.data, color=color, ls=linestyle,
+    ax.plot(x_axis.axis, to_numpy(spectrum.data), color=color, ls=linestyle,
             **kwargs)
     set_xaxis_lims(ax, x_axis)
 
@@ -667,8 +668,8 @@ def plot_images(images,
     for image in im:
         if not isinstance(image, BaseSignal):
             raise ValueError("`images` must be a list of image signals or a "
-                             "multi-dimensional signal."
-                             " " + repr(type(images)) + " was given.")
+                             "multi-dimensional signal. "
+                             f"{repr(type(images))} was given.")
 
     # For list of EDS maps, transpose the BaseSignal
     if isinstance(images, (list, tuple)):
@@ -678,7 +679,7 @@ def plot_images(images,
     # copy it and put it in a list so labeling works out as (x,y) when plotting
     if isinstance(images,
                   BaseSignal) and images.axes_manager.navigation_dimension > 0:
-        images = [images._deepcopy_with_new_data(images.data)]
+        images = [images._deepcopy_with_new_data(to_numpy(images.data))]
 
     n = 0
     for i, sig in enumerate(images):
@@ -780,13 +781,9 @@ def plot_images(images,
 
         # trim off any '(' or ' ' characters at end of basename
         if div_num > 1:
-            while True:
-                if basename[len(basename) - 1] == '(':
-                    basename = basename[:-1]
-                elif basename[len(basename) - 1] == ' ':
-                    basename = basename[:-1]
-                else:
-                    break
+            basename = basename.strip()
+            if len(basename) > 1 and basename[len(basename) - 1] == '(':
+                basename = basename[:-1]
 
         # namefrac is ratio of length of basename to the image name
         # if it is high (e.g. over 0.5), we can assume that all images
@@ -817,7 +814,7 @@ def plot_images(images,
 
     elif isinstance(label, str):
         # Set label_list to an indexed list, based off of label
-        label_list = [label + " " + repr(num) for num in range(n)]
+        label_list = [f"{label} {num}" for num in range(n)]
 
     elif isinstance(label, list) and all(
             isinstance(x, str) for x in label):
@@ -898,7 +895,7 @@ def plot_images(images,
                             'The default values are used instead.')
             vmin, vmax = None, None
         vmin_max = np.array(
-            [contrast_stretching(i.data, vmin, vmax) for i in non_rgb])
+            [contrast_stretching(to_numpy(i.data), vmin, vmax) for i in non_rgb])
         _vmin, _vmax = vmin_max[:, 0].min(), vmin_max[:, 1].max()
         if next(centre_colormaps):
             _vmin, _vmax = centre_colormap_values(_vmin, _vmax)
@@ -1006,7 +1003,7 @@ def plot_images(images,
             for j, im in enumerate(ims):
                 ax = f.add_subplot(rows, per_row, idx + 1)
                 axes_list.append(ax)
-                data = im.data
+                data = to_numpy(im.data)
                 centre = next(centre_colormaps)   # get next value for centreing
 
                 # Enable RGB plotting

--- a/hyperspy/drawing/utils.py
+++ b/hyperspy/drawing/utils.py
@@ -1049,7 +1049,7 @@ def plot_images(images,
                         factor = min_asp ** -1 * float(xaxis.size) / yaxis.size
                     else:
                         factor = 1
-                    asp = np.abs(factor * float(xaxis.scale) / yaxis.scale)
+                    asp = abs(factor * float(xaxis.scale) / yaxis.scale)
                 elif aspect == 'square':
                     asp = abs(extent[1] - extent[0]) / abs(extent[3] - extent[2])
                 elif aspect == 'equal':

--- a/hyperspy/drawing/utils.py
+++ b/hyperspy/drawing/utils.py
@@ -1013,7 +1013,7 @@ def plot_images(images,
             for j, im in enumerate(ims):
                 ax = f.add_subplot(rows, per_row, idx + 1)
                 axes_list.append(ax)
-                centre = next(centre_colormaps) # get next value for centreing
+                centre = next(centre_colormaps) # get next value for centring
                 data = _parse_array(im)
 
                 # Enable RGB plotting

--- a/hyperspy/drawing/widget.py
+++ b/hyperspy/drawing/widget.py
@@ -919,7 +919,7 @@ class ResizersMixin(object):
         if self.resize_pixel_size is None:
             rsize = [ax.scale for ax in self.axes]
         else:
-            rsize = np.abs(invtrans.transform(self.resize_pixel_size) -
+            rsize = abs(invtrans.transform(self.resize_pixel_size) -
                            invtrans.transform((0, 0)))
         return rsize
 
@@ -930,8 +930,8 @@ class ResizersMixin(object):
         invtrans = self.ax.transData.inverted()
         border = self.border_thickness
         # Transform the border thickness into data values
-        dl = np.abs(invtrans.transform((border, border)) -
-                    invtrans.transform((0, 0))) / 2
+        dl = abs(invtrans.transform((border, border)) -
+                 invtrans.transform((0, 0))) / 2
         rsize = self._get_resizer_size()
         return rsize / 2 + dl
 
@@ -941,8 +941,8 @@ class ResizersMixin(object):
         invtrans = self.ax.transData.inverted()
         border = self.border_thickness
         # Transform the border thickness into data values
-        dl = np.abs(invtrans.transform((border, border)) -
-                    invtrans.transform((0, 0))) / 2
+        dl = abs(invtrans.transform((border, border)) -
+                 invtrans.transform((0, 0))) / 2
         rsize = self._get_resizer_size()
         xs, ys = self._size
 

--- a/hyperspy/exceptions.py
+++ b/hyperspy/exceptions.py
@@ -205,3 +205,16 @@ class VisibleDeprecationWarning(UserWarning):
 
     """
     pass
+
+
+class LazyCupyConversion(Exception):
+
+    def __init__(self):
+        self.error = (
+            "Automatically converting data to cupy array is not supported "
+            "for lazy signal. Read the corresponding section in the user "
+            "guide for more information on how to use GPU with lazy signals."
+            )
+
+    def __str__(self):
+        return repr(self.error)

--- a/hyperspy/exceptions.py
+++ b/hyperspy/exceptions.py
@@ -212,7 +212,7 @@ class LazyCupyConversion(Exception):
     def __init__(self):
         self.error = (
             "Automatically converting data to cupy array is not supported "
-            "for lazy signal. Read the corresponding section in the user "
+            "for lazy signals. Read the corresponding section in the user "
             "guide for more information on how to use GPU with lazy signals."
             )
 

--- a/hyperspy/external/mpfit/mpfit.py
+++ b/hyperspy/external/mpfit/mpfit.py
@@ -885,7 +885,7 @@ class mpfit:
                         return
 
                     # If parameters were changed (grrr..) then re-tie
-                    if np.max(np.abs(xnew0 - self.params)) > 0:
+                    if np.max(abs(xnew0 - self.params)) > 0:
                         if self.qanytied:
                             self.params = self.tie(self.params, ptied)
                         x = self.params[ifree]
@@ -988,7 +988,7 @@ class mpfit:
                     l_ = ipvt[j]
                     if wa2[l_] != 0:
                         sum0 = sum(fjac[0 : j + 1, j] * qtf[0 : j + 1]) / self.fnorm
-                        gnorm = np.max([gnorm, np.abs(sum0 / wa2[l_])])
+                        gnorm = np.max([gnorm, abs(sum0 / wa2[l_])])
 
             # Test for convergence of the gradient norm
             if gnorm <= gtol:
@@ -1031,7 +1031,7 @@ class mpfit:
                         if nupeg > 0:
                             wa1[whupeg] = np.clip(wa1[whupeg], np.min(wa1), 0.0)
 
-                        dwa1 = np.abs(wa1) > machep
+                        dwa1 = abs(wa1) > machep
                         whl = (
                             np.nonzero(((dwa1 != 0.0) & qllim) & ((x + wa1) < llim))
                         )[0]
@@ -1053,7 +1053,7 @@ class mpfit:
                         )[0]
                         if len(whmax) > 0:
                             mrat = np.max(
-                                np.abs(nwa1[whmax]) / np.abs(maxstep[ifree[whmax]])
+                                abs(nwa1[whmax]) / abs(maxstep[ifree[whmax]])
                             )
                             if mrat > 1:
                                 alpha /= mrat
@@ -1144,12 +1144,12 @@ class mpfit:
                     self.niter += 1
 
                 # Tests for convergence
-                if (np.abs(actred) <= ftol) and (prered <= ftol) and (0.5 * ratio <= 1):
+                if (abs(actred) <= ftol) and (prered <= ftol) and (0.5 * ratio <= 1):
                     self.status = 1
                 if delta <= xtol * xnorm:
                     self.status = 2
                 if (
-                    (np.abs(actred) <= ftol)
+                    (abs(actred) <= ftol)
                     and (prered <= ftol)
                     and (0.5 * ratio <= 1)
                     and (self.status == 2)
@@ -1162,7 +1162,7 @@ class mpfit:
                 if self.niter >= maxiter:
                     self.status = 5
                 if (
-                    (np.abs(actred) <= machep)
+                    (abs(actred) <= machep)
                     and (prered <= machep)
                     and (0.5 * ratio <= 1)
                 ):
@@ -1404,7 +1404,7 @@ class mpfit:
 
         fjac = np.zeros([m, n])
 
-        h = eps * np.abs(x)
+        h = eps * abs(x)
 
         # if STEP is given, use that
         # STEP includes the fixed parameters
@@ -1420,7 +1420,7 @@ class mpfit:
             dstepi = dstep[ifree]
             wh = (np.nonzero(dstepi > 0))[0]
             if len(wh) > 0:
-                h[wh] = np.abs(dstepi[wh] * x[wh])
+                h[wh] = abs(dstepi[wh] * x[wh])
 
         # In case any of the step values are zero
         h[h == 0] = eps
@@ -1443,7 +1443,7 @@ class mpfit:
             if status < 0:
                 return None
 
-            if np.abs(dside[ifree[j]]) <= 1:
+            if abs(dside[ifree[j]]) <= 1:
                 # COMPUTE THE ONE-SIDED DERIVATIVE
                 # Note optimization fjac(0:*,j)
                 fjac[0:, j] = (fp - fvec) / h[j]
@@ -1682,7 +1682,7 @@ class mpfit:
             for k in range(j, n):
                 if sdiag[k] == 0:
                     break
-                if np.abs(r[k, k]) < np.abs(sdiag[k]):
+                if abs(r[k, k]) < abs(sdiag[k]):
                     cotan = r[k, k] / sdiag[k]
                     sine = 0.5 / np.sqrt(0.25 + 0.25 * cotan * cotan)
                     cosine = sine * cotan
@@ -1818,7 +1818,7 @@ class mpfit:
         # jacobian is rank-deficient, obtain a least-squares solution
         nsing = n
         wa1 = qtb.copy()
-        rdiagabs = np.abs(np.diagonal(r))
+        rdiagabs = abs(np.diagonal(r))
         rthresh = np.max(rdiagabs) * machep
         wh = (np.nonzero(rdiagabs < rthresh))[0]
         if len(wh) > 0:
@@ -1888,7 +1888,7 @@ class mpfit:
             temp = fp
             fp = dxnorm - delta
 
-            if (np.abs(fp) <= 0.1 * delta) or (
+            if (abs(fp) <= 0.1 * delta) or (
                 (parl == 0) and (fp <= temp) and (temp < 0)
             ):
                 break
@@ -1992,9 +1992,9 @@ class mpfit:
 
         # For the inverse of r in the full upper triangle of r
         l_ = -1
-        tolr = tol * np.abs(r[0, 0])
+        tolr = tol * abs(r[0, 0])
         for k in range(n):
-            if np.abs(r[k, k]) <= tolr:
+            if abs(r[k, k]) <= tolr:
                 break
             r[k, k] = 1.0 / r[k, k]
             for j in range(k):

--- a/hyperspy/external/mpfit/mpfit.py
+++ b/hyperspy/external/mpfit/mpfit.py
@@ -428,7 +428,7 @@ _logger = logging.getLogger(__name__)
 
 class machar:
     def __init__(self, double=True):
-        info = np.finfo(np.float64) if double else np.finfo(np.float32)
+        info = np.finfo(float) if double else np.finfo(np.float32)
 
         self.machep = info.eps
         self.maxnum = info.max
@@ -625,7 +625,7 @@ class mpfit:
     """
 
     (blas_enorm32,) = get_blas_funcs(["nrm2"], np.array([0], dtype=np.float32))
-    (blas_enorm64,) = get_blas_funcs(["nrm2"], np.array([0], dtype=np.float64))
+    (blas_enorm64,) = get_blas_funcs(["nrm2"], np.array([0], dtype=float))
 
     def __init__(
         self,
@@ -711,7 +711,7 @@ class mpfit:
         # In the case if the xall is not float or if is float but has less
         # than 64 bits we do convert it into double
         if xall.dtype.kind != "f" or xall.dtype.itemsize <= 4:
-            xall = xall.astype(np.float)
+            xall = xall.astype(float)
 
         npar = len(xall)
         self.fnorm = -1.0

--- a/hyperspy/io_plugins/bruker.py
+++ b/hyperspy/io_plugins/bruker.py
@@ -860,7 +860,7 @@ class HyperHeader(object):
         """calculate and return real time for whole hypermap
         in seconds
         """
-        line_cnt_sum = np.sum(self.line_counter, dtype=np.float64)
+        line_cnt_sum = np.sum(self.line_counter, dtype=float)
         line_avg = self.dsp_metadata['LineAverage']
         pix_avg = self.dsp_metadata['PixelAverage']
         pix_time = self.dsp_metadata['PixelTime']

--- a/hyperspy/io_plugins/emd.py
+++ b/hyperspy/io_plugins/emd.py
@@ -229,7 +229,7 @@ class EMD(object):
         metadata = {}
         for key, value in group.attrs.items():
             metadata[key] = value
-        if signal.data.dtype == np.object:
+        if signal.data.dtype == object:
             self._log.warning('HyperSpy could not load the data in {}, '
                               'skipping it'.format(name))
         else:

--- a/hyperspy/io_plugins/nexus.py
+++ b/hyperspy/io_plugins/nexus.py
@@ -764,8 +764,8 @@ def _find_data(group, search_keys=None, hardlinks_only=False,
                 if isinstance(value, h5py.Dataset):
                     if value.size >= 2:
                         target = _getlink(group, rootkey, key)
-                        if not(value.dtype.type is np.string_ or
-                                value.dtype.type is np.object_):
+                        if not(value.dtype.type is str or
+                                value.dtype.type is object):
                             all_hdf_datasets.append(rootkey)
                             if target is None:
                                 unique_hdf_datasets.append(rootkey)

--- a/hyperspy/io_plugins/phenom.py
+++ b/hyperspy/io_plugins/phenom.py
@@ -572,7 +572,7 @@ class ElidReader:
                 for bin in range(bins):
                     data[y, x, bin] = self._read_varuint32()
         if has_variable_real_time:
-            real_time_values = np.empty([height, width], dtype=np.float64)
+            real_time_values = np.empty([height, width], dtype=float)
             for y in range(height):
                 for x in range(width):
                     real_time_values[y, x] = self._read_float64()
@@ -580,7 +580,7 @@ class ElidReader:
         else:
             eds_metadata['real_time_values'] = np.full([height, width], self._read_float64())
         if has_variable_live_time:
-            live_time_values = np.empty([height, width], dtype=np.float64)
+            live_time_values = np.empty([height, width], dtype=float)
             for y in range(height):
                 for x in range(width):
                     live_time_values[y, x] = self._read_float64()

--- a/hyperspy/learn/mlpca.py
+++ b/hyperspy/learn/mlpca.py
@@ -131,7 +131,7 @@ def mlpca(
 
         # Every second iteration, check the stop criterion
         if itr > 0 and itr % 2 == 0:
-            stop_criterion = np.abs(s_old - s_obj) / s_obj
+            stop_criterion = abs(s_old - s_obj) / s_obj
             _logger.info(f"Iteration: {itr // 2}, convergence: {stop_criterion}")
 
             if stop_criterion < tol:

--- a/hyperspy/learn/mva.py
+++ b/hyperspy/learn/mva.py
@@ -1007,7 +1007,7 @@ class MVA:
             # following code is an experimental attempt to sort them in a
             # more predictable way
             sorting_indices = np.argsort(
-                lr.explained_variance[:number_of_components] @ np.abs(w.T)
+                lr.explained_variance[:number_of_components] @ abs(w.T)
             )[::-1]
             w[:] = w[sorting_indices, :]
 
@@ -2490,7 +2490,7 @@ class MVA:
                     reference_inertia[o_indx]=np.mean(local_inertia)
                     reference_std[o_indx] = np.std(local_inertia)
                 std_error = np.sqrt(1.0 + 1.0/n_ref)*reference_std
-                std_error = np.abs(std_error)
+                std_error = abs(std_error)
                 gap       = reference_inertia-data_inertia
                 to_return = gap
                 # finding the first max..check if first point is max
@@ -2599,7 +2599,7 @@ class MVA:
         else:
             ys = curve_values_adj[:max_points]
 
-        numer = np.abs((x2 - x1) * (y1 - ys) - (x1 - xs) * (y2 - y1))
+        numer = abs((x2 - x1) * (y1 - ys) - (x1 - xs) * (y2 - y1))
         denom = np.sqrt((x2 - x1) ** 2 + (y2 - y1) ** 2)
         distance = np.nan_to_num(numer / denom)
         elbow_position = np.argmax(distance)

--- a/hyperspy/learn/mva.py
+++ b/hyperspy/learn/mva.py
@@ -1460,7 +1460,7 @@ class MVA:
         """
         s = self.get_explained_variance_ratio()
         if is_cupy_array(s.data):
-            s.to_cpu()
+            s.to_host()
 
         n_max = len(self.learning_results.explained_variance_ratio)
         if n is None:

--- a/hyperspy/learn/mva.py
+++ b/hyperspy/learn/mva.py
@@ -146,6 +146,7 @@ class MVA:
             The decomposition algorithm to use. If algorithm is an object,
             it must implement a ``fit_transform()`` method or ``fit()`` and
             ``transform()`` methods, in the same manner as a scikit-learn estimator.
+            For cupy arrays, only "SVD" is supported.
         output_dimension : None or int
             Number of components to keep/calculate.
             Default is None, i.e. ``min(data.shape)``.
@@ -194,7 +195,7 @@ class MVA:
                 number of components to extract is lower than 80% of the smallest
                 dimension of the data, then the more efficient "randomized"
                 method is enabled. Otherwise the exact full SVD is computed and
-                optionally truncated afterwards. For cupy array, only
+                optionally truncated afterwards.
             If full:
                 run exact SVD, calling the standard LAPACK solver via
                 :py:func:`scipy.linalg.svd`, and select the components by postprocessing
@@ -205,6 +206,7 @@ class MVA:
             If randomized:
                 use truncated SVD, calling :py:func:`sklearn.utils.extmath.randomized_svd`
                 to estimate a limited number of components
+             For cupy arrays, only "full" is supported.
         copy : bool, default True
             * If True, stores a copy of the data before any pre-treatments
               such as normalization in ``s._data_before_treatments``. The original
@@ -248,7 +250,7 @@ class MVA:
                 elif svd_solver == 'auto':
                     svd_solver = 'full'
             else:
-                raise TypeError("cupy array are not supported.")
+                raise TypeError("cupy arrays are not supported.")
 
         from hyperspy.signal import BaseSignal
 
@@ -2084,7 +2086,7 @@ class MVA:
                 'sklearn is not installed. Nothing done')
 
         if is_cupy_array(self.data):  # pragma: no cover
-            raise TypeError("cupy array are not supported.")
+            raise TypeError("cupy arrays are not supported.")
 
         if source_for_centers is None:
             source_for_centers = cluster_source

--- a/hyperspy/learn/mva.py
+++ b/hyperspy/learn/mva.py
@@ -250,7 +250,10 @@ class MVA:
                 elif svd_solver == 'auto':
                     svd_solver = 'full'
             else:
-                raise TypeError("cupy arrays are not supported.")
+                raise TypeError(
+                    "Only `algorithm='SVD'` is supported with cupy arrays. "
+                    f"Provided algorithm is '{algorithm}'."
+                    )
 
         from hyperspy.signal import BaseSignal
 

--- a/hyperspy/learn/ornmf.py
+++ b/hyperspy/learn/ornmf.py
@@ -30,7 +30,7 @@ _logger = logging.getLogger(__name__)
 
 def _thresh(X, lambda1, vmax):
     """Soft-thresholding with clipping."""
-    res = np.abs(X) - lambda1
+    res = abs(X) - lambda1
     np.maximum(res, 0.0, out=res)
     res *= np.sign(X)
     np.clip(res, -vmax, vmax, out=res)
@@ -211,7 +211,7 @@ class ORNMF:
         self.W = halfnorm.rvs(
             size=(self.n_features, self.rank), random_state=self.random_state
         )
-        self.W = np.abs(avg * self.W / np.sqrt(self.rank))
+        self.W = abs(avg * self.W / np.sqrt(self.rank))
         self.H = []
 
         if self.subspace_tracking:
@@ -281,7 +281,7 @@ class ORNMF:
             n = 0
             lasttwo = np.zeros(2)
             while n <= 2 or (
-                np.abs((lasttwo[1] - lasttwo[0]) / lasttwo[0]) > 1e-5 and n < 1e9
+                abs((lasttwo[1] - lasttwo[0]) / lasttwo[0]) > 1e-5 and n < 1e9
             ):
                 self.W -= eta * (self.W @ self.A - self.B)
                 self.W = _project(self.W)

--- a/hyperspy/learn/orthomax.py
+++ b/hyperspy/learn/orthomax.py
@@ -18,7 +18,7 @@
 
 import numpy as np
 
-from scipy.linalg import svd
+from numpy.linalg import svd
 
 
 def orthomax(A, gamma=1.0, tol=1.4901e-07, max_iter=256):

--- a/hyperspy/learn/orthomax.py
+++ b/hyperspy/learn/orthomax.py
@@ -77,7 +77,7 @@ def orthomax(A, gamma=1.0, tol=1.4901e-07, max_iter=256):
                 S = np.sum(S)
                 B = A @ W
 
-                if np.abs(S - Sold) < tol * S:
+                if abs(S - Sold) < tol * S:
                     converged = True
                     break
 
@@ -103,7 +103,7 @@ def orthomax(A, gamma=1.0, tol=1.4901e-07, max_iter=256):
                     denom = u.T @ u - v.T @ v - gamma * (usum ** 2 - vsum ** 2) * oo_d
 
                     theta = 0.25 * np.arctan2(numer, denom)
-                    maxTheta = max(maxTheta, np.abs(theta))
+                    maxTheta = max(maxTheta, abs(theta))
 
                     R = np.array(
                         [

--- a/hyperspy/learn/rpca.py
+++ b/hyperspy/learn/rpca.py
@@ -33,7 +33,7 @@ _logger = logging.getLogger(__name__)
 
 def _soft_thresh(X, lambda1):
     """Soft-thresholding of array X."""
-    res = np.abs(X) - lambda1
+    res = abs(X) - lambda1
     np.maximum(res, 0.0, out=res)
     res *= np.sign(X)
     return res

--- a/hyperspy/learn/svd_pca.py
+++ b/hyperspy/learn/svd_pca.py
@@ -60,10 +60,10 @@ def svd_flip_signs(u, v, u_based_decision=True):
     # All rights reserved.
 
     if u_based_decision:
-        max_abs_cols = np.argmax(np.abs(u), axis=0)
+        max_abs_cols = np.argmax(abs(u), axis=0)
         signs = np.sign(u[max_abs_cols, range(u.shape[1])])
     else:
-        max_abs_rows = np.argmax(np.abs(v), axis=1)
+        max_abs_rows = np.argmax(abs(v), axis=1)
         signs = np.sign(v[range(v.shape[0]), max_abs_rows])
 
     u *= signs

--- a/hyperspy/misc/array_tools.py
+++ b/hyperspy/misc/array_tools.py
@@ -17,7 +17,7 @@
 
 
 from collections import OrderedDict
-import math as math
+import math
 import logging
 
 import dask.array as da

--- a/hyperspy/misc/eds/utils.py
+++ b/hyperspy/misc/eds/utils.py
@@ -121,7 +121,7 @@ def get_xray_lines_near_energy(energy, width=0.2, only_lines=None):
             if E_min <= line_energy <= E_max:
                 # Store line in Element_Line format, and energy difference
                 valid_lines.append((element + "_" + line,
-                                    np.abs(line_energy - energy)))
+                                    abs(line_energy - energy)))
     # Sort by energy difference, but return only the line names
     return [line for line, _ in sorted(valid_lines, key=lambda x: x[1])]
 

--- a/hyperspy/misc/eels/electron_inelastic_mean_free_path.py
+++ b/hyperspy/misc/eels/electron_inelastic_mean_free_path.py
@@ -120,7 +120,7 @@ def iMFP_angular_correction(density, beam_energy, alpha, beta):
        https://doi.org/10.1002/jemt.20597
     """
     theta_C = 20 # mrad
-    A = alpha ** 2 + beta ** 2 + 2 * _theta_E(density, beam_energy) ** 2 + np.abs(alpha ** 2 - beta ** 2)
-    B = alpha ** 2 + beta ** 2 + 2 * theta_C ** 2 + np.abs(alpha ** 2 - beta ** 2)
+    A = alpha ** 2 + beta ** 2 + 2 * _theta_E(density, beam_energy) ** 2 + abs(alpha ** 2 - beta ** 2)
+    B = alpha ** 2 + beta ** 2 + 2 * theta_C ** 2 + abs(alpha ** 2 - beta ** 2)
     return np.log(theta_C ** 2 / _theta_E(density, beam_energy) ** 2) / np.log(A * theta_C ** 2 / B / _theta_E(density, beam_energy) ** 2)
 

--- a/hyperspy/misc/eels/hartree_slater_gos.py
+++ b/hyperspy/misc/eels/hartree_slater_gos.py
@@ -147,7 +147,7 @@ class HartreeSlaterGOS(GOSBase):
         info2_1 = float(GOS_list[6])
         info2_2 = float(GOS_list[7])
         nrow = int(GOS_list[8])
-        self.gos_array = np.array(GOS_list[9:], dtype=np.float64)
+        self.gos_array = np.array(GOS_list[9:], dtype=float)
         # The division by R is not in the equations, but it seems that
         # the the GOS was tabulated this way
         self.gos_array = self.gos_array.reshape(nrow, ncol) / R

--- a/hyperspy/misc/eels/hydrogenic_gos.py
+++ b/hyperspy/misc/eels/hydrogenic_gos.py
@@ -157,7 +157,7 @@ class HydrogenicGOS(GOSBase):
 
         q = qa02 / zs ** 2
         kh2 = E / (r * zs ** 2) - 1
-        akh = np.sqrt(np.abs(kh2))
+        akh = np.sqrt(abs(kh2))
         if akh < 0.01:
             akh = 0.01
         if kh2 >= 0.0:
@@ -197,7 +197,7 @@ class HydrogenicGOS(GOSBase):
 
         q = qa02 / zs ** 2
         kh2 = E / (r * zs ** 2) - 0.25
-        akh = np.sqrt(np.abs(kh2))
+        akh = np.sqrt(abs(kh2))
         if kh2 >= 0.0:
             d = 1 - np.exp(-2 * np.pi / akh)
             bp = np.arctan(akh / (q - kh2 + 0.25))
@@ -227,6 +227,6 @@ class HydrogenicGOS(GOSBase):
         # The following commented lines are to give a more accurate GOS
         # for edges presenting white lines. However, this is not relevant
         # for quantification by curve fitting.
-        # if np.abs(iz - 11) <= 5 and E - el3 <= 20:
+        # if abs(iz - 11) <= 5 and E - el3 <= 20:
         #     rf = 1
         return rf * 32 * g * c / a / d * E / r / r / zs ** 4

--- a/hyperspy/misc/eels/tools.py
+++ b/hyperspy/misc/eels/tools.py
@@ -373,7 +373,7 @@ def get_edges_near_energy(energy, width=10, only_major=False, order='closest'):
                 if shell[-1] != 'a' and \
                     Emin <= shell_info['onset_energy (eV)'] <= Emax:
                     subshell = '{}_{}'.format(element, shell)
-                    Ediff = np.abs(shell_info['onset_energy (eV)'] - energy)
+                    Ediff = abs(shell_info['onset_energy (eV)'] - energy)
                     valid_edges.append((subshell,
                                         shell_info['onset_energy (eV)'],
                                         Ediff))

--- a/hyperspy/misc/holography/reconstruct.py
+++ b/hyperspy/misc/holography/reconstruct.py
@@ -69,23 +69,23 @@ def estimate_sideband_position(
         fft_filtered.shape[1] //
         2)  # cb: center band
     if sb == 'lower':
-        fft_sb = np.abs(fft_filtered[:cb_position[0], :])
+        fft_sb = abs(fft_filtered[:cb_position[0], :])
         sb_position = np.asarray(
             np.unravel_index(
                 fft_sb.argmax(),
                 fft_sb.shape))
     elif sb == 'upper':
-        fft_sb = np.abs(fft_filtered[cb_position[0]:, :])
+        fft_sb = abs(fft_filtered[cb_position[0]:, :])
         sb_position = (np.unravel_index(fft_sb.argmax(), fft_sb.shape))
         sb_position = np.asarray(np.add(sb_position, (cb_position[0], 0)))
     elif sb == 'left':
-        fft_sb = np.abs(fft_filtered[:, :cb_position[1]])
+        fft_sb = abs(fft_filtered[:, :cb_position[1]])
         sb_position = np.asarray(
             np.unravel_index(
                 fft_sb.argmax(),
                 fft_sb.shape))
     elif sb == 'right':
-        fft_sb = np.abs(fft_filtered[:, cb_position[1]:])
+        fft_sb = abs(fft_filtered[:, cb_position[1]:])
         sb_position = (np.unravel_index(fft_sb.argmax(), fft_sb.shape))
         sb_position = np.asarray(np.add(sb_position, (0, cb_position[1])))
     # Return sideband position:
@@ -166,7 +166,7 @@ def reconstruct(holo_data, holo_sampling, sb_size, sb_position, sb_smoothness,
 
     if plotting:
         _, axs = plt.subplots(1, 1, figsize=(4, 4))
-        axs.imshow(np.abs(fftshift(fft_aperture)), clim=(0, 0.1))
+        axs.imshow(abs(fftshift(fft_aperture)), clim=(0, 0.1))
         axs.scatter(
             sb_position[1],
             sb_position[0],
@@ -208,7 +208,7 @@ def aperture_function(r, apradius, rsmooth):
         Smoothness in halfwidth. rsmooth = 1 will cause a decay from 1 to 0 over 2 pixel.
     """
 
-    return 0.5 * (1. - np.tanh((np.absolute(r) - apradius) / (0.5 * rsmooth)))
+    return 0.5 * (1. - np.tanh((abs(r) - apradius) / (0.5 * rsmooth)))
 
 
 def freq_array(shape, sampling):

--- a/hyperspy/misc/holography/tools.py
+++ b/hyperspy/misc/holography/tools.py
@@ -90,4 +90,4 @@ def estimate_fringe_contrast_fourier(
 
     fft_exp = fft2(data)
 
-    return 2 * np.abs(fft_exp[tuple(sb_position)]) / np.abs(fft_exp[0, 0])
+    return 2 * abs(fft_exp[tuple(sb_position)]) / abs(fft_exp[0, 0])

--- a/hyperspy/misc/rgb_tools.py
+++ b/hyperspy/misc/rgb_tools.py
@@ -16,6 +16,8 @@
 # You should have received a copy of the GNU General Public License
 # along with HyperSpy. If not, see <http://www.gnu.org/licenses/>.
 
+from distutils.version import LooseVersion
+
 import numpy as np
 from dask.array import Array
 
@@ -77,7 +79,10 @@ def rgbx2regular_array(data, plot_friendly=False):
         if np.ma.is_masked(data):
             data = data.copy(order='C')
         else:
-            data = np.ascontiguousarray(data)
+            kw = {}
+            if LooseVersion(np.__version__) >= LooseVersion("1.20"):
+                 kw['like'] = data
+            data = np.ascontiguousarray(data, **kw)
     if is_rgba(data) is True:
         dt = data.dtype.fields['B'][0]
         data = data.view((dt, 4))
@@ -98,7 +103,10 @@ def regular_array2rgbx(data):
         if np.ma.is_masked(data):
             data = data.copy(order='C')
         else:
-            data = np.ascontiguousarray(data)
+            kw = {}
+            if LooseVersion(np.__version__) >= LooseVersion("1.20"):
+                 kw['like'] = data
+            data = np.ascontiguousarray(data, **kw)
     if data.shape[-1] == 3:
         names = rgb8.names
     elif data.shape[-1] == 4:

--- a/hyperspy/misc/rgb_tools.py
+++ b/hyperspy/misc/rgb_tools.py
@@ -16,10 +16,11 @@
 # You should have received a copy of the GNU General Public License
 # along with HyperSpy. If not, see <http://www.gnu.org/licenses/>.
 
-from distutils.version import LooseVersion
-
 import numpy as np
 from dask.array import Array
+
+from hyperspy.misc.utils import get_numpy_kwargs
+
 
 rgba8 = np.dtype({'names': ['R', 'G', 'B', 'A'],
                   'formats': ['u1', 'u1', 'u1', 'u1']})
@@ -79,10 +80,7 @@ def rgbx2regular_array(data, plot_friendly=False):
         if np.ma.is_masked(data):
             data = data.copy(order='C')
         else:
-            kw = {}
-            if LooseVersion(np.__version__) >= LooseVersion("1.20"):
-                 kw['like'] = data
-            data = np.ascontiguousarray(data, **kw)
+            data = np.ascontiguousarray(data, **get_numpy_kwargs(data))
     if is_rgba(data) is True:
         dt = data.dtype.fields['B'][0]
         data = data.view((dt, 4))
@@ -103,10 +101,7 @@ def regular_array2rgbx(data):
         if np.ma.is_masked(data):
             data = data.copy(order='C')
         else:
-            kw = {}
-            if LooseVersion(np.__version__) >= LooseVersion("1.20"):
-                 kw['like'] = data
-            data = np.ascontiguousarray(data, **kw)
+            data = np.ascontiguousarray(data, **get_numpy_kwargs(data))
     if data.shape[-1] == 3:
         names = rgb8.names
     elif data.shape[-1] == 4:

--- a/hyperspy/misc/signal_tools.py
+++ b/hyperspy/misc/signal_tools.py
@@ -16,10 +16,9 @@
 # You should have received a copy of the GNU General Public License
 # along with HyperSpy. If not, see <http://www.gnu.org/licenses/>.
 
-import logging
 from itertools import zip_longest
+import logging
 
-import dask.array as da
 import numpy as np
 
 from hyperspy.misc.axis_tools import check_axes_calibration
@@ -127,8 +126,14 @@ def broadcast_signals(*args, ignore_axis=None):
     list of signals
 
     """
+    from hyperspy.signal import BaseSignal
+
     if len(args) < 2:
-        raise ValueError("This function requires at least two signal instances")
+        raise ValueError(
+            "This function requires at least two signal instances"
+            )
+    if any([not isinstance(a, BaseSignal) for a in args]):
+        raise ValueError("Arguments must be of signal type.")
     args = list(args)
     if not are_signals_aligned(*args, ignore_axis=ignore_axis):
         raise ValueError("The signals cannot be broadcasted")
@@ -184,10 +189,7 @@ def broadcast_signals(*args, ignore_axis=None):
                 thisshape[_id] = newlen
             thisshape = tuple(thisshape)
             if data.shape != thisshape:
-                if isinstance(data, np.ndarray):
-                    data = np.broadcast_to(data, thisshape)
-                else:
-                    data = da.broadcast_to(data, thisshape)
+                data = np.broadcast_to(data, thisshape)
 
             ns = s._deepcopy_with_new_data(data)
             ns.axes_manager._axes = [ax.copy() for ax in new_axes]

--- a/hyperspy/misc/tv_denoise.py
+++ b/hyperspy/misc/tv_denoise.py
@@ -104,7 +104,7 @@ def _tv_denoise_3d(im, weight=100, eps=2.e-4, keep_type=False, n_iter_max=200):
             E_init = E
             E_previous = E
         else:
-            if np.abs(E_previous - E) < eps * E_init:
+            if abs(E_previous - E) < eps * E_init:
                 break
             else:
                 E_previous = E
@@ -199,7 +199,7 @@ def _tv_denoise_2d(im, weight=50, eps=2.e-4, keep_type=False, n_iter_max=200):
             E_init = E
             E_previous = E
         else:
-            if np.abs(E_previous - E) < eps * E_init:
+            if abs(E_previous - E) < eps * E_init:
                 break
             else:
                 E_previous = E
@@ -277,7 +277,7 @@ def _tv_denoise_1d(im, weight=50, eps=2.e-4, keep_type=False, n_iter_max=200):
         out = im + d
         E = (d ** 2).sum()
         gx[:-1] = np.diff(out)
-        norm = np.abs(gx)
+        norm = abs(gx)
         E += weight * norm.sum()
         norm *= 0.5 / weight
         norm += 1
@@ -288,7 +288,7 @@ def _tv_denoise_1d(im, weight=50, eps=2.e-4, keep_type=False, n_iter_max=200):
             E_init = E
             E_previous = E
         else:
-            if np.abs(E_previous - E) < eps * E_init:
+            if abs(E_previous - E) < eps * E_init:
                 break
             else:
                 E_previous = E

--- a/hyperspy/misc/utils.py
+++ b/hyperspy/misc/utils.py
@@ -1572,7 +1572,7 @@ def is_cupy_array(array):
 
 def to_numpy(array):
     """
-    Returns the array as an numpy array
+    Returns the array as a numpy array
 
     Parameters
     ----------

--- a/hyperspy/misc/utils.py
+++ b/hyperspy/misc/utils.py
@@ -28,6 +28,7 @@ import unicodedata
 from contextlib import contextmanager
 import importlib
 import logging
+from distutils.version import LooseVersion
 
 import numpy as np
 
@@ -1611,3 +1612,21 @@ def get_array_module(array):
         pass
 
     return module
+
+
+def get_numpy_kwargs(array):
+    """
+    Convenience funtion to return a dictionary containing the `like` keyword
+    if numpy>=1.20.
+
+    Note
+    ----
+    `like` keyword is an experimental feature introduced in numpy 1.20 and is
+    pending on acceptance of NEP 35
+
+    """
+    kw = {}
+    if LooseVersion(np.__version__) >= LooseVersion("1.20"):
+         kw['like'] = array
+
+    return kw

--- a/hyperspy/misc/utils.py
+++ b/hyperspy/misc/utils.py
@@ -1543,3 +1543,71 @@ def is_binned(signal, axis=-1):
         return signal.metadata.Signal.binned
     else:
         return signal.axes_manager[axis].is_binned
+
+
+def is_cupy_array(array):
+    """
+    Convenience function to determine if an array is a cupy array
+
+    Parameters
+    ----------
+    array : array
+        The array to determine whether it is a cupy array or not.
+
+    Returns
+    -------
+    bool
+        True if it is cupy array, False otherwise.
+
+    """
+    try:
+        import cupy as cp
+        return isinstance(array, cp.ndarray)
+    except ImportError:
+        return False
+
+
+def to_numpy(array):
+    """
+    Returns the array as an numpy array
+
+    Parameters
+    ----------
+    array : numpy or cupy array
+        Array to determine whether numpy or cupy should be used
+
+    Returns
+    -------
+    array : numpy.ndarray
+
+    """
+    if is_cupy_array(array):
+        import cupy as cp
+        array = cp.asnumpy(array)
+
+    return array
+
+
+def get_array_module(array):
+    """
+    Returns the array module for the given array
+
+    Parameters
+    ----------
+    array : numpy or cupy array
+        Array to determine whether numpy or cupy should be used
+
+    Returns
+    -------
+    module : module
+
+    """
+    module = np
+    try:
+        import cupy as cp
+        if isinstance(array, cp.ndarray):
+            module = cp
+    except ImportError:
+        pass
+
+    return module

--- a/hyperspy/misc/utils.py
+++ b/hyperspy/misc/utils.py
@@ -28,7 +28,7 @@ import unicodedata
 from contextlib import contextmanager
 import importlib
 import logging
-from distutils.version import LooseVersion
+from packaging.version import Version
 
 import numpy as np
 
@@ -41,7 +41,8 @@ _logger = logging.getLogger(__name__)
 
 
 def attrsetter(target, attrs, value):
-    """Sets attribute of the target to specified value, supports nested
+    """
+    Sets attribute of the target to specified value, supports nested
     attributes. Only creates a new attribute if the object supports such
     behaviour (e.g. DictionaryTreeBrowser does)
 
@@ -1329,7 +1330,8 @@ def process_function_blockwise(data,
     chunk_nav_shape = tuple([data.shape[i] for i in sorted(nav_indexes)])
     output_shape = chunk_nav_shape + tuple(output_signal_size)
     # Pre-allocating the output array
-    output_array = np.empty(output_shape, dtype=dtype)
+    kw = get_numpy_kwargs(data)
+    output_array = np.empty(output_shape, dtype=dtype, **kw)
     if len(args) == 0:
         # There aren't any BaseSignals for iterating
         for nav_index in np.ndindex(chunk_nav_shape):
@@ -1626,7 +1628,7 @@ def get_numpy_kwargs(array):
 
     """
     kw = {}
-    if LooseVersion(np.__version__) >= LooseVersion("1.20"):
+    if Version(np.__version__) >= Version("1.20"):
          kw['like'] = array
 
     return kw

--- a/hyperspy/misc/utils.py
+++ b/hyperspy/misc/utils.py
@@ -30,10 +30,11 @@ import importlib
 import logging
 from packaging.version import Version
 
+import dask.array as da
 import numpy as np
 
 from hyperspy.misc.signal_tools import broadcast_signals
-from hyperspy.exceptions import VisibleDeprecationWarning
+from hyperspy.exceptions import VisibleDeprecationWarning, LazyCupyConversion
 from hyperspy.docstrings.signal import SHOW_PROGRESSBAR_ARG
 from hyperspy.docstrings.utils import STACK_METADATA_ARG
 
@@ -1572,18 +1573,26 @@ def is_cupy_array(array):
 
 def to_numpy(array):
     """
-    Returns the array as a numpy array
+    Returns the array as a numpy array. Raises an error when a dask array is
+    provided.
 
     Parameters
     ----------
-    array : numpy or cupy array
-        Array to determine whether numpy or cupy should be used
+    array : numpy.ndarray or cupy.ndarray
+        Array to convert to numpy array.
 
     Returns
     -------
     array : numpy.ndarray
+    
+    Raises
+    ------
+    ValueError
+        If the provided array is a dask array
 
     """
+    if isinstance(array, da.Array):
+        raise LazyCupyConversion
     if is_cupy_array(array):
         import cupy as cp
         array = cp.asnumpy(array)

--- a/hyperspy/model.py
+++ b/hyperspy/model.py
@@ -1221,8 +1221,8 @@ class BaseModel(list):
 
     def _calculate_chisq(self):
         variance = self._get_variance()
-        d = self(onlyactive=True).ravel() - self.signal()[np.where(
-            self.channel_switches)]
+        d = self(onlyactive=True).ravel() - self.signal(as_numpy=True)[
+            np.where(self.channel_switches)]
         d *= d / (1. * variance)  # d = difference^2 / variance.
         self.chisq.data[self.signal.axes_manager.indices[::-1]] = d.sum()
 
@@ -1545,7 +1545,10 @@ class BaseModel(list):
                 # Will proceed with unweighted fitting.
                 weights = None
 
-            args = (self.signal()[np.where(self.channel_switches)], weights)
+            args = (
+                self.signal(as_numpy=True)[np.where(self.channel_switches)],
+                weights
+                )
 
             if optimizer == "lm":
                 if bounded:

--- a/hyperspy/samfire.py
+++ b/hyperspy/samfire.py
@@ -284,7 +284,7 @@ class Samfire:
 
     @_active_strategy_ind.setter
     def _active_strategy_ind(self, value):
-        self.__active_strategy_ind = np.abs(int(value))
+        self.__active_strategy_ind = abs(int(value))
 
     def _run_active_strategy(self):
         if self.pool is not None:
@@ -410,7 +410,7 @@ class Samfire:
                 raise ValueError(
                     "The passed object is not in current strategies list")
 
-        new_strat = np.abs(int(new_strat))
+        new_strat = abs(int(new_strat))
         if new_strat == self._active_strategy_ind:
             self.refresh_database()
 

--- a/hyperspy/samfire_utils/goodness_of_fit_tests/information_theory.py
+++ b/hyperspy/samfire_utils/goodness_of_fit_tests/information_theory.py
@@ -44,8 +44,7 @@ class AIC_test(object):
         m = model.inav[ind[::-1]]
         m.fetch_stored_values()
         _aic = AIC(m)
-        return np.abs(
-            notexp(_aic) - self.expected) < notexp(self.tolerance)
+        return abs(notexp(_aic) - self.expected) < notexp(self.tolerance)
 
     def map(self, model, mask):
         ind_list = np.where(mask)
@@ -67,8 +66,7 @@ class AICc_test(object):
         m = model.inav[ind[::-1]]
         m.fetch_stored_values()
         _aicc = AICc(m)
-        return np.abs(
-            notexp(_aicc) - self.expected) < notexp(self.tolerance)
+        return abs(notexp(_aicc) - self.expected) < notexp(self.tolerance)
 
     def map(self, model, mask):
         ind_list = np.where(mask)
@@ -90,8 +88,7 @@ class BIC_test(object):
         m = model.inav[ind[::-1]]
         m.fetch_stored_values()
         _bic = BIC(m)
-        return np.abs(
-            notexp(_bic) - self.expected) < notexp(self.tolerance)
+        return abs(notexp(_bic) - self.expected) < notexp(self.tolerance)
 
     def map(self, model, mask):
         ind_list = np.where(mask)

--- a/hyperspy/samfire_utils/goodness_of_fit_tests/red_chisq.py
+++ b/hyperspy/samfire_utils/goodness_of_fit_tests/red_chisq.py
@@ -29,11 +29,10 @@ class red_chisq_test(goodness_test):
         self.tolerance = tolerance
 
     def test(self, model, ind):
-        return np.abs(
-            model.red_chisq.data[ind] - self.expected) < self.tolerance
+        return abs(model.red_chisq.data[ind] - self.expected) < self.tolerance
 
     def map(self, model, mask):
         rc = model.red_chisq.data
         rc = np.where(np.isnan(rc), -np.inf, rc)
-        ans = np.abs(rc - self.expected) < self.tolerance
+        ans = abs(rc - self.expected) < self.tolerance
         return np.logical_and(mask, ans)

--- a/hyperspy/samfire_utils/goodness_of_fit_tests/test_general.py
+++ b/hyperspy/samfire_utils/goodness_of_fit_tests/test_general.py
@@ -16,8 +16,6 @@
 # You should have received a copy of the GNU General Public License
 # along with HyperSpy. If not, see <http://www.gnu.org/licenses/>.
 
-import numpy as np
-
 
 class goodness_test(object):
 
@@ -32,4 +30,4 @@ class goodness_test(object):
         if value is None:
             self._tolerance = None
         else:
-            self._tolerance = np.abs(value)
+            self._tolerance = abs(value)

--- a/hyperspy/samfire_utils/samfire_kernel.py
+++ b/hyperspy/samfire_utils/samfire_kernel.py
@@ -84,7 +84,7 @@ def single_kernel(model, ind, values, optional_components, _args, test):
             new_AICc = AICc(model.inav[ind[::-1]])
 
             if new_AICc < AICc_fraction * best_AICc or \
-                    (np.abs(new_AICc - best_AICc) <= np.abs(AICc_fraction * best_AICc)
+                    (abs(new_AICc - best_AICc) <= abs(AICc_fraction * best_AICc)
                      and len(model.p0) < best_dof):
                 best_values = [
                     getattr(
@@ -208,7 +208,7 @@ def multi_kernel(
             new_AICc = AICc(model)
 
             if new_AICc < AICc_fraction * best_AICc or \
-                    (np.abs(new_AICc - best_AICc) <= np.abs(AICc_fraction * best_AICc)
+                    (abs(new_AICc - best_AICc) <= abs(AICc_fraction * best_AICc)
                      and len(model.p0) < best_dof):
                 best_values = [
                     getattr(

--- a/hyperspy/samfire_utils/samfire_worker.py
+++ b/hyperspy/samfire_utils/samfire_worker.py
@@ -204,8 +204,8 @@ class Worker:
         new_AICc = AICc(self.model)
 
         AICc_test = new_AICc < (self._AICc_fraction * self.best_AICc)
-        AICc_absolute_test = np.abs(new_AICc - self.best_AICc) <= \
-            np.abs(self._AICc_fraction * self.best_AICc)
+        AICc_absolute_test = abs(new_AICc - self.best_AICc) <= \
+            abs(self._AICc_fraction * self.best_AICc)
         dof_test = len(self.model.p0) < self.best_dof
 
         if AICc_test or AICc_absolute_test and dof_test:

--- a/hyperspy/samfire_utils/strategy.py
+++ b/hyperspy/samfire_utils/strategy.py
@@ -300,7 +300,7 @@ class LocalStrategy(SamfireStrategy):
             par = []
             for radius in radii:
                 radius_top = np.ceil(radius)
-                par.append(np.abs(np.arange(-radius_top, radius_top + 1)))
+                par.append(abs(np.arange(-radius_top, radius_top + 1)))
             meshg = np.array(np.meshgrid(*par, indexing='ij'))
             self._untruncated = np.sqrt(np.sum(meshg ** 2.0, axis=0))
             distance_mask = np.array(

--- a/hyperspy/samfire_utils/weights/red_chisq.py
+++ b/hyperspy/samfire_utils/weights/red_chisq.py
@@ -26,10 +26,10 @@ class ReducedChiSquaredWeight(object):
         self.model = None
 
     def function(self, ind):
-        return np.abs(self.model.red_chisq.data[ind] - self.expected)
+        return abs(self.model.red_chisq.data[ind] - self.expected)
 
     def map(self, mask, slices=slice(None, None)):
         thing = self.model.red_chisq.data[slices].copy()
         thing = thing.astype('float64')
         thing[np.logical_not(mask)] = np.nan
-        return np.abs(thing - self.expected)
+        return abs(thing - self.expected)

--- a/hyperspy/signal.py
+++ b/hyperspy/signal.py
@@ -2439,9 +2439,10 @@ class BaseSignal(FancySlicing,
 
     @data.setter
     def data(self, value):
-        # Calling asanyarray to convert to numpy array
-        if not isinstance(value, da.Array) or not \
-            hasattr(value, '__cuda_array_interface__'):
+        # Object supporting __array_function__ protocol (NEP-18) or the
+        # array API standard doesn't to be cast to numpy array
+        if not (hasattr(value, '__array_function__') or
+                hasattr(value, '__array_namespace__')):
             value = np.asanyarray(value)
         self._data = np.atleast_1d(value)
 

--- a/hyperspy/signal.py
+++ b/hyperspy/signal.py
@@ -43,21 +43,35 @@ from hyperspy.api_nogui import _ureg
 from hyperspy.drawing import mpl_hie, mpl_hse, mpl_he
 from hyperspy.learn.mva import MVA, LearningResults
 from hyperspy.io import assign_signal_subclass
-import hyperspy.misc.utils
-from hyperspy.misc.utils import DictionaryTreeBrowser
 from hyperspy.drawing import signal as sigdraw
 from hyperspy.misc.io.tools import ensure_directory
-from hyperspy.misc.utils import iterable_not_string
 from hyperspy.exceptions import SignalDimensionError, DataDimensionError
 from hyperspy.misc import rgb_tools
-from hyperspy.misc.utils import underline, isiterable, slugify, to_numpy
+from hyperspy.misc.utils import (
+    add_scalar_axis,
+    DictionaryTreeBrowser,
+    get_array_module,
+    guess_output_signal_size,
+    is_binned, # remove in v2.0
+    is_cupy_array,
+    isiterable,
+    iterable_not_string,
+    process_function_blockwise,
+    rollelem,
+    slugify,
+    to_numpy,
+    underline,
+    )
 from hyperspy.misc.hist_tools import histogram
 from hyperspy.drawing.utils import animate_legend
 from hyperspy.drawing.marker import markers_metadata_dict_to_markers
 from hyperspy.misc.slicing import SpecialSlicers, FancySlicing
 from hyperspy.misc.utils import is_binned # remove in v2.0
 from hyperspy.misc.utils import (
-    process_function_blockwise, guess_output_signal_size,_get_block_pattern)
+    process_function_blockwise,
+    guess_output_signal_size,
+    _get_block_pattern
+    )
 from hyperspy.misc.utils import add_scalar_axis
 from hyperspy.docstrings.signal import (
     ONE_AXIS_PARAMETER, MANY_AXIS_PARAMETER, OUT_ARG, NAN_FUNC, OPTIMIZE_ARG,
@@ -3131,13 +3145,13 @@ class BaseSignal(FancySlicing,
         to_index = self.axes_manager[to_axis].index_in_array
         if axis == to_index:
             return self.deepcopy()
-        new_axes_indices = hyperspy.misc.utils.rollelem(
+        new_axes_indices = rollelem(
             [axis_.index_in_array for axis_ in self.axes_manager._axes],
             index=axis,
             to_index=to_index)
 
         s = self._deepcopy_with_new_data(self.data.transpose(new_axes_indices))
-        s.axes_manager._axes = hyperspy.misc.utils.rollelem(
+        s.axes_manager._axes = rollelem(
             s.axes_manager._axes,
             index=axis,
             to_index=to_index)
@@ -4903,8 +4917,10 @@ class BaseSignal(FancySlicing,
     map.__doc__ %= (SHOW_PROGRESSBAR_ARG, PARALLEL_ARG, LAZY_OUTPUT_ARG, MAX_WORKERS_ARG)
 
     def _map_all(self, function, inplace=True, **kwargs):
-        """The function has to have either 'axis' or 'axes' keyword argument,
-        and hence support operating on the full dataset efficiently."""
+        """
+        The function has to have either 'axis' or 'axes' keyword argument,
+        and hence support operating on the full dataset efficiently.
+        """
         newdata = function(self.data, **kwargs)
         if inplace:
             self.data = newdata
@@ -4934,6 +4950,7 @@ class BaseSignal(FancySlicing,
     ):
         if lazy_output is None:
             lazy_output = self._lazy
+
         if not self._lazy:
             s_input = self.as_lazy()
         else:
@@ -4950,6 +4967,7 @@ class BaseSignal(FancySlicing,
         chunk_span = [
             chunk_span[i] for i in s_input.axes_manager.signal_indices_in_array
         ]
+
         if not all(chunk_span):
             _logger.info(
                 "The chunk size needs to span the full signal size, rechunking..."
@@ -4958,10 +4976,16 @@ class BaseSignal(FancySlicing,
             old_sig = s_input.rechunk(inplace=False, nav_chunks=None)
         else:
             old_sig = s_input
+
         os_am = old_sig.axes_manager
+
         autodetermine = (
             output_signal_size is None or output_dtype is None
         )  # try to guess output dtype and sig size?
+        if autodetermine and is_cupy_array(self.data):
+            raise ValueError('Autodetermination of `output_signal_size` and '
+                             '`output_dtype` is not supported for cupy array.')
+
         args, arg_keys = old_sig._get_iterating_kwargs(iterating_kwargs)
 
         if autodetermine:  # trying to guess the output d-type and size from one signal
@@ -5004,6 +5028,7 @@ class BaseSignal(FancySlicing,
         )
 
         data_stored = False
+
         if inplace:
             if (
                 not self._lazy
@@ -5024,12 +5049,13 @@ class BaseSignal(FancySlicing,
                 data_stored = True
             else:
                 self.data = mapped
-            self._lazy = lazy_output
             sig = self
         else:
             sig = s_input._deepcopy_with_new_data(mapped)
+
         am = sig.axes_manager
         sig._lazy = lazy_output
+
         if ragged:
             axes_dicts = self.axes_manager._get_navigation_axes_dicts()
             sig.axes_manager.__init__(axes_dicts)
@@ -5038,15 +5064,17 @@ class BaseSignal(FancySlicing,
             am.remove(am.signal_axes[len(output_signal_size) :])
             for ind in range(len(output_signal_size) - am.signal_dimension, 0, -1):
                 am._append_axis(size=output_signal_size[-ind], navigate=False)
+
         if not ragged:
             sig.axes_manager._ragged = False
             if output_signal_size == () and am.navigation_dimension == 0:
                 add_scalar_axis(sig)
             sig.get_dimensions_from_data()
         sig._assign_subclass()
-        if not lazy_output:
-            if not data_stored:
-                sig.data = sig.data.compute(num_workers=max_workers)
+
+        if not lazy_output and not data_stored:
+            sig.data = sig.data.compute(num_workers=max_workers)
+
         return sig
 
     def _get_iterating_kwargs(self, iterating_kwargs):

--- a/hyperspy/signal.py
+++ b/hyperspy/signal.py
@@ -6475,12 +6475,39 @@ class BaseSignal(FancySlicing,
                              "`signal_shape`.")
 
     def to_gpu(self):
+        """
+        Transfer data array to GPU device memory using cupy.asarray. Lazy
+        signal will be converted to their non-lazy counterpart, which means
+        the GPU device needs to have enough memory to accomodate the whole
+        dataset.
+
+        Raises
+        ------
+        BaseException
+            Raise expecting if cupy is not installed.
+
+        Returns
+        -------
+        None.
+
+        """
         if not CUPY_INSTALLED:
             raise BaseException('cupy is required.')
         else:
             self.data = cp.asarray(self.data)
+            if self._lazy:
+                self._lazy = False
+                self._assign_subclass()
 
     def to_cpu(self):
+        """
+        Transfer data array to host memory
+
+        Returns
+        -------
+        None.
+
+        """
         self.data = to_numpy(self.data)
 
 

--- a/hyperspy/signal.py
+++ b/hyperspy/signal.py
@@ -6474,14 +6474,15 @@ class BaseSignal(FancySlicing,
     def to_gpu(self):
         """
         Transfer data array to GPU device memory using cupy.asarray. Lazy
-        signal will be converted to their non-lazy counterpart, which means
-        the GPU device needs to have enough memory to accomodate the whole
-        dataset.
+        signal are not supported by this method, see user guide for information
+        on how to process data lazily using GPU.
 
         Raises
         ------
         BaseException
-            Raise expecting if cupy is not installed.
+            Raise expection if cupy is not installed.
+        BaseException
+            Raise expection if signal is lazy.
 
         Returns
         -------
@@ -6502,13 +6503,24 @@ class BaseSignal(FancySlicing,
 
     def to_cpu(self):
         """
-        Transfer data array to host memory
+        Transfer data array to host memory.
+
+        Raises
+        ------
+        BaseException
+            Raise expection if signal is lazy.
 
         Returns
         -------
         None.
 
         """
+        if self._lazy:  # pragma: no cover
+            raise BaseException("Automatically converting data from cupy array "
+                                "is not supported for lazy signal. Read the "
+                                "corresponding section in the user guide "
+                                "for more information on how to use GPU "
+                                "with lazy signals.")
         self.data = to_numpy(self.data)
 
 

--- a/hyperspy/signal.py
+++ b/hyperspy/signal.py
@@ -24,6 +24,7 @@ import inspect
 from itertools import product
 import logging
 import numbers
+from packaging.version import Version
 from pathlib import Path
 import warnings
 
@@ -3621,7 +3622,11 @@ class BaseSignal(FancySlicing,
             _logger.info("{0!r} data is replaced by its optimized copy, see "
                          "optimize parameter of ``Basesignal.transpose`` "
                          "for more information.".format(self))
-            self.data = np.ascontiguousarray(self.data)
+            # `like` keyword is necessary to support cupy array (NEP-35)
+            kw = {}
+            if Version(np.__version__) >= Version("1.20"):
+                 kw['like'] = self.data
+            self.data = np.ascontiguousarray(self.data, **kw)
 
     def _iterate_signal(self, iterpath=None):
         """Iterates over the signal data. It is faster than using the signal

--- a/hyperspy/signal.py
+++ b/hyperspy/signal.py
@@ -2792,7 +2792,7 @@ class BaseSignal(FancySlicing,
 
         def get_static_explorer_wrapper(*args, **kwargs):
             if np.issubdtype(navigator.data.dtype, np.complexfloating):
-                return np.abs(navigator(as_numpy=True))
+                return abs(navigator(as_numpy=True))
             else:
                 return navigator(as_numpy=True)
 
@@ -2814,7 +2814,7 @@ class BaseSignal(FancySlicing,
                 navigator.axes_manager.signal_dimension:]
             navigator.axes_manager._update_attributes()
             if np.issubdtype(navigator().dtype, np.complexfloating):
-                return np.abs(navigator(as_numpy=True))
+                return abs(navigator(as_numpy=True))
             else:
                 return navigator(as_numpy=True)
 
@@ -2888,7 +2888,7 @@ class BaseSignal(FancySlicing,
                 elif navigator == "data":
                     if np.issubdtype(self.data.dtype, np.complexfloating):
                         self._plot.navigator_data_function = \
-                            lambda axes_manager=None: to_numpy(np.abs(self.data))
+                            lambda axes_manager=None: to_numpy(abs(self.data))
                     else:
                         self._plot.navigator_data_function = \
                             lambda axes_manager=None: to_numpy(self.data)

--- a/hyperspy/signal.py
+++ b/hyperspy/signal.py
@@ -51,7 +51,6 @@ from hyperspy.misc import rgb_tools
 from hyperspy.misc.utils import (
     add_scalar_axis,
     DictionaryTreeBrowser,
-    get_array_module,
     guess_output_signal_size,
     is_binned, # remove in v2.0
     is_cupy_array,
@@ -67,13 +66,9 @@ from hyperspy.misc.hist_tools import histogram
 from hyperspy.drawing.utils import animate_legend
 from hyperspy.drawing.marker import markers_metadata_dict_to_markers
 from hyperspy.misc.slicing import SpecialSlicers, FancySlicing
-from hyperspy.misc.utils import is_binned # remove in v2.0
 from hyperspy.misc.utils import (
-    process_function_blockwise,
-    guess_output_signal_size,
     _get_block_pattern
     )
-from hyperspy.misc.utils import add_scalar_axis
 from hyperspy.docstrings.signal import (
     ONE_AXIS_PARAMETER, MANY_AXIS_PARAMETER, OUT_ARG, NAN_FUNC, OPTIMIZE_ARG,
     RECHUNK_ARG, SHOW_PROGRESSBAR_ARG, PARALLEL_ARG, MAX_WORKERS_ARG,
@@ -84,8 +79,7 @@ from hyperspy.docstrings.plot import (BASE_PLOT_DOCSTRING, PLOT1D_DOCSTRING,
 from hyperspy.docstrings.utils import REBIN_ARGS
 from hyperspy.events import Events, Event
 from hyperspy.interactive import interactive
-from hyperspy.misc.signal_tools import (are_signals_aligned,
-                                        broadcast_signals)
+from hyperspy.misc.signal_tools import are_signals_aligned, broadcast_signals
 from hyperspy.misc.math_tools import outer_nd, hann_window_nth_order, check_random_state
 from hyperspy.exceptions import VisibleDeprecationWarning
 

--- a/hyperspy/signal.py
+++ b/hyperspy/signal.py
@@ -6468,8 +6468,8 @@ class BaseSignal(FancySlicing,
     def to_device(self):
         """
         Transfer data array from host to GPU device memory using cupy.asarray.
-        Lazy signal are not supported by this method, see user guide for
-        information on how to process data lazily using GPU.
+        Lazy signals are not supported by this method, see user guide for
+        information on how to process data lazily using the GPU.
 
         Raises
         ------

--- a/hyperspy/signal.py
+++ b/hyperspy/signal.py
@@ -17,9 +17,10 @@
 # along with HyperSpy. If not, see <http://www.gnu.org/licenses/>.
 
 from collections.abc import MutableMapping
-import copy
 from contextlib import contextmanager
+import copy
 from datetime import datetime
+from functools import partial
 import inspect
 from itertools import product
 import logging
@@ -2712,14 +2713,16 @@ class BaseSignal(FancySlicing,
             axes = []
         return axes
 
-    def __call__(self, axes_manager=None, fft_shift=False):
+    def __call__(self, axes_manager=None, fft_shift=False, as_numpy=False):
         if axes_manager is None:
             axes_manager = self.axes_manager
         indices = axes_manager._getitem_tuple
         if self._lazy:
             value = self._get_cache_dask_chunk(indices)
         else:
-            value = to_numpy(self.data.__getitem__(indices))
+            value = self.data.__getitem__(indices)
+        if as_numpy:
+            value = to_numpy(value)
         value = np.atleast_1d(value)
         if fft_shift:
             value = np.fft.fftshift(value)
@@ -2777,7 +2780,7 @@ class BaseSignal(FancySlicing,
                 "for plotting as a 2D signal.")
 
         self._plot.axes_manager = axes_manager
-        self._plot.signal_data_function = self.__call__
+        self._plot.signal_data_function = partial(self.__call__, as_numpy=True)
 
         if self.metadata.has_item("Signal.quantity"):
             self._plot.quantity_label = self.metadata.Signal.quantity
@@ -2789,9 +2792,9 @@ class BaseSignal(FancySlicing,
 
         def get_static_explorer_wrapper(*args, **kwargs):
             if np.issubdtype(navigator.data.dtype, np.complexfloating):
-                return np.abs(navigator())
+                return np.abs(navigator(as_numpy=True))
             else:
-                return navigator()
+                return navigator(as_numpy=True)
 
         def get_1D_sum_explorer_wrapper(*args, **kwargs):
             navigator = self
@@ -2811,9 +2814,9 @@ class BaseSignal(FancySlicing,
                 navigator.axes_manager.signal_dimension:]
             navigator.axes_manager._update_attributes()
             if np.issubdtype(navigator().dtype, np.complexfloating):
-                return np.abs(navigator())
+                return np.abs(navigator(as_numpy=True))
             else:
-                return navigator()
+                return navigator(as_numpy=True)
 
         if not isinstance(navigator, BaseSignal) and navigator == "auto":
             if self.navigator is not None:
@@ -2879,18 +2882,20 @@ class BaseSignal(FancySlicing,
                     raise ValueError(
                         "The dimensions of the provided (or stored) navigator "
                         "are not compatible with this signal.")
-            elif navigator == "slider":
-                self._plot.navigator_data_function = "slider"
+            elif isinstance(navigator, str):
+                if navigator == "slider":
+                    self._plot.navigator_data_function = "slider"
+                elif navigator == "data":
+                    if np.issubdtype(self.data.dtype, np.complexfloating):
+                        self._plot.navigator_data_function = \
+                            lambda axes_manager=None: to_numpy(np.abs(self.data))
+                    else:
+                        self._plot.navigator_data_function = \
+                            lambda axes_manager=None: to_numpy(self.data)
+                elif navigator == "spectrum":
+                    self._plot.navigator_data_function = get_1D_sum_explorer_wrapper
             elif navigator is None:
                 self._plot.navigator_data_function = None
-            elif navigator == "data":
-                if np.issubdtype(self.data.dtype, np.complexfloating):
-                    self._plot.navigator_data_function = lambda axes_manager=None: np.abs(
-                        self.data)
-                else:
-                    self._plot.navigator_data_function = lambda axes_manager=None: to_numpy(self.data)
-            elif navigator == "spectrum":
-                self._plot.navigator_data_function = get_1D_sum_explorer_wrapper
             else:
                 raise ValueError(
                     'navigator must be one of "spectrum","auto", '
@@ -5396,7 +5401,8 @@ class BaseSignal(FancySlicing,
 
         return None
 
-    def get_current_signal(self, auto_title=True, auto_filename=True):
+    def get_current_signal(self, auto_title=True, auto_filename=True,
+                           as_numpy=False):
         """Returns the data at the current coordinates as a
         :py:class:`~hyperspy.signal.BaseSignal` subclass.
 
@@ -5413,6 +5419,9 @@ class BaseSignal(FancySlicing,
             (which is always the case when the Signal has been read from a
             file), the filename stored in the metadata is modified by
             appending an underscore and the current indices in parentheses.
+        as_numpy : bool or None
+            Only with cupy array. If ``True``, return the current signal
+            as numpy array, otherwise return as cupy array.
 
         Returns
         -------
@@ -5453,7 +5462,7 @@ class BaseSignal(FancySlicing,
             lazy=False)
 
         cs = class_(
-            self(),
+            self(as_numpy=as_numpy),
             axes=self.axes_manager._get_signal_axes_dicts(),
             metadata=metadata.as_dictionary())
 

--- a/hyperspy/signal.py
+++ b/hyperspy/signal.py
@@ -94,7 +94,7 @@ _logger = logging.getLogger(__name__)
 
 try:
     import cupy as cp
-    CUPY_INSTALLED = True
+    CUPY_INSTALLED = True  # pragma: no cover
 except ImportError:
     CUPY_INSTALLED = False
 
@@ -5414,7 +5414,8 @@ class BaseSignal(FancySlicing,
         ----------
         auto_title : bool
             If ``True``, the current indices (in parentheses) are appended to
-            the title, separated by a space.
+            the title, separated by a space, otherwise the title of the signal
+            is used unchanged.
         auto_filename : bool
             If ``True`` and `tmp_parameters.filename` is defined
             (which is always the case when the Signal has been read from a
@@ -5439,8 +5440,6 @@ class BaseSignal(FancySlicing,
         <Signal2D, title:  (2, 1), dimensions: (32, 32)>
 
         """
-        from dask.array import Array
-
         metadata = self.metadata.deepcopy()
 
         # Check if marker update
@@ -5466,9 +5465,6 @@ class BaseSignal(FancySlicing,
             self(as_numpy=as_numpy),
             axes=self.axes_manager._get_signal_axes_dicts(),
             metadata=metadata.as_dictionary())
-
-        if isinstance(cs.data, Array):
-            cs.data = cs.data.compute()
 
         if cs.metadata.has_item('Markers'):
             temp_marker_dict = cs.metadata.Markers.as_dictionary()
@@ -6492,13 +6488,17 @@ class BaseSignal(FancySlicing,
         None.
 
         """
+        if self._lazy:
+            raise BaseException("Automatically converting data to cupy array "
+                                "is not supported for lazy signal. Read the "
+                                "corresponding section in the user guide "
+                                "for more information on how to use GPU "
+                                "with lazy signals.")
+
         if not CUPY_INSTALLED:
             raise BaseException('cupy is required.')
-        else:
+        else:  # pragma: no cover
             self.data = cp.asarray(self.data)
-            if self._lazy:
-                self._lazy = False
-                self._assign_subclass()
 
     def to_cpu(self):
         """

--- a/hyperspy/signal_tools.py
+++ b/hyperspy/signal_tools.py
@@ -1060,9 +1060,9 @@ class ImageContrastEditor(t.HasTraits):
         arr = arr.copy()
         _linscale_adj = (self.linscale / (1.0 - np.e ** -1))
         with np.errstate(invalid="ignore"):
-            masked = np.abs(arr) > self.linthresh
+            masked = abs(arr) > self.linthresh
         sign = np.sign(arr[masked])
-        log = (_linscale_adj + np.log(np.abs(arr[masked]) / self.linthresh))
+        log = (_linscale_adj + np.log(abs(arr[masked]) / self.linthresh))
         log *= sign * self.linthresh
         arr[masked] = log
         arr[~masked] *= _linscale_adj

--- a/hyperspy/tests/learn/test_bss.py
+++ b/hyperspy/tests/learn/test_bss.py
@@ -16,6 +16,8 @@
 # You should have received a copy of the GNU General Public License
 # along with HyperSpy. If not, see <http://www.gnu.org/licenses/>.
 
+from packaging.version import Version
+
 import numpy as np
 import pytest
 

--- a/hyperspy/tests/learn/test_bss.py
+++ b/hyperspy/tests/learn/test_bss.py
@@ -28,6 +28,9 @@ from hyperspy.misc.machine_learning.tools import amari
 from hyperspy.signals import BaseSignal
 
 
+skip_sklearn = pytest.mark.skipif(not sklearn_installed, reason="sklearn not installed")
+
+
 def are_bss_components_equivalent(c1_list, c2_list, atol=1e-4):
     """Check if two list of components are equivalent.
 
@@ -69,7 +72,7 @@ def test_amari_distance(n=16, tol=1e-6):
     np.testing.assert_allclose(amari(X, A), 0.0, rtol=tol)
 
 
-@pytest.mark.skipif(not sklearn_installed, reason="sklearn not installed")
+@skip_sklearn
 def test_bss_FastICA_object():
     """Tests that a simple sklearn pipeline is an acceptable algorithm."""
     rng = np.random.RandomState(123)
@@ -87,7 +90,7 @@ def test_bss_FastICA_object():
     assert hasattr(out, "components_")
 
 
-@pytest.mark.skipif(not sklearn_installed, reason="sklearn not installed")
+@skip_sklearn
 def test_bss_pipeline():
     """Tests that a simple sklearn pipeline is an acceptable algorithm."""
     rng = np.random.RandomState(123)
@@ -149,7 +152,7 @@ def test_factors_error():
         s.blind_source_separation(2, factors=factors)
 
 
-@pytest.mark.skipif(not sklearn_installed, reason="sklearn not installed")
+@skip_sklearn
 @pytest.mark.parametrize("num_components", [None, 2])
 def test_num_components(num_components):
     s = artificial_data.get_core_loss_eels_line_scan_signal()
@@ -157,7 +160,7 @@ def test_num_components(num_components):
     s.blind_source_separation(number_of_components=num_components)
 
 
-@pytest.mark.skipif(not sklearn_installed, reason="sklearn not installed")
+@skip_sklearn
 def test_components_list():
     s = artificial_data.get_core_loss_eels_line_scan_signal()
     s.decomposition(output_dimension=3)
@@ -165,7 +168,7 @@ def test_components_list():
     assert s.learning_results.unmixing_matrix.shape == (2, 2)
 
 
-@pytest.mark.skipif(not sklearn_installed, reason="sklearn not installed")
+@skip_sklearn
 def test_num_components_error():
     s = artificial_data.get_core_loss_eels_line_scan_signal()
     s.decomposition()
@@ -185,7 +188,7 @@ def test_algorithm_error():
         s.blind_source_separation(2, algorithm="uniform")
 
 
-@pytest.mark.skipif(not sklearn_installed, reason="sklearn not installed")
+@skip_sklearn
 def test_normalize_components_errors():
     rng = np.random.RandomState(123)
     s = Signal1D(rng.random_sample(size=(20, 100)))
@@ -200,7 +203,7 @@ def test_normalize_components_errors():
         s.normalize_bss_components(target="uniform")
 
 
-@pytest.mark.skipif(not sklearn_installed, reason="sklearn not installed")
+@skip_sklearn
 def test_sklearn_convergence_warning():
     # Import here to avoid error if sklearn missing
     from sklearn.exceptions import ConvergenceWarning
@@ -222,7 +225,7 @@ def test_sklearn_convergence_warning():
         )
 
 
-@pytest.mark.skipif(not sklearn_installed, reason="sklearn not installed")
+@skip_sklearn
 @pytest.mark.parametrize("whiten_method", [None, "PCA", "ZCA"])
 def test_fastica_whiten_method(whiten_method):
     rng = np.random.RandomState(123)
@@ -236,7 +239,7 @@ def test_fastica_whiten_method(whiten_method):
     assert s.learning_results.unmixing_matrix.shape == A.shape
 
 
-@pytest.mark.skipif(not sklearn_installed, reason="sklearn not installed")
+@skip_sklearn
 @lazifyTestClass
 class TestReverseBSS:
     def setup_method(self, method):
@@ -266,7 +269,7 @@ class TestReverseBSS:
             self.s.blind_source_separation(2, reverse_component_criterion="toto")
 
 
-@pytest.mark.skipif(not sklearn_installed, reason="sklearn not installed")
+@skip_sklearn
 @lazifyTestClass
 class TestBSS1D:
     def setup_method(self, method):
@@ -324,7 +327,7 @@ class TestBSS1D:
         )
 
 
-@pytest.mark.skipif(not sklearn_installed, reason="sklearn not installed")
+@skip_sklearn
 @lazifyTestClass
 class TestBSS2D:
     def setup_method(self, method):
@@ -472,7 +475,7 @@ class TestPrintInfo:
         captured = capfd.readouterr()
         assert "Blind source separation info:" in captured.out
 
-    @pytest.mark.skipif(not sklearn_installed, reason="sklearn not installed")
+    @skip_sklearn
     def test_bss_sklearn(self, capfd):
         self.s.blind_source_separation(2)
         captured = capfd.readouterr()
@@ -492,10 +495,10 @@ class TestReturnInfo:
             is None
         )
 
-    @pytest.mark.skipif(not sklearn_installed, reason="sklearn not installed")
+    @skip_sklearn
     def test_bss_supported_return_true(self):
         assert self.s.blind_source_separation(return_info=True) is not None
 
-    @pytest.mark.skipif(not sklearn_installed, reason="sklearn not installed")
+    @skip_sklearn
     def test_bss_supported_return_false(self):
         assert self.s.blind_source_separation(return_info=False) is None

--- a/hyperspy/tests/learn/test_decomposition.py
+++ b/hyperspy/tests/learn/test_decomposition.py
@@ -36,7 +36,7 @@ def generate_low_rank_matrix(m=20, n=100, rank=5, random_seed=123):
     rng = np.random.RandomState(random_seed)
     U = rng.randn(m, rank)
     V = rng.randn(n, rank)
-    X = np.abs(U @ V.T)
+    X = abs(U @ V.T)
     X /= np.linalg.norm(X)
     return X
 

--- a/hyperspy/tests/learn/test_decomposition.py
+++ b/hyperspy/tests/learn/test_decomposition.py
@@ -28,6 +28,9 @@ from hyperspy.exceptions import VisibleDeprecationWarning
 from hyperspy.misc.machine_learning.import_sklearn import sklearn_installed
 
 
+skip_sklearn = pytest.mark.skipif(not sklearn_installed, reason="sklearn not installed")
+
+
 def generate_low_rank_matrix(m=20, n=100, rank=5, random_seed=123):
     """Generate a low-rank matrix with specified size and rank for testing."""
     rng = np.random.RandomState(random_seed)
@@ -144,7 +147,7 @@ class TestGetModel:
         rms = np.sqrt(((sc.data - s.data) ** 2).sum())
         assert rms < 5e-7
 
-    @pytest.mark.skipif(not sklearn_installed, reason="sklearn not installed")
+    @skip_sklearn
     def test_get_bss_model(self):
         s = self.s
         s.decomposition(algorithm="SVD")
@@ -217,7 +220,7 @@ class TestEstimateElbowPosition:
     # Should be removed in scikit-learn 0.26
     # https://scikit-learn.org/dev/whats_new/v0.24.html#sklearn-cross-decomposition
     @pytest.mark.filterwarnings("ignore:The 'init' value, when 'init=None':FutureWarning")
-    @pytest.mark.skipif(not sklearn_installed, reason="sklearn not installed")
+    @skip_sklearn
     def test_store_number_significant_components(self):
         s = signals.Signal1D(generate_low_rank_matrix())
         s.decomposition()
@@ -338,13 +341,16 @@ class TestDecompositionAlgorithm:
     def test_decomposition(self, algorithm):
         self.s.decomposition(algorithm=algorithm, output_dimension=2)
 
-    @pytest.mark.skipif(not sklearn_installed, reason="sklearn not installed")
+    # Warning filter can be removed after scikit-learn >= 0.22
+    # See sklearn.decomposition.sparse_pca.SparsePCA docstring
+    @pytest.mark.filterwarnings("ignore:normalize_components=False:DeprecationWarning")
+    @skip_sklearn
     @pytest.mark.parametrize("algorithm", ["RPCA", "ORPCA", "ORNMF", "MLPCA"])
     def test_decomposition_output_dimension_not_given(self, algorithm):
         with pytest.raises(ValueError, match="`output_dimension` must be specified"):
             self.s.decomposition(algorithm=algorithm, return_info=False)
 
-    @pytest.mark.skipif(not sklearn_installed, reason="sklearn not installed")
+    @skip_sklearn
     @pytest.mark.parametrize("algorithm", ["fast_svd", "fast_mlpca"])
     def test_fast_deprecation_warning(self, algorithm):
         with pytest.warns(
@@ -353,7 +359,7 @@ class TestDecompositionAlgorithm:
         ):
             self.s.decomposition(algorithm=algorithm, output_dimension=2)
 
-    @pytest.mark.skipif(not sklearn_installed, reason="sklearn not installed")
+    @skip_sklearn
     @pytest.mark.parametrize("algorithm", ["RPCA_GoDec", "svd", "mlpca", "nmf",])
     def test_name_deprecation_warning(self, algorithm):
         with pytest.warns(
@@ -377,10 +383,10 @@ class TestPrintInfo:
         captured = capfd.readouterr()
         assert "Decomposition info:" in captured.out
 
-    # Should be removed in scikit-learn 0.26
-    # https://scikit-learn.org/dev/whats_new/v0.24.html#sklearn-cross-decomposition
-    @pytest.mark.filterwarnings("ignore:The 'init' value, when 'init=None':FutureWarning")
-    @pytest.mark.skipif(not sklearn_installed, reason="sklearn not installed")
+    # Warning filter can be removed after scikit-learn >= 0.22
+    # See sklearn.decomposition.sparse_pca.SparsePCA docstring
+    @pytest.mark.filterwarnings("ignore:normalize_components=False:DeprecationWarning")
+    @skip_sklearn
     @pytest.mark.parametrize(
         "algorithm", ["sklearn_pca", "NMF", "sparse_pca", "mini_batch_sparse_pca"]
     )
@@ -410,10 +416,10 @@ class TestReturnInfo:
             is None
         )
 
-    # Should be removed in scikit-learn 0.26
-    # https://scikit-learn.org/dev/whats_new/v0.24.html#sklearn-cross-decomposition
-    @pytest.mark.filterwarnings("ignore:The 'init' value, when 'init=None':FutureWarning")
-    @pytest.mark.skipif(not sklearn_installed, reason="sklearn not installed")
+    # Warning filter can be removed after scikit-learn >= 0.22
+    # See sklearn.decomposition.sparse_pca.SparsePCA docstring
+    @pytest.mark.filterwarnings("ignore:normalize_components=False:DeprecationWarning")
+    @skip_sklearn
     @pytest.mark.parametrize("return_info", [True, False])
     @pytest.mark.parametrize(
         "algorithm",
@@ -509,7 +515,7 @@ def test_decomposition_reproject(reproject):
     s.decomposition(reproject=reproject)
 
 
-@pytest.mark.skipif(not sklearn_installed, reason="sklearn not installed")
+@skip_sklearn
 @pytest.mark.parametrize("reproject", ["signal", "both"])
 def test_decomposition_reproject_warning(reproject):
     s = signals.Signal1D(generate_low_rank_matrix())
@@ -519,7 +525,7 @@ def test_decomposition_reproject_warning(reproject):
         s.decomposition(algorithm="NMF", reproject=reproject)
 
 
-@pytest.mark.skipif(not sklearn_installed, reason="sklearn not installed")
+@skip_sklearn
 def test_decomposition_pipeline():
     """Tests that a simple sklearn pipeline is an acceptable algorithm."""
     s = signals.Signal1D(generate_low_rank_matrix())
@@ -535,7 +541,7 @@ def test_decomposition_pipeline():
     assert hasattr(out.named_steps["PCA"], "explained_variance_")
 
 
-@pytest.mark.skipif(not sklearn_installed, reason="sklearn not installed")
+@skip_sklearn
 def test_decomposition_gridsearchcv():
     """Tests that a simple sklearn GridSearchCV is an acceptable algorithm."""
     s = signals.Signal1D(generate_low_rank_matrix())

--- a/hyperspy/tests/misc/test_signal_tools.py
+++ b/hyperspy/tests/misc/test_signal_tools.py
@@ -1,0 +1,29 @@
+# -*- coding: utf-8 -*-
+# Copyright 2007-2022 The HyperSpy developers
+#
+# This file is part of HyperSpy.
+#
+# HyperSpy is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# HyperSpy is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with HyperSpy. If not, see <http://www.gnu.org/licenses/>.
+
+import pytest
+
+from hyperspy.misc.signal_tools import broadcast_signals
+from hyperspy.signals import Signal1D
+
+
+def test_boardcast_signals_error():
+    with pytest.raises(ValueError):
+        broadcast_signals([0, 1], [2, 3])
+    with pytest.raises(ValueError):
+        broadcast_signals(Signal1D([0, 1]))

--- a/hyperspy/tests/misc/test_utils.py
+++ b/hyperspy/tests/misc/test_utils.py
@@ -31,8 +31,19 @@ from hyperspy.misc.utils import (
     closest_power_of_two,
     shorten_name,
     is_binned,
+    is_cupy_array,
+    to_numpy,
+    get_array_module
 )
 from hyperspy.exceptions import VisibleDeprecationWarning
+
+try:
+    import cupy as cp
+    CUPY_INSTALLED = True
+except ImportError:
+    CUPY_INSTALLED = False
+
+skip_cupy = pytest.mark.skipif(not CUPY_INSTALLED, reason="cupy is required")
 
 
 def test_slugify():
@@ -135,3 +146,27 @@ def test_is_binned():
     with pytest.warns(VisibleDeprecationWarning, match="Use of the `binned`"):
         s.metadata.set_item("Signal.binned", True)
     assert is_binned(s) == s.metadata.Signal.binned
+
+
+@skip_cupy
+def test_is_cupy_array():
+    cp_array = cp.array([0, 1, 2])
+    np_array = np.array([0, 1, 2])
+    assert is_cupy_array(cp_array)
+    assert not is_cupy_array(np_array)
+
+
+@skip_cupy
+def test_to_numpy():
+    cp_array = cp.array([0, 1, 2])
+    np_array = np.array([0, 1, 2])
+    np.testing.assert_allclose(to_numpy(cp_array), np_array)
+    np.testing.assert_allclose(to_numpy(np_array), np_array)
+
+
+@skip_cupy
+def test_get_array_module():
+    cp_array = cp.array([0, 1, 2])
+    np_array = np.array([0, 1, 2])
+    assert get_array_module(cp_array) == cp
+    assert get_array_module(np_array) == np

--- a/hyperspy/tests/misc/test_utils.py
+++ b/hyperspy/tests/misc/test_utils.py
@@ -16,6 +16,7 @@
 # You should have received a copy of the GNU General Public License
 # along with HyperSpy. If not, see <http://www.gnu.org/licenses/>.
 
+import dask.array as da
 import numpy as np
 import pytest
 
@@ -35,7 +36,7 @@ from hyperspy.misc.utils import (
     to_numpy,
     get_array_module
 )
-from hyperspy.exceptions import VisibleDeprecationWarning
+from hyperspy.exceptions import VisibleDeprecationWarning, LazyCupyConversion
 
 try:
     import cupy as cp
@@ -162,6 +163,12 @@ def test_to_numpy():
     np_array = np.array([0, 1, 2])
     np.testing.assert_allclose(to_numpy(cp_array), np_array)
     np.testing.assert_allclose(to_numpy(np_array), np_array)
+
+
+def test_to_numpy_error():
+    da_array = da.array([0, 1, 2])
+    with pytest.raises(LazyCupyConversion):
+        to_numpy(da_array)
 
 
 @skip_cupy

--- a/hyperspy/tests/model/test_fitting.py
+++ b/hyperspy/tests/model/test_fitting.py
@@ -479,7 +479,7 @@ class TestCustomOptimization:
         self.m.append(hs.model.components1D.Gaussian())
 
         def sets_second_parameter_to_two(model, parameters, data, weights=None):
-            return np.abs(parameters[1] - 2)
+            return abs(parameters[1] - 2)
 
         self.fmin = sets_second_parameter_to_two
 

--- a/hyperspy/tests/samfire/test_samfire.py
+++ b/hyperspy/tests/samfire/test_samfire.py
@@ -115,7 +115,7 @@ def generate_test_model():
 
     s = Signal1D(total)
     s.data = rnd.poisson(lam=s.data) + 0.1
-    s.change_dtype(np.float16)
+    s.change_dtype(float)
     s.estimate_poissonian_noise_variance()
 
     m = s.inav[:, :7].create_model()
@@ -150,7 +150,7 @@ class TestSamfireEmpty:
         self.shape = (7, 15)
         n_im = 50
         s = hs.signals.Signal1D(np.ones(self.shape + (n_im,)) + 3.)
-        s.change_dtype(np.float16)
+        s.change_dtype(float)
         s.estimate_poissonian_noise_variance()
         m = s.create_model()
         m.append(hs.model.components1D.Gaussian())
@@ -419,7 +419,7 @@ class TestSamfireWorker:
             l1.function(ax - self.centres[2])
         s = hs.signals.Signal1D(np.array([d, d]))
         s.add_poissonian_noise()
-        s.change_dtype(np.float16)
+        s.change_dtype(float)
         s.metadata.Signal.set_item("Noise_properties.variance",
                                    s.deepcopy() + 1.)
         m = s.create_model()

--- a/hyperspy/tests/signals/test_check_mask.py
+++ b/hyperspy/tests/signals/test_check_mask.py
@@ -45,7 +45,11 @@ def test_check_navigation_mask():
     with pytest.raises(ValueError, match=error_message):
         s._check_navigation_mask(mask)
 
-
+    s = hs.signals.Signal1D(np.arange(2*3*4).reshape(3, 2, 4))
+    navigation_mask = s.sum(-1)
+    s._check_navigation_mask(navigation_mask)
+    with pytest.raises(ValueError):
+        s._check_navigation_mask(navigation_mask.T)
 
 def test_check_signal_mask():
     s = hs.signals.Signal1D(np.ones(shape=(32, 32, 1024)))
@@ -69,3 +73,9 @@ def test_check_signal_mask():
     error_message = 'The signal mask signal must have the `navigation_dimension`'
     with pytest.raises(ValueError, match=error_message):
         s._check_signal_mask(mask)
+
+    s = hs.signals.Signal1D(np.arange(2*3*4).reshape(3, 2, 4))
+    signal_mask = s.sum([0, 1])
+    s._check_signal_mask(signal_mask)
+    with pytest.raises(ValueError):
+        s._check_signal_mask(signal_mask.T)

--- a/hyperspy/tests/signals/test_complex_signal.py
+++ b/hyperspy/tests/signals/test_complex_signal.py
@@ -123,7 +123,7 @@ class TestComplexProperties:
                                            (False, False),
                                            (False, True)])
 def test_get_unwrapped_phase_1D(parallel, lazy):
-    phase = 6 * (1 - np.abs(np.indices((9,)) - 4) / 4)
+    phase = 6 * (1 - abs(np.indices((9,)) - 4) / 4)
     s = hs.signals.ComplexSignal1D(np.ones_like(phase) * np.exp(1j * phase))
     if lazy:
         s = s.as_lazy()
@@ -138,7 +138,7 @@ def test_get_unwrapped_phase_1D(parallel, lazy):
                                            (False, False),
                                            (False, True)])
 def test_get_unwrapped_phase_2D(parallel, lazy):
-    phase = 5 * (1 - np.abs(np.indices((9, 9)) - 4).sum(axis=0) / 8)
+    phase = 5 * (1 - abs(np.indices((9, 9)) - 4).sum(axis=0) / 8)
     s = hs.signals.ComplexSignal(np.ones_like(phase) * np.exp(1j * phase))
     if lazy:
         s = s.as_lazy()
@@ -153,7 +153,7 @@ def test_get_unwrapped_phase_2D(parallel, lazy):
                                            (False, False),
                                            (False, True)])
 def test_get_unwrapped_phase_3D(parallel, lazy):
-    phase = 4 * (1 - np.abs(np.indices((9, 9, 9)) - 4).sum(axis=0) / 12)
+    phase = 4 * (1 - abs(np.indices((9, 9, 9)) - 4).sum(axis=0) / 12)
     s = hs.signals.ComplexSignal(np.ones_like(phase) * np.exp(1j * phase))
     if lazy:
         s = s.as_lazy()

--- a/hyperspy/tests/signals/test_cuda.py
+++ b/hyperspy/tests/signals/test_cuda.py
@@ -97,3 +97,15 @@ class TestCupy:
         m = s.create_model()
         m.append(hs.model.components1D.Polynomial(legacy=False, order=1))
         m.fit()
+
+
+@pytest.mark.parametrize('lazy', [False, True])
+def test_to_gpu(lazy):
+    s = hs.signals.Signal1D(np.arange(10))
+    if lazy:
+        s = s.as_lazy()
+        assert isinstance(s, hs.hyperspy._signals.signal1d.LazySignal1D)
+
+    s.to_gpu()
+    assert isinstance(s, hs.signals.Signal1D)
+    assert isinstance(s.data, cp.ndarray)

--- a/hyperspy/tests/signals/test_cuda.py
+++ b/hyperspy/tests/signals/test_cuda.py
@@ -1,0 +1,51 @@
+# -*- coding: utf-8 -*-
+# Copyright 2007-2021 The HyperSpy developers
+#
+# This file is part of  HyperSpy.
+#
+#  HyperSpy is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+#  HyperSpy is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with  HyperSpy.  If not, see <http://www.gnu.org/licenses/>.
+
+import numpy as np
+import pytest
+
+import hyperspy.api as hs
+
+try:
+    import cupy as cp
+except ImportError:
+    pytest.skip("cupy is required", allow_module_level=True)
+
+
+class TestCupy:
+    def setup_method(self, method):
+        N = 100
+        ndim = 3
+        data = cp.arange(N**3).reshape([N]*ndim)
+        s = hs.signals.Signal1D(data)
+        self.s = s
+
+    def test_call_signal(self):
+        s = self.s
+        np.testing.assert_allclose(s(), np.arange(100))
+
+    def test_roi(self):
+        s = self.s
+        roi = hs.roi.CircleROI(40, 60, 15)
+        sr = roi(s)
+        sr.plot()
+        assert isinstance(sr.data, cp.ndarray)
+        sr0 = cp.asnumpy(sr.inav[0, 0].data)
+        np.testing.assert_allclose(np.nan_to_num(sr0), np.zeros_like(sr0))
+        assert sr.isig[0].nansum() == 4.360798E08
+

--- a/hyperspy/tests/signals/test_cuda.py
+++ b/hyperspy/tests/signals/test_cuda.py
@@ -91,3 +91,9 @@ class TestCupy:
         s2 = s.inav[:5, 0]
         hs.plot.plot_spectra(s2, style=style)
         assert isinstance(s2.data, cp.ndarray)
+
+    def test_fit(self):
+        s = self.s
+        m = s.create_model()
+        m.append(hs.model.components1D.Polynomial(legacy=False, order=1))
+        m.fit()

--- a/hyperspy/tests/signals/test_cuda.py
+++ b/hyperspy/tests/signals/test_cuda.py
@@ -49,6 +49,20 @@ class TestCupy:
         np.testing.assert_allclose(np.nan_to_num(sr0), np.zeros_like(sr0))
         assert sr.isig[0].nansum() == 4.360798E08
 
-    def as_signal(self):
+    def test_as_signal(self):
         s = self.s
-        s2 = s.as_signal2D([0, 1])
+        _ = s.as_signal2D([0, 1])
+
+    @pytest.mark.parametrize('parallel', [True, False, None])
+    def test_map(self, parallel):
+        s = self.s
+        data_ref = s.data.copy()
+
+        def dummy_function(data):
+            return data * 10
+
+        s.map(dummy_function, parallel, inplace=True,
+              output_signal_size=s.axes_manager.signal_shape,
+              output_dtype=s.data.dtype)
+
+        assert (s.data == data_ref * 10).all()

--- a/hyperspy/tests/signals/test_cuda.py
+++ b/hyperspy/tests/signals/test_cuda.py
@@ -49,3 +49,6 @@ class TestCupy:
         np.testing.assert_allclose(np.nan_to_num(sr0), np.zeros_like(sr0))
         assert sr.isig[0].nansum() == 4.360798E08
 
+    def as_signal(self):
+        s = self.s
+        s2 = s.as_signal2D([0, 1])

--- a/hyperspy/tests/signals/test_cuda.py
+++ b/hyperspy/tests/signals/test_cuda.py
@@ -35,9 +35,14 @@ class TestCupy:
         s = hs.signals.Signal1D(data)
         self.s = s
 
-    def test_call_signal(self):
+    @pytest.mark.parametrize('as_numpy', [True, False, None])
+    def test_call_signal(self, as_numpy):
         s = self.s
-        np.testing.assert_allclose(s(), np.arange(100))
+        s2 = s(as_numpy=as_numpy)
+        if not as_numpy:
+            assert isinstance(s2, cp.ndarray)
+            s2 = cp.asnumpy(s2)
+        np.testing.assert_allclose(s2, np.arange(100))
 
     def test_roi(self):
         s = self.s
@@ -66,3 +71,23 @@ class TestCupy:
               output_dtype=s.data.dtype)
 
         assert (s.data == data_ref * 10).all()
+
+    def test_plot_images(self):
+        s = self.s
+        s2 = s.T.inav[:5]
+        hs.plot.plot_images(s2, axes_decor=None)
+        assert isinstance(s2.data, cp.ndarray)
+
+        s_list = [_s for _s in s2]
+        hs.plot.plot_images(s_list, axes_decor=None)
+        assert isinstance(s_list[0].data, cp.ndarray)
+
+        hs.plot.plot_images(s_list, axes_decor=None, colorbar='single')
+        assert isinstance(s_list[0].data, cp.ndarray)
+
+    @pytest.mark.parametrize('style', ['overlap', 'cascade', 'mosaic', 'heatmap'])
+    def test_plot_spectra(self, style):
+        s = self.s
+        s2 = s.inav[:5, 0]
+        hs.plot.plot_spectra(s2, style=style)
+        assert isinstance(s2.data, cp.ndarray)

--- a/hyperspy/tests/signals/test_cuda.py
+++ b/hyperspy/tests/signals/test_cuda.py
@@ -159,3 +159,20 @@ def test_to_gpu(lazy):
         np.testing.assert_allclose(s.data, data)
         # we have a different copy now
         assert s.data is not data
+
+
+def test_decomposition():
+    data = cp.random.random(size=(20, 10, 10))
+    s = hs.signals.Signal1D(data)
+
+    with pytest.raises(TypeError):
+        s.decomposition(algorithm="NMF")
+    with pytest.raises(ValueError):
+        s.decomposition(algorithm="SVD", svd_solver='randomized')
+
+    s.decomposition()
+    s.plot_explained_variance_ratio()
+    s.plot_decomposition_loadings(3)
+    s.plot_decomposition_factors(3)
+
+    s.blind_source_separation(2, algorithm='orthomax')

--- a/hyperspy/tests/signals/test_cuda.py
+++ b/hyperspy/tests/signals/test_cuda.py
@@ -83,6 +83,8 @@ class TestCupy:
         s = self.s
         data_ref = s.data.copy()
         s = s.as_lazy()
+        assert isinstance(s.data, dask.array.Array)
+        assert isinstance(s.data[0, 0, 0].compute(), cp.ndarray)
 
         def dummy_function(data):
             return data * 10
@@ -91,7 +93,11 @@ class TestCupy:
               output_signal_size=s.axes_manager.signal_shape,
               output_dtype=s.data.dtype)
 
-        assert (s.data == data_ref * 10).all()
+        assert isinstance(s.data, dask.array.Array)
+        assert isinstance(s.data[0, 0, 0].compute(), cp.ndarray)
+
+        s.compute()
+        cp.testing.assert_allclose(s.data, data_ref * 10)
 
     def test_plot_images(self):
         s = self.s

--- a/hyperspy/tests/signals/test_cuda.py
+++ b/hyperspy/tests/signals/test_cuda.py
@@ -147,19 +147,19 @@ class TestCupy:
 
 
 @pytest.mark.parametrize('lazy', [False, True])
-def test_to_gpu(lazy):
+def test_to_device(lazy):
     data = np.arange(10)
     s = hs.signals.Signal1D(data)
     if lazy:
         s = s.as_lazy()
         assert isinstance(s, hs.hyperspy._signals.signal1d.LazySignal1D)
         with pytest.raises(BaseException):
-            s.to_gpu()
+            s.to_device()
     else:
-        s.to_gpu()
+        s.to_device()
         assert isinstance(s, hs.signals.Signal1D)
         assert isinstance(s.data, cp.ndarray)
-        s.to_cpu()
+        s.to_host()
         assert isinstance(s, hs.signals.Signal1D)
         assert isinstance(s.data, np.ndarray)
         np.testing.assert_allclose(s.data, data)

--- a/hyperspy/tests/signals/test_hologram_image.py
+++ b/hyperspy/tests/signals/test_hologram_image.py
@@ -18,6 +18,7 @@
 
 import gc
 
+import matplotlib.pyplot as plt
 import numpy as np
 import pytest
 from scipy.interpolate import interp2d
@@ -102,7 +103,10 @@ def test_reconstruct_phase_single(lazy):
     if lazy:
         ref_image = ref_image.as_lazy()
         holo_image = holo_image.as_lazy()
-    wave_image = holo_image.reconstruct_phase(ref, store_parameters=True)
+    wave_image = holo_image.reconstruct_phase(
+        ref, store_parameters=True, plotting=True
+        )
+    plt.close('all')
 
     metadata = wave_image.metadata.Signal.Holography.Reconstruction_parameters
     sb_pos_cc = metadata.sb_position * (-1) + [img_size, img_size]

--- a/hyperspy/tests/signals/test_lazy.py
+++ b/hyperspy/tests/signals/test_lazy.py
@@ -24,7 +24,10 @@ from dask.threaded import get
 import hyperspy.api as hs
 from hyperspy import _lazy_signals
 from hyperspy._signals.lazy import (
-    _reshuffle_mixed_blocks, to_array, _get_navigation_dimension_chunk_slice)
+    _reshuffle_mixed_blocks,
+    to_array,
+    _get_navigation_dimension_chunk_slice
+    )
 from hyperspy.exceptions import VisibleDeprecationWarning
 
 
@@ -32,7 +35,7 @@ def _signal():
     ar = da.from_array(np.arange(6. * 9 * 7 * 11).reshape((6, 9, 7, 11)),
                        chunks=((2, 1, 3), (4, 5), (7,), (11,))
                        )
-    return _lazy_signals.LazySignal2D(ar)
+    return hs.signals.Signal2D(ar).as_lazy()
 
 @pytest.fixture
 def signal():

--- a/hyperspy/tests/signals/test_map_method.py
+++ b/hyperspy/tests/signals/test_map_method.py
@@ -539,7 +539,7 @@ class TestOutputSignalSizeScalarWithNavigationDimensions:
         s_out = s.map(a_function, inplace=False, lazy_output=False)
         assert s_out.data.shape == nav_shape
         assert s_out.axes_manager.navigation_shape == nav_shape[::-1]
-        assert (s_out.data == np.ones(nav_shape, dtype=np.float) * 10).all()
+        assert (s_out.data == np.ones(nav_shape, dtype=float) * 10).all()
         assert s.data.shape == data_shape
         assert s.axes_manager.shape == nav_shape[::-1] + (30, 20)
 
@@ -1086,7 +1086,7 @@ def test_ragged():
     s = hs.signals.Signal1D(np.ones((10, 8, 100)))
     s_out = s.map(afunction, inplace=False, ragged=True, parallel=False)
     assert s_out.axes_manager.shape == s.axes_manager.navigation_shape
-    assert s_out.data.dtype == np.object
+    assert s_out.data.dtype == object
     with pytest.raises(ValueError):
         s.map(afunction, inplace=False, ragged=False, parallel=False)
 

--- a/hyperspy/tests/signals/test_tools.py
+++ b/hyperspy/tests/signals/test_tools.py
@@ -306,3 +306,33 @@ class TestOutArg:
         ss = s.sum()  # Sum over navigation, data shape (6,)
         with pytest.raises(ValueError):
             s.sum(axis=s.axes_manager._axes, out=ss)
+
+
+@pytest.mark.parametrize('lazy', [False, True])
+def test_get_current_signal(lazy):
+    data = np.arange(100)
+    s = signals.Signal1D(data.reshape((10, 10)))
+    s.metadata.General.title = 'A signal'
+    if lazy:
+        s = s.as_lazy()
+
+    s.axes_manager.indices = (1,)
+    cs = s.get_current_signal()
+    assert cs.metadata.General.title == 'A signal (1,)'
+    np.testing.assert_allclose(cs.data, np.arange(start=10, stop=20))
+
+    cs = s.get_current_signal(auto_title=False)
+    assert cs.metadata.General.title == 'A signal'
+
+
+def test_to_cpu():
+    data = np.arange(10)
+    s = signals.BaseSignal(data)
+    s.to_cpu()
+    s.data is data
+
+
+def test_lazy_to_gpu():
+    s = signals.BaseSignal(np.arange(10)).as_lazy()
+    with pytest.raises(BaseException):
+        s.to_gpu()

--- a/hyperspy/tests/signals/test_tools.py
+++ b/hyperspy/tests/signals/test_tools.py
@@ -325,14 +325,14 @@ def test_get_current_signal(lazy):
     assert cs.metadata.General.title == 'A signal'
 
 
-def test_to_cpu():
+def test_to_host():
     data = np.arange(10)
     s = signals.BaseSignal(data)
-    s.to_cpu()
+    s.to_host()
     s.data is data
 
 
-def test_lazy_to_gpu():
+def test_lazy_to_device():
     s = signals.BaseSignal(np.arange(10)).as_lazy()
     with pytest.raises(BaseException):
-        s.to_gpu()
+        s.to_device()

--- a/hyperspy/utils/parallel_pool.py
+++ b/hyperspy/utils/parallel_pool.py
@@ -76,7 +76,7 @@ class ParallelPool:
         self.pool = None
         if num_workers is None:
             num_workers = np.inf
-        self.num_workers = np.abs(num_workers)
+        self.num_workers = abs(num_workers)
         self.timestep = 0.001
         self.setup(ipyparallel=ipyparallel)
 

--- a/upcoming_changes/2670.new.rst
+++ b/upcoming_changes/2670.new.rst
@@ -1,0 +1,1 @@
+Add initial support for :ref:`GPU computation<gpu_processing>` using cupy


### PR DESCRIPTION
I pushed the `cupy_support` branch to `hyperspy/hyperspy` to give it visibility and so that others can make pull request to this branch. Also this PR should give an overview of what needs to be changed. I have used this branch to explore how hyperspy needs to be changed to work with cupy array. In short: not much, if we use the numpy >=1.20 and the experimental `like` keyword.

### Working (AFAIK!)
- [x] plotting,
- [x] `map` function,
- [x] ROI

### General consideration
- even for operation which are not particularly suitable for GPU computation, it is easy to get a 10x speed up.
- fitting with data on GPU works but doesn't use the GPU... This should be possible once `sympy` adds support for a [`cupy` backend](https://github.com/sympy/sympy/pull/20622).
- mask are not supported by `cupy` and where possible we should use `nan` instead - as this is done for example for the `CircleROI`.

### Relevant links:
https://numba.readthedocs.io/en/latest/cuda/cuda_array_interface.html
https://data-apis.github.io/array-api/latest
https://numpy.org/neps/nep-0035-array-creation-dispatch-with-array-function.html (see [numpy.zeros](https://numpy.org/doc/stable/reference/generated/numpy.zeros.html) docstring, for example)

### Progress of the PR:
- [x] change implemented,
- [x] update docstring (if appropriate),
- [x] update user guide (if appropriate),
- [x] add an changelog entry in the `upcoming_changes` folder (see [`upcoming_changes/README.rst`](https://github.com/hyperspy/hyperspy/blob/RELEASE_next_minor/upcoming_changes/README.rst)),
- [x] Check formatting changelog entry in the `readthedocs` doc build of this PR (link in github checks)
- [x] add tests,
- [x] ready for review.