### PR TITLE
Fix setting offset in rebin: the offset was changed in the wrong axis.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -46,6 +46,7 @@ RELEASE_next_patch (Unreleased)
 * Add option not to snap ROI when calling the `interactive` method of a ROI (`#2686 <https://github.com/hyperspy/hyperspy/pull/2686>`_)
 * Fix broken events when changing signal type `#2683 <https://github.com/hyperspy/hyperspy/pull/2683>`_
 * Make DictionaryTreeBrowser lazy by default - see `#368 <https://github.com/hyperspy/hyperspy/issues/368>`_ (`#2623 <https://github.com/hyperspy/hyperspy/pull/2623>`_)
+* Fix setting offset in rebin: the offset was changed in the wrong axis (`#2690 <https://github.com/hyperspy/hyperspy/pull/2690>`_)
 
 
 Changelog

--- a/hyperspy/signal.py
+++ b/hyperspy/signal.py
@@ -3080,12 +3080,11 @@ class BaseSignal(FancySlicing,
         else:
             s.data = data
         s.get_dimensions_from_data()
-        for i, factor in enumerate(factors):
-            s.axes_manager[i].offset += ((factor - 1)
-                                         * s.axes_manager[i].scale) / 2
         for axis, axis_src in zip(s.axes_manager._axes,
                                   self.axes_manager._axes):
-            axis.scale = axis_src.scale * factors[axis.index_in_array]
+            factor = factors[axis.index_in_array]
+            axis.scale = axis_src.scale * factor
+            axis.offset = axis_src.offset + (factor - 1) * axis_src.scale / 2
         if s.metadata.has_item('Signal.Noise_properties.variance'):
             if isinstance(s.metadata.Signal.Noise_properties.variance,
                           BaseSignal):

--- a/hyperspy/tests/signals/test_linear_rebin.py
+++ b/hyperspy/tests/signals/test_linear_rebin.py
@@ -24,9 +24,10 @@ from hyperspy.signals import EDSTEMSpectrum
 
 
 class TestLinearRebin:
+
     @pytest.mark.parametrize('dtype', ['<u2', 'u2', '>u2', '<f4', 'f4', '>f4'])
     def test_linear_downsize(self, dtype):
-        spectrum = EDSTEMSpectrum(np.ones([3, 5, 1],dtype=dtype))
+        spectrum = EDSTEMSpectrum(np.ones([3, 5, 1], dtype=dtype))
         scale = (1.5, 2.5, 1)
         res = spectrum.rebin(scale=scale, crop=True)
         np.testing.assert_allclose(res.data, 3.75 * np.ones((1, 3, 1)))
@@ -37,7 +38,7 @@ class TestLinearRebin:
 
     @pytest.mark.parametrize('dtype', ['<u2', 'u2', '>u2', '<f4', 'f4', '>f4'])
     def test_linear_upsize(self, dtype):
-        spectrum = EDSTEMSpectrum(np.ones([4, 5, 10],dtype=dtype))
+        spectrum = EDSTEMSpectrum(np.ones([4, 5, 10], dtype=dtype))
         scale = [0.3, 0.2, 0.5]
         res = spectrum.rebin(scale=scale)
         np.testing.assert_allclose(res.data, 0.03 * np.ones((20, 16, 20)))
@@ -48,31 +49,26 @@ class TestLinearRebin:
 
     def test_linear_downscale_out(self):
         spectrum = EDSTEMSpectrum(np.ones([4, 1, 1]))
-        scale = [1, 0.4, 1]
+        scale = [1, 2, 1]
+        offset = [0, 0.5, 0]
         res = spectrum.rebin(scale=scale)
         spectrum.data[2][0] = 5
         spectrum.rebin(scale=scale, out=res)
         np.testing.assert_allclose(
             res.data,
             [
-                [[0.4]],
-                [[0.4]],
-                [[0.4]],
-                [[0.4]],
-                [[0.4]],
-                [[2.0]],
-                [[2.0]],
-                [[1.2]],
-                [[0.4]],
-                [[0.4]],
+                [[2.]],
+                [[6.]],
             ],
         )
         for axis in res.axes_manager._axes:
             assert scale[axis.index_in_axes_manager] == axis.scale
+            assert offset[axis.index_in_axes_manager] == axis.offset
 
     def test_linear_upscale_out(self):
         spectrum = EDSTEMSpectrum(np.ones([4, 1, 1]))
         scale = [1, 0.4, 1]
+        offset = [0, -0.3, 0]
         res = spectrum.rebin(scale=scale)
         spectrum.data[2][0] = 5
         spectrum.rebin(scale=scale, out=res)
@@ -94,3 +90,4 @@ class TestLinearRebin:
         )
         for axis in res.axes_manager._axes:
             assert scale[axis.index_in_axes_manager] == axis.scale
+            assert offset[axis.index_in_axes_manager] == axis.offset


### PR DESCRIPTION
### Progress of the PR
- [x] Change the offset in the correct axis,
- [x] add entry to `CHANGES.rst`,
- [x] add tests,
- [x] ready for review.

### Minimal example of the bug fix
```python
import hyperspy.api as hs

s = hs.datasets.artificial_data.get_low_loss_eels_line_scan_signal()
s = hs.stack([s]*10)
print(s.axes_manager)

s2 = s.rebin(scale=(3, 1, 1))
print(s2.axes_manager)
```
Before rebinning
```python
<Axes manager, axes: (12, 10|1000)>
            Name |   size |  index |  offset |   scale |  units 
================ | ====== | ====== | ======= | ======= | ====== 
  Probe position |     12 |      0 |       0 |       1 |     nm 
   stack_element |     10 |      0 |       0 |       1 | <undefined> 
---------------- | ------ | ------ | ------- | ------- | ------ 
Electron energy  |   1000 |        |  -1e+02 |     0.5 |     eV 
```

Currently shows after rebinning:
```python
<Axes manager, axes: (4, 10|1000)>
            Name |   size |  index |  offset |   scale |  units 
================ | ====== | ====== | ======= | ======= | ====== 
  Probe position |      4 |      0 |       0 |       3 |     nm 
   stack_element |     10 |      0 |       1 |       1 | <undefined> 
---------------- | ------ | ------ | ------- | ------- | ------ 
Electron energy  |   1000 |        |  -1e+02 |     0.5 |     eV 
```

Expected results after rebinning:
```python
<Axes manager, axes: (4, 10|1000)>
            Name |   size |  index |  offset |   scale |  units 
================ | ====== | ====== | ======= | ======= | ====== 
  Probe position |      4 |      0 |       1 |       3 |     nm 
   stack_element |     10 |      0 |       0 |       1 | <undefined> 
---------------- | ------ | ------ | ------- | ------- | ------ 
Electron energy  |   1000 |        |  -1e+02 |     0.5 |     eV 
```

