### PR TITLE
Fix broken events when changing signal type

### DIFF
--- a/hyperspy/signal.py
+++ b/hyperspy/signal.py
@@ -2162,28 +2162,33 @@ class BaseSignal(FancySlicing,
             imported from the original data file.
 
         """
-        self._create_metadata()
-        self.models = ModelManager(self)
-        self.learning_results = LearningResults()
-        kwds['data'] = data
-        self._load_dictionary(kwds)
-        self._plot = None
-        self.inav = SpecialSlicersSignal(self, True)
-        self.isig = SpecialSlicersSignal(self, False)
-        self.events = Events()
-        self.events.data_changed = Event("""
-            Event that triggers when the data has changed
+        # the 'full_initialisation' keyword is private API to be used by the
+        # _assign_subclass method. Purposely not exposed as public API.
+        # Its purpose is to avoid creating new attributes, which breaks events
+        # and to reduce overhead when changing 'signal_type'.
+        if kwds.get('full_initialisation', True):
+            self._create_metadata()
+            self.models = ModelManager(self)
+            self.learning_results = LearningResults()
+            kwds['data'] = data
+            self._load_dictionary(kwds)
+            self._plot = None
+            self.inav = SpecialSlicersSignal(self, True)
+            self.isig = SpecialSlicersSignal(self, False)
+            self.events = Events()
+            self.events.data_changed = Event("""
+                Event that triggers when the data has changed
 
-            The event trigger when the data is ready for consumption by any
-            process that depend on it as input. Plotted signals automatically
-            connect this Event to its `BaseSignal.plot()`.
+                The event trigger when the data is ready for consumption by any
+                process that depend on it as input. Plotted signals automatically
+                connect this Event to its `BaseSignal.plot()`.
 
-            Note: The event only fires at certain specific times, not everytime
-            that the `BaseSignal.data` array changes values.
+                Note: The event only fires at certain specific times, not everytime
+                that the `BaseSignal.data` array changes values.
 
-            Arguments:
-                obj: The signal that owns the data.
-            """, arguments=['obj'])
+                Arguments:
+                    obj: The signal that owns the data.
+                """, arguments=['obj'])
 
     def _create_metadata(self):
         self.metadata = DictionaryTreeBrowser()
@@ -2482,12 +2487,12 @@ class BaseSignal(FancySlicing,
     def squeeze(self):
         """Remove single-dimensional entries from the shape of an array
         and the axes. See :py:func:`numpy.squeeze` for more details.
-        
+
         Returns
         -------
         s : signal
             A new signal object with single-entry dimensions removed
-        
+
         Examples
         --------
         >>> s = hs.signals.Signal2D(np.random.random((2,1,1,6,8,8)))
@@ -5313,7 +5318,7 @@ class BaseSignal(FancySlicing,
             lazy=self._lazy)
         if self._alias_signal_types:  # In case legacy types exist:
             mp.Signal.signal_type = self._signal_type  # set to default!
-        self.__init__(**self._to_dictionary(add_models=True))
+        self.__init__(self.data, full_initialisation=False)
         if self._lazy:
             self._make_lazy()
 

--- a/hyperspy/tests/signal/test_assign_subclass.py
+++ b/hyperspy/tests/signal/test_assign_subclass.py
@@ -76,6 +76,17 @@ def test_assignment_class(caplog):
         assert new_subclass is getattr(_lazy_signals, lazyclass)
 
 
+def test_id_set_signal_type():
+    s = hs.signals.BaseSignal(np.zeros((3, 3)))
+    id_events = id(s.events)
+    id_metadata = id(s.metadata)
+    id_om = id(s.original_metadata)
+    s.set_signal_type()
+    assert id_events == id(s.events)
+    assert id_metadata == id(s.metadata)
+    assert id_om == id(s.original_metadata)
+
+
 class TestConvertBaseSignal:
 
     def setup_method(self, method):


### PR DESCRIPTION
Fix #2612. When the signal type is changed, new instances of signal attributes, such as `events`, `axes_manager` are created and if the signal have event connections between them, these are broken.

### Progress of the PR
- [x] Don't fully initialised the signal attribute when calling the class constructor in `_assign_subclass`
- [ ] add entry to `CHANGES.rst`,
- [x] add tests,
- [x] ready for review.


