### PR TITLE
Fix estimate_parameters for binned and non uniform axis

### DIFF
--- a/hyperspy/_components/arctan.py
+++ b/hyperspy/_components/arctan.py
@@ -55,7 +55,7 @@ class Arctan(Expression):
         # Not to break scripts once we remove the legacy Arctan
         if "minimum_at_zero" in kwargs:
             del kwargs["minimum_at_zero"]
-        super(Arctan, self).__init__(
+        super().__init__(
             expression="A * arctan(k * (x - x0))",
             name="Arctan",
             A=A,

--- a/hyperspy/_components/bleasdale.py
+++ b/hyperspy/_components/bleasdale.py
@@ -23,29 +23,29 @@ from hyperspy._components.expression import Expression
 class Bleasdale(Expression):
 
     r"""Bleasdale function component.
-    
+
     Also called the Bleasdale-Nelder function. Originates from the description of the yield-density relationship in crop growth.
 
     .. math::
-    
+
         f(x) = \left(a+b\cdot x\right)^{-1/c}
 
     Parameters
     -----------
         a : Float
-        
+
         b : Float
-        
+
         c : Float
-    
+
         **kwargs
             Extra keyword arguments are passed to the ``Expression`` component.
-    
+
     For :math:`(a+b\cdot x)\leq0`, the component will be set to 0.
     """
-    
+
     def __init__(self, a=1., b=1., c=1., module="numexpr", **kwargs):
-        super(Bleasdale, self).__init__(
+        super().__init__(
             expression="where((a + b * x) > 0, (a + b * x) ** (-1 / c), 0)",
             name="Bleasdale",
             a=a,
@@ -84,5 +84,5 @@ class Bleasdale(Expression):
         a = self.a.value
         b = self.b.value
         c = self.c.value
-        return np.where((a + b * x) > 0, np.log(a + b * x) / (c ** 2. * 
+        return np.where((a + b * x) > 0, np.log(a + b * x) / (c ** 2. *
                (b * x + a) ** (1. / c)), 0)

--- a/hyperspy/_components/doniach.py
+++ b/hyperspy/_components/doniach.py
@@ -83,7 +83,7 @@ class Doniach(Expression):
 
     def __init__(self, centre=0., A=1., sigma=1., alpha=0.5,
                  module=["numpy", "scipy"], **kwargs):
-        super(Doniach, self).__init__(
+        super().__init__(
             expression="A*cos(0.5*pi*alpha+\
             ((1.0 - alpha) * arctan( (x-centre+offset)/sigma) ) )\
             /(sigma**2 + (x-centre+offset)**2)**(0.5 * (1.0 - alpha));\

--- a/hyperspy/_components/doniach.py
+++ b/hyperspy/_components/doniach.py
@@ -19,6 +19,7 @@
 import math
 import numpy as np
 
+from hyperspy.component import _get_scaling_factor
 from hyperspy._components.expression import Expression
 from hyperspy._components.gaussian import _estimate_gaussian_parameters
 from hyperspy.misc.utils import is_binned # remove in v2.0
@@ -145,8 +146,8 @@ class Doniach(Expression):
         axis = signal.axes_manager.signal_axes[0]
         centre, height, sigma = _estimate_gaussian_parameters(signal, x1, x2,
                                                               only_current)
-        scaling_factor = axis.scale if axis.is_uniform \
-                         else np.gradient(axis.axis)[axis.value2index(centre)]
+        scaling_factor = _get_scaling_factor(signal, axis, centre)
+
         if only_current is True:
             self.centre.value = centre
             self.sigma.value = sigma

--- a/hyperspy/_components/eels_arctan.py
+++ b/hyperspy/_components/eels_arctan.py
@@ -87,7 +87,7 @@ class EELSArctan(Expression):
         # Not to break scripts once we remove the legacy Arctan
         if "minimum_at_zero" in kwargs:
             del kwargs["minimum_at_zero"]
-        super(EELSArctan, self).__init__(
+        super().__init__(
             expression="A * (pi /2 + arctan(k * (x - x0)))",
             name="Arctan",
             A=A,

--- a/hyperspy/_components/eels_double_power_law.py
+++ b/hyperspy/_components/eels_double_power_law.py
@@ -59,10 +59,10 @@ class DoublePowerLaw(Expression):
     the component will return 0.
     """
 
-    def __init__(self, A=1e-5, r=3., origin=0., shift=20., ratio=1., 
-                 left_cutoff=0.0, module="numexpr", compute_gradients=False, 
+    def __init__(self, A=1e-5, r=3., origin=0., shift=20., ratio=1.,
+                 left_cutoff=0.0, module="numexpr", compute_gradients=False,
                  **kwargs):
-        super(DoublePowerLaw, self).__init__(
+        super().__init__(
             expression="where(x > left_cutoff, \
                         A * (ratio * (x - origin - shift) ** -r \
                         + (x - origin) ** -r), 0)",
@@ -106,25 +106,25 @@ class DoublePowerLaw(Expression):
         return self.function(x) / self.A.value
 
     def grad_r(self, x):
-        return np.where(x > self.left_cutoff.value, -self.A.value * 
+        return np.where(x > self.left_cutoff.value, -self.A.value *
                         self.ratio.value * (x - self.origin.value -
                         self.shift.value) ** (-self.r.value) *
                         np.log(x - self.origin.value - self.shift.value) -
-                        self.A.value * (x - self.origin.value) ** 
+                        self.A.value * (x - self.origin.value) **
                         (-self.r.value) * np.log(x - self.origin.value), 0)
 
     def grad_origin(self, x):
         return np.where(x > self.left_cutoff.value, self.A.value * self.r.value
-                        * self.ratio.value * (x - self.origin.value - self.shift.value) 
+                        * self.ratio.value * (x - self.origin.value - self.shift.value)
                         ** (-self.r.value - 1) + self.A.value * self.r.value
                         * (x - self.origin.value) ** (-self.r.value - 1), 0)
 
     def grad_shift(self, x):
         return np.where(x > self.left_cutoff.value, self.A.value * self.r.value
-                        * self.ratio.value * (x - self.origin.value - 
+                        * self.ratio.value * (x - self.origin.value -
                         self.shift.value) ** (-self.r.value - 1), 0)
 
     def grad_ratio(self, x):
         return np.where(x > self.left_cutoff.value, self.A.value *
-                        (x - self.origin.value - self.shift.value) ** 
+                        (x - self.origin.value - self.shift.value) **
                         (-self.r.value), 0)

--- a/hyperspy/_components/error_function.py
+++ b/hyperspy/_components/error_function.py
@@ -27,16 +27,16 @@ class Erf(Expression):
 
     .. math::
 
-        f(x) = \frac{A}{2}~\mathrm{erf}\left[\frac{(x - x_0)}{\sqrt{2} 
+        f(x) = \frac{A}{2}~\mathrm{erf}\left[\frac{(x - x_0)}{\sqrt{2}
             \sigma}\right]
 
 
     ============== =============
-    Variable        Parameter 
+    Variable        Parameter
     ============== =============
-    :math:`A`       A 
-    :math:`\sigma`  sigma 
-    :math:`x_0`     origin 
+    :math:`A`       A
+    :math:`\sigma`  sigma
+    :math:`x_0`     origin
     ============== =============
 
     Parameters
@@ -48,13 +48,13 @@ class Erf(Expression):
         origin : float
             Position of the zero crossing.
     """
-    
+
     def __init__(self, A=1., sigma=1., origin=0., module=["numpy", "scipy"],
                  **kwargs):
         if LooseVersion(sympy.__version__) < LooseVersion("1.3"):
             raise ImportError("The `ErrorFunction` component requires "
                               "SymPy >= 1.3")
-        super(Erf, self).__init__(
+        super().__init__(
             expression="A * erf((x - origin) / sqrt(2) / sigma) / 2",
             name="Erf",
             A=A,

--- a/hyperspy/_components/exponential.py
+++ b/hyperspy/_components/exponential.py
@@ -52,7 +52,7 @@ class Exponential(Expression):
     """
 
     def __init__(self, A=1., tau=1., module="numexpr", **kwargs):
-        super(Exponential, self).__init__(
+        super().__init__(
             expression="A * exp(-x / tau)",
             name="Exponential",
             A=A,
@@ -86,7 +86,7 @@ class Exponential(Expression):
         bool
 
         """
-        super(Exponential, self)._estimate_parameters(signal)
+        super()._estimate_parameters(signal)
         axis = signal.axes_manager.signal_axes[0]
         i1, i2 = axis.value_range_to_indices(x1, x2)
         if i1 + 1 == i2:

--- a/hyperspy/_components/gaussian.py
+++ b/hyperspy/_components/gaussian.py
@@ -102,7 +102,7 @@ class Gaussian(Expression):
     """
 
     def __init__(self, A=1., sigma=1., centre=0., module="numexpr", **kwargs):
-        super(Gaussian, self).__init__(
+        super().__init__(
             expression="A * (1 / (sigma * sqrt(2*pi))) * exp(-(x - centre)**2 \
                         / (2 * sigma**2))",
             name="Gaussian",

--- a/hyperspy/_components/gaussian.py
+++ b/hyperspy/_components/gaussian.py
@@ -21,6 +21,7 @@ import math
 import numpy as np
 import dask.array as da
 
+from hyperspy.component import _get_scaling_factor
 from hyperspy._components.expression import Expression
 from hyperspy.misc.utils import is_binned # remove in v2.0
 
@@ -160,12 +161,12 @@ class Gaussian(Expression):
         >>> g.estimate_parameters(s, -10, 10, False)
         """
 
-        super(Gaussian, self)._estimate_parameters(signal)
+        super()._estimate_parameters(signal)
         axis = signal.axes_manager.signal_axes[0]
         centre, height, sigma = _estimate_gaussian_parameters(signal, x1, x2,
                                                               only_current)
-        scaling_factor = axis.scale if axis.is_uniform \
-                         else np.gradient(axis.axis)[axis.value2index(centre)]
+        scaling_factor = _get_scaling_factor(signal, axis, centre)
+
         if only_current is True:
             self.centre.value = centre
             self.sigma.value = sigma

--- a/hyperspy/_components/gaussian2d.py
+++ b/hyperspy/_components/gaussian2d.py
@@ -69,7 +69,7 @@ class Gaussian2D(Expression):
 
     def __init__(self, A=1., sigma_x=1., sigma_y=1., centre_x=0.,
                  centre_y=0, module="numexpr", **kwargs):
-        super(Gaussian2D, self).__init__(
+        super().__init__(
             expression="A * (1 / (sigma_x * sigma_y * 2 * pi)) * \
                        exp(-((x - centre_x) ** 2 / (2 * sigma_x ** 2) \
                        + (y - centre_y) ** 2 / (2 * sigma_y ** 2)))",

--- a/hyperspy/_components/gaussianhf.py
+++ b/hyperspy/_components/gaussianhf.py
@@ -17,10 +17,10 @@
 # along with  HyperSpy.  If not, see <http://www.gnu.org/licenses/>.
 
 import math
-import numpy as np
 
 from hyperspy._components.expression import Expression
 from hyperspy._components.gaussian import _estimate_gaussian_parameters
+from hyperspy.component import _get_scaling_factor
 from hyperspy.misc.utils import is_binned # remove in v2.0
 
 sqrt2pi = math.sqrt(2 * math.pi)
@@ -136,12 +136,12 @@ class GaussianHF(Expression):
         >>> g.estimate_parameters(s, -10, 10, False)
         """
 
-        super(GaussianHF, self)._estimate_parameters(signal)
+        super()._estimate_parameters(signal)
         axis = signal.axes_manager.signal_axes[0]
         centre, height, sigma = _estimate_gaussian_parameters(signal, x1, x2,
                                                               only_current)
-        scaling_factor = axis.scale if axis.is_uniform \
-                         else np.gradient(axis.axis)[axis.value2index(centre)]
+        scaling_factor = _get_scaling_factor(signal, axis, centre)
+
         if only_current is True:
             self.centre.value = centre
             self.fwhm.value = sigma * sigma2fwhm

--- a/hyperspy/_components/gaussianhf.py
+++ b/hyperspy/_components/gaussianhf.py
@@ -78,7 +78,7 @@ class GaussianHF(Expression):
 
     def __init__(self, height=1., fwhm=1., centre=0., module="numexpr",
                  **kwargs):
-        super(GaussianHF, self).__init__(
+        super().__init__(
             expression="height * exp(-(x - centre)**2 * 4 * log(2)/fwhm**2)",
             name="GaussianHF",
             height=height,

--- a/hyperspy/_components/heaviside.py
+++ b/hyperspy/_components/heaviside.py
@@ -58,7 +58,7 @@ class HeavisideStep(Expression):
 
     def __init__(self, A=1., n=0., module="numpy", compute_gradients=True,
                  **kwargs):
-        super(HeavisideStep, self).__init__(
+        super().__init__(
             expression="A*heaviside(x-n,0.5)",
             name="HeavisideStep",
             A=A,
@@ -71,4 +71,3 @@ class HeavisideStep(Expression):
 
         self.isbackground = True
         self.convolved = False
-

--- a/hyperspy/_components/logistic.py
+++ b/hyperspy/_components/logistic.py
@@ -24,27 +24,27 @@ class Logistic(Expression):
     r"""Logistic function (sigmoid or s-shaped curve) component.
 
     .. math::
-    
-        f(x) = \frac{a}{1 + b\cdot \mathrm{exp}\left[-c 
+
+        f(x) = \frac{a}{1 + b\cdot \mathrm{exp}\left[-c
             \left((x - x_0\right)\right]}
 
     ============== =============
-    Variable        Parameter 
+    Variable        Parameter
     ============== =============
-    :math:`A`       a 
-    :math:`b`       b 
-    :math:`c`       c 
-    :math:`x_0`     origin 
+    :math:`A`       a
+    :math:`b`       b
+    :math:`c`       c
+    :math:`x_0`     origin
     ============== =============
 
 
     Parameters
     -----------
     a : Float
-        The curve's maximum y-value,  
+        The curve's maximum y-value,
         :math:`\mathrm{lim}_{x\to\infty}\left(y\right) = a`
     b : Float
-        Additional parameter: 
+        Additional parameter:
         b>1 shifts origin to larger values;
         0<b<1 shifts origin to smaller values;
         b<0 introduces an asymptote
@@ -57,7 +57,7 @@ class Logistic(Expression):
     """
 
     def __init__(self, a=1., b=1., c=1., origin=0., module="numexpr", **kwargs):
-        super(Logistic, self).__init__(
+        super().__init__(
             expression="a / (1 + b * exp(-c * (x - origin)))",
             name="Logistic",
             a=a,

--- a/hyperspy/_components/lorentzian.py
+++ b/hyperspy/_components/lorentzian.py
@@ -97,7 +97,7 @@ class Lorentzian(Expression):
     def __init__(self, A=1., gamma=1., centre=0., module="numexpr", **kwargs):
         # We use `_gamma` internally to workaround the use of the `gamma`
         # function in sympy
-        super(Lorentzian, self).__init__(
+        super().__init__(
             expression="A / pi * (_gamma / ((x - centre)**2 + _gamma**2))",
             name="Lorentzian",
             A=A,

--- a/hyperspy/_components/lorentzian.py
+++ b/hyperspy/_components/lorentzian.py
@@ -19,6 +19,7 @@
 import numpy as np
 import dask.array as da
 
+from hyperspy.component import _get_scaling_factor
 from hyperspy._components.expression import Expression
 from hyperspy.misc.utils import is_binned # remove in v2.0
 
@@ -160,12 +161,12 @@ class Lorentzian(Expression):
         >>> g.estimate_parameters(s, -10, 10, False)
         """
 
-        super(Lorentzian, self)._estimate_parameters(signal)
+        super()._estimate_parameters(signal)
         axis = signal.axes_manager.signal_axes[0]
         centre, height, gamma = _estimate_lorentzian_parameters(signal, x1, x2,
                                                               only_current)
-        scaling_factor = axis.scale if axis.is_uniform \
-                         else np.gradient(axis.axis)[axis.value2index(centre)]
+        scaling_factor = _get_scaling_factor(signal, axis, centre)
+
         if only_current is True:
             self.centre.value = centre
             self.gamma.value = gamma

--- a/hyperspy/_components/offset.py
+++ b/hyperspy/_components/offset.py
@@ -29,19 +29,19 @@ class Offset(Component):
     r"""Component to add a constant value in the y-axis.
 
     .. math::
-    
+
         f(x) = k
 
     ============ =============
-    Variable      Parameter 
+    Variable      Parameter
     ============ =============
-    :math:`k`     offset   
+    :math:`k`     offset
     ============ =============
 
     Parameters
     -----------
-    offset : float 
-        
+    offset : float
+
     """
 
     def __init__(self, offset=0.):
@@ -86,13 +86,17 @@ class Offset(Component):
         bool
 
         """
-        super(Offset, self)._estimate_parameters(signal)
+        super()._estimate_parameters(signal)
         axis = signal.axes_manager.signal_axes[0]
         i1, i2 = axis.value_range_to_indices(x1, x2)
-        # using the mean of the gradient for non-uniform axes is a best guess
-        # to the scaling of binned signals for the estimation
-        scaling_factor = axis.scale if axis.is_uniform \
-                         else np.mean(np.gradient(axis.axis))
+        if is_binned(signal):
+        # in v2 replace by
+        #if axis.is_binned:
+            # using the mean of the gradient for non-uniform axes is a best
+            # guess to the scaling of binned signals for the estimation
+            scaling_factor = axis.scale if axis.is_uniform \
+                             else np.mean(np.gradient(axis.axis), axis=-1)
+
         if only_current is True:
             self.offset.value = signal()[i1:i2].mean()
             if is_binned(signal):

--- a/hyperspy/_components/pes_voigt.py
+++ b/hyperspy/_components/pes_voigt.py
@@ -19,7 +19,7 @@
 import numpy as np
 import math
 
-from hyperspy.component import Component
+from hyperspy.component import Component, _get_scaling_factor
 from hyperspy._components.gaussian import _estimate_gaussian_parameters
 from hyperspy.misc.utils import is_binned # remove in v2.0
 
@@ -292,12 +292,12 @@ class PESVoigt(Component):
         >>> g.estimate_parameters(s, -10, 10, False)
 
         """
-        super(PESVoigt, self)._estimate_parameters(signal)
+        super()._estimate_parameters(signal)
         axis = signal.axes_manager.signal_axes[0]
         centre, height, sigma = _estimate_gaussian_parameters(signal, E1, E2,
                                                               only_current)
-        scaling_factor = axis.scale if axis.is_uniform \
-                         else np.gradient(axis.axis)[axis.value2index(centre)]
+        scaling_factor = _get_scaling_factor(signal, axis, centre)
+
         if only_current is True:
             self.centre.value = centre
             self.FWHM.value = sigma * sigma2fwhm

--- a/hyperspy/_components/polynomial.py
+++ b/hyperspy/_components/polynomial.py
@@ -31,7 +31,7 @@ class Polynomial(Expression):
     """n-order polynomial component.
 
     Polynomial component consisting of order + 1 parameters.
-    The parameters are named "a" followed by the corresponding order, 
+    The parameters are named "a" followed by the corresponding order,
     i.e.
 
     .. math::
@@ -58,10 +58,10 @@ class Polynomial(Expression):
             raise ValueError("Polynomial of order 0 is not supported.")
         coeff_list = ['{}'.format(o).zfill(len(list(str(order)))) for o in
                       range(order, -1, -1)]
-        expr = "+".join(["a{}*x**{}".format(c, o) for c, o in 
+        expr = "+".join(["a{}*x**{}".format(c, o) for c, o in
                          zip(coeff_list, range(order, -1, -1))])
         name = "{} order Polynomial".format(ordinal(order))
-        super().__init__(expression=expr, name=name, module=module, 
+        super().__init__(expression=expr, name=name, module=module,
              autodoc=False, **kwargs)
         self._id_name = "eab91275-88db-4855-917a-cdcbe7209592"
 
@@ -92,10 +92,15 @@ class Polynomial(Expression):
         super()._estimate_parameters(signal)
         axis = signal.axes_manager.signal_axes[0]
         i1, i2 = axis.value_range_to_indices(x1, x2)
-        # using the mean of the gradient for non-uniform axes is a best guess
-        # to the scaling of binned signals for the estimation
-        scaling_factor = axis.scale if axis.is_uniform \
-                         else np.mean(np.gradient(axis.axis))
+
+        if is_binned(signal):
+        # in v2 replace by
+        #if axis.is_binned:
+            # using the mean of the gradient for non-uniform axes is a best
+            # guess to the scaling of binned signals for the estimation
+            scaling_factor = axis.scale if axis.is_uniform \
+                             else np.mean(np.gradient(axis.axis), axis=-1)
+
         if only_current is True:
             estimation = np.polyfit(axis.axis[i1:i2],
                                     signal()[i1:i2],
@@ -147,7 +152,7 @@ def convert_to_polynomial(poly_dict):
     """
     _logger.info("Converting the polynomial to the new definition")
     poly_order = poly_dict['order']
-    coeff_list = ['{}'.format(o).zfill(len(list(str(poly_dict['order'])))) 
+    coeff_list = ['{}'.format(o).zfill(len(list(str(poly_dict['order']))))
                   for o in range(poly_dict['order'], -1, -1)]
     poly2_dict = dict(poly_dict)
     coefficient_dict = poly_dict['parameters'][0]

--- a/hyperspy/_components/polynomial_deprecated.py
+++ b/hyperspy/_components/polynomial_deprecated.py
@@ -126,13 +126,18 @@ class Polynomial(Component):
         -------
         bool
         """
-        super(Polynomial, self)._estimate_parameters(signal)
+        super()._estimate_parameters(signal)
         axis = signal.axes_manager.signal_axes[0]
         i1, i2 = axis.value_range_to_indices(x1, x2)
-        # using the mean of the gradient for non-uniform axes is a best guess
-        # to the scaling of binned signals for the estimation
-        scaling_factor = axis.scale if axis.is_uniform \
-                         else np.mean(np.gradient(axis.axis))
+
+        if is_binned(signal):
+        # in v2 replace by
+        #if axis.is_binned:
+            # using the mean of the gradient for non-uniform axes is a best
+            # guess to the scaling of binned signals for the estimation
+            scaling_factor = axis.scale if axis.is_uniform \
+                             else np.mean(np.gradient(axis.axis), axis=-1)
+
         if only_current is True:
             estimation = np.polyfit(axis.axis[i1:i2],
                                     signal()[i1:i2],

--- a/hyperspy/_components/power_law.py
+++ b/hyperspy/_components/power_law.py
@@ -111,7 +111,7 @@ class PowerLaw(Expression):
         {bool, tuple of values}
 
         """
-        super(PowerLaw, self)._estimate_parameters(signal)
+        super()._estimate_parameters(signal)
         axis = signal.axes_manager.signal_axes[0]
         i1, i2 = axis.value_range_to_indices(x1, x2)
         if not (i2 + i1) % 2 == 0:

--- a/hyperspy/_components/rc.py
+++ b/hyperspy/_components/rc.py
@@ -22,7 +22,7 @@ from hyperspy._components.expression import Expression
 class RC(Expression):
 
     r"""
-    RC function component (based on the time-domain capacitor voltage response 
+    RC function component (based on the time-domain capacitor voltage response
     of an RC-circuit)
 
     .. math::
@@ -31,18 +31,18 @@ class RC(Expression):
             -\frac{x}{\tau}\right)\right]
 
     ====================== =============
-    Variable                Parameter 
+    Variable                Parameter
     ====================== =============
-    :math:`V_\mathrm{max}`  Vmax 
-    :math:`V_\mathrm{0}`    V0 
-    :math:`\tau`            tau 
+    :math:`V_\mathrm{max}`  Vmax
+    :math:`V_\mathrm{0}`    V0
+    :math:`\tau`            tau
     ====================== =============
 
 
     Parameters
     -----------
     Vmax : float
-        maximum voltage, asymptote of the function for 
+        maximum voltage, asymptote of the function for
         :math:`\mathrm{lim}_{x\to\infty}`
     V0 : float
         vertical offset
@@ -54,7 +54,7 @@ class RC(Expression):
     """
 
     def __init__(self, Vmax=1., V0=0., tau=1., module="numexpr", **kwargs):
-        super(RC, self).__init__(
+        super().__init__(
             expression="V0 + Vmax * (1 - exp(-x / tau))",
             name="RC",
             Vmax=Vmax,

--- a/hyperspy/_components/skew_normal.py
+++ b/hyperspy/_components/skew_normal.py
@@ -144,7 +144,7 @@ class SkewNormal(Expression):
                               "SymPy >= 1.3")
         # We use `_shape` internally because `shape` is already taken in sympy
         # https://github.com/sympy/sympy/pull/20791
-        super(SkewNormal, self).__init__(
+        super().__init__(
             expression="2 * A * normpdf * normcdf;\
                 normpdf = exp(- t ** 2 / 2) / sqrt(2 * pi);\
                 normcdf = (1 + erf(_shape * t / sqrt(2))) / 2;\

--- a/hyperspy/_components/skew_normal.py
+++ b/hyperspy/_components/skew_normal.py
@@ -20,6 +20,7 @@ import numpy as np
 import dask.array as da
 import sympy
 
+from hyperspy.component import _get_scaling_factor
 from hyperspy._components.expression import Expression
 from hyperspy.misc.utils import is_binned # remove in v2.0
 
@@ -205,12 +206,13 @@ class SkewNormal(Expression):
         >>> g.estimate_parameters(s, -10, 10, False)
         """
 
-        super(SkewNormal, self)._estimate_parameters(signal)
+        super()._estimate_parameters(signal)
         axis = signal.axes_manager.signal_axes[0]
-        x0, height, scale, shape = _estimate_skewnormal_parameters(signal, x1,
-                                                                   x2, only_current)
-        scaling_factor = axis.scale if axis.is_uniform \
-                         else np.gradient(axis.axis)[axis.value2index(x0)]
+        x0, height, scale, shape = _estimate_skewnormal_parameters(
+            signal, x1, x2, only_current
+            )
+        scaling_factor = _get_scaling_factor(signal, axis, x0)
+
         if only_current is True:
             self.x0.value = x0
             self.A.value = height * sqrt2pi

--- a/hyperspy/_components/split_voigt.py
+++ b/hyperspy/_components/split_voigt.py
@@ -18,7 +18,7 @@
 
 import numpy as np
 
-from hyperspy.component import Component
+from hyperspy.component import Component, _get_scaling_factor
 from hyperspy._components.gaussian import _estimate_gaussian_parameters
 from hyperspy.docstrings.parameters import FUNCTION_ND_DOCSTRING
 from hyperspy.misc.utils import is_binned # remove in v2.0
@@ -190,12 +190,12 @@ class SplitVoigt(Component):
         >>> g.estimate_parameters(s, -10,10, False)
 
         """
-        super(SplitVoigt, self)._estimate_parameters(signal)
+        super()._estimate_parameters(signal)
         axis = signal.axes_manager.signal_axes[0]
         centre, height, sigma = _estimate_gaussian_parameters(signal, x1, x2,
                                                               only_current)
-        scaling_factor = axis.scale if axis.is_uniform \
-                         else np.gradient(axis.axis)[axis.value2index(centre)]
+        scaling_factor = _get_scaling_factor(signal, axis, centre)
+
         if only_current is True:
             self.centre.value = centre
             self.sigma1.value = sigma

--- a/hyperspy/_components/voigt.py
+++ b/hyperspy/_components/voigt.py
@@ -95,7 +95,7 @@ class Voigt(Expression):
                               "SymPy >= 1.3")
         # We use `_gamma` internally to workaround the use of the `gamma`
         # function in sympy
-        super(Voigt, self).__init__(
+        super().__init__(
             expression="area * real(V); \
                 V = wofz(z) / (sqrt(2.0 * pi) * sigma); \
                 z = (x - centre + 1j * _gamma) / (sigma * sqrt(2.0))",

--- a/hyperspy/_components/voigt.py
+++ b/hyperspy/_components/voigt.py
@@ -20,6 +20,7 @@ import math
 import sympy
 import numpy as np
 
+from hyperspy.component import _get_scaling_factor
 from hyperspy._components.expression import Expression
 from hyperspy._components.gaussian import _estimate_gaussian_parameters
 from hyperspy.misc.utils import is_binned # remove in v2.0
@@ -157,12 +158,12 @@ class Voigt(Expression):
         >>> g.estimate_parameters(s, -10, 10, False)
 
         """
-        super(Voigt, self)._estimate_parameters(signal)
+        super()._estimate_parameters(signal)
         axis = signal.axes_manager.signal_axes[0]
         centre, height, sigma = _estimate_gaussian_parameters(signal, x1, x2,
                                                               only_current)
-        scaling_factor = axis.scale if axis.is_uniform \
-                         else np.gradient(axis.axis)[axis.value2index(centre)]
+        scaling_factor = _get_scaling_factor(signal, axis, centre)
+
         if only_current is True:
             self.centre.value = centre
             self.sigma.value = sigma

--- a/hyperspy/_components/volume_plasmon_drude.py
+++ b/hyperspy/_components/volume_plasmon_drude.py
@@ -31,11 +31,11 @@ class VolumePlasmonDrude(Expression):
        f(E) = I_0 \frac{E(\Delta E_p)E_p^2}{(E^2-E_p^2)^2+(E\Delta E_p)^2}
 
     ================== ===============
-    Variable            Parameter 
+    Variable            Parameter
     ================== ===============
-    :math:`I_0`         intensity 
-    :math:`E_p`         plasmon_energy 
-    :math:`\Delta E_p`  fwhm 
+    :math:`I_0`         intensity
+    :math:`E_p`         plasmon_energy
+    :math:`\Delta E_p`  fwhm
     ================== ===============
 
     Parameters
@@ -52,7 +52,7 @@ class VolumePlasmonDrude(Expression):
     """
 
     def __init__(self, intensity=1., plasmon_energy=15., fwhm=1.5,
-                 module="numexpr", compute_gradients=False, **kwargs):                 
+                 module="numexpr", compute_gradients=False, **kwargs):
         super().__init__(
             expression="where(x > 0, intensity * (pe2 * x * fwhm) \
                         / ((x ** 2 - pe2) ** 2 + (x * fwhm) ** 2), 0); \

--- a/hyperspy/axes.py
+++ b/hyperspy/axes.py
@@ -545,7 +545,7 @@ class BaseDataAxis(t.HasTraits):
         return value
 
     def value2index(self, value, rounding=round):
-        """Return the closest index to the given value if between the limit.
+        """Return the closest index to the given value if between the axis limits.
 
         Parameters
         ----------
@@ -558,10 +558,8 @@ class BaseDataAxis(t.HasTraits):
         Raises
         ------
         ValueError
-            If any value is out of the axis limits.
-            If value is NaN
-            If value is an array containing at least 1 NaN value
-            If value is an array containing at least 1 out-of-bound value
+            If value is out of bounds or contains out of bounds values (array).
+            If value is NaN or contains NaN values (array).
         """
         if value is None:
             return None
@@ -1173,10 +1171,12 @@ class UniformDataAxis(BaseDataAxis, UnitConversion):
         Raises
         ------
         ValueError
-            If any value is out of the axis limits.
-            If the value is incorrectly formatted.
-
+            If value is out of bounds or contains out of bounds values (array).
+            If value is NaN or contains NaN values (array).
+            If value is incorrectly formatted str or contains incorrectly
+                formatted str (array).
         """
+
         if value is None:
             return None
 

--- a/hyperspy/axes.py
+++ b/hyperspy/axes.py
@@ -569,7 +569,7 @@ class BaseDataAxis(t.HasTraits):
         #nan values in array
         if np.all((value >= self.low_value)*(value <= self.high_value)):
             #initialise the index same dimension as input, force type to int
-            index = np.asarray(value).astype(int).copy()
+            index = np.empty_like(value,dtype=int)
             #assign on flat, iterate on flat.
             for i,v in enumerate(np.asarray(value).flat):
                 index.flat[i] = (np.abs(self.axis - v)).argmin()

--- a/hyperspy/component.py
+++ b/hyperspy/component.py
@@ -26,7 +26,7 @@ from distutils.version import LooseVersion
 from pathlib import Path
 
 import hyperspy
-from hyperspy.misc.utils import slugify
+from hyperspy.misc.utils import slugify, is_binned
 from hyperspy.misc.io.tools import (incremental_filename,
                                     append2pathname,)
 from hyperspy.misc.export_dictionary import export_to_dictionary, \
@@ -1216,3 +1216,40 @@ class Component(t.HasTraits):
         else:
             display_pretty(current_component_values(
                 self, only_free=only_free))
+
+
+def _get_scaling_factor(signal, axis, parameter):
+    """
+    Convenience function to get the scaling factor required to take into
+    account binned and/or non uniform axes.
+
+    Parameters
+    ----------
+    signal : BaseSignal
+    axis : BaseDataAxis
+    parameter : float or numpy array
+        The axis value at which scaling factor is evaluated (ignored if the axis
+        is uniform)
+
+    Returns
+    -------
+    scaling_factor
+
+    """
+
+    if is_binned(signal):
+    # in v2 replace by
+    #if axis.is_binned:
+        if axis.is_uniform:
+            scaling_factor = axis.scale
+        else:
+            # if isinstance(parameter, (int, float)):
+            #     parameter_idx = axis.value2index(parameter)
+            # else:
+                # parameter_idx = [axis.value2index(p) for p in parameter]
+            parameter_idx  = axis.value2index(parameter)
+            scaling_factor = np.gradient(axis.axis)[parameter_idx]
+    else:
+        scaling_factor = 1
+
+    return scaling_factor

--- a/hyperspy/component.py
+++ b/hyperspy/component.py
@@ -1243,10 +1243,6 @@ def _get_scaling_factor(signal, axis, parameter):
         if axis.is_uniform:
             scaling_factor = axis.scale
         else:
-            # if isinstance(parameter, (int, float)):
-            #     parameter_idx = axis.value2index(parameter)
-            # else:
-                # parameter_idx = [axis.value2index(p) for p in parameter]
             parameter_idx  = axis.value2index(parameter)
             scaling_factor = np.gradient(axis.axis)[parameter_idx]
     else:

--- a/hyperspy/misc/array_tools.py
+++ b/hyperspy/misc/array_tools.py
@@ -451,3 +451,72 @@ def get_signal_chunk_slice(index, chunks):
             elif _slice[1].start <= index[1] < _slice[1].stop:
                 return chunk_slice
     raise ValueError("Index out of signal range.")
+
+@njit(cache=True)
+def numba_closest_index_round(axis_array,value_array):
+    """For each value in value_array, find the closest value in axis_array and
+        return the result as a numpy array of the same shape as value_array.
+        Parameters
+        ----------
+        axis_array : numpy array
+        value_array : numpy array
+
+        Returns
+        -------
+        numpy array
+
+    """
+    #initialise the index same dimension as input, force type to int
+    index_array = np.empty_like(value_array,dtype='uint')
+    #assign on flat, iterate on flat.
+    for i,v in enumerate(value_array.flat):
+        index_array.flat[i] = np.abs(axis_array - v).argmin()
+
+    return index_array
+
+@njit(cache=True)
+def numba_closest_index_floor(axis_array,value_array):
+    """For each value in value_array, find the closest smaller value in
+        axis_array and return the result as a numpy array of the same shape
+        as value_array.
+        Parameters
+        ----------
+        axis_array : numpy array
+        value_array : numpy array
+
+        Returns
+        -------
+        numpy array
+
+    """
+    #initialise the index same dimension as input, force type to int
+    index_array = np.empty_like(value_array,dtype='uint')
+    #assign on flat, iterate on flat.
+    for i,v in enumerate(value_array.flat):
+        x = axis_array - v
+        index_array.flat[i] = np.where(x>0,-np.inf,x).argmax()
+
+    return index_array
+
+@njit(cache=True)
+def numba_closest_index_ceil(axis_array,value_array):
+    """For each value in value_array, find the closest larger value in
+        axis_array and return the result as a numpy array of the same shape
+        as value_array.
+        Parameters
+        ----------
+        axis_array : numpy array
+        value_array : numpy array
+
+        Returns
+        -------
+        numpy array
+    """
+    #initialise the index same dimension as input, force type to int
+    index_array = np.empty_like(value_array,dtype='uint')
+    #assign on flat, iterate on flat.
+    for i,v in enumerate(value_array.flat):
+        x = axis_array - v
+        index_array.flat[i] = np.where(x<0,+np.inf,x).argmin()
+
+    return index_array

--- a/hyperspy/signal.py
+++ b/hyperspy/signal.py
@@ -3697,7 +3697,7 @@ class BaseSignal(FancySlicing,
         axes = self.axes_manager[axis]
         if not np.iterable(axes):
             axes = (axes,)
-        if any([(not ax.is_uniform and not ax.is_binned) for ax in axes]):
+        if any([not ax.is_uniform and not is_binned(self, ax) for ax in axes]):
             warnings.warn("You are summing over an unbinned, non-uniform axis. "
                           "The result can not be used as an approximation of "
                           "the integral of the signal. For this functionality, "
@@ -4323,13 +4323,10 @@ class BaseSignal(FancySlicing,
         if is_binned(self, axis=axis):
         # in v2 replace by
         # self.axes_manager[axis].is_binned
-            with warnings.catch_warnings():
-                warnings.filterwarnings("ignore", category= UserWarning,
-                                        module='hyperspy'
-                                        )
-                return self.sum(axis=axis, out=out)
+            return self.sum(axis=axis, out=out)
         else:
             return self.integrate_simpson(axis=axis, out=out)
+
     integrate1D.__doc__ %= (ONE_AXIS_PARAMETER, OUT_ARG)
 
     def indexmin(self, axis, out=None, rechunk=True):

--- a/hyperspy/signal.py
+++ b/hyperspy/signal.py
@@ -2655,7 +2655,13 @@ class BaseSignal(FancySlicing,
             navigator = self
             # Sum over all but the first navigation axis.
             am = navigator.axes_manager
-            navigator = navigator.sum(am.signal_axes + am.navigation_axes[1:])
+            with warnings.catch_warnings():
+                warnings.filterwarnings("ignore", category=UserWarning,
+                                        module='hyperspy'
+                                        )
+                navigator = navigator.sum(
+                    am.signal_axes + am.navigation_axes[1:]
+                    )
             return np.nan_to_num(navigator.data).squeeze()
 
         def get_dynamic_explorer_wrapper(*args, **kwargs):
@@ -4316,7 +4322,11 @@ class BaseSignal(FancySlicing,
         if is_binned(self, axis=axis):
         # in v2 replace by
         # self.axes_manager[axis].is_binned
-            return self.sum(axis=axis, out=out)
+            with warnings.catch_warnings():
+                warnings.filterwarnings("ignore", category= UserWarning,
+                                        module='hyperspy'
+                                        )
+                return self.sum(axis=axis, out=out)
         else:
             return self.integrate_simpson(axis=axis, out=out)
     integrate1D.__doc__ %= (ONE_AXIS_PARAMETER, OUT_ARG)

--- a/hyperspy/tests/axes/test_data_axis.py
+++ b/hyperspy/tests/axes/test_data_axis.py
@@ -66,6 +66,12 @@ class TestBaseDataAxis:
         with pytest.raises(ValueError):
             self.axis._parse_value_from_string('spam')
 
+    #Note: The following methods from BaseDataAxis rely on the self.axis.axis
+    #numpy array to be initialized, and are tested in the subclasses:
+    #BaseDataAxis.value2index --> tested in FunctionalDataAxis
+    #BaseDataAxis.index2value --> NOT EXPLICITLY TESTED
+    #BaseDataAxis.value_range_to_indices --> tested in UniformDataAxis
+    #BaseDataAxis.update_from --> tested in DataAxis and FunctionalDataAxis
 
 class TestDataAxis:
 

--- a/hyperspy/tests/axes/test_data_axis.py
+++ b/hyperspy/tests/axes/test_data_axis.py
@@ -352,7 +352,7 @@ class TestFunctionalDataAxis:
             self.axis.value2index(arval)
         #Single-value-array-in --> scalar out
         arval = np.array([1.0])
-        assert type(self.axis.value2index(arval)) == np.int32
+        assert np.isscalar(self.axis.value2index(arval))
 
 
 class TestReciprocalDataAxis:

--- a/hyperspy/tests/axes/test_data_axis.py
+++ b/hyperspy/tests/axes/test_data_axis.py
@@ -204,7 +204,7 @@ class TestDataAxis:
         assert axis.size == 12
         np.testing.assert_almost_equal(axis.axis[0], 4)
         np.testing.assert_almost_equal(axis.axis[-1], 169)
-    
+
     def test_error_DataAxis(self):
         with pytest.raises(ValueError):
             axis = DataAxis(axis=np.arange(16)**2, _type='UniformDataAxis')
@@ -259,7 +259,7 @@ class TestFunctionalDataAxis:
         with pytest.raises(ValueError, match="The values of"):
             self.axis = FunctionalDataAxis(
                 size=10,
-                expression=expression,)        
+                expression=expression,)
 
     @pytest.mark.parametrize("use_indices", (True, False))
     def test_crop(self, use_indices):
@@ -313,6 +313,46 @@ class TestFunctionalDataAxis:
     def test_calibrate(self):
         with pytest.raises(TypeError, match="only for uniform axes"):
             self.axis.calibrate(value_tuple=(11,12), index_tuple=(0,5))
+
+    def test_functional_value2index(self):
+        #Tests for value2index
+        #Works as intended
+        assert self.axis.value2index(44.7) == 7
+        #Input None --> output None
+        assert self.axis.value2index(None) == None
+        #NaN in --> error out
+        with pytest.raises(ValueError):
+            self.axis.value2index(np.nan)
+        #Values in out of bounds --> error out (both sides of axis)
+        with pytest.raises(ValueError):
+            self.axis.value2index(-2)
+        with pytest.raises(ValueError):
+            self.axis.value2index(111)
+        #str in --> error out
+        with pytest.raises(TypeError):
+            self.axis.value2index("69")
+        #Empty str in --> error out
+        with pytest.raises(TypeError):
+            self.axis.value2index("")
+
+        #Tests with array Input
+        #Array in --> array out
+        arval = np.array([[0,4],[16.,36.]])
+        assert np.all(self.axis.value2index(arval) == np.array([[0,2],[4,6]]))
+        #One value out of bound in array in --> error out (both sides)
+        arval[1,1] = 111
+        with pytest.raises(ValueError):
+            self.axis.value2index(arval)
+        arval[1,1] = -0.3
+        with pytest.raises(ValueError):
+            self.axis.value2index(arval)
+        #One NaN in array in --> error out
+        arval[1,1] = np.nan
+        with pytest.raises(ValueError):
+            self.axis.value2index(arval)
+        #Single-value-array-in --> scalar out
+        arval = np.array([1.0])
+        assert type(self.axis.value2index(arval)) == np.int32
 
 
 class TestReciprocalDataAxis:

--- a/hyperspy/tests/axes/test_data_axis.py
+++ b/hyperspy/tests/axes/test_data_axis.py
@@ -446,85 +446,81 @@ class TestUniformDataAxis:
         ac.offset = 100
         assert ac.axis[0] == ac.offset
 
-    def test_value2index_None(self):
-        assert self.axis.value2index(None) is None
-
-    def test_value2index_fail_string_in(self):
-        ax = self.axis
-        ax.units = 'nm'
+    def test_uniform_value2index(self):
+        #Tests for value2index
+        #Works as intended
+        assert self.axis.value2index(10.15) == 2
+        assert self.axis.value2index(10.17,rounding=math.floor) == 1
+        assert self.axis.value2index(10.13,rounding=math.ceil) == 2
+        #Endpoint left
+        assert self.axis.value2index(10.) == 0
+        #Endpoint right
+        assert self.axis.value2index(10.9) == 9
+        #Input None --> output None
+        assert self.axis.value2index(None) == None
+        #NaN in --> error out
         with pytest.raises(ValueError):
-            ax.value2index("10.15")
-
-    def test_value2index_fail_empty_string_in(self):
+            self.axis.value2index(np.nan)
+        #Values in out of bounds --> error out (both sides of axis)
+        with pytest.raises(ValueError):
+            self.axis.value2index(-2)
+        with pytest.raises(ValueError):
+            self.axis.value2index(111)
+        #str without unit in --> error out
+        with pytest.raises(ValueError):
+            self.axis.value2index("69")
+        #Empty str in --> error out
         with pytest.raises(ValueError):
             self.axis.value2index("")
-
-    def test_value2index_float_in(self):
-        assert self.axis.value2index(10.15) == 2
-
-    def test_value2index_float_end_point_left(self):
-        assert self.axis.value2index(10.) == 0
-
-    def test_value2index_float_end_point_right(self):
-        assert self.axis.value2index(10.9) == 9
-
-    def test_value2index_float_out(self):
+        #Value with unit when axis is unitless --> Error out
         with pytest.raises(ValueError):
-            self.axis.value2index(11)
+            self.axis.value2index("0.0101um")
 
-    def test_value2index_array_in(self):
-        assert (
-            self.axis.value2index(np.array([10.15, 10.15])).tolist() ==
-            [2, 2])
+        #Tests with array Input
+        #Arrays work as intended
+        arval = np.array([[10.15,10.15],[10.24,10.28]])
+        assert np.all(self.axis.value2index(arval) == np.array([[2,2],[2,3]]))
+        assert np.all(self.axis.value2index(arval,rounding=math.floor) \
+                        == np.array([[1,1],[2,2]]))
+        assert np.all(self.axis.value2index(arval,rounding=math.ceil)\
+                        == np.array([[2,2],[3,3]]))
+        #List in --> array out
+        assert np.all(self.axis.value2index(arval.tolist()) \
+                                            == np.array([[2,2],[2,3]]))
+        #One value out of bound in array in --> error out (both sides)
+        arval[1,1] = 111
+        with pytest.raises(ValueError):
+            self.axis.value2index(arval)
+        arval[1,1] = -0.3
+        with pytest.raises(ValueError):
+            self.axis.value2index(arval)
+        #One NaN in array in --> error out
+        arval[1,1] = np.nan
+        with pytest.raises(ValueError):
+            self.axis.value2index(arval)
 
-    def test_value2index_list_in(self):
-        assert (
-            self.axis.value2index([10.15, 10.15]).tolist() ==
-            [2, 2])
-
-    def test_value2index_array_in_ceil(self):
-        assert (
-            self.axis.value2index(np.array([10.14, 10.14]),
-                                  rounding=math.ceil).tolist() ==
-            [2, 2])
-
-    def test_value2index_array_in_floor(self):
-        assert (
-            self.axis.value2index(np.array([10.15, 10.15]),
-                                  rounding=math.floor).tolist() ==
-            [1, 1])
-
-    def test_calibrated_value2index_list_in(self):
+        #Copy of axis with units
         axis = copy.deepcopy(self.axis)
         axis.units = 'nm'
+
+        #Value with unit in --> OK out
+        assert axis.value2index("0.0101um") == 1
+        #Value with relative units in --> OK out
+        assert self.axis.value2index("rel0.5") == 4
+
+        #Works with arrays of values with units in
         np.testing.assert_allclose(
             axis.value2index(['0.01um', '0.0101um', '0.0103um']),
             np.array([0, 1, 3])
             )
+        #Raises errors if a weird unit is passed in
         with pytest.raises(BaseException):
             axis.value2index(["0.01uma", '0.0101uma', '0.0103uma'])
-
-    def test_calibrated_value2index_error_missing_units(self):
-        with pytest.raises(ValueError):
-            self.axis.value2index("0.0101um")
-
-    def test_calibrated_value2index_in(self):
-        axis = copy.deepcopy(self.axis)
-        axis.units = 'nm'
-        assert axis.value2index("0.0101um") == 1
-
-    def test_relative_value2index_in(self):
-        assert self.axis.value2index("rel0.5") == 4
-
-    def test_relative_value2index_list_in(self):
+        #Values
         np.testing.assert_allclose(
             self.axis.value2index(["rel0.0", "rel0.5", "rel1.0"]),
             np.array([0, 4, 9])
             )
-
-    def test_value2index_array_out(self):
-        with pytest.raises(ValueError):
-            self.axis.value2index(np.array([10, 11]))
 
     def test_slice_me(self):
         assert (

--- a/hyperspy/tests/component/test_component.py
+++ b/hyperspy/tests/component/test_component.py
@@ -16,12 +16,14 @@
 # You should have received a copy of the GNU General Public License
 # along with  HyperSpy.  If not, see <http://www.gnu.org/licenses/>.
 
+import pytest
 from unittest import mock
 
 import numpy as np
 
 from hyperspy.axes import AxesManager
-from hyperspy.component import Component
+from hyperspy.component import Component, _get_scaling_factor
+from hyperspy._signals.signal1d import Signal1D
 
 
 class TestMultidimensionalActive:
@@ -263,3 +265,23 @@ class TestCallMethods:
         c.model.__call__.return_value = np.array([1.1, 1.3])
         res = c._component2plot(c.model.axes_manager, out_of_range2nans=True)
         np.testing.assert_array_equal(res, np.array([1.1, np.nan, 1.3]))
+
+
+@pytest.mark.parametrize('is_binned', [True, False])
+@pytest.mark.parametrize('non_uniform', [True, False])
+@pytest.mark.parametrize('dim', [1, 2, 3])
+def test_get_scaling_parameter(is_binned, non_uniform, dim):
+    shape = [10 + i for i in range(dim)]
+    signal = Signal1D(np.arange(np.prod(shape)).reshape(shape[::-1]))
+    axis = signal.axes_manager.signal_axes[0]
+    axis.is_binned = is_binned
+    axis.scale = 0.5
+    if non_uniform:
+        axis.convert_to_non_uniform_axis()
+    centre = np.ones(shape[::-2])
+    scaling_factor = _get_scaling_factor(signal, axis, centre)
+
+    if is_binned:
+        assert np.all(scaling_factor == 0.5)
+    else:
+        assert scaling_factor == 1


### PR DESCRIPTION
### Description of the change
Rebase of PR #2740 with the correct version of `non_uniform_axes`.
Fixes #2739.

Summary: this PR fixes incorrect behaviour in `BaseDataAxis.value2index()` which was not accepting arrays as input and was computing the axis gradient even for non-binned axes.

### Progress of the PR
- [x] Change implemented (can be split into several points),
- [x] update docstring (if appropriate),
- [x] add tests,
- [x] ready for review.