### PR TITLE
shift1d broken?

### DIFF
--- a/hyperspy/_signals/signal1d.py
+++ b/hyperspy/_signals/signal1d.py
@@ -471,7 +471,7 @@ class Signal1D(BaseSignal, CommonSignal1D):
             axis.offset += minimum
             axis.size += axis.high_index - ihigh + 1 + ilow - axis.low_index
         if isinstance(shift_array, np.ndarray):
-            shift_array = BaseSignal(shift_array.ravel()).T
+            shift_array = BaseSignal(shift_array).T
 
         self.map(_shift1D,
                  shift=shift_array,


### PR DESCRIPTION
### Description of the change
It seems the `hs.signals.Signal1D.shift1d` method is broken when using signals with navigation dimension greater than one. I have noticed while trying to align the zero-loss-peak on some EELS. It looks like there's an issue as `shift1d` looses the information of the navigation dimensions from the shift array through a `ravel` call. It seems the `map` computation used to calculate the actual shifts needs this information.

### Progress of the PR
- [x] Change implemented (can be split into several points),
- [ ] add tests,
- [x] ready for review.

### Minimal example of the bug fix or the new feature
```python
%matplotlib qt
import numpy as np
import matplotlib.pyplot as plt
import hyperspy.api as hs

from itertools import product

navigation_shape = [11, 10, ]
signal_shape = [128,]

# generate a synthetic ZLP data set
zdata = np.random.random(navigation_shape + signal_shape)
ids = np.random.randint(signal_shape[0]*0.25, signal_shape[0]*0.75, size=navigation_shape)
for ii in product(*[range(ii) for ii in navigation_shape]):
    zdata[ii][ids[ii]] = 10. 
z = hs.signals.EELSSpectrum(zdata)
z.gaussian_filter(2.5)

# align: this is broken, and this PR fixes it
z.align_zero_loss_peak()
```

I understand if this PR is useless as I only contribute code from time to time. At least this can serve as bug report. 

Thanks for the great work with hyperspy !

Best regards,
Alberto.

