### PR TITLE
Fix extension registration that was not working in some complex scenarions

### DIFF
--- a/hyperspy/extensions.py
+++ b/hyperspy/extensions.py
@@ -19,10 +19,10 @@
 import logging
 import copy
 import pkgutil
-import pkg_resources
 import yaml
 
 from pathlib import Path
+import importlib_metadata as metadata
 
 
 _logger = logging.getLogger(__name__)
@@ -37,8 +37,8 @@ EXTENSIONS["GUI"]["widgets"] = {}
 ALL_EXTENSIONS = copy.deepcopy(EXTENSIONS)
 
 _external_extensions = [
-    entry_point.module_name
-    for entry_point in pkg_resources.iter_entry_points('hyperspy.extensions')]
+    entry_point.module
+    for entry_point in metadata.entry_points()['hyperspy.extensions']]
 
 for _external_extension_mod in _external_extensions:
     _logger.info("Enabling extension %s" % _external_extension_mod)

--- a/hyperspy/extensions.py
+++ b/hyperspy/extensions.py
@@ -38,7 +38,7 @@ ALL_EXTENSIONS = copy.deepcopy(EXTENSIONS)
 
 _external_extensions = [
     entry_point.module
-    for entry_point in metadata.entry_points()['hyperspy.extensions']]
+    for entry_point in metadata.entry_points(group="hyperspy.extensions")]
 
 for _external_extension_mod in _external_extensions:
     _logger.info("Enabling extension %s" % _external_extension_mod)

--- a/setup.py
+++ b/setup.py
@@ -69,6 +69,8 @@ install_req = ['scipy>=1.1',
                'prettytable',
                'tifffile>=2018.10.18',
                'numba',
+                # included in stdlib since v3.8, but this required version requires Python 3.9
+               'importlib_metadata>=1.6.0',
                ]
 
 extras_require = {


### PR DESCRIPTION
### Description of the change

In order to find extension hyperspy uses ``pkg_resources.iter_entry_points``. However, that can fail in certain cases. This PR replace it with ``importlib_metadata`` that is know to work more reliably.

``importlib_metadata`` is now part of the standard library. However, only Python 3.9 ships with the minimum version of the library that we need, so I have added it as a requirement.

This should fix extension discovery in some online services such as Kaggle notebooks.

