### PR TITLE
Set snap option in roi.interactive

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -42,7 +42,8 @@ RELEASE_next_patch (Unreleased)
 * Fix ``navigation_mask`` bug in decomposition when provided as numpy array (`#2679 <https://github.com/hyperspy/hyperspy/pull/2679>`_)
 * Fix closing image constrat tool and setting vmin/vmax values (`#2684 <https://github.com/hyperspy/hyperspy/pull/2684>`_)
 * Fix range widget with matplotlib 3.4 (`#2684 <https://github.com/hyperspy/hyperspy/pull/2684>`_)
-
+* Fix bug in `hs.interactive` with function returning `None`. Improve user guide example. (`#2686 <https://github.com/hyperspy/hyperspy/pull/2686>`_)
+* Add option not to snap ROI when calling the `interactive` method of a ROI (`#2686 <https://github.com/hyperspy/hyperspy/pull/2686>`_)
 
 Changelog
 *********

--- a/doc/user_guide/interactive_operations_ROIs.rst
+++ b/doc/user_guide/interactive_operations_ROIs.rst
@@ -158,10 +158,10 @@ order to increase responsiveness.
    >>> im.plot()
    >>> roi = hs.roi.RectangularROI(left=30, right=500, top=200, bottom=400)
    >>> im_roi = roi.interactive(im, color="red")
-   >>> roi_hist =hs.interactive(im_roi.get_histogram,
-   ...                          event=im_roi.axes_manager.events.\
-   ...                                any_axis_changed,
-   ...                          recompute_out_event=None)
+   >>> roi_hist = hs.interactive(im_roi.get_histogram,
+   ...                           event=roi.events.changed,
+                                 bins=150, # Set number of bins for `get_histogram`
+   ...                           recompute_out_event=None)
    >>> roi_hist.plot()
 
 

--- a/hyperspy/drawing/_widgets/range.py
+++ b/hyperspy/drawing/_widgets/range.py
@@ -233,13 +233,15 @@ class RangeWidget(ResizableDraggableWidgetBase):
 
     def _set_snap_position(self, value):
         super(RangeWidget, self)._set_snap_position(value)
-        self.span.snap_position = value
-        self._update_patch_geometry()
+        if self.span is not None:
+            self.span.snap_position = value
+            self._update_patch_geometry()
 
     def _set_snap_size(self, value):
         super(RangeWidget, self)._set_snap_size(value)
-        self.span.snap_size = value
-        self._update_patch_size()
+        if self.span is not None:
+            self.span.snap_size = value
+            self._update_patch_size()
 
     def _validate_geometry(self, x1=None):
         """Make sure the entire patch always stays within bounds. First the

--- a/hyperspy/interactive.py
+++ b/hyperspy/interactive.py
@@ -58,7 +58,7 @@ class Interactive:
             object are then copied over to the existing `out` object. Only
             useful for `Signal` or other objects that have an attribute
             `axes_manager`. If "auto" and `f` is a method of a Signal class
-            instance its `AxesManager` `any_axis_chaged` event is selected.
+            instance its `AxesManager` `any_axis_changed` event is selected.
             Otherwise the `Signal` `data_changed` event is selected.
             If None, `recompute_out` is not connected to any event.
             The default is "auto". It is also possible to pass an iterable of
@@ -111,6 +111,8 @@ class Interactive:
 
     def recompute_out(self):
         out = self.f(*self.args, **self.kwargs)
+        if out is None:
+            return
         if out.data.shape == self.out.data.shape:
             # Keep the same array if possible.
             self.out.data[:] = out.data[:]

--- a/hyperspy/roi.py
+++ b/hyperspy/roi.py
@@ -340,7 +340,7 @@ class BaseInteractiveROI(BaseROI):
         raise NotImplementedError()
 
     def interactive(self, signal, navigation_signal="same", out=None,
-                    color="green", **kwargs):
+                    color="green", snap=True, **kwargs):
         """Creates an interactively sliced Signal (sliced by this ROI) via
         hyperspy.interactive.
 
@@ -360,6 +360,9 @@ class BaseInteractiveROI(BaseROI):
             The color for the widget. Any format that matplotlib uses should be
             ok. This will not change the color fo any widget passed with the
             'widget' argument.
+        snap : bool, optional
+            If True, the ROI will be snapped to the axes values. Default is
+            True.
         **kwargs
             All kwargs are passed to the roi __call__ method which is called
             interactively on any roi attribute change.
@@ -378,7 +381,7 @@ class BaseInteractiveROI(BaseROI):
             navigation_signal = signal
         if navigation_signal is not None:
             if navigation_signal not in self.signal_map:
-                self.add_widget(navigation_signal, color=color,
+                self.add_widget(navigation_signal, color=color, snap=snap,
                                 axes=kwargs.get("axes", None))
         if (self.update not in
                 signal.axes_manager.events.any_axis_changed.connected):
@@ -411,8 +414,8 @@ class BaseInteractiveROI(BaseROI):
         self._update_widgets(exclude=(widget,))
         self.events.changed.trigger(self)
 
-    def add_widget(self, signal, axes=None, widget=None,
-                   color='green', **kwargs):
+    def add_widget(self, signal, axes=None, widget=None, color='green',
+                   snap=True, **kwargs):
         """Add a widget to visually represent the ROI, and connect it so any
         changes in either are reflected in the other. Note that only one
         widget can be added per signal/axes combination.
@@ -443,6 +446,9 @@ class BaseInteractiveROI(BaseROI):
             The color for the widget. Any format that matplotlib uses should be
             ok. This will not change the color fo any widget passed with the
             'widget' argument.
+        snap : bool, optional
+            If True, the ROI will be snapped to the axes values. Default is
+            True.
         kwargs:
             All keyword argument are passed to the widget constructor.
         """
@@ -452,6 +458,10 @@ class BaseInteractiveROI(BaseROI):
                 axes, signal)(
                 signal.axes_manager, **kwargs)
             widget.color = color
+            if hasattr(widget, 'snap_all'):
+                widget.snap_all = snap
+            else:
+                widget.snap_position = snap
 
         # Remove existing ROI, if it exsists and axes match
         if signal in self.signal_map and \

--- a/hyperspy/tests/test_interactive.py
+++ b/hyperspy/tests/test_interactive.py
@@ -151,3 +151,10 @@ class TestInteractive():
         s.data[:] = 1
         e2.trigger()
         np.testing.assert_equal(ss.data, np.sum(s.data, axis=1))
+
+    def test_interactive_function_return_None(self):
+        e = Event()
+        def function_return_None():
+            print('function called')
+        hs.interactive(function_return_None, e)
+        e.trigger()

--- a/hyperspy/tests/utils/test_roi.py
+++ b/hyperspy/tests/utils/test_roi.py
@@ -549,48 +549,70 @@ class TestInteractive:
         sr2 = r(s)
         np.testing.assert_array_equal(sr.data, sr2.data)
 
-    def test_interactive_snap_False(self):
+    @pytest.mark.parametrize('snap', [True, False, 'default'])
+    def test_interactive_snap(self, snap):
+        kwargs = {}
+        if snap != 'default':
+            kwargs['snap'] = snap
+        else:
+            # default is True
+            snap = True
         s = self.s
         r = RectangularROI(left=3, right=7, top=2, bottom=5)
         s.plot()
-        _ = r.interactive(s, snap=False)
-        r.x = 3.5
-        assert r.x == 3.5
+        _ = r.interactive(s, **kwargs)
         for w in r.widgets:
-            assert not w.snap_all
-            assert not w.snap_position
-            assert not w.snap_size
+            old_position = w.position
+            new_position = (3.25, 2.2)
+            w.position = new_position
+            assert w.position == old_position if snap else new_position
+            assert w.snap_all == snap
+            assert w.snap_position == snap
+            assert w.snap_size == snap
 
         p1 = Point1DROI(4)
-        _ = p1.interactive(s, snap=False)
-        p1.value = 4.9
-        assert p1.value == 4.9
+        _ = p1.interactive(s, **kwargs)
         for w in p1.widgets:
-            assert not w.snap_position
+            old_position = w.position
+            new_position = (4.2, )
+            w.position = new_position
+            assert w.position == old_position if snap else new_position
+            assert w.snap_position == snap
 
         p2 = Point2DROI(4, 5)
-        _ = p2.interactive(s, snap=False)
-        p2.x, p2.y = 4.3, 5.3
-        assert (p2.x, p2.y) == (4.3, 5.3)
+        _ = p2.interactive(s, **kwargs)
         for w in p2.widgets:
-            assert not w.snap_position
+            old_position = w.position
+            new_position = (4.3, 5.3)
+            w.position = new_position
+            assert w.position == old_position if snap else new_position
+            assert w.snap_position == snap
 
-    def test_interactive_snap_default(self):
-        s = self.s
-        r = RectangularROI(left=3, right=7, top=2, bottom=5)
-        s.plot()
-        _ = r.interactive(s)
-        for w in r.widgets:
-            assert w.snap_all
-            assert w.snap_position
-            assert w.snap_size
+        span = SpanROI(4, 5)
+        _ = span.interactive(s, **kwargs)
+        for w in span.widgets:
+            old_position = w.position
+            new_position = (4.2, )
+            w.position = new_position
+            assert w.position == old_position if snap else new_position
+            assert w.snap_all == snap
+            assert w.snap_position == snap
+            assert w.snap_size == snap
 
-        p1 = Point1DROI(4)
-        _ = p1.interactive(s)
-        for w in p1.widgets:
-            assert w.snap_position
+            # check that changing snap is working fine
+            new_snap = not snap
+            w.snap_all = new_snap
+            new_position = (4.2, )
+            w.position = new_position
+            assert w.position == old_position if new_snap else new_position
 
-        p2 = Point2DROI(4, 5)
-        _ = p2.interactive(s)
-        for w in p2.widgets:
-            assert w.snap_position
+        line2d = Line2DROI(4, 5, 6, 6, 1)
+        _ = line2d.interactive(s, **kwargs)
+        for w in line2d.widgets:
+            old_position = w.position
+            new_position = ([4.3, 5.3], [6.0, 6.0])
+            w.position = new_position
+            assert w.position == old_position if snap else new_position
+            assert w.snap_all == snap
+            assert w.snap_position == snap
+            assert w.snap_size == snap

--- a/hyperspy/tests/utils/test_roi.py
+++ b/hyperspy/tests/utils/test_roi.py
@@ -548,3 +548,49 @@ class TestInteractive:
         r.x += 5
         sr2 = r(s)
         np.testing.assert_array_equal(sr.data, sr2.data)
+
+    def test_interactive_snap_False(self):
+        s = self.s
+        r = RectangularROI(left=3, right=7, top=2, bottom=5)
+        s.plot()
+        _ = r.interactive(s, snap=False)
+        r.x = 3.5
+        assert r.x == 3.5
+        for w in r.widgets:
+            assert not w.snap_all
+            assert not w.snap_position
+            assert not w.snap_size
+
+        p1 = Point1DROI(4)
+        _ = p1.interactive(s, snap=False)
+        p1.value = 4.9
+        assert p1.value == 4.9
+        for w in p1.widgets:
+            assert not w.snap_position
+
+        p2 = Point2DROI(4, 5)
+        _ = p2.interactive(s, snap=False)
+        p2.x, p2.y = 4.3, 5.3
+        assert (p2.x, p2.y) == (4.3, 5.3)
+        for w in p2.widgets:
+            assert not w.snap_position
+
+    def test_interactive_snap_default(self):
+        s = self.s
+        r = RectangularROI(left=3, right=7, top=2, bottom=5)
+        s.plot()
+        _ = r.interactive(s)
+        for w in r.widgets:
+            assert w.snap_all
+            assert w.snap_position
+            assert w.snap_size
+
+        p1 = Point1DROI(4)
+        _ = p1.interactive(s)
+        for w in p1.widgets:
+            assert w.snap_position
+
+        p2 = Point2DROI(4, 5)
+        _ = p2.interactive(s)
+        for w in p2.widgets:
+            assert w.snap_position


### PR DESCRIPTION
### Progress of the PR
- [x] Allow setting whether the ROI should snap or not in `roi.interactive`,
- [x] fix a bug when using `hs.interactive` with function returning `None`, 
- [x] improve user guide,
- [x] add entry to `CHANGES.rst` (if appropriate),
- [x] add tests,
- [x] ready for review.

### Minimal example of the bug fix or the new feature
```python
import hyperspy.api as hs
import numpy as np

im = hs.signals.Signal2D(np.arange(100).reshape(10, 10))
im.plot()

roi = hs.roi.CircleROI(cx=1.5, cy=3.2, r=1.2)
im_roi = roi.interactive(im, color="red", snap=False)

def print_centre(roi):
    print(roi.cx, roi.cy)

hs.interactive(print_centre, roi=roi, event=roi.events.changed,
               recompute_out_event=None)
```
Note that this example can be useful to update the user guide.

