### PR TITLE
Fix image contrast tool

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -40,6 +40,8 @@ RELEASE_next_patch (Unreleased)
 * Use native endianess in numba jitted functions. (`#2678 <https://github.com/hyperspy/hyperspy/pull/2678>`_)
 * Fix error in Cliff-Lorimer quantification using absorption correction (`#2681 <https://github.com/hyperspy/hyperspy/pull/2681>`_)
 * Fix ``navigation_mask`` bug in decomposition when provided as numpy array (`#2679 <https://github.com/hyperspy/hyperspy/pull/2679>`_)
+* Fix closing image constrat tool and setting vmin/vmax values (`#2684 <https://github.com/hyperspy/hyperspy/pull/2684>`_)
+* Fix range widget with matplotlib 3.4 (`#2684 <https://github.com/hyperspy/hyperspy/pull/2684>`_)
 
 
 Changelog

--- a/hyperspy/drawing/_widgets/circle.py
+++ b/hyperspy/drawing/_widgets/circle.py
@@ -140,7 +140,7 @@ class CircleWidget(Widget2DBase, ResizersMixin):
         return np.array(self._size / self.axes[0].scale)
 
     def _update_patch_position(self):
-        if self.is_on() and self.patch:
+        if self.is_on and self.patch:
             self.patch[0].center = self._get_patch_xy()
             if self.size[1] > 0:
                 self.patch[1].center = self.patch[0].center
@@ -148,7 +148,7 @@ class CircleWidget(Widget2DBase, ResizersMixin):
             self.draw_patch()
 
     def _update_patch_size(self):
-        if self.is_on() and self.patch:
+        if self.is_on and self.patch:
             ro, ri = self.size
             self.patch[0].radius = ro
             if ri > 0:
@@ -164,7 +164,7 @@ class CircleWidget(Widget2DBase, ResizersMixin):
             self.draw_patch()
 
     def _update_patch_geometry(self):
-        if self.is_on() and self.patch:
+        if self.is_on and self.patch:
             ro, ri = self.size
             self.patch[0].center = self._get_patch_xy()
             self.patch[0].radius = ro

--- a/hyperspy/drawing/_widgets/horizontal_line.py
+++ b/hyperspy/drawing/_widgets/horizontal_line.py
@@ -27,7 +27,7 @@ class HorizontalLineWidget(Widget1DBase):
     """
 
     def _update_patch_position(self):
-        if self.is_on() and self.patch:
+        if self.is_on and self.patch:
             self.patch[0].set_ydata(self._pos[0])
             self.draw_patch()
 

--- a/hyperspy/drawing/_widgets/label.py
+++ b/hyperspy/drawing/_widgets/label.py
@@ -79,13 +79,13 @@ class LabelWidget(Widget1DBase):
         return pos
 
     def _update_patch_position(self):
-        if self.is_on() and self.patch:
+        if self.is_on and self.patch:
             self.patch[0].set_x(self._pos[0])
             self.patch[0].set_y(self._pos[1])
             self.draw_patch()
 
     def _update_patch_string(self):
-        if self.is_on() and self.patch:
+        if self.is_on and self.patch:
             self.patch[0].set_text(self.string)
             self.draw_patch()
 

--- a/hyperspy/drawing/_widgets/line2d.py
+++ b/hyperspy/drawing/_widgets/line2d.py
@@ -251,7 +251,7 @@ class Line2DWidget(ResizableDraggableWidgetBase):
     def _update_patch_geometry(self):
         """Set line position, and set width indicator's if appropriate
         """
-        if self.is_on() and self.patch:
+        if self.is_on and self.patch:
             self.patch[0].set_data(np.array(self._pos).T)
             # Update width indicator if present
             if self._width_indicator_patches:

--- a/hyperspy/drawing/_widgets/range.py
+++ b/hyperspy/drawing/_widgets/range.py
@@ -16,11 +16,11 @@
 # You should have received a copy of the GNU General Public License
 # along with  HyperSpy.  If not, see <http://www.gnu.org/licenses/>.
 
+import inspect
+import logging
 
 import numpy as np
 from matplotlib.widgets import SpanSelector
-import inspect
-import logging
 
 from hyperspy.drawing.widgets import ResizableDraggableWidgetBase
 from hyperspy.events import Events, Event
@@ -392,7 +392,6 @@ class ModifiableSpanSelector(SpanSelector):
         # And connect to the new ones
         self.connect_event('button_press_event', self.mm_on_press)
         self.connect_event('button_release_event', self.mm_on_release)
-        self.connect_event('draw_event', self.update_background)
 
         self.rect.set_visible(True)
         self.rect.contains = self.contains
@@ -400,7 +399,7 @@ class ModifiableSpanSelector(SpanSelector):
     def update(self, *args):
         # Override the SpanSelector `update` method to blit properly all
         # artirts before we go to "modify mode" in `set_initial`.
-        self.draw_patch()
+        self.set_visible(True)
 
     def draw_patch(self, *args):
         """Update the patch drawing.

--- a/hyperspy/drawing/_widgets/range.py
+++ b/hyperspy/drawing/_widgets/range.py
@@ -63,7 +63,7 @@ class RangeWidget(ResizableDraggableWidgetBase):
         self.span = None
 
     def set_on(self, value, render_figure=True):
-        if value is not self.is_on() and self.ax is not None:
+        if value is not self.is_on and self.ax is not None:
             if value is True:
                 self._add_patch_to(self.ax)
                 self.connect(self.ax)
@@ -72,11 +72,12 @@ class RangeWidget(ResizableDraggableWidgetBase):
             if render_figure:
                 try:
                     self.ax.figure.canvas.draw_idle()
-                except BaseException:  # figure does not exist
+                except BaseException:  # pragma: no cover
+                    # figure does not exist
                     pass
             if value is False:
                 self.ax = None
-        self.__is_on = value
+        self._is_on = value
 
     def _add_patch_to(self, ax):
         self.span = ModifiableSpanSelector(ax, **self._SpanSelector_kwargs)
@@ -221,7 +222,7 @@ class RangeWidget(ResizableDraggableWidgetBase):
         self._update_patch_geometry()
 
     def _update_patch_geometry(self):
-        if self.is_on() and self.span is not None:
+        if self.is_on and self.span is not None:
             self.span.range = self._get_range()
 
     def disconnect(self):
@@ -409,7 +410,7 @@ class ModifiableSpanSelector(SpanSelector):
                 self.ax.hspy_fig.render_figure()
             elif self.ax.figure is not None:
                 self.ax.figure.canvas.draw_idle()
-        except AttributeError:
+        except AttributeError:  # pragma: no cover
             pass  # When figure is None, typically when closing
 
     def contains(self, mouseevent):

--- a/hyperspy/drawing/_widgets/range.py
+++ b/hyperspy/drawing/_widgets/range.py
@@ -62,17 +62,18 @@ class RangeWidget(ResizableDraggableWidgetBase):
         super(RangeWidget, self).__init__(axes_manager, alpha=alpha, **kwargs)
         self.span = None
 
-    def set_on(self, value):
+    def set_on(self, value, render_figure=True):
         if value is not self.is_on() and self.ax is not None:
             if value is True:
                 self._add_patch_to(self.ax)
                 self.connect(self.ax)
             elif value is False:
                 self.disconnect()
-            try:
-                self.ax.figure.canvas.draw_idle()
-            except BaseException:  # figure does not exist
-                pass
+            if render_figure:
+                try:
+                    self.ax.figure.canvas.draw_idle()
+                except BaseException:  # figure does not exist
+                    pass
             if value is False:
                 self.ax = None
         self.__is_on = value
@@ -574,7 +575,8 @@ class ModifiableSpanSelector(SpanSelector):
         self.draw_patch()
 
     def move_rect(self, event):
-        if self._button_down is False or self.ignore(event):
+        if (self._button_down is False or self.ignore(event) or
+            self._get_mouse_position(event) is None):
             return
         x_increment = self._get_mouse_position(event) - self.pressv
         if self.step_ax is not None:

--- a/hyperspy/drawing/_widgets/rectangles.py
+++ b/hyperspy/drawing/_widgets/rectangles.py
@@ -330,14 +330,14 @@ class RectangleWidget(SquareWidget, ResizersMixin):
 
     def _update_patch_position(self):
         # Override to include resizer positioning
-        if self.is_on() and self.patch:
+        if self.is_on and self.patch:
             self.patch[0].set_xy(self._get_patch_xy())
             self._update_resizers()
             self.draw_patch()
 
     def _update_patch_geometry(self):
         # Override to include resizer positioning
-        if self.is_on() and self.patch:
+        if self.is_on and self.patch:
             self.patch[0].set_bounds(*self._get_patch_bounds())
             self._update_resizers()
             self.draw_patch()

--- a/hyperspy/drawing/_widgets/vertical_line.py
+++ b/hyperspy/drawing/_widgets/vertical_line.py
@@ -27,7 +27,7 @@ class VerticalLineWidget(Widget1DBase):
     """
 
     def _update_patch_position(self):
-        if self.is_on() and self.patch:
+        if self.is_on and self.patch:
             self.patch[0].set_xdata(self._pos[0])
             self.draw_patch()
 

--- a/hyperspy/drawing/figure.py
+++ b/hyperspy/drawing/figure.py
@@ -63,7 +63,7 @@ class BlittedFigure(object):
     def _on_blit_draw(self, *args):
         fig = self.figure
         # As draw doesn't draw animated elements, in its current state the
-        # canvas only contains the backgroud. The following line simply stores
+        # canvas only contains the background. The following line simply stores
         # it for the consumption of _update_animated.
         self._background = fig.canvas.copy_from_bbox(fig.bbox)
         # draw does not draw animated elements, so we must draw them

--- a/hyperspy/drawing/signal1d.py
+++ b/hyperspy/drawing/signal1d.py
@@ -378,8 +378,8 @@ class Signal1DLine(object):
                              "'log' for Signal1D.")
         else:
             plot = self.ax.plot
-        self.line, = plot(self.axis.axis, data, **self.line_properties)
-        self.line.set_animated(self.ax.figure.canvas.supports_blit)
+        self.line, = plot(self.axis.axis, data, **self.line_properties,
+                          animated=self.ax.figure.canvas.supports_blit)
         if not self.axes_manager or self.axes_manager.navigation_size == 0:
             self.plot_indices = False
         if self.plot_indices is True:

--- a/hyperspy/drawing/widget.py
+++ b/hyperspy/drawing/widget.py
@@ -55,7 +55,7 @@ class WidgetBase(object):
         self._selected_artist = None
         self._size = 1.
         self._pos = np.array([0.])
-        self.__is_on = True
+        self._is_on = True
         self.background = None
         self.patch = []
         self.color = color
@@ -99,10 +99,11 @@ class WidgetBase(object):
     axes = property(lambda s: s._get_axes(),
                     lambda s, v: s._set_axes(v))
 
+    @property
     def is_on(self):
         """Determines if the widget is set to draw if valid (turned on).
         """
-        return self.__is_on
+        return self._is_on
 
     def set_on(self, value, render_figure=True):
         """Change the on state of the widget. If turning off, all patches will
@@ -111,7 +112,7 @@ class WidgetBase(object):
         matplotlib axes, and the widget will connect to its default events.
         """
         did_something = False
-        if value is not self.is_on() and self.ax is not None:
+        if value is not self.is_on and self.ax is not None:
             did_something = True
             if value is True:
                 self._add_patch_to(self.ax)
@@ -133,7 +134,7 @@ class WidgetBase(object):
                 self.draw_patch()
             if value is False:
                 self.ax = None
-        self.__is_on = value
+        self._is_on = value
 
     @property
     def color(self):
@@ -181,10 +182,10 @@ class WidgetBase(object):
         if ax is self.ax:
             return  # Do nothing
         # Disconnect from previous axes if set
-        if self.ax is not None and self.is_on():
+        if self.ax is not None and self.is_on:
             self.disconnect()
         self.ax = ax
-        if self.is_on() is True:
+        if self.is_on is True:
             self._add_patch_to(ax)
             self.connect(ax)
             ax.figure.canvas.draw_idle()
@@ -195,7 +196,7 @@ class WidgetBase(object):
         Cause this widget to be the selected widget in its MPL axes. This
         assumes that the widget has its patch added to the MPL axes.
         """
-        if not self.patch or not self.is_on() or not self.ax:
+        if not self.patch or not self.is_on or not self.ax:
             return
 
         canvas = self.ax.figure.canvas
@@ -795,7 +796,7 @@ class Widget2DBase(ResizableDraggableWidgetBase):
         return (xy[0], xy[1], xs, ys)        # x,y,w,h
 
     def _update_patch_position(self):
-        if self.is_on() and self.patch:
+        if self.is_on and self.patch:
             self.patch[0].set_xy(self._get_patch_xy())
             self.draw_patch()
 
@@ -803,7 +804,7 @@ class Widget2DBase(ResizableDraggableWidgetBase):
         self._update_patch_geometry()
 
     def _update_patch_geometry(self):
-        if self.is_on() and self.patch:
+        if self.is_on and self.patch:
             self.patch[0].set_bounds(*self._get_patch_bounds())
             self.draw_patch()
 

--- a/hyperspy/extensions.py
+++ b/hyperspy/extensions.py
@@ -17,7 +17,6 @@
 # along with  HyperSpy.  If not, see <http://www.gnu.org/licenses/>.
 
 import logging
-import importlib
 import copy
 import pkgutil
 import pkg_resources
@@ -25,7 +24,6 @@ import yaml
 
 from pathlib import Path
 
-import hyperspy.misc.config_dir
 
 _logger = logging.getLogger(__name__)
 

--- a/hyperspy/signal_tools.py
+++ b/hyperspy/signal_tools.py
@@ -1078,8 +1078,7 @@ class ImageContrastEditor(t.HasTraits):
                 self.image.vmin = f"{self.vmin_percentile}th"
                 self.image.vmax = f"{self.vmax_percentile}th"
             else:
-                self.image.vmin = self._vmin
-                self.image.vmax = self._vmax
+                self.image.vmin, self.image.vmax = self._get_current_range()
             self.image.connect()
         self.hspy_fig.close()
 

--- a/hyperspy/signal_tools.py
+++ b/hyperspy/signal_tools.py
@@ -813,9 +813,11 @@ class ImageContrastEditor(t.HasTraits):
         self.norm_original = copy.deepcopy(self.norm)
 
         self.span_selector = None
-        self.span_selector_switch(on=True)
-
         self.plot_histogram()
+
+        # After the figure have been rendered to follow the same pattern as
+        # for other tools
+        self.span_selector_switch(on=True)
 
         if self.image.axes_manager is not None:
             self.image.axes_manager.events.indices_changed.connect(
@@ -830,9 +832,6 @@ class ImageContrastEditor(t.HasTraits):
 
     def create_axis(self):
         self.ax = self.hspy_fig.figure.add_subplot(111)
-        animated = self.hspy_fig.figure.canvas.supports_blit
-        self.ax.yaxis.set_animated(animated)
-        self.ax.xaxis.set_animated(animated)
         self.hspy_fig.ax = self.ax
 
     def _gamma_changed(self, old, new):
@@ -923,10 +922,11 @@ class ImageContrastEditor(t.HasTraits):
 
     def _set_xaxis(self):
         self.xaxis = np.linspace(self._vmin, self._vmax, self.bins)
-        # Set this attribute to restrict the span selector to the xaxis
-        self.span_selector.step_ax = DataAxis(size=len(self.xaxis),
-                                              offset=self.xaxis[1],
-                                              scale=self.xaxis[1]-self.xaxis[0])
+        if self.span_selector is not None:
+            # Set this attribute to restrict the span selector to the xaxis
+            self.span_selector.step_ax = DataAxis(size=len(self.xaxis),
+                                                  offset=self.xaxis[1],
+                                                  scale=self.xaxis[1]-self.xaxis[0])
 
     def plot_histogram(self, max_num_bins=250):
         """Plot a histogram of the data.
@@ -968,10 +968,10 @@ class ImageContrastEditor(t.HasTraits):
         self.ax.set_ylim(0, self.hist_data.max())
         self.ax.set_xticks([])
         self.ax.set_yticks([])
-        self.line = self.ax.plot(*self._get_line(),
-                                       color='#ff7f0e')[0]
-        self.line.set_animated(self.ax.figure.canvas.supports_blit)
+        self.line = self.ax.plot(*self._get_line(), color='#ff7f0e',
+                                 animated=self.ax.figure.canvas.supports_blit)[0]
         plt.tight_layout(pad=0)
+        self.ax.figure.canvas.draw()
 
     plot_histogram.__doc__ %= HISTOGRAM_MAX_BIN_ARGS
 
@@ -1065,7 +1065,7 @@ class ImageContrastEditor(t.HasTraits):
         self.linscale = self.linscale_original
 
     def _get_current_range(self):
-        if self.span_selector._get_span_width() != 0:
+        if self.span_selector and self.span_selector._get_span_width() != 0:
             # if we have a span selector, use it to set the display
             return self.ss_left_value, self.ss_right_value
         else:

--- a/hyperspy/tests/drawing/test_plot_roi_widgets.py
+++ b/hyperspy/tests/drawing/test_plot_roi_widgets.py
@@ -87,6 +87,13 @@ class TestPlotROI():
         p.add_widget(signal=self.im, axes=[0, ], color="cyan")
         return self.im._plot.navigator_plot.figure
 
+    def test_plot_spanroi_close(self):
+        self.im.plot()
+        p = roi.SpanROI(0.5, 0.7)
+        p.add_widget(signal=self.im, axes=[0, ], color="cyan")
+        for widget in p.widgets:
+            widget.close()
+
     @pytest.mark.mpl_image_compare(baseline_dir=BASELINE_DIR,
                                    tolerance=DEFAULT_TOL, style=STYLE_PYTEST_MPL)
     def test_plot_spanroi_axis_1(self):

--- a/hyperspy/tests/signal/test_image_contrast_editor_tool.py
+++ b/hyperspy/tests/signal/test_image_contrast_editor_tool.py
@@ -16,7 +16,7 @@
 # You should have received a copy of the GNU General Public License
 # along with  HyperSpy.  If not, see <http://www.gnu.org/licenses/>.
 
-
+import matplotlib.pyplot as plt
 import numpy as np
 import pytest
 
@@ -112,3 +112,28 @@ class TestContrastEditorTool:
 
         np.testing.assert_allclose(ceditor._vmin, 9.9)
         np.testing.assert_allclose(ceditor._vmax, 98.01)
+
+
+def test_close_vmin_vmax():
+    data = np.random.random(10*10*10).reshape([10]*3)
+    s = hs.signals.Signal2D(data)
+    s.plot()
+
+    image_plot = s._plot.signal_plot
+    display_range = (0.6, 0.9)
+
+    ceditor = ImageContrastEditor(image_plot)
+
+    # Simulate selecting a range on the histogram
+    ceditor.span_selector_switch(True)
+    ceditor.span_selector.set_initial = (0, 1)
+    ceditor.span_selector.range = display_range
+    plt.pause(0.001) # in case, interactive backend is used
+    ceditor.update_span_selector_traits()
+
+    # Need to use auto=False to pick up the current display when closing
+    ceditor.auto = False
+    ceditor.close()
+
+    assert image_plot.vmin == display_range[0]
+    assert image_plot.vmax == display_range[1]


### PR DESCRIPTION
### Progress of the PR
- [x] Fix closing image contrast tool,
- [x] Fix setting vmin, vmax values when closing (previously, it will reset the value when changing navigation axis),
- [x] Fix blitting issue with matplotlib 3.4 (infinite recursive loop with the `draw_event`), related to https://github.com/matplotlib/matplotlib/pull/17480.
- [x] add entry to `CHANGES.rst` (if appropriate),
- [x] add tests,
- [x] ready for review.

### Minimal example of the bug fix or the new feature
```python
import numpy as np
import hyperspy.api as hs

N_nav, N_sig = 100, 128
nnav, nsig = 2, 2
data = np.random.random(N_nav**nnav*N_sig**nsig).reshape([N_nav]*nnav + [N_sig]*nsig)

s = hs.signals.Signal2D(data)
s.plot()
# press `h` key on a figure
```

