### PR TITLE
Fix parse value string nua and fix circular import

### DIFF
--- a/hyperspy/api_nogui.py
+++ b/hyperspy/api_nogui.py
@@ -24,10 +24,10 @@ _logger = logging.getLogger(__name__)
 from hyperspy.logger import set_log_level
 from hyperspy.defaults_parser import preferences
 set_log_level(preferences.General.logging_level)
-from hyperspy import datasets
+from hyperspy import signals
 from hyperspy.utils import *
 from hyperspy.io import load
-from hyperspy import signals
+from hyperspy import datasets
 from hyperspy.Release import version as __version__
 from hyperspy import docstrings
 

--- a/hyperspy/axes.py
+++ b/hyperspy/axes.py
@@ -536,7 +536,11 @@ class BaseDataAxis(t.HasTraits):
         # if first character is a digit, try unit conversion
         # otherwise we don't support it
         elif value[0].isdigit():
-            value = self._get_value_from_value_with_units(value)
+            if self.is_uniform:
+                value = self._get_value_from_value_with_units(value)
+            else:
+                raise ValueError("Unit conversion is only supported for "
+                                 "uniform axis.")
         else:
             raise ValueError(f"`{value}` is not a suitable string for slicing.")
 

--- a/hyperspy/datasets/artificial_data.py
+++ b/hyperspy/datasets/artificial_data.py
@@ -6,10 +6,11 @@ For use in things like docstrings or to test HyperSpy functionalities.
 
 import numpy as np
 
+from hyperspy import components1d, components2d
+from hyperspy import signals
 from hyperspy.misc.math_tools import check_random_state
-from hyperspy.signals import Signal1D,Signal2D,EELSSpectrum
-from hyperspy import components1d,components2d
-from hyperspy.axes import FunctionalDataAxis, UniformDataAxis
+from hyperspy.axes import UniformDataAxis
+
 
 ADD_POWERLAW_DOCSTRING = \
 """add_powerlaw : bool
@@ -69,7 +70,7 @@ def get_low_loss_eels_signal(add_noise=True, random_state=None):
     if add_noise:
         data += random_state.uniform(size=len(x)) * 0.7
 
-    s = EELSSpectrum(data)
+    s = signals.EELSSpectrum(data)
     s.axes_manager[0].offset = x[0]
     s.axes_manager[0].scale = x[1] - x[0]
     s.metadata.General.title = 'Artifical low loss EEL spectrum'
@@ -141,7 +142,7 @@ def get_core_loss_eels_signal(add_powerlaw=False, add_noise=True, random_state=N
         powerlaw = components1d.PowerLaw(A=10e8, r=3, origin=0)
         data += powerlaw.function(x)
 
-    s = EELSSpectrum(data)
+    s = signals.EELSSpectrum(data)
     s.axes_manager[0].offset = x[0]
     s.metadata.General.title = 'Artifical core loss EEL spectrum'
     s.axes_manager[0].name = 'Electron energy loss'
@@ -192,7 +193,7 @@ def get_low_loss_eels_line_scan_signal(add_noise=True, random_state=None):
         if add_noise:
             data[i] += random_state.uniform(size=len(x)) * 0.7
 
-    s = EELSSpectrum(data)
+    s = signals.EELSSpectrum(data)
     s.axes_manager.signal_axes[0].offset = x[0]
     s.axes_manager.signal_axes[0].scale = x[1] - x[0]
     s.metadata.General.title = 'Artifical low loss EEL spectrum'
@@ -262,7 +263,7 @@ def get_core_loss_eels_line_scan_signal(add_powerlaw=False, add_noise=True, rand
         powerlaw = components1d.PowerLaw(A=10e8, r=3, origin=0)
         data += powerlaw.function(x)
 
-    s = EELSSpectrum(data)
+    s = signals.EELSSpectrum(data)
     s.axes_manager.signal_axes[0].offset = x[0]
     s.metadata.General.title = 'Artifical core loss EEL spectrum'
     s.axes_manager.signal_axes[0].name = 'Electron energy loss'
@@ -341,7 +342,7 @@ def get_atomic_resolution_tem_signal2d():
             gaussian2d.centre_y.value = y
             image += gaussian2d.function(x_array, y_array)
 
-    s = Signal2D(image)
+    s = signals.Signal2D(image)
     return s
 
 
@@ -437,7 +438,7 @@ def get_luminescence_signal(navigation_dimension=0,
                 is_binned=False,
                 )  for i in range(navigation_dimension)]
         #Generate empty signal
-        sig = Signal1D(data,axes = spaxes + [nm_axis])
+        sig = signals.Signal1D(data,axes = spaxes + [nm_axis])
         sig.metadata.General.title = '{:d}d-map Artificial Luminescence Signal'\
                                         .format(navigation_dimension)
     else:

--- a/hyperspy/drawing/utils.py
+++ b/hyperspy/drawing/utils.py
@@ -32,7 +32,6 @@ from functools import partial
 from matplotlib.colors import LinearSegmentedColormap
 from matplotlib.colors import BASE_COLORS, to_rgba
 
-import hyperspy as hs
 from hyperspy.defaults_parser import preferences
 
 
@@ -418,8 +417,7 @@ def _make_overlap_plot(spectra, ax, color="blue", line_style='-'):
         spectrum = _transpose_if_required(spectrum, 1)
         ax.plot(x_axis.axis, spectrum.data, color=color, ls=line_style)
         set_xaxis_lims(ax, x_axis)
-    _set_spectrum_xlabel(spectra if isinstance(spectra, hs.signals.BaseSignal)
-                         else spectra[-1], ax)
+    _set_spectrum_xlabel(spectra, ax)
     ax.set_ylabel('Intensity')
     ax.autoscale(tight=True)
 
@@ -444,8 +442,7 @@ def _make_cascade_subplot(
                         float(max_value) + spectrum_index * padding)
         ax.plot(x_axis.axis, data_to_plot, color=color, ls=line_style)
         set_xaxis_lims(ax, x_axis)
-    _set_spectrum_xlabel(spectra if isinstance(spectra, hs.signals.BaseSignal)
-                         else spectra[-1], ax)
+    _set_spectrum_xlabel(spectra, ax)
     ax.set_yticks([])
     ax.autoscale(tight=True)
 
@@ -457,7 +454,8 @@ def _plot_spectrum(spectrum, ax, color="blue", line_style='-'):
 
 
 def _set_spectrum_xlabel(spectrum, ax):
-    x_axis = spectrum.axes_manager.signal_axes[0]
+    s = spectrum[-1] if isinstance(spectrum, (list, tuple)) else spectrum
+    x_axis = s.axes_manager.signal_axes[0]
     ax.set_xlabel("%s (%s)" % (x_axis.name, x_axis.units))
 
 

--- a/hyperspy/tests/axes/test_data_axis.py
+++ b/hyperspy/tests/axes/test_data_axis.py
@@ -178,6 +178,18 @@ class TestDataAxis:
         with pytest.raises(ValueError):
             self.axis.value2index(226)
 
+    def test_parse_value_from_relative_string(self):
+        ax = self.axis
+        assert ax._parse_value_from_string('rel0.0') == 0.0
+        assert ax._parse_value_from_string('rel0.5') == 112.5
+        assert ax._parse_value_from_string('rel1.0') == 225.0
+        with pytest.raises(ValueError):
+            ax._parse_value_from_string('rela0.5')
+        with pytest.raises(ValueError):
+            ax._parse_value_from_string('rel1.5')
+        with pytest.raises(ValueError):
+            ax._parse_value_from_string('abcd')
+
     @pytest.mark.parametrize("use_indices", (False, True))
     def test_crop(self, use_indices):
         axis = DataAxis(axis=self._axis)
@@ -204,7 +216,7 @@ class TestDataAxis:
         assert axis.size == 12
         np.testing.assert_almost_equal(axis.axis[0], 4)
         np.testing.assert_almost_equal(axis.axis[-1], 169)
-    
+
     def test_error_DataAxis(self):
         with pytest.raises(ValueError):
             axis = DataAxis(axis=np.arange(16)**2, _type='UniformDataAxis')
@@ -259,7 +271,7 @@ class TestFunctionalDataAxis:
         with pytest.raises(ValueError, match="The values of"):
             self.axis = FunctionalDataAxis(
                 size=10,
-                expression=expression,)        
+                expression=expression,)
 
     @pytest.mark.parametrize("use_indices", (True, False))
     def test_crop(self, use_indices):
@@ -626,12 +638,6 @@ class TestUniformDataAxis:
         assert ax._parse_value_from_string('rel0.0') == 10.0
         assert ax._parse_value_from_string('rel0.5') == 10.45
         assert ax._parse_value_from_string('rel1.0') == 10.9
-        with pytest.raises(ValueError):
-            ax._parse_value_from_string('rela0.5')
-        with pytest.raises(ValueError):
-            ax._parse_value_from_string('rel1.5')
-        with pytest.raises(ValueError):
-            ax._parse_value_from_string('abcd')
 
     def test_slice_empty_string(self):
         ax = self.axis

--- a/hyperspy/tests/axes/test_data_axis.py
+++ b/hyperspy/tests/axes/test_data_axis.py
@@ -190,6 +190,12 @@ class TestDataAxis:
         with pytest.raises(ValueError):
             ax._parse_value_from_string('abcd')
 
+    def test_parse_value_from_string_with_units(self):
+        ax = self.axis
+        ax.units = 'nm'
+        with pytest.raises(ValueError):
+            ax._parse_value_from_string('0.02 um')
+
     @pytest.mark.parametrize("use_indices", (False, True))
     def test_crop(self, use_indices):
         axis = DataAxis(axis=self._axis)
@@ -219,7 +225,7 @@ class TestDataAxis:
 
     def test_error_DataAxis(self):
         with pytest.raises(ValueError):
-            axis = DataAxis(axis=np.arange(16)**2, _type='UniformDataAxis')
+            _ = DataAxis(axis=np.arange(16)**2, _type='UniformDataAxis')
         with pytest.raises(AttributeError):
             self.axis.index_in_axes_manager()
         with pytest.raises(IndexError):

--- a/hyperspy/utils/__init__.py
+++ b/hyperspy/utils/__init__.py
@@ -31,12 +31,8 @@ Subpackages:
         Tools for plotting.
     eds
         Tools for energy-dispersive X-ray data analysis.
-    example_signals
-        A few example of signal
-
 
 """
-import hyperspy.datasets.example_signals
 import hyperspy.utils.eds
 import hyperspy.utils.material
 import hyperspy.utils.model

--- a/hyperspy/utils/model_selection.py
+++ b/hyperspy/utils/model_selection.py
@@ -18,7 +18,6 @@
 
 import numpy as np
 
-from hyperspy import model
 from hyperspy.exceptions import NavigationSizeError
 
 


### PR DESCRIPTION
Merging #2386 into the `non_uniform_axes` wasn't done correctly.

Moving imports to the top of `artificial_data.py` introduces a circular import, for example:
```python
from hyperspy.signals import Signal1D
```
gives the following circular `ImportError`:
```python
Traceback (most recent call last):

  File "<ipython-input-1-d9a231321fff>", line 1, in <module>
    from hyperspy.signals import Signal1D

  File "/home/eric/Dev/hyperspy/hyperspy/signals.py", line 67, in <module>
    importlib.import_module(

  File "/opt/miniconda3/lib/python3.8/importlib/__init__.py", line 127, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)

  File "/home/eric/Dev/hyperspy/hyperspy/_signals/signal2d.py", line 46, in <module>
    from hyperspy.utils.peakfinders2D import (

  File "/home/eric/Dev/hyperspy/hyperspy/utils/__init__.py", line 39, in <module>
    import hyperspy.datasets.example_signals

  File "/home/eric/Dev/hyperspy/hyperspy/datasets/__init__.py", line 21, in <module>
    from hyperspy.datasets import artificial_data

  File "/home/eric/Dev/hyperspy/hyperspy/datasets/artificial_data.py", line 10, in <module>
    from hyperspy.signals import Signal1D,Signal2D,EELSSpectrum

ImportError: cannot import name 'Signal2D' from partially initialized module 'hyperspy.signals' (most likely due to a circular import) (/home/eric/Dev/hyperspy/hyperspy/signals.py)
```


### Progress of the PR
- [x] Fix circular import and remove unnecessary import,
- [x] fix relative slicing, 
- [x] raise `ValueError` when converting units with non-uniform axis, 
- [x] add tests,
- [x] ready for review.

### Minimal example of the bug fix or the new feature
```python
import hyperspy.api as hs
s = hs.datasets.artificial_data.get_luminescence_signal(2)
s2 = s.isig[:'rel0.5']
```
Would give the following error message (fixed with this PR):
```python

  File "/home/eric/Dev/hyperspy/hyperspy/misc/slicing.py", line 193, in __getitem__
    return self.obj._slicer(slices, self.isNavigation, out=out)

  File "/home/eric/Dev/hyperspy/hyperspy/misc/slicing.py", line 276, in _slicer
    array_slices = self._get_array_slices(slices, isNavigation)

  File "/home/eric/Dev/hyperspy/hyperspy/misc/slicing.py", line 268, in _get_array_slices
    array_slices.append(axis._get_array_slices(slice_))

  File "/home/eric/Dev/hyperspy/hyperspy/axes.py", line 428, in _get_array_slices
    stop = self._parse_value(stop)

  File "/home/eric/Dev/hyperspy/hyperspy/axes.py", line 540, in _parse_value
    value = self._parse_value_from_string(value)

  File "/home/eric/Dev/hyperspy/hyperspy/axes.py", line 532, in _parse_value_from_string
    raise ValueError(f"`{value}` is not a suitable string for slicing.")

ValueError: `rel0.5` is not a suitable string for slicing.
```

```python
import numpy as np
from hyperspy.axes import DataAxis

axis = DataAxis(axis=np.arange(16)**2)
axis._parse_value_from_string('0.02 um')
```
now raises a `ValueError`:
```python
Traceback (most recent call last):

  File "<ipython-input-1-67c4429ebebc>", line 5, in <module>
    axis._parse_value_from_string('0.02 um')

  File "/home/eric/Dev/hyperspy/hyperspy/axes.py", line 542, in _parse_value_from_string
    raise ValueError("Unit conversion is only supported for "

ValueError: Unit conversion is only supported for uniform axis.
```
 