### PR TITLE
Fix disconnecting events when closing figure and remove_background is active

### DIFF
--- a/hyperspy/tests/drawing/test_plot_signal_tools.py
+++ b/hyperspy/tests/drawing/test_plot_signal_tools.py
@@ -51,6 +51,34 @@ def test_plot_BackgroundRemoval():
     return br.signal._plot.signal_plot.figure
 
 
+def test_plot_BackgroundRemoval_close_figure():
+    s = signals.Signal1D(np.arange(1000).reshape(10, 100))
+    br = BackgroundRemoval(s, background_type='Gaussian')
+    signal_plot = s._plot.signal_plot
+
+    assert len(signal_plot.events.closed.connected) == 5
+    assert len(s.axes_manager.events.indices_changed.connected) == 4
+    s._plot.close()
+    assert not br._fit in s.axes_manager.events.indices_changed.connected
+    assert not br.disconnect in signal_plot.events.closed.connected
+
+
+def test_plot_BackgroundRemoval_close_tool():
+    s = signals.Signal1D(np.arange(1000).reshape(10, 100))
+    br = BackgroundRemoval(s, background_type='Gaussian')
+    br.span_selector.set_initial((20, 40))
+    br.span_selector.onmove_callback()
+    br.span_selector_changed()
+    signal_plot = s._plot.signal_plot
+
+    assert len(signal_plot.events.closed.connected) == 5
+    assert len(s.axes_manager.events.indices_changed.connected) == 4
+    br.on_disabling_span_selector()
+    assert not br._fit in s.axes_manager.events.indices_changed.connected
+    s._plot.close()
+    assert not br.disconnect in signal_plot.events.closed.connected
+
+
 @pytest.mark.mpl_image_compare(baseline_dir=BASELINE_DIR,
                                tolerance=DEFAULT_TOL, style=STYLE_PYTEST_MPL)
 @pytest.mark.parametrize("gamma", (0.7, 1.2))


### PR DESCRIPTION
### Progress of the PR
- [x] Fix disconnecting events when closing figure and remove_background is active
- [x] add tests,
- [x] ready for review.

### Minimal example of the bug fix or the new feature
```python
import hyperspy.api as hs
import matplotlib.pyplot as plt
import numpy as np

s = hs.signals.Signal1D(np.arange(1000).reshape((10, 100)))
s.plot()
number_connected_events = len(s.axes_manager.events.indices_changed.connected)
s.remove_background(background_type='Polynomial')
plt.close()
s.plot()

# check the events connected to `axes_manager` when calling `remove_background` are disconnected when closing the figure plot
assert number_connected_events == len(s.axes_manager.events.indices_changed.connected)
```

