### PR TITLE
Fix snapping

### DIFF
--- a/hyperspy/axes.py
+++ b/hyperspy/axes.py
@@ -541,7 +541,11 @@ class DataAxis(t.HasTraits, UnitConversion):
             if self.size > index >= 0:
                 return index
             else:
-                raise ValueError("The value is out of the axis limits")
+                raise ValueError(
+                    f'The value {value} is out of the limits '
+                    f'[{self.low_value:.3g}-{self.high_value:.3g}] of the '
+                    f'"{self._get_name()}" axis.'
+                    )
 
     def index2value(self, index):
         if isinstance(index, da.Array):

--- a/hyperspy/drawing/_widgets/line2d.py
+++ b/hyperspy/drawing/_widgets/line2d.py
@@ -187,9 +187,8 @@ class Line2DWidget(ResizableDraggableWidgetBase):
 
     def _do_snap_position(self, value=None):
         value = np.array(value) if value is not None else self._pos
-
-        ret1 = super(Line2DWidget, self)._do_snap_position(value[0, :])
-        ret2 = super(Line2DWidget, self)._do_snap_position(value[1, :])
+        ret1 = super()._do_snap_position(value[0, :])
+        ret2 = super()._do_snap_position(value[1, :])
 
         return np.array([ret1, ret2])
 

--- a/hyperspy/roi.py
+++ b/hyperspy/roi.py
@@ -458,10 +458,6 @@ class BaseInteractiveROI(BaseROI):
                 axes, signal)(
                 signal.axes_manager, **kwargs)
             widget.color = color
-            if hasattr(widget, 'snap_all'):
-                widget.snap_all = snap
-            else:
-                widget.snap_position = snap
 
         # Remove existing ROI, if it exsists and axes match
         if signal in self.signal_map and \
@@ -472,6 +468,12 @@ class BaseInteractiveROI(BaseROI):
         widget.axes = axes
         with widget.events.changed.suppress_callback(self._on_widget_change):
             self._apply_roi2widget(widget)
+            # We need to snap after the widget value have been set
+            if hasattr(widget, 'snap_all'):
+                widget.snap_all = snap
+            else:
+                widget.snap_position = snap
+
         if widget.ax is None:
             if signal._plot is None or signal._plot.signal_plot is None:
                 raise Exception(

--- a/hyperspy/tests/drawing/test_plot_roi_widgets.py
+++ b/hyperspy/tests/drawing/test_plot_roi_widgets.py
@@ -187,6 +187,7 @@ class TestPlotROI():
 
         return objs["figure"]
 
+
 def test_error_message():
     im = Signal2D(np.arange(50000).reshape([10, 50, 100]))
     im.plot()
@@ -194,3 +195,13 @@ def test_error_message():
     p = roi.Point1DROI(0.5)
     with pytest.raises(Exception, match='does not have an active plot.'):
         p.add_widget(signal=im, axes=[0, ], color="cyan")
+
+
+@pytest.mark.parametrize('snap', [True, False])
+def test_snapping_axis_values(snap):
+    s = Signal2D(np.arange(100).reshape(10, 10))
+    s.axes_manager[0].offset = 5
+
+    r = roi.Line2DROI(x1=6, y1=0, x2=12, y2=4, linewidth=0)
+    s.plot()
+    _ = r.interactive(s, snap=snap)


### PR DESCRIPTION
Fix regression introduced in #2686: snapping was call too early - before the widget values were set and it was snapping at the default values, typically 0.
Close #2720.

### Progress of the PR
- [x] snap widget after the widget values have been set,
- [x] Add tests,
- [x] ready for review.


