### PR TITLE
clarifications on integrate/sum for binned/non-uniform axes  

### DIFF
--- a/doc/user_guide/signal.rst
+++ b/doc/user_guide/signal.rst
@@ -278,9 +278,6 @@ The following example shows how to transform between different subclasses.
        <ComplexSignal1D, title: , dimensions: (20, 10|100)>
 
 
-
-
-
 .. _signal.binned:
 
 Binned and unbinned signals
@@ -288,7 +285,9 @@ Binned and unbinned signals
 
 Signals that are a histogram of a probability density function (pdf) should
 have the ``is_binned`` attribute of the signal axis set to ``True``. The reason
-is that some methods operate differently on signals that are *binned*.
+is that some methods operate differently on signals that are *binned*. An
+example of *binned* signals are EDS spectra, where the multichannel analyzer
+integrates the signal counts in every channel (=bin).
 Note that for 2D signals each signal axis has an ``is_binned``
 attribute that can be set independently. For example, for the first signal
 axis: ``signal.axes_manager.signal_axes[0].is_binned``.
@@ -332,6 +331,14 @@ To change the default value:
 .. versionchanged:: 1.7 The ``binned`` attribute from the metadata has been
     replaced by the axis attributes ``is_binned``.
 
+Integration of binned signals
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+For binned axes, the detector already provides the per-channel integration of
+the signal. Therefore, in this case, :py:meth:`~.signal.BaseSignal.integrate1D`
+performs a simple summation along the given axis. In contrast, for unbinned
+axes, :py:meth:`~.signal.BaseSignal.integrate1D` calls the
+:py:meth:`~.signal.BaseSignal.integrate_simpson` method.
 
 
 Generic tools

--- a/hyperspy/signal.py
+++ b/hyperspy/signal.py
@@ -4285,7 +4285,7 @@ class BaseSignal(FancySlicing,
         The integration is performed using
         `Simpson's rule <https://en.wikipedia.org/wiki/Simpson%%27s_rule>`_ if
         `axis.is_binned` is ``False`` and simple summation over the given axis 
-        if ``True`` (for binned signals, the detector already provides
+        if ``True`` (along binned axes, the detector already provides
         integrated counts per bin).
 
         Parameters

--- a/hyperspy/signal.py
+++ b/hyperspy/signal.py
@@ -3664,10 +3664,10 @@ class BaseSignal(FancySlicing,
 
         Note
         ----
-        If you intend to calculate the numerical integral, please use the
-        :py:meth:`integrate1D` function instead. To avoid erroneous misuse of the
-        `sum` function as integral, it raises a warning when working with 
-        a non-uniform axis.
+        If you intend to calculate the numerical integral of an unbinned signal,
+        please use the :py:meth:`integrate1D` function instead. To avoid
+        erroneous misuse of the `sum` function as integral, it raises a warning
+        when working with an unbinned, non-uniform axis.
 
         See also
         --------
@@ -3690,10 +3690,10 @@ class BaseSignal(FancySlicing,
         axes = self.axes_manager[axis]
         if not np.iterable(axes):
             axes = (axes,)
-        if any([not ax.is_uniform for ax in axes]):
-            warnings.warn("You are summing over a non-uniform axis. The result "
-                          "can not be used as an approximation of the "
-                          "integral of the signal. For this functionality, "
+        if any([(not ax.is_uniform and not ax.is_binned) for ax in axes]):
+            warnings.warn("You are summing over an unbinned, non-uniform axis. "
+                          "The result can not be used as an approximation of "
+                          "the integral of the signal. For this functionality, "
                           "use integrate1D instead.")
 
         return self._apply_function_on_data_and_remove_axis(
@@ -4285,7 +4285,8 @@ class BaseSignal(FancySlicing,
         The integration is performed using
         `Simpson's rule <https://en.wikipedia.org/wiki/Simpson%%27s_rule>`_ if
         `axis.is_binned` is ``False`` and simple summation over the given axis 
-        if ``True``.
+        if ``True`` (for binned signals, the detector already provides
+        integrated counts per bin).
 
         Parameters
         ----------
@@ -4312,12 +4313,12 @@ class BaseSignal(FancySlicing,
         (64,64)
 
         """
-        if not is_binned(self, axis=axis):
+        if is_binned(self, axis=axis):
         # in v2 replace by
-        # not self.axes_manager[axis].is_binned
-            return self.integrate_simpson(axis=axis, out=out)
-        else:
+        # self.axes_manager[axis].is_binned
             return self.sum(axis=axis, out=out)
+        else:
+            return self.integrate_simpson(axis=axis, out=out)
     integrate1D.__doc__ %= (ONE_AXIS_PARAMETER, OUT_ARG)
 
     def indexmin(self, axis, out=None, rechunk=True):

--- a/hyperspy/tests/signals/test_tools.py
+++ b/hyperspy/tests/signals/test_tools.py
@@ -275,11 +275,16 @@ class TestOutArg:
         s = signals.Signal1D(np.arange(100))
         if mask:
             s.data = np.ma.masked_array(s.data, mask=(s < 50))
-        # Since s haven't any navigation axis, it returns the same signal as
-        # default
+        # Since s does not have any navigation axis, it returns the same signal
+        # as default
         np.testing.assert_array_equal(s, s.sum())
         # When we specify an axis, it actually takes the sum.
         np.testing.assert_array_equal(s.data.sum(), s.sum(axis=0))
+
+    def test_sum_non_uniform_unbinned(self):
+        self.s.axes_manager["E"].convert_to_non_uniform_axis()
+        with pytest.warns(UserWarning, match="You are summing over"):
+            self._run_single(self.s.sum, self.s, dict(axis=("E")))
 
     def test_masked_arrays_out(self):
         s = self.s


### PR DESCRIPTION
### Description of the change
Based on the discussion in #2735, I did some small clarifications to the docstrings and warnings concerning the inegration/summation of binned axes in view of the non-uniform axes implementation.

### Progress of the PR
- [X] Change implemented,
- [X] update docstring,
- [X] update user guide,
- [X] add tests,
- [X] ready for review.
