### PR TITLE
Artificialdata nonlinearaxis 2

### DIFF
--- a/hyperspy/_signals/signal2d.py
+++ b/hyperspy/_signals/signal2d.py
@@ -18,7 +18,6 @@
 
 import matplotlib.pyplot as plt
 import numpy as np
-import scipy as sp
 import numpy.ma as ma
 import dask.array as da
 import logging
@@ -222,7 +221,7 @@ def estimate_image_shift(ref, image, roi=None, sobel=True,
             # which was the previous implementation.
             # The size is fixed at 3 to be consistent
             # with the previous implementation.
-            im[:] = sp.ndimage.median_filter(im, size=3)
+            im[:] = ndimage.median_filter(im, size=3)
         if sobel is True:
             im[:] = sobel_filter(im)
 

--- a/hyperspy/axes.py
+++ b/hyperspy/axes.py
@@ -1636,6 +1636,19 @@ class AxesManager(t.HasTraits):
                 self._axes.append(axis_dict)
 
     def set_axis(self, axis, index_in_axes_manager):
+        """Replace an axis of current signal with one given in argument.
+        Parameters
+        ----------
+        axis: BaseDataAxis axis to replace the current axis with
+
+        index_in_axes_manager: index of the axis in current signal to remplace
+            with axis passed in argument 
+
+        See also
+        --------
+        _append_axis
+
+        """
         self._axes[index_in_axes_manager] = axis
 
     def _update_max_index(self):

--- a/hyperspy/datasets/artificial_data.py
+++ b/hyperspy/datasets/artificial_data.py
@@ -7,13 +7,21 @@ For use in things like docstrings or to test HyperSpy functionalities.
 import numpy as np
 
 from hyperspy.misc.math_tools import check_random_state
-
+from hyperspy.signals import Signal1D,Signal2D,EELSSpectrum
+from hyperspy import components1d,components2d
+from hyperspy.axes import FunctionalDataAxis, UniformDataAxis
 
 ADD_POWERLAW_DOCSTRING = \
 """add_powerlaw : bool
         If True, adds a powerlaw background to the spectrum. Default is False.
     """
 
+ADD_BASELINE_DOCSTRING = \
+"""add_baseline : bool
+        If true, adds a constant baseline to the spectrum. Conversion to
+        energy representation will turn the constant baseline into inverse
+        powerlaw.
+    """
 
 ADD_NOISE_DOCSTRING = \
 """add_noise : bool
@@ -28,6 +36,7 @@ RETURNS_DOCSTRING = \
     -------
     :py:class:`~hyperspy._signals.eels.EELSSpectrum`
     """
+
 
 
 def get_low_loss_eels_signal(add_noise=True, random_state=None):
@@ -55,9 +64,6 @@ def get_low_loss_eels_signal(add_noise=True, random_state=None):
     get_low_loss_eels_line_scan_signal, get_core_loss_eels_line_scan_signal
 
     """
-
-    from hyperspy.signals import EELSSpectrum
-    from hyperspy import components1d
 
     random_state = check_random_state(random_state)
 
@@ -125,9 +131,6 @@ def get_core_loss_eels_signal(add_powerlaw=False, add_noise=True, random_state=N
 
     """
 
-    from hyperspy.signals import EELSSpectrum
-    from hyperspy import components1d
-
     random_state = check_random_state(random_state)
 
     x = np.arange(400, 800, 1)
@@ -182,9 +185,6 @@ def get_low_loss_eels_line_scan_signal(add_noise=True, random_state=None):
 
     """
 
-    from hyperspy.signals import EELSSpectrum
-    from hyperspy import components1d
-
     random_state = check_random_state(random_state)
 
     x = np.arange(-100, 400, 0.5)
@@ -237,9 +237,6 @@ def get_core_loss_eels_line_scan_signal(add_powerlaw=False, add_noise=True, rand
     get_low_loss_eels_line_scan_signal, get_core_loss_eels_model
 
     """
-
-    from hyperspy.signals import EELSSpectrum
-    from hyperspy import components1d
 
     random_state = check_random_state(random_state)
 
@@ -341,9 +338,6 @@ def get_atomic_resolution_tem_signal2d():
     >>> s.plot()
 
     """
-    from hyperspy.signals import Signal2D
-    from hyperspy import components2d
-
     sX, sY = 2, 2
     x_array, y_array = np.mgrid[0:200, 0:200]
     image = np.zeros_like(x_array, dtype=np.float32)
@@ -356,3 +350,126 @@ def get_atomic_resolution_tem_signal2d():
 
     s = Signal2D(image)
     return s
+
+
+def get_luminescence_signal(navigation_dimension=0,
+                            uniform=False,
+                            add_baseline=False,
+                            add_noise=True,
+                            random_state=None):
+    """Get an artificial luminescence signal in wavelength (nm, uniform) or
+        energy (eV, non-uniform) scale, simulating luminescence data recorded with a
+        diffracting spectrometer. Some random noise is also added to the spectrum,
+        to simulate experimental noise.
+
+        Parameters
+        ----------
+        navigation_dimension: positive int.
+            The navigation dimension(s) of the signal. 0 = single spectrum,
+            1 = linescan, 2 = spectral map etc...
+        uniform: bool.
+            return uniform (wavelength) or non-uniform (energy) spectrum
+        %s
+        %s
+        random_state: None or int
+            initialise state of the random number generator
+
+        Example
+        -------
+        >>> import hyperspy.datasets.artifical_data as ad
+        >>> s = ad.get_luminescence_signal()
+        >>> s.plot()
+
+        With constant baseline
+
+        >>> s = ad.get_luminescence_signal(uniform=True, add_baseline=True)
+        >>> s.plot()
+
+        To make the noise the same for multiple spectra, which can
+        be useful for testing fitting routines
+
+        >>> s1 = ad.get_luminescence_signal(random_state=10)
+        >>> s2 = ad.get_luminescence_signal(random_state=10)
+        >>> (s1.data == s2.data).all()
+        True
+
+        2D map
+
+        >>> s = ad.get_luminescence_signal(navigation_dimension=2)
+        >>> s.plot()
+
+        See also
+        --------
+        get_low_loss_eels_signal,
+        get_core_loss_eels_signal,
+        get_low_loss_eels_line_scan_signal,
+        get_core_loss_eels_line_scan_signal,
+        get_core_loss_eels_model,
+        get_atomic_resolution_tem_signal2d,
+        """
+
+    #Initialisation of random number generator
+    random_state = check_random_state(random_state)
+
+    #Creating a uniform data axis, roughly similar to Horiba iHR320 with a 150 mm-1 grating
+    nm_axis = UniformDataAxis(
+        index_in_array=None,
+        name="Wavelength",
+        units="nm",
+        navigate=False,
+        size=1024,
+        scale=0.54,
+        offset=222.495,
+        is_binned=False,
+        )
+
+    #Artificial luminescence peak
+    gaussian_peak = components1d.Gaussian(A=5000, centre=375, sigma=25)
+
+    if navigation_dimension>=0:
+        #Generate empty data (ones)
+        data = np.ones([10 for i in range(navigation_dimension)]+[nm_axis.size])
+        #Generate spatial axes
+        spaxes = [UniformDataAxis(index_in_array=None,
+                name="X{:d}".format(i),
+                units="um",
+                navigate=False,
+                size=10,
+                scale=2.1,
+                offset=0,
+                is_binned=False,
+                )  for i in range(navigation_dimension)]
+        #Generate empty signal
+        sig = Signal1D(data,axes = spaxes + [nm_axis])
+        sig.metadata.General.title = '{:d}d-map Artificial Luminescence Signal'\
+                                        .format(navigation_dimension)
+    else:
+        raise ValueError("Value {:d} invalid as navigation dimension.".format(\
+                            navigation_dimension))
+
+    #Populating data array, possibly with noise and baseline
+    sig.data *= gaussian_peak.function(nm_axis.axis)
+    if add_noise:
+        sig.data += (random_state.uniform(size=sig.data.shape) - 0.5)*1.4
+    if add_baseline:
+        data += 350.
+
+    #if not uniform, transformation into non-linear axis
+    if not uniform:
+        hc = 1239.84198 #nm/eV
+        #converting to non uniform axis
+        sig.axes_manager.signal_axes[0].convert_to_functional_data_axis(\
+                                                              expression="a/x",
+                                                              name='Energy',
+                                                              units='eV',
+                                                              a=hc,
+                                                          )
+        #Reverting the orientation of signal axis to have increasing Energy
+        sig = sig.isig[::-1]
+        #Jacobian transformation
+        Eax = sig.axes_manager.signal_axes[0].axis
+        sig *= hc/Eax**2
+    return sig
+
+get_luminescence_signal.__doc__ %= (ADD_BASELINE_DOCSTRING,
+                                    ADD_NOISE_DOCSTRING)

--- a/hyperspy/datasets/artificial_data.py
+++ b/hyperspy/datasets/artificial_data.py
@@ -16,13 +16,6 @@ ADD_POWERLAW_DOCSTRING = \
         If True, adds a powerlaw background to the spectrum. Default is False.
     """
 
-ADD_BASELINE_DOCSTRING = \
-"""add_baseline : bool
-        If true, adds a constant baseline to the spectrum. Conversion to
-        energy representation will turn the constant baseline into inverse
-        powerlaw.
-    """
-
 ADD_NOISE_DOCSTRING = \
 """add_noise : bool
         If True, add noise to the signal. See note to seed the noise to
@@ -369,14 +362,17 @@ def get_luminescence_signal(navigation_dimension=0,
             1 = linescan, 2 = spectral map etc...
         uniform: bool.
             return uniform (wavelength) or non-uniform (energy) spectrum
-        %s
+        add_baseline : bool
+                If true, adds a constant baseline to the spectrum. Conversion to
+                energy representation will turn the constant baseline into inverse
+                powerlaw.
         %s
         random_state: None or int
             initialise state of the random number generator
 
         Example
         -------
-        >>> import hyperspy.datasets.artifical_data as ad
+        >>> import hyperspy.datasets.artificial_data as ad
         >>> s = ad.get_luminescence_signal()
         >>> s.plot()
 
@@ -472,5 +468,4 @@ def get_luminescence_signal(navigation_dimension=0,
         sig *= hc/Eax**2
     return sig
 
-get_luminescence_signal.__doc__ %= (ADD_BASELINE_DOCSTRING,
-                                    ADD_NOISE_DOCSTRING)
+get_luminescence_signal.__doc__ %= (ADD_NOISE_DOCSTRING)

--- a/hyperspy/datasets/artificial_data.py
+++ b/hyperspy/datasets/artificial_data.py
@@ -357,8 +357,8 @@ def get_luminescence_signal(navigation_dimension=0,
                             add_baseline=False,
                             add_noise=True,
                             random_state=None):
-    """Get an artificial luminescence signal in wavelength (nm, uniform) or
-        energy (eV, non-uniform) scale, simulating luminescence data recorded with a
+    """Get an artificial luminescence signal in wavelength scale (nm, uniform) or
+        energy scale (eV, non-uniform), simulating luminescence data recorded with a
         diffracting spectrometer. Some random noise is also added to the spectrum,
         to simulate experimental noise.
 
@@ -406,6 +406,7 @@ def get_luminescence_signal(navigation_dimension=0,
         get_core_loss_eels_line_scan_signal,
         get_core_loss_eels_model,
         get_atomic_resolution_tem_signal2d,
+
         """
 
     #Initialisation of random number generator

--- a/hyperspy/misc/eels/hartree_slater_gos.py
+++ b/hyperspy/misc/eels/hartree_slater_gos.py
@@ -16,13 +16,12 @@
 # You should have received a copy of the GNU General Public License
 # along with  HyperSpy.  If not, see <http://www.gnu.org/licenses/>.
 
-import math
 import logging
+import math
+from pathlib import Path
 
 import numpy as np
-import scipy as sp
-
-from pathlib import Path
+from scipy import constants, integrate, interpolate
 
 from hyperspy.defaults_parser import preferences
 from hyperspy.misc.eels.base_gos import GOSBase
@@ -30,11 +29,11 @@ from hyperspy.misc.elements import elements
 from hyperspy.misc.export_dictionary import (
     export_to_dictionary, load_from_dictionary)
 
+
 _logger = logging.getLogger(__name__)
 
-
-R = sp.constants.value("Rydberg constant times hc in eV")
-a0 = sp.constants.value("Bohr radius")
+R = constants.value("Rydberg constant times hc in eV")
+a0 = constants.value("Bohr radius")
 
 
 class HartreeSlaterGOS(GOSBase):
@@ -183,10 +182,10 @@ class HartreeSlaterGOS(GOSBase):
             # Perform the integration in a log grid
             qaxis, gos = self.get_qaxis_and_gos(i, qmin, qmax)
             logsqa0qaxis = np.log((a0 * qaxis) ** 2)
-            qint[i] = sp.integrate.simps(gos, logsqa0qaxis)
+            qint[i] = integrate.simps(gos, logsqa0qaxis)
         E = self.energy_axis + energy_shift
         # Energy differential cross section in (barn/eV/atom)
         qint *= (4.0 * np.pi * a0 ** 2.0 * R ** 2 / E / T *
                  self.subshell_factor) * 1e28
         self.qint = qint
-        return sp.interpolate.interp1d(E, qint, kind=3)
+        return interpolate.interp1d(E, qint, kind=3)

--- a/hyperspy/misc/eels/hydrogenic_gos.py
+++ b/hyperspy/misc/eels/hydrogenic_gos.py
@@ -20,8 +20,7 @@ import math
 import logging
 
 import numpy as np
-import scipy as sp
-import scipy.interpolate
+from scipy import integrate, interpolate, constants
 
 from hyperspy.misc.eels.base_gos import GOSBase
 
@@ -36,7 +35,7 @@ XU = [
 # IE1=[118,149,189,229,270,320,377,438,500,564,628,695,769,846,
 # 926,1008,1096,1194,1142,1248,1359,1476,1596,1727]
 
-R = sp.constants.value("Rydberg constant times hc in eV")
+R = constants.value("Rydberg constant times hc in eV")
 
 
 class HydrogenicGOS(GOSBase):
@@ -140,12 +139,11 @@ class HydrogenicGOS(GOSBase):
 
             # dsbyde IS THE ENERGY-DIFFERENTIAL X-SECN (barn/eV/atom)
             qint[i] = 3.5166e8 * (R / T) * (R / E) * (
-                scipy.integrate.quad(
+                integrate.quad(
                     lambda x: self.gosfunc(E, np.exp(x)),
                     math.log(qa0sqmin), math.log(qa0sqmax))[0])
         self.qint = qint
-        return sp.interpolate.interp1d(self.energy_axis + energy_shift,
-                                       qint)
+        return interpolate.interp1d(self.energy_axis + energy_shift, qint)
 
     def gosfuncK(self, E, qa02):
         # gosfunc calculates (=DF/DE) which IS PER EV AND PER ATOM

--- a/hyperspy/signal.py
+++ b/hyperspy/signal.py
@@ -26,7 +26,8 @@ from pint import UnitRegistry, UndefinedUnitError
 from pathlib import Path
 
 import numpy as np
-import scipy as sp
+from scipy import integrate
+from scipy import signal as sp_signal
 import dask.array as da
 from matplotlib import pyplot as plt
 import traits.api as t
@@ -2148,8 +2149,8 @@ class BaseSignal(FancySlicing,
         data : :py:class:`numpy.ndarray`
            The signal data. It can be an array of any dimensions.
         axes : [dict/axes], optional
-            List of either dictionaries or axes objects to define the axes (see 
-            the documentation of the :py:class:`~hyperspy.axes.AxesManager` 
+            List of either dictionaries or axes objects to define the axes (see
+            the documentation of the :py:class:`~hyperspy.axes.AxesManager`
             class for more details).
         attributes : dict, optional
             A dictionary whose items are stored as attributes.
@@ -2676,7 +2677,7 @@ class BaseSignal(FancySlicing,
                 navigator = "slider"
             elif (self.axes_manager.navigation_dimension == 1 and
                     self.axes_manager.signal_dimension == 1):
-                if (self.axes_manager.navigation_axes[0].is_uniform and 
+                if (self.axes_manager.navigation_axes[0].is_uniform and
                         self.axes_manager.signal_axes[0].is_uniform):
                     navigator = "data"
                 else:
@@ -3095,7 +3096,7 @@ class BaseSignal(FancySlicing,
 
         Raises
         ------
-        NotImplementedError 
+        NotImplementedError
             If trying to rebin over a non-uniform axis.
 
         Examples
@@ -3200,7 +3201,7 @@ class BaseSignal(FancySlicing,
 
         Raises
         ------
-        NotImplementedError 
+        NotImplementedError
             If trying to split along a non-uniform axis.
 
         Returns
@@ -3965,7 +3966,7 @@ class BaseSignal(FancySlicing,
         proper :py:meth:`derivative` function instead. To avoid erroneous
         misuse of the `diff` function as derivative, it raises an error when
         when working with a non-uniform axis.
-        
+
         See also
         --------
         derivative, integrate1D, integrate_simpson
@@ -4086,8 +4087,8 @@ class BaseSignal(FancySlicing,
         """
         axis = self.axes_manager[axis]
         s = out or self._deepcopy_with_new_data(None)
-        data = sp.integrate.simps(y=self.data, x=axis.axis,
-                                  axis=axis.index_in_array)
+        data = integrate.simps(y=self.data, x=axis.axis,
+                               axis=axis.index_in_array)
         if out is not None:
             out.data[:] = data
             out.events.data_changed.trigger(obj=out)
@@ -4130,7 +4131,7 @@ class BaseSignal(FancySlicing,
 
         Raises
         ------
-        NotImplementedError 
+        NotImplementedError
             If performing FFT along a non-uniform axis.
 
         Examples
@@ -4226,7 +4227,7 @@ class BaseSignal(FancySlicing,
 
         Raises
         ------
-        NotImplementedError 
+        NotImplementedError
             If performing IFFT along a non-uniform axis.
 
         Examples
@@ -4284,7 +4285,7 @@ class BaseSignal(FancySlicing,
 
         The integration is performed using
         `Simpson's rule <https://en.wikipedia.org/wiki/Simpson%%27s_rule>`_ if
-        `axis.is_binned` is ``False`` and simple summation over the given axis 
+        `axis.is_binned` is ``False`` and simple summation over the given axis
         if ``True`` (along binned axes, the detector already provides
         integrated counts per bin).
 
@@ -6146,7 +6147,7 @@ class BaseSignal(FancySlicing,
         elif window == 'hamming':
             def window_function(m): return np.hamming(m)
         elif window == 'tukey':
-            def window_function(m): return sp.signal.tukey(m, tukey_alpha)
+            def window_function(m): return sp_signal.tukey(m, tukey_alpha)
         else:
             raise ValueError('Wrong type parameter value.')
 

--- a/hyperspy/signal_tools.py
+++ b/hyperspy/signal_tools.py
@@ -21,7 +21,8 @@ import functools
 import copy
 
 import numpy as np
-import scipy as sp
+from scipy import interpolate
+from scipy import signal as sp_signal
 import matplotlib.colors
 import matplotlib.pyplot as plt
 import matplotlib.text as mpl_text
@@ -738,15 +739,15 @@ class ButterworthFilter(Smoothing):
         self.update_lines()
 
     def model2plot(self, axes_manager=None):
-        b, a = sp.signal.butter(self.order, self.cutoff_frequency_ratio,
+        b, a = sp_signal.butter(self.order, self.cutoff_frequency_ratio,
                                 self.type)
-        smoothed = sp.signal.filtfilt(b, a, self.signal())
+        smoothed = sp_signal.filtfilt(b, a, self.signal())
         return smoothed
 
     def apply(self):
-        b, a = sp.signal.butter(self.order, self.cutoff_frequency_ratio,
+        b, a = sp_signal.butter(self.order, self.cutoff_frequency_ratio,
                                 self.type)
-        f = functools.partial(sp.signal.filtfilt, b, a)
+        f = functools.partial(sp_signal.filtfilt, b, a)
         self.signal.map(f)
 
 
@@ -1254,7 +1255,7 @@ class BackgroundRemoval(SpanSelectorInSignal1D):
         self.fast = fast
         self.plot_remainder = plot_remainder
         if plot_remainder:
-            # When plotting the remainder on the right hand side axis, we 
+            # When plotting the remainder on the right hand side axis, we
             # adjust the layout here to avoid doing it later to avoid
             # corrupting the background when using blitting
             figure = signal._plot.signal_plot.figure
@@ -1682,7 +1683,7 @@ class SpikesRemoval:
             # Interpolate
             x = np.hstack((axis.axis[ileft:left], axis.axis[right:iright]))
             y = np.hstack((data[ileft:left], data[right:iright]))
-            intp = sp.interpolate.interp1d(x, y, kind=self.kind)
+            intp = interpolate.interp1d(x, y, kind=self.kind)
             data[left:right] = intp(axis.axis[left:right])
 
         # Add noise

--- a/hyperspy/tests/datasets/test_artificial_data.py
+++ b/hyperspy/tests/datasets/test_artificial_data.py
@@ -41,7 +41,6 @@ def test_get_core_loss_eels_signal():
     s3 = ad.get_core_loss_eels_signal(add_noise=True)
     assert (s2.data == s3.data).all()
 
-
 @pytest.mark.parametrize("add_noise", (True, False))
 def test_get_core_loss_eels_model(add_noise):
     m = ad.get_core_loss_eels_model(add_powerlaw=False, add_noise=add_noise)
@@ -67,3 +66,42 @@ def test_get_core_loss_eels_line_scan_signal(add_powerlaw, add_noise):
 def test_get_atomic_resolution_tem_signal2d():
     s = ad.get_atomic_resolution_tem_signal2d()
     assert s.axes_manager.signal_dimension == 2
+
+# @pytest.mark.parametrize("uniform",(True,False))
+# @pytest.mark.parametrize("add_baseline",(True,False))
+# @pytest.mark.parametrize("add_noise",(True,False))
+# def test_get_luminescence_map_nonuniform(uniform, add_baseline, add_noise):
+#     s = ad.get_luminescence_map_nonuniform(uniform, add_baseline, add_noise)
+#     assert s.axes_manager[1].name == 'Y'
+#     assert s.axes_manager[0].name == 'X'
+#     sax = s.axes_manager.signal_axes[0]
+#     assert sax.is_uniform == uniform
+#     if add_baseline:
+#         assert s.data.min()>340
+
+
+@pytest.mark.parametrize("navigation_dimension",(0,1,2,3))
+@pytest.mark.parametrize("uniform",(True,False))
+@pytest.mark.parametrize("add_baseline",(True,False))
+@pytest.mark.parametrize("add_noise",(True,False))
+def test_get_luminescence_signal(navigation_dimension, uniform, add_baseline, add_noise):
+    #Creating signal
+    s = ad.get_luminescence_signal(navigation_dimension,
+                                                uniform,
+                                                add_baseline,
+                                                add_noise)
+    #Checking that dimension initialisation works
+    assert tuple([10 for i in range(navigation_dimension)]+[1024]) == s.data.shape
+    #Verifying that both functional and uniform data axis work
+    sax = s.axes_manager.signal_axes[0]
+    assert sax.is_uniform == uniform
+    #Verifying that baseline works
+    if add_baseline:
+        assert s.data.min()>340
+    #Verification that noise works
+    #Case of baseline + energy axis is discarded because of
+    #jacobian transformation
+    if not(add_baseline and not uniform):
+        #Verify that adding noise works
+        noisedat = s.isig[:100].data
+        assert (noisedat.std()>0.1)==add_noise

--- a/hyperspy/tests/datasets/test_artificial_data.py
+++ b/hyperspy/tests/datasets/test_artificial_data.py
@@ -67,19 +67,6 @@ def test_get_atomic_resolution_tem_signal2d():
     s = ad.get_atomic_resolution_tem_signal2d()
     assert s.axes_manager.signal_dimension == 2
 
-# @pytest.mark.parametrize("uniform",(True,False))
-# @pytest.mark.parametrize("add_baseline",(True,False))
-# @pytest.mark.parametrize("add_noise",(True,False))
-# def test_get_luminescence_map_nonuniform(uniform, add_baseline, add_noise):
-#     s = ad.get_luminescence_map_nonuniform(uniform, add_baseline, add_noise)
-#     assert s.axes_manager[1].name == 'Y'
-#     assert s.axes_manager[0].name == 'X'
-#     sax = s.axes_manager.signal_axes[0]
-#     assert sax.is_uniform == uniform
-#     if add_baseline:
-#         assert s.data.min()>340
-
-
 @pytest.mark.parametrize("navigation_dimension",(0,1,2,3))
 @pytest.mark.parametrize("uniform",(True,False))
 @pytest.mark.parametrize("add_baseline",(True,False))


### PR DESCRIPTION
### Description of the change
Re-implementation of artificial non linear data. Following the discussion in #2741
-Moved all imports in `/datasets/artificial_data.py`  to the top
-Implemented a single function for generating n-d maps of spectra
-Used convert_to_functional_data_axis
-updated docstring to set_axis method of axesmanager
-updated tests

See #2741 for discussion

### Progress of the PR
- [x] Change implemented (can be split into several points),
- [x] update docstring (if appropriate),
- [x] add tests,
- [x] ready for review.

### Minimal example of the bug fix or the new feature
```python
>>> import hyperspy.datasets.artifical_data as ad
>>> s = ad.get_luminescence_signal()
>>> s.plot()
#With constant baseline
>>> s = ad.get_luminescence_signal(uniform=True, add_baseline=True)
>>> s.plot()
#To make the noise the same for multiple spectra, which can
#be useful for testing fitting routines
>>> s1 = ad.get_luminescence_signal(random_state=10)
>>> s2 = ad.get_luminescence_signal(random_state=10)
>>> (s1.data == s2.data).all()
True
#2D map
>>> s = ad.get_luminescence_signal(navigation_dimension=2)
>>> s.plot()
```
Note that this example can be useful to update the user guide.

