### PR TITLE
Update nightly merge workflow

### DIFF
--- a/.github/workflows/nightly-merge.yml
+++ b/.github/workflows/nightly-merge.yml
@@ -6,15 +6,16 @@ on:
 
 jobs:
   nightly-merge:
-
+    permissions:
+      contents: write
     runs-on: ubuntu-latest
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v1
+      uses: actions/checkout@v2
 
     - name: Nightly Merge
-      uses: robotology/gh-action-nightly-merge@v1.2.0
+      uses: robotology/gh-action-nightly-merge@v1.3.2
       with:
         stable_branch: 'RELEASE_next_patch'
         development_branch: 'RELEASE_next_minor'

--- a/.github/workflows/nightly-merge_non_uniform.yml
+++ b/.github/workflows/nightly-merge_non_uniform.yml
@@ -6,15 +6,16 @@ on:
 
 jobs:
   nightly-merge:
-
+    permissions:
+      contents: write
     runs-on: ubuntu-latest
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v1
+      uses: actions/checkout@v2
 
     - name: Nightly Merge
-      uses: robotology/gh-action-nightly-merge@v1.2.0
+      uses: robotology/gh-action-nightly-merge@v1.3.2
       with:
         stable_branch: 'RELEASE_next_minor'
         development_branch: 'non_uniform_axes'


### PR DESCRIPTION
Following setting the default permissions for the hyperspy organization to "read contents" as mentioned in https://github.com/hyperspy/hyperspy/issues/2727#issuecomment-830233782, the nightly merge workflow fails as expected.

### Progress of the PR
- [x] Review action code and update robotology/gh-action-nightly-merge version
- [x] Add _write contents_ permission. 
- [x] Ready for review.