### PR TITLE
Avoid importing extensions on registration

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -69,8 +69,9 @@ install_req = ['scipy>=1.1',
                'prettytable',
                'tifffile>=2018.10.18',
                'numba',
-                # included in stdlib since v3.8, but this required version requires Python 3.9
-               'importlib_metadata>=1.6.0',
+                # included in stdlib since v3.8, but this required version requires Python 3.10
+                # We can remove this requirement when the minimum supported version becomes Python 3.10
+               'importlib_metadata>=3.6',
                ]
 
 extras_require = {


### PR DESCRIPTION
HyperSpy currently uses ``pkgutil.get_loader`` to find the path of the extensions in order to register them. However that method imports the package just to retrieve the path. This PR uses ``import lib_metadata`` to retrieve the path and read the YAML file without importing the extension.
