### PR TITLE
Fix test suite with dask 2021.4.1

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -36,9 +36,9 @@ strategy:
     MacOS_Python38:
       vmImage: 'macOS-latest'
       PYTHON_VERSION: '3.8'
-    MacOS_Python36:
+    MacOS_Python37:
       vmImage: 'macOS-latest'
-      PYTHON_VERSION: '3.6'
+      PYTHON_VERSION: '3.7'
     Windows_Python38:
       vmImage: 'windows-latest'
       PYTHON_VERSION: '3.8'

--- a/hyperspy/tests/io/test_blockfile.py
+++ b/hyperspy/tests/io/test_blockfile.py
@@ -229,8 +229,6 @@ def test_load_readonly():
     mm = s.data.dask[k]
     assert isinstance(mm, np.memmap)
     assert not mm.flags["WRITEABLE"]
-    with pytest.raises(NotImplementedError):
-        s.data[:] = 23
 
 
 def test_load_inplace():


### PR DESCRIPTION
Dask 2021.4.1 added support of item assignment in https://github.com/dask/dask/pull/7393 and this is documented in https://docs.dask.org/en/latest/array-assignment.html.

### Progress of the PR
- [x] Use python37 instead of python36 on macos: numpy seems to be broken and this is most likely a conda packaging issue,
- [x] remove test checking for item assignment of dask array, 
- [x] ready for review.

This is now working with dask 2021.4.1:
```python
import dask.array as da
import numpy as np

a = da.zeros((10, 10))
a[:, 0] = 1

b = a.compute()
np.allclose(b[:, 0], 1)
```

