### PR TITLE
Fix align1D

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -31,7 +31,9 @@ RELEASE_next_patch (Unreleased)
 * Add Releasing guide (`#2595 <https://github.com/hyperspy/hyperspy/pull/2595>`_)
 * Fix setting signal range of model with negative axis scales (`#2656 <https://github.com/hyperspy/hyperspy/pull/2656>`_)
 * Fix and improve mask handling in lazy decomposition; Close `#2605 <https://github.com/hyperspy/hyperspy/issues/2605>`_ (`#2657 <https://github.com/hyperspy/hyperspy/pull/2657>`_)
-* Plot scalebar when the axis scales have different sign, fixes `#2557 <https://github.com/hyperspy/hyperspy/issues/2557>`_ (#2657 `<https://github.com/hyperspy/hyperspy/pull/2657>`_)
+* Plot scalebar when the axis scales have different sign, fixes `#2557 <https://github.com/hyperspy/hyperspy/issues/2557>`_ (`#2657 <https://github.com/hyperspy/hyperspy/pull/2657>`_)
+* Fix align1D returning zeros shifts (`#2675 <https://github.com/hyperspy/hyperspy/pull/2675>`_)
+
 
 Changelog
 *********

--- a/hyperspy/_signals/signal1d.py
+++ b/hyperspy/_signals/signal1d.py
@@ -226,12 +226,8 @@ def interpolate1D(number_of_interpolation_points, data):
     return interpolator(new_ax)
 
 
-def _estimate_shift1D(data, **kwargs):
-    mask = kwargs.get('mask', None)
-    ref = kwargs.get('ref', None)
-    interpolate = kwargs.get('interpolate', True)
-    ip = kwargs.get('ip', 5)
-    data_slice = kwargs.get('data_slice', slice(None))
+def _estimate_shift1D(data, data_slice=slice(None), ref=None, ip=5,
+                      interpolate=True, mask=None, **kwargs):
     if bool(mask):
         # asarray is required for consistensy as argmax
         # returns a numpy scalar array
@@ -239,6 +235,9 @@ def _estimate_shift1D(data, **kwargs):
     data = data[data_slice]
     if interpolate is True:
         data = interpolate1D(ip, data)
+    # Normalise the data before the cross correlation
+    ref = ref - ref.mean()
+    data = data - data.mean()
     return np.argmax(np.correlate(ref, data, 'full')) - len(ref) + 1
 
 
@@ -653,7 +652,7 @@ class Signal1D(BaseSignal, CommonSignal1D):
             shift_array.clip(-max_shift, max_shift)
         if interpolate is True:
             shift_array = shift_array / ip
-        shift_array *= axis.scale
+        shift_array = shift_array * axis.scale
         if self._lazy:
             # We must compute right now because otherwise any changes to the
             # axes_manager of the signal later in the workflow may result in

--- a/hyperspy/tests/signal/test_1D_tools.py
+++ b/hyperspy/tests/signal/test_1D_tools.py
@@ -103,6 +103,19 @@ class TestAlignTools:
         np.testing.assert_allclose(s.data[:, i_zlp], 12)
 
 
+def test_align1D():
+    scale = 0.1
+    g = hs.model.components1D.Gaussian(sigma=scale*5)
+    x = np.stack([np.linspace(-5, 5, 100)]*5)
+    s = hs.signals.Signal1D(g.function(x) + 1E5)
+    s.axes_manager[-1].scale = scale
+    shifts = np.random.random(len(s.axes_manager[0].axis)) * 2
+    shifts[0] = 0
+    s.shift1D(-shifts, show_progressbar=False)
+    shifts2 = s.estimate_shift1D(show_progressbar=False)
+    np.testing.assert_allclose(shifts, shifts2, rtol=0.3)
+
+
 @lazifyTestClass
 class TestShift1D:
 


### PR DESCRIPTION
As reported by @mwalls on [gitter](https://gitter.im/hyperspy/hyperspy?at=604a3dd0457d6b4a94bb0363), the `align1D` is not working properly. The reason is that the data is not normalised before computing the cross correlation. I am surprised that it was not reported before!

### Progress of the PR
- [x] Normalise by subtracting the mean before calculating the cross correlation,
- [x] add tests,
- [x] add entry to `CHANGES.rst `,
- [x] ready for review.

### Minimal example of the bug fix
```python
scale = 0.1
g = hs.model.components1D.Gaussian(sigma=scale*5)
x = np.stack([np.linspace(-5, 5, 100)]*5)
s = hs.signals.Signal1D(g.function(x) + 1E5)
s.axes_manager[-1].scale = scale
shifts = np.random.random(len(s.axes_manager[0].axis)) * 2
shifts[0] = 0
s.shift1D(-shifts, show_progressbar=False)
shifts2 = s.estimate_shift1D(show_progressbar=False)
np.testing.assert_allclose(shifts, shifts2, rtol=0.3)
```

