### PR TITLE
fix squeeze, add tests and improve docs

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -36,6 +36,7 @@ RELEASE_next_patch (Unreleased)
 * Fix finding dataset path for EMD NCEM file containing more than one dataset in a  group `#2673 <https://github.com/hyperspy/hyperspy/pull/2673>`_
 * Add support for python 3.9, fix deprecation warning with matplotlib 3.4.0 and bump minimum requirement to numpy 1.17.1 and dask 2.1.0. (`#2663 <https://github.com/hyperspy/hyperspy/pull/2663>`_)
 * Add integration test suite documentation in the developer guide. (`#2663 <https://github.com/hyperspy/hyperspy/pull/2663>`_)
+* Fix squeeze function for multiple zero-dimensional entries, improved docstring, added to user guide. (`#2676 <https://github.com/hyperspy/hyperspy/pull/2676>`_)
 
 
 Changelog

--- a/doc/user_guide/signal.rst
+++ b/doc/user_guide/signal.rst
@@ -1021,7 +1021,7 @@ Squeezing
 ^^^^^^^^^
 
 The :py:meth:`~.signal.BaseSignal.squeeze` method removes any zero-dimensional
-axes, i.e. axes of `size=1`, and the attributed data dimensions from a signal.
+axes, i.e. axes of ``size=1``, and the attributed data dimensions from a signal.
 The method returns a reduced copy of the signal and does not operate in place.
 
 .. code-block:: python
@@ -1033,7 +1033,7 @@ The method returns a reduced copy of the signal and does not operate in place.
     <Signal2D, title: , dimensions: (6, 2|8, 8)>
 
 Squeezing can be particularly useful after a rebinning operation that leaves
-one dimension with `shape=1`:
+one dimension with ``shape=1``:
 
     >>> s = hs.signals.Signal2D(np.random.random((5,5,5,10,10)))
     >>> s.rebin(new_shape=(5,1,5,5,5))

--- a/doc/user_guide/signal.rst
+++ b/doc/user_guide/signal.rst
@@ -1015,6 +1015,32 @@ cannot be performed lazily:
     NotImplementedError: Lazy rebin requires scale to be integer and divisor of the original signal shape
 
 
+.. _squeeze-label:
+
+Squeezing
+^^^^^^^^^
+
+The :py:meth:`~.signal.BaseSignal.squeeze` method removes any zero-dimensional
+axes, i.e. axes of `size=1`, and the attributed data dimensions from a signal.
+The method returns a reduced copy of the signal and does not operate in place.
+
+.. code-block:: python
+
+    >>> s = hs.signals.Signal2D(np.random.random((2,1,1,6,8,8)))
+    <Signal2D, title: , dimensions: (6, 1, 1, 2|8, 8)>
+    >>> s = s.squeeze()
+    >>> s
+    <Signal2D, title: , dimensions: (6, 2|8, 8)>
+
+Squeezing can be particularly useful after a rebinning operation that leaves
+one dimension with `shape=1`:
+
+    >>> s = hs.signals.Signal2D(np.random.random((5,5,5,10,10)))
+    >>> s.rebin(new_shape=(5,1,5,5,5))
+    <Signal2D, title: , dimensions: (5, 1, 5|5, 5)>
+    >>> s.rebin(new_shape=(5,1,5,5,5)).squeeze()
+    <Signal2D, title: , dimensions: (5, 5|5, 5)>
+
 
 Folding and unfolding
 ^^^^^^^^^^^^^^^^^^^^^

--- a/hyperspy/signal.py
+++ b/hyperspy/signal.py
@@ -2482,10 +2482,23 @@ class BaseSignal(FancySlicing,
     def squeeze(self):
         """Remove single-dimensional entries from the shape of an array
         and the axes. See :py:func:`numpy.squeeze` for more details.
+        
+        Returns
+        -------
+        s : signal
+            A new signal object with single-entry dimensions removed
+        
+        Examples
+        --------
+        >>> s = hs.signals.Signal2D(np.random.random((2,1,1,6,8,8)))
+        <Signal2D, title: , dimensions: (6, 1, 1, 2|8, 8)>
+        >>> s = s.squeeze()
+        >>> s
+        <Signal2D, title: , dimensions: (6, 2|8, 8)>
         """
         # We deepcopy everything but data
         self = self._deepcopy_with_new_data(self.data)
-        for axis in self.axes_manager._axes:
+        for axis in reversed(self.axes_manager._axes):
             if axis.size == 1:
                 self._remove_axis(axis.index_in_axes_manager)
         self.data = self.data.squeeze()

--- a/hyperspy/signal.py
+++ b/hyperspy/signal.py
@@ -2502,7 +2502,7 @@ class BaseSignal(FancySlicing,
             for axis in reversed(ax):
                 if axis.size == 1:
                     self._remove_axis(axis.index_in_axes_manager)
-            self.data = self.data.squeeze()
+        self.data = self.data.squeeze()
         return self
 
     def _to_dictionary(self, add_learning_results=True, add_models=False):

--- a/hyperspy/signal.py
+++ b/hyperspy/signal.py
@@ -2498,10 +2498,11 @@ class BaseSignal(FancySlicing,
         """
         # We deepcopy everything but data
         self = self._deepcopy_with_new_data(self.data)
-        for axis in reversed(self.axes_manager._axes):
-            if axis.size == 1:
-                self._remove_axis(axis.index_in_axes_manager)
-        self.data = self.data.squeeze()
+        for ax in (self.axes_manager.signal_axes, self.axes_manager.navigation_axes):
+            for axis in reversed(ax):
+                if axis.size == 1:
+                    self._remove_axis(axis.index_in_axes_manager)
+            self.data = self.data.squeeze()
         return self
 
     def _to_dictionary(self, add_learning_results=True, add_models=False):

--- a/hyperspy/tests/signal/test_eds_tem.py
+++ b/hyperspy/tests/signal/test_eds_tem.py
@@ -210,7 +210,7 @@ class Test_quantification:
         intensities = s.get_lines_intensity()
         res = s.quantification(intensities, method, kfactors,
                                composition_units)
-        s2 = s.rebin(new_shape=(1,1,1024)).squeeze().squeeze()
+        s2 = s.rebin(new_shape=(1,1,1024)).squeeze()
         s2.quantification(intensities, method, kfactors,
                                composition_units, plot_result=True)
         np.testing.assert_allclose(res[0].data, np.ones((2, 2)) * 22.70779,

--- a/hyperspy/tests/signal/test_tools.py
+++ b/hyperspy/tests/signal/test_tools.py
@@ -51,16 +51,11 @@ def test_signal_iterator():
         for i, signal in enumerate(s):
             assert i == signal.data[0]
 
-@pytest.mark.parametrize('shape', 
-                         [(2,1,1,6,7,8), (2,6,1,1,7,8), (1,1,2,6,7,8)])
-@pytest.mark.parametrize('shape2', 
+@pytest.mark.parametrize('shape',
                          [(2,1,1,6,8,7,1,1), (2,6,1,1,8,1,7,1),
                          (1,1,2,6,8,1,1,7)])
-def test_squeeze(shape, shape2):
-    s = signals.Signal2D(np.random.random(shape))
-    assert s.squeeze().axes_manager.shape == (6, 2, 8, 7)
-    assert s.squeeze().data.shape == (2, 6, 7, 8)
-    s = signals.BaseSignal(np.random.random((2,1,1,6,8,7,1,1)))
+def test_squeeze(shape):
+    s = signals.BaseSignal(np.random.random(shape))
     s2 = s.transpose(signal_axes=[0, 1, 2])
     s3 = s2.squeeze()
     assert s2.data.squeeze().shape == s3.data.shape

--- a/hyperspy/tests/signal/test_tools.py
+++ b/hyperspy/tests/signal/test_tools.py
@@ -52,9 +52,14 @@ def test_signal_iterator():
             assert i == signal.data[0]
 
 def test_squeeze():
-    s = signals.Signal2D(np.random.random((2,1,1,6,8,8)))
-    assert s.squeeze().axes_manager.shape == (6, 2, 8, 8)
-    assert s.squeeze().data.shape == (2, 6, 8, 8)
+    s = signals.Signal2D(np.random.random((2,1,1,6,7,8)))
+    assert s.squeeze().axes_manager.shape == (6, 2, 8, 7)
+    assert s.squeeze().data.shape == (2, 6, 7, 8)
+    s = signals.BaseSignal(np.random.random((2,1,1,6,8,7,1,1)))
+    s2 = s.transpose(signal_axes=[0, 1, 2])
+    s3 = s2.squeeze()
+    assert s2.data.squeeze().shape == s3.data.shape
+    assert s3.axes_manager.shape == (8, 6, 2, 7)
 
 
 @lazifyTestClass

--- a/hyperspy/tests/signal/test_tools.py
+++ b/hyperspy/tests/signal/test_tools.py
@@ -51,8 +51,13 @@ def test_signal_iterator():
         for i, signal in enumerate(s):
             assert i == signal.data[0]
 
-def test_squeeze():
-    s = signals.Signal2D(np.random.random((2,1,1,6,7,8)))
+@pytest.mark.parametrize('shape', 
+                         [(2,1,1,6,7,8), (2,6,1,1,7,8), (1,1,2,6,7,8)])
+@pytest.mark.parametrize('shape2', 
+                         [(2,1,1,6,8,7,1,1), (2,6,1,1,8,1,7,1),
+                         (1,1,2,6,8,1,1,7)])
+def test_squeeze(shape, shape2):
+    s = signals.Signal2D(np.random.random(shape))
     assert s.squeeze().axes_manager.shape == (6, 2, 8, 7)
     assert s.squeeze().data.shape == (2, 6, 7, 8)
     s = signals.BaseSignal(np.random.random((2,1,1,6,8,7,1,1)))

--- a/hyperspy/tests/signal/test_tools.py
+++ b/hyperspy/tests/signal/test_tools.py
@@ -51,6 +51,11 @@ def test_signal_iterator():
         for i, signal in enumerate(s):
             assert i == signal.data[0]
 
+def test_squeeze():
+    s = signals.Signal2D(np.random.random((2,1,1,6,8,8)))
+    assert s.squeeze().axes_manager.shape == (6, 2, 8, 8)
+    assert s.squeeze().data.shape == (2, 6, 8, 8)
+
 
 @lazifyTestClass
 class TestDerivative:


### PR DESCRIPTION
### Description of the change
Closes #2121

The `BaseSignal.squeeze()` function missed the case where two axes with zero-dimension directly follow one on the other. Fixed by `reversed` iteration.
Improved Docstring, added to User Guide, added test.

### Progress of the PR
- [X] Change implemented (can be split into several points),
- [X] update docstring (if appropriate),
- [X] update user guide (if appropriate),
- [X] add entry to `CHANGES.rst` (if appropriate),
- [X] add tests,
- [X] ready for review.

### Minimal example of the bug fix or the new feature
```
>>> s = hs.signals.Signal2D(np.random.random((2,1,1,6,8,8)))
>>> s = s.squeeze()
>>> s
```
