### PR TITLE
Fix SkewNormal component compatibility with sympy 1.8

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -50,6 +50,7 @@ RELEASE_next_patch (Unreleased)
 * Fix reading XRF bruker file, close `#2689 <https://github.com/hyperspy/hyperspy/issues/2689>`_ (`#2694 <https://github.com/hyperspy/hyperspy/pull/2694>`_)
 * Speed up setting CI on azure pipeline (`#2694 <https://github.com/hyperspy/hyperspy/pull/2694>`_)
 * Fix performance issue with the lazy map method of lazy (`#2617 <https://github.com/hyperspy/hyperspy/pull/2617>`_)
+* Fix SkewNormal component compatibility with sympy 1.8 (`#2701 <https://github.com/hyperspy/hyperspy/pull/2701>`_)
 
 
 Changelog

--- a/hyperspy/_components/skew_normal.py
+++ b/hyperspy/_components/skew_normal.py
@@ -139,9 +139,12 @@ class SkewNormal(Expression):
         if LooseVersion(sympy.__version__) < LooseVersion("1.3"):
             raise ImportError("The `SkewNormal` component requires "
                               "SymPy >= 1.3")
+        # We use `_shape` internally because `shape` is already taken in sympy
+        # https://github.com/sympy/sympy/pull/20791
         super(SkewNormal, self).__init__(
-            expression="2 * A * normpdf * normcdf; normpdf = exp(- t ** 2 / 2) \
-                / sqrt(2 * pi); normcdf = (1 + erf(shape * t / sqrt(2))) / 2; \
+            expression="2 * A * normpdf * normcdf;\
+                normpdf = exp(- t ** 2 / 2) / sqrt(2 * pi);\
+                normcdf = (1 + erf(_shape * t / sqrt(2))) / 2;\
                 t = (x - x0) / scale",
             name="SkewNormal",
             x0=x0,
@@ -150,6 +153,7 @@ class SkewNormal(Expression):
             shape=shape,
             module=module,
             autodoc=False,
+            rename_pars={"_shape": "shape"},
             **kwargs,
         )
 


### PR DESCRIPTION
### Progress of the PR
- [x] Fix `SkewNormal` component, following addition of the `shape` function in sympy 1.8 (https://github.com/sympy/sympy/pull/20791).
- [x] add entry to `CHANGES.rst`,
- [x] ready for review.

### Minimal example of the bug fix or the new feature
```python
from hyperspy.components1d import SkewNormal
SkewNormal()
```
Give the following error with sympy 1.8
```python
ValueError: Error from parse_expr with transformed code: "(Integer (1 )+erf (shape *Symbol ('t' )/sqrt (Integer (2 ))))/Integer (2 )"


The above exception was the direct cause of the following exception:

Traceback (most recent call last):

  File "/home/eric/Dev/7-cupy.py", line 20, in <module>
    SkewNormal()

  File "/home/eric/Dev/hyperspy/hyperspy/_components/skew_normal.py", line 142, in __init__
    super(SkewNormal, self).__init__(

  File "/home/eric/Dev/hyperspy/hyperspy/_components/expression.py", line 158, in __init__
    self.compile_function(module=module, position=position)

  File "/home/eric/Dev/hyperspy/hyperspy/_components/expression.py", line 209, in compile_function
    expr = _parse_substitutions(self._str_expression)

  File "/home/eric/Dev/hyperspy/hyperspy/_components/expression.py", line 61, in _parse_substitutions
    expr = expr.subs(t[0], sympy.sympify(t[1]))

  File "/home/eric/Dev/others/sympy/sympy/core/sympify.py", line 479, in sympify
    expr = parse_expr(a, local_dict=locals, transformations=transformations, evaluate=evaluate)

  File "/home/eric/Dev/others/sympy/sympy/parsing/sympy_parser.py", line 1018, in parse_expr
    raise e from ValueError(f"Error from parse_expr with transformed code: {code!r}")

  File "/home/eric/Dev/others/sympy/sympy/parsing/sympy_parser.py", line 1016, in parse_expr
    return eval_expr(code, local_dict, global_dict)

  File "/home/eric/Dev/others/sympy/sympy/parsing/sympy_parser.py", line 910, in eval_expr
    expr = eval(

  File "<string>", line 1, in <module>

TypeError: unsupported operand type(s) for *: 'function' and 'Symbol'
```