### PR TITLE
Add option not to stack original metadata in hs.stack

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -50,7 +50,7 @@ RELEASE_next_patch (Unreleased)
 * Fix reading XRF bruker file, close `#2689 <https://github.com/hyperspy/hyperspy/issues/2689>`_ (`#2694 <https://github.com/hyperspy/hyperspy/pull/2694>`_)
 * Speed up setting CI on azure pipeline (`#2694 <https://github.com/hyperspy/hyperspy/pull/2694>`_)
 * Fix performance issue with the lazy map method of lazy (`#2617 <https://github.com/hyperspy/hyperspy/pull/2617>`_)
-* Fix slowdown due to large metadata, add option to copy/load original metadata in ``hs.stack`` and ``hs.load``. Close `#1398 <https://github.com/hyperspy/hyperspy/issues/1398>`_, `#2045 <https://github.com/hyperspy/hyperspy/issues/2045>`_ and `#2536 <https://github.com/hyperspy/hyperspy/issues/2536>`_. (`#2691 <https://github.com/hyperspy/hyperspy/pull/2691>`_)
+* Fix slowdown due to large metadata, add option to copy/load original metadata in ``hs.stack`` and ``hs.load``. Close `#1398 <https://github.com/hyperspy/hyperspy/issues/1398>`_, `#1568 <https://github.com/hyperspy/hyperspy/issues/1568>`_, `#2045 <https://github.com/hyperspy/hyperspy/issues/2045>`_ and `#2536 <https://github.com/hyperspy/hyperspy/issues/2536>`_. (`#2691 <https://github.com/hyperspy/hyperspy/pull/2691>`_)
 
 
 Changelog

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -50,7 +50,7 @@ RELEASE_next_patch (Unreleased)
 * Fix reading XRF bruker file, close `#2689 <https://github.com/hyperspy/hyperspy/issues/2689>`_ (`#2694 <https://github.com/hyperspy/hyperspy/pull/2694>`_)
 * Speed up setting CI on azure pipeline (`#2694 <https://github.com/hyperspy/hyperspy/pull/2694>`_)
 * Fix performance issue with the lazy map method of lazy (`#2617 <https://github.com/hyperspy/hyperspy/pull/2617>`_)
-* Fix slowdown due to large metadata, add option to copy/load original metadata in ``hs.stack`` and ``hs.load``. Close `#1398 <https://github.com/hyperspy/hyperspy/issues/1398>`_, `#1568 <https://github.com/hyperspy/hyperspy/issues/1568>`_, `#2045 <https://github.com/hyperspy/hyperspy/issues/2045>`_ and `#2536 <https://github.com/hyperspy/hyperspy/issues/2536>`_. (`#2691 <https://github.com/hyperspy/hyperspy/pull/2691>`_)
+* Add option to copy/load original metadata in ``hs.stack`` and ``hs.load`` to avoid large ``original_metadata`` which can slowdown processing. Close `#1398 <https://github.com/hyperspy/hyperspy/issues/1398>`_, `#2045 <https://github.com/hyperspy/hyperspy/issues/2045>`_ and `#1568 <https://github.com/hyperspy/hyperspy/issues/1568>`_. (`#2691 <https://github.com/hyperspy/hyperspy/pull/2691>`_)
 
 
 Changelog

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -25,7 +25,7 @@ RELEASE_next_patch (Unreleased)
 * Fix various future and deprecation warnings from numpy and scikit-learn (`#2646 <https://github.com/hyperspy/hyperspy/pull/2646>`_)
 * Improve error message when initialising SpanROI with left >= right (`#2604 <https://github.com/hyperspy/hyperspy/pull/2604>`_)
 * Fix ``iterpath`` VisibleDeprecationWarning when using ``fit_component`` (`#2654 <https://github.com/hyperspy/hyperspy/pull/2654>`_)
-* Fix various bugs with `CircleWidget` and `Line2DWidget` (`#2625 <https://github.com/hyperspy/hyperspy/pull/2625>`_)
+* Fix various bugs with ``CircleWidget`` and ``Line2DWidget`` (`#2625 <https://github.com/hyperspy/hyperspy/pull/2625>`_)
 * Allow running the test suite without the pytest-mpl plugin (`#2624 <https://github.com/hyperspy/hyperspy/pull/2624>`_)
 * Fix warnings when building documentation (`#2596 <https://github.com/hyperspy/hyperspy/pull/2596>`_)
 * Add Releasing guide (`#2595 <https://github.com/hyperspy/hyperspy/pull/2595>`_)
@@ -50,6 +50,7 @@ RELEASE_next_patch (Unreleased)
 * Fix reading XRF bruker file, close `#2689 <https://github.com/hyperspy/hyperspy/issues/2689>`_ (`#2694 <https://github.com/hyperspy/hyperspy/pull/2694>`_)
 * Speed up setting CI on azure pipeline (`#2694 <https://github.com/hyperspy/hyperspy/pull/2694>`_)
 * Fix performance issue with the lazy map method of lazy (`#2617 <https://github.com/hyperspy/hyperspy/pull/2617>`_)
+* Fix slowdown due to large metadata, add option to copy/load original metadata in ``hs.stack`` and ``hs.load``. Close `#1398 <https://github.com/hyperspy/hyperspy/issues/1398>`_, `#2045 <https://github.com/hyperspy/hyperspy/issues/2045>`_ and `#2536 <https://github.com/hyperspy/hyperspy/issues/2536>`_. (`#2691 <https://github.com/hyperspy/hyperspy/pull/2691>`_)
 
 
 Changelog

--- a/doc/user_guide/io.rst
+++ b/doc/user_guide/io.rst
@@ -65,7 +65,7 @@ override this using the ``reader`` keyword:
     >>> s = hs.load("filename.some_extension", reader="hspy")
 
 Some file formats store some extra information about the data (metadata) and
-HyperSpy read most of them and store them in the
+HyperSpy reads most of them and stores them in the
 :py:attr:`~.signal.BaseSignal.original_metadata` attribute. Also, depending on
 the file format, a part of this information will be mapped by HyperSpy to the
 :py:attr:`~.signal.BaseSignal.metadata` attribute, where it can be used by
@@ -74,10 +74,10 @@ e.g. routines operating on the signal. See :ref:`metadata structure
 
 .. note::
 
-    Very large amount of metadata can slow down loading and processing, and
-    loading the :py:attr:`~.signal.BaseSignal.original_metadata` can be disable
+    Extensive metadata can slow down loading and processing, and
+    loading the :py:attr:`~.signal.BaseSignal.original_metadata` can be disabled
     using the ``load_original_metadata`` argument of the :py:func:`~.load`
-    function; in this case the :py:attr:`~.signal.BaseSignal.metadata` will
+    function; in this case, the :py:attr:`~.signal.BaseSignal.metadata` will
     still be populated.
 
 To print the content of the attributes simply use:

--- a/doc/user_guide/io.rst
+++ b/doc/user_guide/io.rst
@@ -64,14 +64,21 @@ override this using the ``reader`` keyword:
     # Load a .hspy file with an unknown extension
     >>> s = hs.load("filename.some_extension", reader="hspy")
 
-Some file formats store some extra information about the data (metadata), which
-can be stored in `attributes` of the signal object. If HyperSpy manages to read
-such metadata, it is stored in the
+Some file formats store some extra information about the data (metadata) and
+HyperSpy read most of them and store them in the
 :py:attr:`~.signal.BaseSignal.original_metadata` attribute. Also, depending on
 the file format, a part of this information will be mapped by HyperSpy to the
 :py:attr:`~.signal.BaseSignal.metadata` attribute, where it can be used by
 e.g. routines operating on the signal. See :ref:`metadata structure
 <metadata_structure>` for details.
+
+.. note::
+
+    Very large amount of metadata can slow down loading and processing, and
+    loading the :py:attr:`~.signal.BaseSignal.original_metadata` can be disable
+    using the ``load_original_metadata`` argument of the :py:func:`~.load`
+    function; in this case the :py:attr:`~.signal.BaseSignal.metadata` will
+    still be populated.
 
 To print the content of the attributes simply use:
 
@@ -144,7 +151,7 @@ Alternatively, regular expression type character classes can be used such as
 
     Wildcards are implemented using ``glob.glob()``, which treats ``*``, ``[``
     and ``]`` as special characters for pattern matching. If your filename or
-    path contains square brackets, you may want to set 
+    path contains square brackets, you may want to set
     ``escape_square_brackets=True``:
 
     .. code-block:: python

--- a/doc/user_guide/signal.rst
+++ b/doc/user_guide/signal.rst
@@ -1079,6 +1079,14 @@ with same dimension.
 
   Stacking example.
 
+.. note::
+
+    When stacking signals with large amount of
+    :py:attr:`~.signal.BaseSignal.original_metadata`, these metadata will be
+    stacked and this can lead to very large amount of metadata which can in
+    turn slow down processing. The ``stack_original_metadata`` argument can be
+    used to disable stacking :py:attr:`~.signal.BaseSignal.original_metadata`.
+
 An object can be split into several objects
 with the :py:meth:`~.signal.BaseSignal.split` method. This function can be used
 to reverse the :py:func:`~.utils.stack` function:
@@ -1100,13 +1108,13 @@ to reverse the :py:func:`~.utils.stack` function:
 Fast Fourier Transform (FFT)
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-The `fast Fourier transform <https://en.wikipedia.org/wiki/Fast_Fourier_transform>`_ 
-of a signal can be computed using the :py:meth:`~.signal.BaseSignal.fft` method. By default, 
-the FFT is calculated with the origin at (0, 0), which will be displayed at the 
-bottom left and not in the centre of the FFT. Conveniently, the ``shift`` argument of the 
-the :py:meth:`~.signal.BaseSignal.fft` method can be used to center the output of the FFT. 
-In the following example, the FFT of a hologram is computed using ``shift=True`` and its 
-output signal is displayed, which shows that the FFT results in a complex signal with a 
+The `fast Fourier transform <https://en.wikipedia.org/wiki/Fast_Fourier_transform>`_
+of a signal can be computed using the :py:meth:`~.signal.BaseSignal.fft` method. By default,
+the FFT is calculated with the origin at (0, 0), which will be displayed at the
+bottom left and not in the centre of the FFT. Conveniently, the ``shift`` argument of the
+the :py:meth:`~.signal.BaseSignal.fft` method can be used to center the output of the FFT.
+In the following example, the FFT of a hologram is computed using ``shift=True`` and its
+output signal is displayed, which shows that the FFT results in a complex signal with a
 real and an imaginary parts:
 
 .. code-block:: python
@@ -1119,11 +1127,11 @@ real and an imaginary parts:
   :align:   center
   :width:   800
 
-The strong features in the real and imaginary parts correspond to the lattice fringes of the 
+The strong features in the real and imaginary parts correspond to the lattice fringes of the
 hologram.
 
-For visual inspection of the FFT it is convenient to display its power spectrum 
-(i.e. the square of the absolute value of the FFT) rather than FFT itself as it is done 
+For visual inspection of the FFT it is convenient to display its power spectrum
+(i.e. the square of the absolute value of the FFT) rather than FFT itself as it is done
 in the example above by using the ``power_spectum`` argument:
 
 .. code-block:: python
@@ -1132,8 +1140,8 @@ in the example above by using the ``power_spectum`` argument:
     >>> fft = im.fft(True)
     >>> fft.plot(True)
 
-Where ``power_spectum`` is set to ``True`` since it is the first argument of the 
-:py:meth:`~._signals.complex_signal.ComplexSignal_mixin.plot` method for complex signal. 
+Where ``power_spectum`` is set to ``True`` since it is the first argument of the
+:py:meth:`~._signals.complex_signal.ComplexSignal_mixin.plot` method for complex signal.
 When ``power_spectrum=True``, the plot will be displayed on a log scale by default.
 
 
@@ -1141,7 +1149,7 @@ When ``power_spectrum=True``, the plot will be displayed on a log scale by defau
   :align:   center
   :width:   400
 
-The visualisation can be further improved by setting the minimum value to display to the 30-th 
+The visualisation can be further improved by setting the minimum value to display to the 30-th
 percentile; this can be done by using ``vmin="30th"`` in the plot function:
 
 .. code-block:: python
@@ -1154,12 +1162,12 @@ percentile; this can be done by using ``vmin="30th"`` in the plot function:
   :align:   center
   :width:   400
 
-The streaks visible in the FFT come from the edge of the image and can be removed by  
-applying an `apodization <https://en.wikipedia.org/wiki/Apodization>`_ function to the original 
-signal before the computation of the FFT. This can be done using the ``apodization`` argument of 
-the :py:meth:`~.signal.BaseSignal.fft` method and it is usually used for visualising FFT patterns 
-rather than for quantitative analyses. By default, the so-called ``hann`` windows is 
-used but different type of windows such as the ``hamming`` and ``tukey`` windows. 
+The streaks visible in the FFT come from the edge of the image and can be removed by
+applying an `apodization <https://en.wikipedia.org/wiki/Apodization>`_ function to the original
+signal before the computation of the FFT. This can be done using the ``apodization`` argument of
+the :py:meth:`~.signal.BaseSignal.fft` method and it is usually used for visualising FFT patterns
+rather than for quantitative analyses. By default, the so-called ``hann`` windows is
+used but different type of windows such as the ``hamming`` and ``tukey`` windows.
 
 .. code-block:: python
 
@@ -1177,8 +1185,8 @@ used but different type of windows such as the ``hamming`` and ``tukey`` windows
 Inverse Fast Fourier Transform (iFFT)
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Inverse fast Fourier transform can be calculated from a complex signal by using the 
-:py:meth:`~.signal.BaseSignal.ifft` method. Similarly to the :py:meth:`~.signal.BaseSignal.fft` method, 
+Inverse fast Fourier transform can be calculated from a complex signal by using the
+:py:meth:`~.signal.BaseSignal.ifft` method. Similarly to the :py:meth:`~.signal.BaseSignal.fft` method,
 the ``shift`` argument can be provided to shift the origin of the iFFT when necessary:
 
 .. code-block:: python

--- a/hyperspy/_signals/eds.py
+++ b/hyperspy/_signals/eds.py
@@ -1022,8 +1022,9 @@ class EDS_mixin:
             line_energy.append(self._get_line_energy(xray_line))
             relative_factor = elements_db[element][
                 'Atomic_properties']['Xray_lines'][line]['weight']
-            a_eng = self._get_line_energy(element + '_' + line[0] + 'a')
-            intensity.append(self.isig[a_eng].data * relative_factor)
+            a_eng = self._get_line_energy(f'{element}_{line[0]}a')
+            idx = self.axes_manager[-1].value2index(a_eng)
+            intensity.append(self.data[..., idx] * relative_factor)
         for i in range(len(line_energy)):
             line = markers.vertical_line_segment(
                 x=line_energy[i], y1=None, y2=intensity[i] * 0.8)

--- a/hyperspy/_signals/eds.py
+++ b/hyperspy/_signals/eds.py
@@ -1027,7 +1027,7 @@ class EDS_mixin:
             relative_factor = elements_db[element][
                 'Atomic_properties']['Xray_lines'][line]['weight']
             a_eng = self._get_line_energy(f'{element}_{line[0]}a')
-            idx = self.axes_manager[-1].value2index(a_eng)
+            idx = self.axes_manager.signal_axes[0].value2index(a_eng)
             intensity.append(self.data[..., idx] * relative_factor)
         for i in range(len(line_energy)):
             line = markers.vertical_line_segment(

--- a/hyperspy/_signals/eds.py
+++ b/hyperspy/_signals/eds.py
@@ -84,8 +84,8 @@ class EDS_mixin:
             else:
                 raise NotImplementedError(
                     "This method only works for EDS_TEM or EDS_SEM signals. "
-                    "You can use `set_signal_type(\"EDS_TEM\")` or"
-                    "`set_signal_type(\"EDS_SEM\")` to convert to one of these"
+                    "You can use `set_signal_type('EDS_TEM')` or"
+                    "`set_signal_type('EDS_SEM')` to convert to one of these"
                     "signal types.")
         line_energy = utils_eds._get_energy_xray_line(Xray_line)
         if units_name == 'eV':
@@ -99,11 +99,10 @@ class EDS_mixin:
                                                          line_energy)
         else:
             raise ValueError(
-                "%s is not a valid units for the energy axis. "
+                f"{units_name} is not a valid units for the energy axis. "
                 "Only `eV` and `keV` are supported. "
                 "If `s` is the variable containing this EDS spectrum:\n "
-                ">>> s.axes_manager.signal_axes[0].units = \'keV\' \n"
-                % units_name)
+                ">>> s.axes_manager.signal_axes[0].units = 'keV' \n")
         if FWHM_MnKa is None:
             return line_energy
         else:
@@ -287,7 +286,7 @@ class EDS_mixin:
                 elements_.add(element)
             else:
                 raise ValueError(
-                    "%s is not a valid chemical element symbol." % element)
+                    f"{element} is not a valid chemical element symbol.")
         self.metadata.set_item('Sample.elements', sorted(list(elements_)))
 
     def _get_xray_lines(self, xray_lines=None, only_one=None,
@@ -432,15 +431,15 @@ class EDS_mixin:
                     lines_len = len(xray_lines)
                     xray_lines.add(line)
                     if lines_len != len(xray_lines):
-                        _logger.info("%s line added," % line)
+                        _logger.info(f"{line} line added,")
                     else:
-                        _logger.info("%s line already in." % line)
+                        _logger.info(f"{line} line already in.")
                 else:
                     raise ValueError(
-                        "%s is not a valid line of %s." % (line, element))
+                        f"{line} is not a valid line of {element}.")
             else:
                 raise ValueError(
-                    "%s is not a valid symbol of an element." % element)
+                    f"{element} is not a valid symbol of an element.")
         xray_not_here = self._get_xray_lines_in_spectral_range(xray_lines)[1]
         for xray in xray_not_here:
             warnings.warn(f"{xray} is not in the data energy range.",
@@ -517,9 +516,8 @@ class EDS_mixin:
                 element_lines = [element_lines[select_this], ]
 
             if not element_lines:
-                _logger.info(
-                    ("There is no X-ray line for element %s " % element) +
-                    "in the data spectral range")
+                _logger.info("There is no X-ray line for element {element} "
+                             "in the data spectral range")
             else:
                 lines.extend(element_lines)
         lines.sort()
@@ -532,10 +530,9 @@ class EDS_mixin:
         xray_lines, xray_not_here = self._get_xray_lines_in_spectral_range(
             xray_lines)
         for xray in xray_not_here:
-            warnings.warn("%s is not in the data energy range." % xray +
-                          "You can remove it with" +
-                          "s.metadata.Sample.xray_lines.remove('%s')"
-                          % xray)
+            warnings.warn(f"{xray} is not in the data energy range. "
+                          "You can remove it with: "
+                          "`s.metadata.Sample.xray_lines.remove('{xray}')`")
         return xray_lines
 
     def get_lines_intensity(self,
@@ -632,7 +629,7 @@ class EDS_mixin:
 
             raise TypeError(
                 "xray_lines must be a compatible iterable, but was "
-                "mistakenly provided as a %s." % type(xray_lines))
+                "mistakenly provided as a {type(xray_lines)}.")
 
         xray_lines = self._parse_xray_lines(xray_lines, only_one, only_lines)
         if hasattr(integration_windows, '__iter__') is False:
@@ -668,19 +665,13 @@ class EDS_mixin:
                     (indexes[1] - indexes[0]) + (indexes[3] - indexes[2]))
                 img = img - (bck1 + bck2) * corr_factor
             img.metadata.General.title = (
-                'X-ray line intensity of %s: %s at %.2f %s' %
-                (self.metadata.General.title,
-                 Xray_line,
-                 line_energy,
-                 self.axes_manager.signal_axes[0].units,
-                 ))
+                f'X-ray line intensity of {self.metadata.General.title}: '
+                f'{Xray_line} at {line_energy:.2f} '
+                f'{self.axes_manager.signal_axes[0].units}')
             img.axes_manager.set_signal_dimension(0)
             if plot_result and img.axes_manager.navigation_size == 1:
-                print("%s at %s %s : Intensity = %.2f"
-                      % (Xray_line,
-                         line_energy,
-                         ax.units,
-                         img.data))
+                print(f"{Xray_line} at {line_energy} {ax.units} : "
+                      f"Intensity = {img.data:.2f}")
             img.metadata.set_item("Sample.elements", ([element]))
             img.metadata.set_item("Sample.xray_lines", ([Xray_line]))
             intensities.append(img)
@@ -947,15 +938,15 @@ class EDS_mixin:
     def _plot_xray_lines(self, xray_lines=False, only_lines=("a", "b"),
                          only_one=False, background_windows=None,
                          integration_windows=None, render_figure=True):
-        if (xray_lines is not False or\
-                background_windows is not None or\
-                integration_windows is not None:
+        if (xray_lines is not False or
+                background_windows is not None or
+                integration_windows is not None):
             if xray_lines is False:
                 xray_lines = True
             only_lines = utils_eds._parse_only_lines(only_lines)
             if xray_lines is True or xray_lines == 'from_elements':
-                if 'Sample.xray_lines' in self.metadata \
-                        and xray_lines != 'from_elements':
+                if ('Sample.xray_lines' in self.metadata and
+                        xray_lines != 'from_elements'):
                     xray_lines = self.metadata.Sample.xray_lines
                 elif 'Sample.elements' in self.metadata:
                     xray_lines = self._get_lines_from_elements(
@@ -970,7 +961,7 @@ class EDS_mixin:
             xray_lines, xray_not_here = self._get_xray_lines_in_spectral_range(
                 xray_lines)
             for xray in xray_not_here:
-                _logger.warning("%s is not in the data energy range." % xray)
+                _logger.warning(f"{xray} is not in the data energy range.")
             xray_lines = np.unique(xray_lines)
             self.add_xray_lines_markers(xray_lines,
                                         render_figure=False)

--- a/hyperspy/_signals/eds.py
+++ b/hyperspy/_signals/eds.py
@@ -670,8 +670,10 @@ class EDS_mixin:
                 f'{self.axes_manager.signal_axes[0].units}')
             img.axes_manager.set_signal_dimension(0)
             if plot_result and img.axes_manager.navigation_size == 1:
+                if img._lazy:
+                    img.compute()
                 print(f"{Xray_line} at {line_energy} {ax.units} : "
-                      f"Intensity = {img.data:.2f}")
+                      f"Intensity = {img.data[0]:.2f}")
             img.metadata.set_item("Sample.elements", ([element]))
             img.metadata.set_item("Sample.xray_lines", ([Xray_line]))
             intensities.append(img)
@@ -958,6 +960,7 @@ class EDS_mixin:
                         "No elements defined, set them with `add_elements`")
                     # No X-rays lines, nothing to do then
                     return
+
             xray_lines, xray_not_here = self._get_xray_lines_in_spectral_range(
                 xray_lines)
             for xray in xray_not_here:

--- a/hyperspy/_signals/eds.py
+++ b/hyperspy/_signals/eds.py
@@ -937,15 +937,17 @@ class EDS_mixin:
                      navigator_kwds=navigator_kwds,
                      **kwargs)
         self._plot_xray_lines(xray_lines, only_lines, only_one,
-                              background_windows, integration_windows)
+                              background_windows, integration_windows,
+                              render_figure=False)
+        self._render_figure(plot=['signal_plot'])
 
     plot.__doc__ %= (BASE_PLOT_DOCSTRING_PARAMETERS,
                      PLOT1D_DOCSTRING)
 
     def _plot_xray_lines(self, xray_lines=False, only_lines=("a", "b"),
                          only_one=False, background_windows=None,
-                         integration_windows=None):
-        if xray_lines is not False or\
+                         integration_windows=None, render_figure=True):
+        if (xray_lines is not False or\
                 background_windows is not None or\
                 integration_windows is not None:
             if xray_lines is False:
@@ -970,9 +972,11 @@ class EDS_mixin:
             for xray in xray_not_here:
                 _logger.warning("%s is not in the data energy range." % xray)
             xray_lines = np.unique(xray_lines)
-            self.add_xray_lines_markers(xray_lines)
+            self.add_xray_lines_markers(xray_lines,
+                                        render_figure=False)
             if background_windows is not None:
-                self._add_background_windows_markers(background_windows)
+                self._add_background_windows_markers(background_windows,
+                                                     render_figure=False)
             if integration_windows is not None:
                 if integration_windows == 'auto':
                     integration_windows = 2.0
@@ -981,9 +985,14 @@ class EDS_mixin:
                         windows_width=integration_windows,
                         xray_lines=xray_lines)
                 self._add_vertical_lines_groups(integration_windows,
-                                                linestyle='--')
+                                                linestyle='--',
+                                                render_figure=False)
+        # Render figure only at the end
+        if render_figure:
+            self._render_figure(plot=['signal_plot'])
 
-    def _add_vertical_lines_groups(self, position, **kwargs):
+    def _add_vertical_lines_groups(self, position, render_figure=True,
+                                   **kwargs):
         """
         Add vertical markers for each group that shares the color.
 
@@ -1002,9 +1011,10 @@ class EDS_mixin:
         for x, color in zip(np.ravel(position), colors):
             line = markers.vertical_line(x=x, color=color, **kwargs)
             self.add_marker(line, render_figure=False)
-        self._render_figure(plot=['signal_plot'])
+        if render_figure:
+            self._render_figure(plot=['signal_plot'])
 
-    def add_xray_lines_markers(self, xray_lines):
+    def add_xray_lines_markers(self, xray_lines, render_figure=True):
         """
         Add marker on a spec.plot() with the name of the selected X-ray
         lines
@@ -1038,7 +1048,8 @@ class EDS_mixin:
             self._xray_markers[xray_lines[i]] = [line, text]
             line.events.closed.connect(self._xray_marker_closed)
             text.events.closed.connect(self._xray_marker_closed)
-        self._render_figure(plot=['signal_plot'])
+        if render_figure:
+            self._render_figure(plot=['signal_plot'])
 
     def _xray_marker_closed(self, obj):
         marker = obj
@@ -1049,7 +1060,7 @@ class EDS_mixin:
             if not line_markers:
                 self._xray_markers.pop(xray_line)
 
-    def remove_xray_lines_markers(self, xray_lines):
+    def remove_xray_lines_markers(self, xray_lines, render_figure=True):
         """
         Remove marker previosuly added on a spec.plot() with the name of the
         selected X-ray lines
@@ -1065,10 +1076,11 @@ class EDS_mixin:
                 while line_markers:
                     m = line_markers.pop()
                     m.close(render_figure=False)
-        self._render_figure(plot=['signal_plot'])
+        if render_figure:
+            self._render_figure(plot=['signal_plot'])
 
-    def _add_background_windows_markers(self,
-                                        windows_position):
+    def _add_background_windows_markers(self, windows_position,
+                                        render_figure=True):
         """
         Plot the background windows associated with each X-ray lines.
 
@@ -1103,7 +1115,8 @@ class EDS_mixin:
                 x1=(bw[0] + bw[1]) / 2., x2=(bw[2] + bw[3]) / 2.,
                 y1=y1, y2=y2, color='black')
             self.add_marker(line, render_figure=False)
-        self._render_figure(plot=['signal_plot'])
+        if render_figure:
+            self._render_figure(plot=['signal_plot'])
 
 
 class EDSSpectrum(EDS_mixin, Signal1D):

--- a/hyperspy/_signals/eds.py
+++ b/hyperspy/_signals/eds.py
@@ -516,7 +516,7 @@ class EDS_mixin:
                 element_lines = [element_lines[select_this], ]
 
             if not element_lines:
-                _logger.info("There is no X-ray line for element {element} "
+                _logger.info(f"There is no X-ray line for element {element} "
                              "in the data spectral range")
             else:
                 lines.extend(element_lines)
@@ -532,7 +532,7 @@ class EDS_mixin:
         for xray in xray_not_here:
             warnings.warn(f"{xray} is not in the data energy range. "
                           "You can remove it with: "
-                          "`s.metadata.Sample.xray_lines.remove('{xray}')`")
+                          f"`s.metadata.Sample.xray_lines.remove('{xray}')`")
         return xray_lines
 
     def get_lines_intensity(self,
@@ -629,7 +629,7 @@ class EDS_mixin:
 
             raise TypeError(
                 "xray_lines must be a compatible iterable, but was "
-                "mistakenly provided as a {type(xray_lines)}.")
+                f"mistakenly provided as a {type(xray_lines)}.")
 
         xray_lines = self._parse_xray_lines(xray_lines, only_one, only_lines)
         if hasattr(integration_windows, '__iter__') is False:

--- a/hyperspy/_signals/lazy.py
+++ b/hyperspy/_signals/lazy.py
@@ -137,11 +137,13 @@ class LazySignal(BaseSignal):
                 sig_chunks=-1,
                 inplace=True,
                 **kwargs):
-        """Rechunks the data using the same rechunking formula from Dask expect
-        that the navigation and signal chunks are defined seperately. Note, for most
-        functions sig_chunks should remain None so that it spans the entire signal.
+        """Rechunks the data using the same rechunking formula from Dask
+        expect that the navigation and signal chunks are defined seperately.
+        Note, for most functions sig_chunks should remain ``None`` so that it
+        spans the entire signal axes.
 
-        Parameters:
+        Parameters
+        ----------
         nav_chunks : {tuple, int, "auto", None}
             The navigation block dimensions to create.
             -1 indicates the full size of the corresponding dimension.
@@ -151,7 +153,7 @@ class LazySignal(BaseSignal):
             -1 indicates the full size of the corresponding dimension.
             Default is -1 which automatically spans the full signal dimension
         **kwargs : dict
-            Any other keyword arguments for `dask.array.rechunk`
+            Any other keyword arguments for :py:func:`dask.array.rechunk`.
         """
         if not isinstance(sig_chunks, tuple):
             sig_chunks = (sig_chunks,)*len(self.axes_manager.signal_shape)

--- a/hyperspy/docstrings/utils.py
+++ b/hyperspy/docstrings/utils.py
@@ -20,8 +20,8 @@
 
 """
 
-COPY_METADATA_ARG = \
-    """copy_metadata : {bool, int}
+STACK_METADATA_ARG = \
+    """stack_metadata : {bool, int}
         If integer, this value defines the index of the signal in the signal
         list, from which the ``metadata`` and ``original_metadata`` are taken.
         If ``True``, the ``original_metadata`` and ``metadata`` of each signals

--- a/hyperspy/docstrings/utils.py
+++ b/hyperspy/docstrings/utils.py
@@ -1,0 +1,31 @@
+# -*- coding: utf-8 -*-
+# Copyright 2007-2021 The HyperSpy developers
+#
+# This file is part of  HyperSpy.
+#
+#  HyperSpy is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+#  HyperSpy is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with  HyperSpy.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Common docstring snippets for utils.
+
+"""
+
+COPY_METADATA_ARG = \
+    """copy_metadata : {bool, int}
+        If integer, this value defines the index of the signal in the signal
+        list, from which the ``metadata`` and ``original_metadata`` are taken.
+        If ``True``, the ``original_metadata`` and ``metadata`` of each signals
+        are stacked and saved in ``original_metadata.stack_elements`` of the
+        returned signal. In this case, the ``metadata`` are copied from the
+        first signal in the list.
+        If False, the ``metadata`` and ``original_metadata`` are not copied."""

--- a/hyperspy/io.py
+++ b/hyperspy/io.py
@@ -36,6 +36,9 @@ from hyperspy.io_plugins import io_plugins, default_write_ext
 from hyperspy.exceptions import VisibleDeprecationWarning
 from hyperspy.ui_registry import get_gui
 from hyperspy.extensions import ALL_EXTENSIONS
+from hyperspy.docstrings.signal import SHOW_PROGRESSBAR_ARG
+from hyperspy.docstrings.utils import COPY_METADATA_ARG
+
 
 _logger = logging.getLogger(__name__)
 
@@ -124,6 +127,8 @@ def load(filenames=None,
          lazy=False,
          convert_units=False,
          escape_square_brackets=False,
+         copy_metadata=True,
+         show_progressbar=None,
          **kwds):
     """Load potentially multiple supported files into HyperSpy.
 
@@ -188,6 +193,8 @@ def load(filenames=None,
         then square brackets are escaped before wildcard matching with
         ``glob.glob()``. If False, square brackets are used to represent
         character classes (e.g. ``[a-z]`` matches lowercase letters).
+    %s
+    %s Only used with ``stack=True``.
     reader : None, str, custom file reader object, optional
         Specify the file reader to use when loading the file(s). If None
         (default), will use the file extension to infer the file type and
@@ -249,7 +256,7 @@ def load(filenames=None,
         Only for EMD NCEM. Stack datasets of groups with common name. Relevant
         for emd file version >= 0.5 where groups can be named 'group0000',
         'group0001', etc.
-    ignore_non_linear_dims : bool, optional 
+    ignore_non_linear_dims : bool, optional
         Only for HDF5 USID files: if True (default), parameters that were varied
         non-linearly in the desired dataset will result in Exceptions.
         Else, all such non-linearly varied parameters will be treated as
@@ -398,6 +405,8 @@ def load(filenames=None,
                 axis=stack_axis,
                 new_axis_name=new_axis_name,
                 lazy=lazy,
+                copy_metadata=copy_metadata,
+                show_progressbar=show_progressbar,
             )
             signal.metadata.General.title = Path(filenames[0]).parent.stem
             _logger.info('Individual files loaded correctly')
@@ -411,6 +420,8 @@ def load(filenames=None,
         objects = objects[0]
 
     return objects
+
+load.__doc__ %= (COPY_METADATA_ARG, SHOW_PROGRESSBAR_ARG)
 
 
 def load_single_file(filename, **kwds):
@@ -458,7 +469,7 @@ def load_single_file(filename, **kwds):
         # Try and load the file
         return load_with_reader(filename=filename, reader=reader, **kwds)
 
-    except BaseException as e:
+    except BaseException:
         _logger.error(
             "If this file format is supported, please "
             "report this error to the HyperSpy developers."
@@ -614,12 +625,12 @@ def dict2signal(signal_dict, lazy=False):
             importlib.import_module(signal_dict["package"])
         except ImportError:
             _logger.warning(
-                f"This file contains a signal provided by the " +
-                f'{signal_dict["package"]} Python package that is not ' +
-                f'currently installed. The signal will be loaded into a '
-                f'generic HyperSpy signal. Consider installing ' +
+                "This file contains a signal provided by the "
+                f'{signal_dict["package"]} Python package that is not '
+                'currently installed. The signal will be loaded into a '
+                'generic HyperSpy signal. Consider installing '
                 f'{signal_dict["package"]} to load this dataset into its '
-                f'original signal class.')
+                'original signal class.')
     signal_dimension = -1  # undefined
     signal_type = ""
     if "metadata" in signal_dict:

--- a/hyperspy/io.py
+++ b/hyperspy/io.py
@@ -37,7 +37,7 @@ from hyperspy.exceptions import VisibleDeprecationWarning
 from hyperspy.ui_registry import get_gui
 from hyperspy.extensions import ALL_EXTENSIONS
 from hyperspy.docstrings.signal import SHOW_PROGRESSBAR_ARG
-from hyperspy.docstrings.utils import COPY_METADATA_ARG
+from hyperspy.docstrings.utils import STACK_METADATA_ARG
 
 
 _logger = logging.getLogger(__name__)
@@ -127,7 +127,7 @@ def load(filenames=None,
          lazy=False,
          convert_units=False,
          escape_square_brackets=False,
-         copy_metadata=True,
+         stack_metadata=True,
          show_progressbar=None,
          **kwds):
     """Load potentially multiple supported files into HyperSpy.
@@ -405,7 +405,7 @@ def load(filenames=None,
                 axis=stack_axis,
                 new_axis_name=new_axis_name,
                 lazy=lazy,
-                copy_metadata=copy_metadata,
+                stack_metadata=stack_metadata,
                 show_progressbar=show_progressbar,
             )
             signal.metadata.General.title = Path(filenames[0]).parent.stem
@@ -421,7 +421,7 @@ def load(filenames=None,
 
     return objects
 
-load.__doc__ %= (COPY_METADATA_ARG, SHOW_PROGRESSBAR_ARG)
+load.__doc__ %= (STACK_METADATA_ARG, SHOW_PROGRESSBAR_ARG)
 
 
 def load_single_file(filename, **kwds):

--- a/hyperspy/io.py
+++ b/hyperspy/io.py
@@ -197,8 +197,9 @@ def load(filenames=None,
     %s
     %s Only used with ``stack=True``.
     load_original_metadata : bool
-        If ``True``, all metadata will be added them to ``original_metadata``.
-        This doesn't change the metadata added to ``metadata``.
+        If ``True``, all metadata contained in the input file will be added
+        to ``original_metadata``.
+        This does not affect parsing the metadata to ``metadata``.
     reader : None, str, custom file reader object, optional
         Specify the file reader to use when loading the file(s). If None
         (default), will use the file extension to infer the file type and

--- a/hyperspy/misc/utils.py
+++ b/hyperspy/misc/utils.py
@@ -526,10 +526,12 @@ class DictionaryTreeBrowser:
         """Returns its dictionary representation.
 
         """
-        par_dict = {}
 
         if len(self._lazy_attributes) > 0:
-            par_dict.update(self._lazy_attributes)
+            return copy.copy(self._lazy_attributes)
+
+        par_dict = {}
+
         from hyperspy.signal import BaseSignal
         for key_, item_ in self.__dict__.items():
             if not isinstance(item_, types.MethodType):
@@ -1060,15 +1062,14 @@ def stack(signal_list, axis=None, new_axis_name="stack_element", lazy=None,
              isinstance(copy_metadata, int)):
             obj = signal_list[copy_metadata]
             signal.metadata = copy.deepcopy(obj.metadata)
-            signal.original_metadata = DictionaryTreeBrowser(
-                obj.original_metadata.as_dictionary())
+            signal.original_metadata = copy.copy(obj.original_metadata)
         elif copy_metadata:
             signal.original_metadata.add_node('stack_elements')
             for i, obj in enumerate(signal_list):
                 signal.original_metadata.stack_elements.add_node(f'element{i}')
                 node = signal.original_metadata.stack_elements[f'element{i}']
-                node.original_metadata = obj.original_metadata.as_dictionary()
-                node.metadata = obj.metadata.as_dictionary()
+                node.original_metadata = obj.original_metadata.copy()
+                node.metadata = obj.metadata.copy()
         else:
             signal.original_metadata = DictionaryTreeBrowser({})
 

--- a/hyperspy/misc/utils.py
+++ b/hyperspy/misc/utils.py
@@ -34,7 +34,7 @@ import numpy as np
 from hyperspy.misc.signal_tools import broadcast_signals
 from hyperspy.exceptions import VisibleDeprecationWarning
 from hyperspy.docstrings.signal import SHOW_PROGRESSBAR_ARG
-from hyperspy.docstrings.utils import COPY_METADATA_ARG
+from hyperspy.docstrings.utils import STACK_METADATA_ARG
 
 
 _logger = logging.getLogger(__name__)
@@ -935,7 +935,7 @@ def closest_power_of_two(n):
 
 
 def stack(signal_list, axis=None, new_axis_name="stack_element", lazy=None,
-          copy_metadata=True, show_progressbar=None, **kwargs):
+          stack_metadata=True, show_progressbar=None, **kwargs):
     """Concatenate the signals in the list over a given axis or a new axis.
 
     The title is set to that of the first signal in the list.
@@ -1058,8 +1058,8 @@ def stack(signal_list, axis=None, new_axis_name="stack_element", lazy=None,
 
         signal.get_dimensions_from_data()
 
-        if isinstance(copy_metadata, bool):
-            if copy_metadata:
+        if isinstance(stack_metadata, bool):
+            if stack_metadata:
                 signal.original_metadata.add_node('stack_elements')
                 for i, obj in enumerate(signal_list):
                     signal.original_metadata.stack_elements.add_node(f'element{i}')
@@ -1068,12 +1068,12 @@ def stack(signal_list, axis=None, new_axis_name="stack_element", lazy=None,
                     node.metadata = obj.metadata.copy()
             else:
                 signal.original_metadata = DictionaryTreeBrowser({})
-        elif isinstance(copy_metadata, int):
-            obj = signal_list[copy_metadata]
+        elif isinstance(stack_metadata, int):
+            obj = signal_list[stack_metadata]
             signal.metadata = copy.deepcopy(obj.metadata)
             signal.original_metadata = copy.copy(obj.original_metadata)
         else:
-            raise ValueError('`copy_metadata` must a boolean or an integer.')
+            raise ValueError('`stack_metadata` must a boolean or an integer.')
 
         if axis_input is None:
             axis_input = signal.axes_manager[-1 + 1j].index_in_axes_manager
@@ -1102,7 +1102,7 @@ def stack(signal_list, axis=None, new_axis_name="stack_element", lazy=None,
 
     return signal
 
-stack.__doc__ %= (COPY_METADATA_ARG, SHOW_PROGRESSBAR_ARG)
+stack.__doc__ %= (STACK_METADATA_ARG, SHOW_PROGRESSBAR_ARG)
 
 
 def shorten_name(name, req_l):

--- a/hyperspy/misc/utils.py
+++ b/hyperspy/misc/utils.py
@@ -34,6 +34,7 @@ import numpy as np
 from hyperspy.misc.signal_tools import broadcast_signals
 from hyperspy.exceptions import VisibleDeprecationWarning
 from hyperspy.docstrings.signal import SHOW_PROGRESSBAR_ARG
+from hyperspy.docstrings.utils import COPY_METADATA_ARG
 
 
 _logger = logging.getLogger(__name__)
@@ -955,12 +956,7 @@ def stack(signal_list, axis=None, new_axis_name="stack_element", lazy=None,
     lazy : {bool, None}
         Returns a LazySignal if True. If None, only returns lazy result if at
         least one is lazy.
-    copy_metadata : {bool, int}
-        If integer, this value define the index of the signal in ``signal_list``
-        from which the ``original_metadata`` are copied. If ``True``, the
-        ``original_metadata`` and ``metadata`` are stacked and saved in
-        ``original_metadata.stack_elements`` of the returned signal.
-        If False, the ``metadata`` and ``original_metadata`` are not copied.
+    %s
     %s
 
     Returns
@@ -1103,7 +1099,7 @@ def stack(signal_list, axis=None, new_axis_name="stack_element", lazy=None,
 
     return signal
 
-stack.__doc__ %= (SHOW_PROGRESSBAR_ARG)
+stack.__doc__ %= (COPY_METADATA_ARG, SHOW_PROGRESSBAR_ARG)
 
 
 def shorten_name(name, req_l):

--- a/hyperspy/misc/utils.py
+++ b/hyperspy/misc/utils.py
@@ -1252,12 +1252,12 @@ def guess_output_signal_size(test_signal,
         The function to be applied to the dataset
     ragged: bool
         If the data is ragged then the output signal size is () and the
-        data type is np.object
+        data type is 'object'
     **kwargs: dict
         Any other keyword arguments passed to the function.
     """
     if ragged:
-        output_dtype = np.object
+        output_dtype = object
         output_signal_size = ()
     else:
         output = function(test_signal, **kwargs)

--- a/hyperspy/misc/utils.py
+++ b/hyperspy/misc/utils.py
@@ -528,7 +528,7 @@ class DictionaryTreeBrowser:
         """
 
         if len(self._lazy_attributes) > 0:
-            return copy.copy(self._lazy_attributes)
+            return copy.deepcopy(self._lazy_attributes)
 
         par_dict = {}
 

--- a/hyperspy/misc/utils.py
+++ b/hyperspy/misc/utils.py
@@ -1058,20 +1058,22 @@ def stack(signal_list, axis=None, new_axis_name="stack_element", lazy=None,
 
         signal.get_dimensions_from_data()
 
-        if (not isinstance(copy_metadata, bool) and
-             isinstance(copy_metadata, int)):
+        if isinstance(copy_metadata, bool):
+            if copy_metadata:
+                signal.original_metadata.add_node('stack_elements')
+                for i, obj in enumerate(signal_list):
+                    signal.original_metadata.stack_elements.add_node(f'element{i}')
+                    node = signal.original_metadata.stack_elements[f'element{i}']
+                    node.original_metadata = obj.original_metadata.copy()
+                    node.metadata = obj.metadata.copy()
+            else:
+                signal.original_metadata = DictionaryTreeBrowser({})
+        elif isinstance(copy_metadata, int):
             obj = signal_list[copy_metadata]
             signal.metadata = copy.deepcopy(obj.metadata)
             signal.original_metadata = copy.copy(obj.original_metadata)
-        elif copy_metadata:
-            signal.original_metadata.add_node('stack_elements')
-            for i, obj in enumerate(signal_list):
-                signal.original_metadata.stack_elements.add_node(f'element{i}')
-                node = signal.original_metadata.stack_elements[f'element{i}']
-                node.original_metadata = obj.original_metadata.copy()
-                node.metadata = obj.metadata.copy()
         else:
-            signal.original_metadata = DictionaryTreeBrowser({})
+            raise ValueError('`copy_metadata` must a boolean or an integer.')
 
         if axis_input is None:
             axis_input = signal.axes_manager[-1 + 1j].index_in_axes_manager

--- a/hyperspy/signal.py
+++ b/hyperspy/signal.py
@@ -3140,7 +3140,7 @@ class BaseSignal(FancySlicing,
         ----------
         axis %s
             If ``'auto'`` and if the object has been created with
-            :py:func:`~hyperspy.misc.utils.stack` (and ``copy_metadata=True``),
+            :py:func:`~hyperspy.misc.utils.stack` (and ``stack_metadata=True``),
             this method will return the former list of signals (information
             stored in `metadata._HyperSpy.Stacking_history`).
             If it was not created with :py:func:`~hyperspy.misc.utils.stack`,

--- a/hyperspy/signal.py
+++ b/hyperspy/signal.py
@@ -2191,7 +2191,7 @@ class BaseSignal(FancySlicing,
                 """, arguments=['obj'])
 
     def _create_metadata(self):
-        self.metadata = DictionaryTreeBrowser(lazy=False)
+        self.metadata = DictionaryTreeBrowser()
         mp = self.metadata
         mp.add_node("_HyperSpy")
         mp.add_node("General")

--- a/hyperspy/signal.py
+++ b/hyperspy/signal.py
@@ -2529,11 +2529,9 @@ class BaseSignal(FancySlicing,
         """
         dic = {'data': self.data,
                'axes': self.axes_manager._get_axes_dicts(),
-               'metadata': self.metadata.deepcopy().as_dictionary(),
-               'original_metadata':
-               self.original_metadata.deepcopy().as_dictionary(),
-               'tmp_parameters':
-               self.tmp_parameters.deepcopy().as_dictionary(),
+               'metadata': self.metadata.as_dictionary(),
+               'original_metadata': self.original_metadata.as_dictionary(),
+               'tmp_parameters': self.tmp_parameters.as_dictionary(),
                'attributes': {'_lazy': self._lazy},
                }
         if add_learning_results and hasattr(self, 'learning_results'):
@@ -3112,7 +3110,7 @@ class BaseSignal(FancySlicing,
         ----------
         axis %s
             If ``'auto'`` and if the object has been created with
-            :py:func:`~hyperspy.misc.utils.stack`,
+            :py:func:`~hyperspy.misc.utils.stack` (and ``copy_metadata=True``),
             this method will return the former list of signals (information
             stored in `metadata._HyperSpy.Stacking_history`).
             If it was not created with :py:func:`~hyperspy.misc.utils.stack`,

--- a/hyperspy/signal.py
+++ b/hyperspy/signal.py
@@ -2191,7 +2191,7 @@ class BaseSignal(FancySlicing,
                 """, arguments=['obj'])
 
     def _create_metadata(self):
-        self.metadata = DictionaryTreeBrowser()
+        self.metadata = DictionaryTreeBrowser(lazy=False)
         mp = self.metadata
         mp.add_node("_HyperSpy")
         mp.add_node("General")

--- a/hyperspy/signal.py
+++ b/hyperspy/signal.py
@@ -2556,12 +2556,14 @@ class BaseSignal(FancySlicing,
         """
         dic = {'data': self.data,
                'axes': self.axes_manager._get_axes_dicts(),
-               'metadata': self.metadata.as_dictionary(),
+               'metadata': copy.deepcopy(self.metadata.as_dictionary()),
                'tmp_parameters': self.tmp_parameters.as_dictionary(),
                'attributes': {'_lazy': self._lazy},
                }
         if add_original_metadata:
-            dic['original_metadata'] = self.original_metadata.as_dictionary()
+            dic['original_metadata'] = copy.deepcopy(
+                self.original_metadata.as_dictionary()
+                )
         if add_learning_results and hasattr(self, 'learning_results'):
             dic['learning_results'] = copy.deepcopy(
                 self.learning_results.__dict__)
@@ -4805,11 +4807,9 @@ class BaseSignal(FancySlicing,
             self._plot = backup_plot
 
     def __deepcopy__(self, memo):
-        dc = type(self)(**self._to_dictionary(add_original_metadata=False))
+        dc = type(self)(**self._to_dictionary())
         if isinstance(dc.data, np.ndarray):
             dc.data = dc.data.copy()
-
-        dc.original_metadata = self.original_metadata.copy()
 
         # uncomment if we want to deepcopy models as well:
 
@@ -4835,8 +4835,7 @@ class BaseSignal(FancySlicing,
         """
         Return a "deep copy" of this Signal using the
         standard library's :py:func:`~copy.deepcopy` function. Note: this means
-        the underlying data structure will be duplicated in memory, except for
-        the ``original_metadata`` which will be a "shallow copy".
+        the underlying data structure will be duplicated in memory.
 
         See Also
         --------

--- a/hyperspy/tests/io/test_fei.py
+++ b/hyperspy/tests/io/test_fei.py
@@ -457,14 +457,18 @@ class TestFEIReader():
             unit = _guess_units_from_mode({}, header0)
         assert unit == 'meters'
 
-    def test_load_multisignal_stack(self):
+    @pytest.mark.parametrize('copy_metadata', [True, False, 0])
+    def test_load_multisignal_stack(self, copy_metadata):
         fname0 = os.path.join(
             self.dirpathnew, '16x16-line_profile_horizontal_5x128x128_EDS.emi')
-        s = load([fname0, fname0], stack=True)
+        s = load([fname0, fname0], stack=True, copy_metadata=copy_metadata)
         assert s[0].axes_manager.navigation_shape == (5, 2)
         assert s[0].axes_manager.signal_shape == (4000, )
         assert s[1].axes_manager.navigation_shape == (5, 2)
         assert s[1].axes_manager.signal_shape == (128, 128)
+
+        om = s[0].original_metadata
+        assert om.has_item('stack_elements') is (copy_metadata is True)
 
     def test_load_multisignal_stack_mismatch(self):
         fname0 = os.path.join(

--- a/hyperspy/tests/io/test_fei.py
+++ b/hyperspy/tests/io/test_fei.py
@@ -457,18 +457,18 @@ class TestFEIReader():
             unit = _guess_units_from_mode({}, header0)
         assert unit == 'meters'
 
-    @pytest.mark.parametrize('copy_metadata', [True, False, 0])
-    def test_load_multisignal_stack(self, copy_metadata):
+    @pytest.mark.parametrize('stack_metadata', [True, False, 0])
+    def test_load_multisignal_stack(self, stack_metadata):
         fname0 = os.path.join(
             self.dirpathnew, '16x16-line_profile_horizontal_5x128x128_EDS.emi')
-        s = load([fname0, fname0], stack=True, copy_metadata=copy_metadata)
+        s = load([fname0, fname0], stack=True, stack_metadata=stack_metadata)
         assert s[0].axes_manager.navigation_shape == (5, 2)
         assert s[0].axes_manager.signal_shape == (4000, )
         assert s[1].axes_manager.navigation_shape == (5, 2)
         assert s[1].axes_manager.signal_shape == (128, 128)
 
         om = s[0].original_metadata
-        assert om.has_item('stack_elements') is (copy_metadata is True)
+        assert om.has_item('stack_elements') is (stack_metadata is True)
 
     def test_load_multisignal_stack_mismatch(self):
         fname0 = os.path.join(

--- a/hyperspy/tests/io/test_io.py
+++ b/hyperspy/tests/io/test_io.py
@@ -200,3 +200,19 @@ def test_save_default_format():
 
         t = hs.load(Path(dirpath, "temp.hspy"))
         assert len(t) == 1
+
+
+def test_load_original_metadata():
+    s = Signal1D(np.arange(10))
+    s.original_metadata.a = 0
+
+    with tempfile.TemporaryDirectory() as dirpath:
+        f = os.path.join(dirpath, "temp")
+        s.save(f)
+        assert s.original_metadata.as_dictionary() != {}
+
+        t = hs.load(Path(dirpath, "temp.hspy"))
+        assert t.original_metadata.as_dictionary() == s.original_metadata.as_dictionary()
+
+        t = hs.load(Path(dirpath, "temp.hspy"), load_original_metadata=False)
+        assert t.original_metadata.as_dictionary() == {}

--- a/hyperspy/tests/signals/test_copy.py
+++ b/hyperspy/tests/signals/test_copy.py
@@ -1,0 +1,33 @@
+# Copyright 2007-2021 The HyperSpy developers
+#
+# This file is part of  HyperSpy.
+#
+#  HyperSpy is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+#  HyperSpy is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with  HyperSpy.  If not, see <http://www.gnu.org/licenses/>.
+
+
+from hyperspy.signals import BaseSignal
+
+
+def test_deepcopy():
+    s = BaseSignal([0])
+    s.metadata.test = [0]
+    s.original_metadata.test = [0]
+    s_deepcopy = s.deepcopy()
+    s.metadata.test.append(1)
+    s.original_metadata.test.append(1)
+    assert s.metadata.test == [0, 1]
+    assert s.original_metadata.test == [0, 1]
+    assert s_deepcopy.metadata.test == [0]
+    assert s_deepcopy.original_metadata.test == [0]
+

--- a/hyperspy/tests/signals/test_eds_sem.py
+++ b/hyperspy/tests/signals/test_eds_sem.py
@@ -298,6 +298,11 @@ class Test_get_lines_intensity:
                                     integration_windows=5)[0]
         np.testing.assert_allclose(24.99516, sAl.data[0, 0, 0], atol=1e-3)
 
+    def test_plot_result_single_spectrum(self):
+        s = self.signal.inav[0, 0, 0]
+        intensities = s.get_lines_intensity(["Al_Ka"], plot_result=True)
+        assert intensities[0].data.size == 1
+
     def test_background_substraction(self):
         s = self.signal
         intens = s.get_lines_intensity(["Al_Ka"], plot_result=False)[0].data

--- a/hyperspy/tests/signals/test_eds_tem.py
+++ b/hyperspy/tests/signals/test_eds_tem.py
@@ -573,3 +573,5 @@ class Test_eds_markers:
         assert sorted(s._xray_markers.keys()) == ['Zn_Ka', 'Zn_La']
         s.remove_xray_lines_markers(['Zn_Ka'], render_figure=False)
         assert sorted(s._xray_markers.keys()) == ['Zn_La']
+        s.remove_xray_lines_markers(['Zn_La'], render_figure=True)
+        assert sorted(s._xray_markers.keys()) == []

--- a/hyperspy/tests/signals/test_eds_tem.py
+++ b/hyperspy/tests/signals/test_eds_tem.py
@@ -570,6 +570,6 @@ class Test_eds_markers:
         s = self.signal
         s.add_xray_lines_markers(['Zn_Ka', 'Zn_Kb', 'Zn_La'])
         s.remove_xray_lines_markers(['Zn_Kb'])
-        assert (
-            sorted(s._xray_markers.keys()) ==
-            ['Zn_Ka', 'Zn_La'])
+        assert sorted(s._xray_markers.keys()) == ['Zn_Ka', 'Zn_La']
+        s.remove_xray_lines_markers(['Zn_Ka'], render_figure=False)
+        assert sorted(s._xray_markers.keys()) == ['Zn_La']

--- a/hyperspy/tests/utils/test_stack.py
+++ b/hyperspy/tests/utils/test_stack.py
@@ -83,6 +83,12 @@ class TestUtilsStack:
                 _s.original_metadata.as_dictionary()
             assert el.metadata.as_dictionary() == _s.metadata.as_dictionary()
 
+    def test_stack_copy_metadata_error(self):
+        s = self.signal
+        s2 = s.deepcopy()
+        with pytest.raises(ValueError):
+            utils.stack([s, s2], copy_metadata='not supported argument')
+
     def test_stack_copy_metadata_index(self):
         s = self.signal
         s1 = s.deepcopy() + 1

--- a/hyperspy/tests/utils/test_stack.py
+++ b/hyperspy/tests/utils/test_stack.py
@@ -92,19 +92,15 @@ class TestUtilsStack:
         np.testing.assert_array_almost_equal(
             result_list[0].data, result_signal.inav[:, :, 0].data)
 
-    @pytest.mark.parametrize('copy_metadata', ['first', 'all'])
-    def test_stack_of_stack(self, copy_metadata):
+    def test_stack_of_stack(self):
         s = self.signal
-        s1 = utils.stack([s] * 2, copy_metadata=copy_metadata)
-        s2 = utils.stack([s1] * 3, copy_metadata=copy_metadata)
+        s1 = utils.stack([s] * 2)
+        s2 = utils.stack([s1] * 3)
         s3 = s2.split()[0]
         s4 = s3.split()[0]
-        if copy_metadata == 'all':
-            # only when copying all the metadata, we can reconstruct the only
-            # list of signal
-            np.testing.assert_array_almost_equal(s4.data, s.data)
-            assert not hasattr(s4.original_metadata, 'stack_elements')
-            assert s4.metadata.General.title == 'test'
+        np.testing.assert_array_almost_equal(s4.data, s.data)
+        assert not hasattr(s4.original_metadata, 'stack_elements')
+        assert s4.metadata.General.title == 'test'
 
     def test_stack_not_default(self):
         s = self.signal

--- a/hyperspy/tests/utils/test_stack.py
+++ b/hyperspy/tests/utils/test_stack.py
@@ -65,6 +65,24 @@ class TestUtilsStack:
         else:
             assert om.as_dictionary() == s.original_metadata.as_dictionary()
 
+    def test_stack_copy_metadata_value(self):
+        s = BaseSignal(1)
+        s.metadata.General.title = 'title 1'
+        s.original_metadata.set_item('a', 1)
+
+        s2 = BaseSignal(2)
+        s2.metadata.General.title = 'title 2'
+        s2.original_metadata.set_item('a', 2)
+
+        stack_out = utils.stack([s, s2], copy_metadata=True)
+        elem0 = stack_out.original_metadata.stack_elements.element0
+        elem1 = stack_out.original_metadata.stack_elements.element1
+
+        for el, _s in zip([elem0, elem1], [s, s2]):
+            assert el.original_metadata.as_dictionary() == \
+                _s.original_metadata.as_dictionary()
+            assert el.metadata.as_dictionary() == _s.metadata.as_dictionary()
+
     def test_stack_copy_metadata_index(self):
         s = self.signal
         s1 = s.deepcopy() + 1

--- a/hyperspy/tests/utils/test_stack.py
+++ b/hyperspy/tests/utils/test_stack.py
@@ -44,28 +44,28 @@ class TestUtilsStack:
         s.original_metadata = DictionaryTreeBrowser({'om': 'some metadata'})
         self.signal = s
 
-    @pytest.mark.parametrize('copy_metadata', [True, False, 0, 1])
-    def test_stack_copy_metadata(self, copy_metadata):
+    @pytest.mark.parametrize('stack_metadata', [True, False, 0, 1])
+    def test_stack_stack_metadata(self, stack_metadata):
         s = self.signal
         s1 = s.deepcopy() + 1
         s2 = s.deepcopy() * 4
         test_axis = s.axes_manager[0].index_in_array
-        result_signal = utils.stack([s, s1, s2], copy_metadata=copy_metadata)
+        result_signal = utils.stack([s, s1, s2], stack_metadata=stack_metadata)
         result_list = result_signal.split()
         assert test_axis == s.axes_manager[0].index_in_array
         assert len(result_list) == 3
         np.testing.assert_array_almost_equal(
             result_list[0].data, result_signal.inav[:, :, 0].data)
-        if copy_metadata is True:
+        if stack_metadata is True:
             om = result_signal.original_metadata.stack_elements.element0.original_metadata
-        elif copy_metadata in [0, 1]:
+        elif stack_metadata in [0, 1]:
             om = result_signal.original_metadata
-        if copy_metadata is False:
+        if stack_metadata is False:
             assert om.as_dictionary() == {}
         else:
             assert om.as_dictionary() == s.original_metadata.as_dictionary()
 
-    def test_stack_copy_metadata_value(self):
+    def test_stack_stack_metadata_value(self):
         s = BaseSignal(1)
         s.metadata.General.title = 'title 1'
         s.original_metadata.set_item('a', 1)
@@ -74,7 +74,7 @@ class TestUtilsStack:
         s2.metadata.General.title = 'title 2'
         s2.original_metadata.set_item('a', 2)
 
-        stack_out = utils.stack([s, s2], copy_metadata=True)
+        stack_out = utils.stack([s, s2], stack_metadata=True)
         elem0 = stack_out.original_metadata.stack_elements.element0
         elem1 = stack_out.original_metadata.stack_elements.element1
 
@@ -83,13 +83,13 @@ class TestUtilsStack:
                 _s.original_metadata.as_dictionary()
             assert el.metadata.as_dictionary() == _s.metadata.as_dictionary()
 
-    def test_stack_copy_metadata_error(self):
+    def test_stack_stack_metadata_error(self):
         s = self.signal
         s2 = s.deepcopy()
         with pytest.raises(ValueError):
-            utils.stack([s, s2], copy_metadata='not supported argument')
+            utils.stack([s, s2], stack_metadata='not supported argument')
 
-    def test_stack_copy_metadata_index(self):
+    def test_stack_stack_metadata_index(self):
         s = self.signal
         s1 = s.deepcopy() + 1
         s1.metadata.General.title = 'first signal'
@@ -98,10 +98,10 @@ class TestUtilsStack:
         s2.metadata.General.title = 'second_signal'
         s2.original_metadata.om_title = 'second signal om'
 
-        res = utils.stack([s1, s2, s], copy_metadata=0)
+        res = utils.stack([s1, s2, s], stack_metadata=0)
         assert res.metadata.General.title == s1.metadata.General.title
 
-        res2 = utils.stack([s1, s2, s], copy_metadata=2)
+        res2 = utils.stack([s1, s2, s], stack_metadata=2)
         assert res2.metadata.General.title == s.metadata.General.title
 
     def test_stack_number_of_parts(self):


### PR DESCRIPTION
Fixes #2045, #2536, #1398 and #1568.
~The issue mentioned in #1398 is still not fixed...~

### Progress of the PR
- [x] Add option not to copy or load `original_metadata` in `hs.stack` or `hs.load`,
- [x] update docstring,
- [x] update user guide,
- [x] add entry to `CHANGES.rst`,
- [x] add tests,
- [x] ready for review.

### Minimal example of the bug fix
An example to reproduce the issue in #1398
```python
import hyperspy.api as hs
s = hs.datasets.example_signals.EDS_SEM_Spectrum()

s2 = hs.stack([s]*1000, copy_metadata=True) # if False or an integer, there is no slowdown when displaying the plot
s2.add_poissonian_noise()

lines = ['C_Ka', 'O_Ka', 'F_Ka', 'Na_Ka', 'Mg_Ka',
         'Al_Ka', 'Si_Ka', 'P_Ka', 'Zr_La', 'Nb_La',
         'K_Ka', 'Ca_Ka', 'Ti_Ka', 'Cr_Ka','Fe_Ka',
         'Ni_Ka', 'S_Ka', 'Cl_Ka', 'La_La', 'Ce_La',
         'Nd_La','Cu_Ka', 'Zn_Ka', 'Au_La', 'Th_Ma']
s2.add_lines(lines)
s2.plot(xray_lines=True)
```
In this case, the slowdown comes from the call of `_plot_xray_lines` and surprisingly, it depends on `original_metadata`:
```python
%time s2._plot_xray_lines(True) # ~12 s
```