### PR TITLE
Ensure correct endian in numba_histogram

### DIFF
--- a/hyperspy/misc/array_tools.py
+++ b/hyperspy/misc/array_tools.py
@@ -313,6 +313,9 @@ def _linear_bin(dat, scale, crop=True):
         # Set up the result np.array to have a new axis[0] size for after
         # cropping.
         result = np.zeros((dim,) + dat.shape[1:])
+        # Make sure that native endian is used
+        if not dat.dtype.isnative:
+            dat = dat.astype(dat.dtype.type)
         # Carry out binning over axis[0]
         _linear_bin_loop(result=result, data=dat, scale=s)
         # Swap axis[0] back to the original axis location.
@@ -391,16 +394,16 @@ def numba_histogram(data, bins, ranges):
     hist : array
         The values of the histogram.
     """
-    if data.dtype.byteorder == '>':
-        return _numba_histogram(data.byteswap().newbyteorder(), bins, ranges)
-    else:
-        return _numba_histogram(data, bins, ranges)
+    # Make sure that native endian is used
+    if not data.dtype.isnative:
+        data = data.astype(data.dtype.type)
+    return _numba_histogram(data, bins, ranges)
 
 
 @njit(cache=True)
 def _numba_histogram(data, bins, ranges):
     """
-    Numba histogram computation requiring little endian datatype.
+    Numba histogram computation requiring native endian datatype.
     """
     # Adapted from https://iscinumpy.gitlab.io/post/histogram-speeds-in-python/
     hist = np.zeros((bins,), dtype=np.intp)

--- a/hyperspy/misc/array_tools.py
+++ b/hyperspy/misc/array_tools.py
@@ -375,7 +375,6 @@ def dict2sarray(dictionary, sarray=None, dtype=None):
     return sarray
 
 
-@njit(cache=True)
 def numba_histogram(data, bins, ranges):
     """
     Parameters
@@ -391,6 +390,17 @@ def numba_histogram(data, bins, ranges):
     -------
     hist : array
         The values of the histogram.
+    """
+    if data.dtype.byteorder == '>':
+        return _numba_histogram(data.byteswap().newbyteorder(), bins, ranges)
+    else:
+        return _numba_histogram(data, bins, ranges)
+
+
+@njit(cache=True)
+def _numba_histogram(data, bins, ranges):
+    """
+    Numba histogram computation requiring little endian datatype.
     """
     # Adapted from https://iscinumpy.gitlab.io/post/histogram-speeds-in-python/
     hist = np.zeros((bins,), dtype=np.intp)

--- a/hyperspy/misc/lowess_smooth.py
+++ b/hyperspy/misc/lowess_smooth.py
@@ -46,8 +46,6 @@ def lowess(y, x, f=2.0 / 3.0, n_iter=3):
         The estimated (smooth) values of y.
 
     """
-    if not x.dtype.isnative:
-        x = x.astype(x.dtype.type)
     if not y.dtype.isnative:
         y = y.astype(y.dtype.type)
     return _lowess(y, x, f, n_iter)

--- a/hyperspy/misc/lowess_smooth.py
+++ b/hyperspy/misc/lowess_smooth.py
@@ -21,8 +21,7 @@ import numpy as np
 from numba import njit
 
 
-@njit(cache=True, nogil=True)
-def lowess(y, x, f=2.0 / 3.0, n_iter=3):  # pragma: no cover
+def lowess(y, x, f=2.0 / 3.0, n_iter=3):
     """Lowess smoother (robust locally weighted regression).
 
     Fits a nonparametric regression curve to a scatterplot.
@@ -45,6 +44,18 @@ def lowess(y, x, f=2.0 / 3.0, n_iter=3):  # pragma: no cover
     -------
     yest : np.ndarray
         The estimated (smooth) values of y.
+
+    """
+    if not x.dtype.isnative:
+        x = x.astype(x.dtype.type)
+    if not y.dtype.isnative:
+        y = y.astype(y.dtype.type)
+    return _lowess(y, x, f, n_iter)
+
+
+@njit(cache=True, nogil=True)
+def _lowess(y, x, f=2.0 / 3.0, n_iter=3):  # pragma: no cover
+    """Lowess smoother requiring native endian datatype (for numba).
 
     """
     n = len(x)

--- a/hyperspy/tests/misc/test_array_tools.py
+++ b/hyperspy/tests/misc/test_array_tools.py
@@ -25,6 +25,7 @@ from hyperspy.misc.array_tools import (
     dict2sarray,
     get_array_memory_size_in_GiB,
     get_signal_chunk_slice,
+    numba_histogram,
 )
 
 dt = [("x", np.uint8), ("y", np.uint16), ("text", (bytes, 6))]
@@ -185,3 +186,9 @@ def test_get_signal_chunk_slice_not_square(sig_chunks, index, expected):
     else:
         chunk_slice = get_signal_chunk_slice(index, data.chunks)
         assert chunk_slice == expected
+
+@pytest.mark.parametrize('type', ['<u2', 'u2', '>u2', '<f4', 'f4', '>f4'])
+def test_numba_histogram(type):
+    arr = np.arange(100, dtype=type)
+    np.testing.assert_array_equal(numba_histogram(arr, 5, (0, 100)), [20, 20, 20, 20, 20])
+

--- a/hyperspy/tests/misc/test_array_tools.py
+++ b/hyperspy/tests/misc/test_array_tools.py
@@ -157,6 +157,7 @@ def test_d2s_arrayX():
      ((5, 5), (1, 12), [slice(0, 5, None), slice(10, 15, None)]),
      ((5, ), (1, ), [slice(0, 5, None), ]),
      ((20, ), (1, ), [slice(0, 20, None), ]),
+     ((5, ), [1], [slice(0, 5, None), ]),
      ((5, ), (25, ), 'error'),
      ((20, 20), (25, 21), 'error'),
       ]

--- a/hyperspy/tests/misc/test_array_tools.py
+++ b/hyperspy/tests/misc/test_array_tools.py
@@ -187,8 +187,8 @@ def test_get_signal_chunk_slice_not_square(sig_chunks, index, expected):
         chunk_slice = get_signal_chunk_slice(index, data.chunks)
         assert chunk_slice == expected
 
-@pytest.mark.parametrize('type', ['<u2', 'u2', '>u2', '<f4', 'f4', '>f4'])
-def test_numba_histogram(type):
-    arr = np.arange(100, dtype=type)
+@pytest.mark.parametrize('dtype', ['<u2', 'u2', '>u2', '<f4', 'f4', '>f4'])
+def test_numba_histogram(dtype):
+    arr = np.arange(100, dtype=dtype)
     np.testing.assert_array_equal(numba_histogram(arr, 5, (0, 100)), [20, 20, 20, 20, 20])
 

--- a/hyperspy/tests/signal/test_1D_tools.py
+++ b/hyperspy/tests/signal/test_1D_tools.py
@@ -316,11 +316,13 @@ class TestSmoothing:
         self.atol = 0
 
     @pytest.mark.parametrize('parallel', [True, False])
-    def test_lowess(self, parallel):
+    @pytest.mark.parametrize('dtype', ['<f4', 'f4', '>f4'])
+    def test_lowess(self, parallel, dtype):
         from hyperspy.misc.lowess_smooth import lowess
         f = 0.5
         n_iter = 1
-        data = np.asanyarray(self.s.data, dtype='float')
+        self.rtol = 1e-5
+        data = np.asanyarray(self.s.data, dtype=dtype)
         for i in range(data.shape[0]):
             data[i, :] = lowess(
                 x=self.s.axes_manager[-1].axis,

--- a/hyperspy/tests/signal/test_linear_rebin.py
+++ b/hyperspy/tests/signal/test_linear_rebin.py
@@ -18,13 +18,15 @@
 
 
 import numpy as np
+import pytest
 
 from hyperspy.signals import EDSTEMSpectrum
 
 
 class TestLinearRebin:
-    def test_linear_downsize(self):
-        spectrum = EDSTEMSpectrum(np.ones([3, 5, 1]))
+    @pytest.mark.parametrize('dtype', ['<u2', 'u2', '>u2', '<f4', 'f4', '>f4'])
+    def test_linear_downsize(self, dtype):
+        spectrum = EDSTEMSpectrum(np.ones([3, 5, 1],dtype=dtype))
         scale = (1.5, 2.5, 1)
         res = spectrum.rebin(scale=scale, crop=True)
         np.testing.assert_allclose(res.data, 3.75 * np.ones((1, 3, 1)))
@@ -33,8 +35,9 @@ class TestLinearRebin:
         res = spectrum.rebin(scale=scale, crop=False)
         np.testing.assert_allclose(res.data.sum(), spectrum.data.sum())
 
-    def test_linear_upsize(self):
-        spectrum = EDSTEMSpectrum(np.ones([4, 5, 10]))
+    @pytest.mark.parametrize('dtype', ['<u2', 'u2', '>u2', '<f4', 'f4', '>f4'])
+    def test_linear_upsize(self, dtype):
+        spectrum = EDSTEMSpectrum(np.ones([4, 5, 10],dtype=dtype))
         scale = [0.3, 0.2, 0.5]
         res = spectrum.rebin(scale=scale)
         np.testing.assert_allclose(res.data, 0.03 * np.ones((20, 16, 20)))

--- a/hyperspy/utils/peakfinders2D.py
+++ b/hyperspy/utils/peakfinders2D.py
@@ -361,6 +361,8 @@ def find_peaks_stat(z, alpha=1.0, window_radius=10, convergence_ratio=0.05):
         """Calculates rolling method 'func' over a circular kernel."""
         x, y = np.ogrid[-radius : radius + 1, -radius : radius + 1]
         kernel = np.hypot(x, y) < radius
+        if not image.dtype.isnative:
+            image = image.astype(image.dtype.type)
         stat = ndi.filters.generic_filter(image, func, footprint=kernel)
         return stat
 
@@ -375,6 +377,8 @@ def find_peaks_stat(z, alpha=1.0, window_radius=10, convergence_ratio=0.05):
     def single_pixel_desensitize(image):
         """Reduces single-pixel anomalies by nearest-neighbor smoothing."""
         kernel = np.array([[0.5, 1, 0.5], [1, 1, 1], [0.5, 1, 0.5]])
+        if not image.dtype.isnative:
+            image = data.astype(image.dtype.type)
         smoothed_image = ndi.filters.generic_filter(image, _fast_mean, footprint=kernel)
         return smoothed_image
 

--- a/hyperspy/utils/peakfinders2D.py
+++ b/hyperspy/utils/peakfinders2D.py
@@ -361,8 +361,6 @@ def find_peaks_stat(z, alpha=1.0, window_radius=10, convergence_ratio=0.05):
         """Calculates rolling method 'func' over a circular kernel."""
         x, y = np.ogrid[-radius : radius + 1, -radius : radius + 1]
         kernel = np.hypot(x, y) < radius
-        if not image.dtype.isnative:
-            image = image.astype(image.dtype.type)
         stat = ndi.filters.generic_filter(image, func, footprint=kernel)
         return stat
 
@@ -377,8 +375,6 @@ def find_peaks_stat(z, alpha=1.0, window_radius=10, convergence_ratio=0.05):
     def single_pixel_desensitize(image):
         """Reduces single-pixel anomalies by nearest-neighbor smoothing."""
         kernel = np.array([[0.5, 1, 0.5], [1, 1, 1], [0.5, 1, 0.5]])
-        if not image.dtype.isnative:
-            image = data.astype(image.dtype.type)
         smoothed_image = ndi.filters.generic_filter(image, _fast_mean, footprint=kernel)
         return smoothed_image
 


### PR DESCRIPTION
### Description of the change
Makes sure that `numba_histogram` runs for big endian datatypes like `>u2` or `>f4` by converting data to little endian for execution.

Closes #2668

### Progress of the PR
- [X] Change implemented,
- [X] extend to other numba functions,
- [x] add tests,
- [X] ready for review.

### Minimal example of the bug fix or the new feature
```python
import numpy as np
from hyperspy.misc.array_tools import numba_histogram

# works
arr = np.arange(100, dtype='<u2')
numba_histogram(arr, 5, (0, 100))

# works
arr = np.arange(100, dtype='u2')
numba_histogram(arr, 5, (0, 100))

# works
arr = np.arange(100, dtype='>u2')
numba_histogram(arr, 5, (0, 100))
```