### PR TITLE
Fix CL Quant Error

### DIFF
--- a/doc/user_guide/eds.rst
+++ b/doc/user_guide/eds.rst
@@ -684,10 +684,11 @@ must be determined experimentally using standards.
 
 Zeta-factors should be provided in units of kg/m^2. The method is described
 further in :ref:`[Watanabe1996] <Watanabe1996>`
-and :ref:`[Watanabe2006] <Watanabe2006>`. Cross sections should be
-provided in units of barns (b). Further details on the cross section method can
-be found in :ref:`[MacArthur2016] <MacArthur2016>`. Conversion between
-zeta-factors and cross sections is possible using
+and :ref:`[Watanabe2006] <Watanabe2006>`. K-factors are unitless but are based
+on the assumption of weight percent. Cross sections should be provided in units
+of barns (b). Further details on the cross section method can be found in
+:ref:`[MacArthur2016] <MacArthur2016>`. Conversion between zeta-factors and
+cross sections is possible using
 :py:func:`~.misc.eds.utils.edx_cross_section_to_zeta` or
 :py:func:`~.misc.eds.utils.zeta_to_edx_cross_section`.
 
@@ -811,13 +812,13 @@ composition maps for each element.
         >>>                  factors=factors, absorption_correction=True
         >>>                  thickness = 100.)
 
-At this stage absorption correction is only applicable for parallel-sided, 
-thin-film samples. Absorption correction is calculated on a pixel by pixel 
+At this stage absorption correction is only applicable for parallel-sided,
+thin-film samples. Absorption correction is calculated on a pixel by pixel
 basis after having determined a sample mass-thickness map. It therefore may
 be a source of error in particularly inhomogeneous specimens.
-  
+
 Absorption correction can also only be applied to spectra from a single EDS
-detector. For systems that consist of multiple detectors, such as the Thermo 
+detector. For systems that consist of multiple detectors, such as the Thermo
 Fisher Super-X, it is therefore necessary to load the spectra from each
 detector separately.
 
@@ -847,13 +848,13 @@ is available:
 Electron and X-ray range
 ^^^^^^^^^^^^^^^^^^^^^^^^
 
-The electron and X-ray range in a bulk material can be estimated with 
+The electron and X-ray range in a bulk material can be estimated with
 :py:meth:`hs.eds.electron_range` and :py:meth:`hs.eds.xray_range`
 
 To calculate the X-ray range of Cu Ka in pure Copper at 30 kV in micron:
 
 .. code-block:: python
-    
+
     >>> hs.eds.xray_range('Cu_Ka', 30.)
     1.9361716759499248
 
@@ -871,4 +872,3 @@ To calculate the electron range in pure Copper at 30 kV in micron
 
     >>> hs.eds.electron_range('Cu', 30.)
     2.8766744984001607
-

--- a/doc/user_guide/eds.rst
+++ b/doc/user_guide/eds.rst
@@ -684,11 +684,10 @@ must be determined experimentally using standards.
 
 Zeta-factors should be provided in units of kg/m^2. The method is described
 further in :ref:`[Watanabe1996] <Watanabe1996>`
-and :ref:`[Watanabe2006] <Watanabe2006>`. K-factors are unitless but are based
-on the assumption of weight percent. Cross sections should be provided in units
-of barns (b). Further details on the cross section method can be found in
-:ref:`[MacArthur2016] <MacArthur2016>`. Conversion between zeta-factors and
-cross sections is possible using
+and :ref:`[Watanabe2006] <Watanabe2006>`. Cross sections should be
+provided in units of barns (b). Further details on the cross section method can
+be found in :ref:`[MacArthur2016] <MacArthur2016>`. Conversion between
+zeta-factors and cross sections is possible using
 :py:func:`~.misc.eds.utils.edx_cross_section_to_zeta` or
 :py:func:`~.misc.eds.utils.zeta_to_edx_cross_section`.
 

--- a/hyperspy/misc/eds/utils.py
+++ b/hyperspy/misc/eds/utils.py
@@ -440,7 +440,7 @@ def quantification_cliff_lorimer(intensities,
     else:
         index = np.where(intensities > min_intensity)[0]
         if absorption_correction is not None:
-            absorption_correction = absorption_correction.reshape(dim[0], dim2)
+            absorption_correction = absorption_correction
         else:
             # default to ones
             absorption_correction = np.ones_like(intens, dtype='float')

--- a/hyperspy/misc/eds/utils.py
+++ b/hyperspy/misc/eds/utils.py
@@ -440,7 +440,7 @@ def quantification_cliff_lorimer(intensities,
     else:
         index = np.where(intensities > min_intensity)[0]
         if absorption_correction is not None:
-            absorption_correction = absorption_correction
+            absorption_correction = absorption_correction.reshape(dim[0], dim2)
         else:
             # default to ones
             absorption_correction = np.ones_like(intens, dtype='float')
@@ -498,8 +498,9 @@ def _quantification_cliff_lorimer(intensities,
     other_index = list(range(len(kfactors)))
     other_index.pop(ref_index)
     for i in other_index:
-        ab[i] = intensities[ref_index] * kfactors[ref_index]  \
-            / (intensities[i] * absorption_correction[i]) / kfactors[i]
+        ab[i] = (intensities[ref_index] * absorption_correction[ref_index]) \
+            / (intensities[i] * absorption_correction[i]) \
+            *( kfactors[ref_index] / kfactors[i])
     # Ca = ab /(1 + ab + ab/ac + ab/ad + ...)
     ab = ab
     for i in other_index:

--- a/hyperspy/tests/signal/test_eds_tem.py
+++ b/hyperspy/tests/signal/test_eds_tem.py
@@ -250,6 +250,13 @@ class Test_quantification:
                                composition_units,
                                absorption_correction=True,
                                thickness=0.0001)
+        list.reverse(intensities)
+        list.reverse(kfactors)
+        res5 = s.quantification(intensities, method, kfactors,
+                               composition_units,
+                               absorption_correction=True,
+                               thickness=300.)
+        np.testing.assert_allclose(res5[0][0].data, res3[0][1].data, atol=1e-5)
         np.testing.assert_allclose(res2[0][0].data, np.ones((2, 2)) * 22.70779,
                                    atol=1e-3)
         np.testing.assert_allclose(res3[0][0].data, np.ones((2, 2)) * 22.587251,

--- a/hyperspy/tests/signal/test_eds_tem.py
+++ b/hyperspy/tests/signal/test_eds_tem.py
@@ -259,7 +259,7 @@ class Test_quantification:
         np.testing.assert_allclose(res5[0][0].data, res3[0][1].data, atol=1e-5)
         np.testing.assert_allclose(res2[0][0].data, np.ones((2, 2)) * 22.743013,
                                    atol=1e-3)
-        np.testing.assert_allclose(res3[0][0].data, np.ones((2, 2)) * 22.587251,
+        np.testing.assert_allclose(res3[0][0].data, np.ones((2, 2)) * 31.816908,
                                    atol=1e-3)
         np.testing.assert_allclose(res[0].data, res4[0][0].data, atol=1e-5)
 

--- a/hyperspy/tests/signal/test_eds_tem.py
+++ b/hyperspy/tests/signal/test_eds_tem.py
@@ -257,7 +257,7 @@ class Test_quantification:
                                absorption_correction=True,
                                thickness=300.)
         np.testing.assert_allclose(res5[0][0].data, res3[0][1].data, atol=1e-5)
-        np.testing.assert_allclose(res2[0][0].data, np.ones((2, 2)) * 22.70779,
+        np.testing.assert_allclose(res2[0][0].data, np.ones((2, 2)) * 22.743013,
                                    atol=1e-3)
         np.testing.assert_allclose(res3[0][0].data, np.ones((2, 2)) * 22.587251,
                                    atol=1e-3)


### PR DESCRIPTION
Previously the following code would produce different composition values in the EDX quantification.
```python
import hyperspy.api as hs
import numpy as np
def get_composition(intensities, xray_lines, kfactors, thickness):
    spc = hs.signals.EDSTEMSpectrum(np.array([0]))
    signals = []
    for index, intensity in enumerate(intensities):
        signal = hs.signals.BaseSignal(np.array([intensity]))
        signal.metadata.add_node('Sample')
        xray_line = xray_lines[index]
        element = xray_line[:-3]
        signal.metadata.Sample.elements = [element]
        signal.metadata.Sample.xray_lines = [xray_line]
        signals.append(signal)
        
    results = spc.quantification(intensities=signals, method='CL', factors=kfactors, absorption_correction=True, thickness=thickness)
    atomic_percents = [result.data[0] for result in results[0]]
    return atomic_percents

get_composition([1000, 180], ['Al_Ka', 'N_Ka'], [1.040, 2.547], 100)

get_composition([180, 1000], ['N_Ka', 'Al_Ka'], [2.547, 1.040], 100)
```

This pull request aims to fix that and add a unit test to check for this error in the future.