### PR TITLE
Fix navigation_mask decomposition

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -37,6 +37,9 @@ RELEASE_next_patch (Unreleased)
 * Add support for python 3.9, fix deprecation warning with matplotlib 3.4.0 and bump minimum requirement to numpy 1.17.1 and dask 2.1.0. (`#2663 <https://github.com/hyperspy/hyperspy/pull/2663>`_)
 * Add integration test suite documentation in the developer guide. (`#2663 <https://github.com/hyperspy/hyperspy/pull/2663>`_)
 * Fix squeeze function for multiple zero-dimensional entries, improved docstring, added to user guide. (`#2676 <https://github.com/hyperspy/hyperspy/pull/2676>`_)
+* Use native endianess in numba jitted functions. (`#2678 <https://github.com/hyperspy/hyperspy/pull/2678>`_)
+* Fix error in Cliff-Lorimer quantification using absorption correction (`#2681 <https://github.com/hyperspy/hyperspy/pull/2681>`_)
+* Fix ``navigation_mask`` bug in decomposition when provided as numpy array (`#2679 <https://github.com/hyperspy/hyperspy/pull/2679>`_)
 
 
 Changelog

--- a/hyperspy/drawing/image.py
+++ b/hyperspy/drawing/image.py
@@ -385,9 +385,12 @@ class ImagePlot(BlittedFigure):
 
     def _update_data(self):
         # self._current_data caches the displayed data.
-        self._current_data =  self.data_function(
-                axes_manager=self.axes_manager,
+        data = self.data_function(axes_manager=self.axes_manager,
                 **self.data_function_kwargs)
+        # the colorbar of matplotlib ~< 3.2 doesn't support bool array
+        if data.dtype == bool:
+            data = data.astype(int)
+        self._current_data = data
 
     def update(self, data_changed=True, auto_contrast=None, vmin=None,
                vmax=None, **kwargs):

--- a/hyperspy/learn/mva.py
+++ b/hyperspy/learn/mva.py
@@ -365,9 +365,9 @@ class MVA:
             _logger.info("Performing decomposition analysis")
 
             if isinstance(navigation_mask, BaseSignal):
-                navigation_mask = navigation_mask.data
-            if hasattr(navigation_mask, "ravel"):
-                navigation_mask = navigation_mask.ravel()
+                navigation_mask = navigation_mask.data.ravel()
+            elif hasattr(navigation_mask, "ravel"):
+                navigation_mask = navigation_mask.T.ravel()
 
             if isinstance(signal_mask, BaseSignal):
                 signal_mask = signal_mask.data

--- a/hyperspy/learn/mva.py
+++ b/hyperspy/learn/mva.py
@@ -802,9 +802,12 @@ class MVA:
                 if mask.axes_manager.signal_shape != ref_shape:
                     raise ValueError(
                         f"`mask` shape is not equal to {space} shape. "
-                        f"Mask shape: {mask.axes_manager.signal_shape}\t"
+                        f"Mask shape: {mask.axes_manager.signal_shape}; "
                         f"{space} shape: {ref_shape}"
                     )
+            else:
+                raise ValueError("`mask` must be a HyperSpy signal.")
+
             if hasattr(mask, "compute"):
                 # if the mask is lazy, we compute them, which should be fine
                 # since we already reduce the dimensionality of the data.

--- a/hyperspy/tests/drawing/test_plot_signal.py
+++ b/hyperspy/tests/drawing/test_plot_signal.py
@@ -311,3 +311,6 @@ def test_plot_autoscale(sdim):
     s = test_plot_nav1d.signal
     with pytest.raises(ValueError):
         s.plot(autoscale='xa')
+
+    s.change_dtype(bool)
+    s.plot()

--- a/hyperspy/tests/learn/test_bss.py
+++ b/hyperspy/tests/learn/test_bss.py
@@ -286,6 +286,14 @@ class TestBSS1D:
         self.mask_nav = mask_nav
         self.mask_sig = mask_sig
 
+    def test_mask_error(self):
+        with pytest.raises(ValueError):
+            self.s.blind_source_separation(3, mask=self.mask_sig.data)
+
+    def test_mask_shape_error(self):
+        with pytest.raises(ValueError):
+            self.s.blind_source_separation(3, mask=self.mask_nav)
+
     def test_on_loadings(self):
         self.s.blind_source_separation(3, diff_order=0, fun="exp", on_loadings=False)
         s2 = self.s.as_signal1D(0)

--- a/hyperspy/tests/learn/test_decomposition.py
+++ b/hyperspy/tests/learn/test_decomposition.py
@@ -646,6 +646,11 @@ def test_decomposition_navigation_mask(mask_as_array):
     if mask_as_array:
         navigation_mask = navigation_mask
     s.decomposition(navigation_mask=navigation_mask)
+    data = s.get_decomposition_loadings().inav[0].data
+    # Use np.argwhere(np.isnan(data)) to get the indices
+    np.testing.assert_allclose(data[[2, 5, 7, 8, 12, 13, 15, 19]],
+                               np.full(8, np.nan))
+    assert not np.isnan(s.get_decomposition_factors().data).any()
 
 
 @pytest.mark.parametrize('mask_as_array', [True, False])
@@ -655,6 +660,12 @@ def test_decomposition_signal_mask(mask_as_array):
     if mask_as_array:
         signal_mask = signal_mask.data
     s.decomposition(signal_mask=signal_mask)
+    data = s.get_decomposition_factors().inav[0].data
+    # Use np.argwhere(np.isnan(data)) to get the indices
+    np.testing.assert_allclose(data[[ 5, 12, 14, 15, 18, 21, 27, 28, 32, 43,
+                                     52, 55, 57, 59, 62, 79, 83]],
+                                np.full(17, np.nan))
+    assert not np.isnan(s.get_decomposition_loadings().data).any()
 
 
 @pytest.mark.parametrize('normalise_poissonian_noise', [True, False])


### PR DESCRIPTION
Fixes #2677. When passing a numpy array for the `navigation_mask` argument of `decomposition`, the array was missing a transpose operation. Passing hyperspy signal is working fine.

### Progress of the PR
- [x] Fix plotting boolean array (didn't play well with auto contrast).
- [x] add entry to `CHANGES.rst` (if appropriate),
- [x] add tests,
- [x] ready for review.

### Minimal example of the bug fix.



