### PR TITLE
Set requirement matplotlib <3.4

### DIFF
--- a/hyperspy/drawing/_widgets/range.py
+++ b/hyperspy/drawing/_widgets/range.py
@@ -402,7 +402,7 @@ class ModifiableSpanSelector(SpanSelector):
     def update(self, *args):
         # Override the SpanSelector `update` method to blit properly all
         # artirts before we go to "modify mode" in `set_initial`.
-        self.set_visible(True)
+        self.draw_patch()
 
     def draw_patch(self, *args):
         """Update the patch drawing.

--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,7 @@ setup_path = os.path.dirname(__file__)
 
 
 install_req = ['scipy>=1.1',
-               'matplotlib>=2.2.3',
+               'matplotlib>=2.2.3,<3.4',
                'numpy>=1.17.1',
                'traits>=4.5.0',
                'natsort',


### PR DESCRIPTION
When checking #2698, I notice that #2684 didn't fully add support for matplotlib 3.4 and in the following example, the widget doesn't appear when it should:

```python
import numpy as np
import hyperspy.api as hs
from hyperspy.drawing._widgets.range import ModifiableSpanSelector

s = hs.signals.Signal1D(np.arange(100))
s.plot()
ax = s._plot.signal_plot.ax

span = ModifiableSpanSelector(ax, useblit=True)
```

This is not straightforward to fix and the simplest is to pin matplotlib for the moment...

### Progress of the PR
- [x] Set requirement matplotlib <3.4
- [x] ready for review.


