### PR TITLE
Handle data with 2D navigation axis in shift1D

### DIFF
--- a/hyperspy/_signals/signal1d.py
+++ b/hyperspy/_signals/signal1d.py
@@ -469,7 +469,7 @@ class Signal1D(BaseSignal, CommonSignal1D):
             axis.offset += minimum
             axis.size += axis.high_index - ihigh + 1 + ilow - axis.low_index
         if isinstance(shift_array, np.ndarray):
-            shift_array = BaseSignal(shift_array.ravel()).T
+            shift_array = BaseSignal(shift_array.squeeze()).T
 
         self.map(_shift1D,
                  shift=shift_array,

--- a/hyperspy/tests/signals/test_1D_tools.py
+++ b/hyperspy/tests/signals/test_1D_tools.py
@@ -138,6 +138,16 @@ class TestShift1D:
         np.testing.assert_allclose(s.axes_manager[0].axis,
                                    np.arange(0., 1.8, 0.2))
 
+    def test_2D_nav_shift1D(self):
+        sig = np.empty((3, 4, 10))
+        sig[...] = np.arange(10)
+        s = hs.signals.Signal1D(sig)
+        s.axes_manager[0].scale = 0.2
+        s.axes_manager[1].scale = 0.2
+        shifts = np.ones((3, 4))*0.1
+        s.shift1D(shifts, crop=True)
+        np.testing.assert_allclose(s.data[0, 0, :], np.arange(0.9, 9))
+
 
 @lazifyTestClass
 class TestFindPeaks1D:


### PR DESCRIPTION
### Description of the change
This is a small fix related to #2726. Changing `ravel` back to `squeeze` to handle data with 2D navigation axis in shift1D.

### Progress of the PR
- [x] Change implemented,
- [x] add tests,
- [x] ready for review.

After the change, the following code will work:
### Minimal example of the bug fix or the new feature
```python
import numpy as np
import hyperspy.api as hs
s = hs.signals.EELSSpectrum(np.zeros((10, 20, 100)))
s.align_zero_loss_peak()
```