### PR TITLE
Cleanup for the implementation of shift1D

### DIFF
--- a/hyperspy/_signals/signal1d.py
+++ b/hyperspy/_signals/signal1d.py
@@ -251,16 +251,14 @@ def _shift1D(data, **kwargs):
     size = kwargs.get('size', 2)
     if np.isnan(shift) or shift == 0:
         return data
-    axis = np.linspace(offset, offset + scale * (size - 1), size)
 
-    si = sp.interpolate.interp1d(original_axis,
-                                 data,
-                                 bounds_error=False,
-                                 fill_value=fill_value,
-                                 kind=kind)
-    offset = float(offset - shift)
-    axis = np.linspace(offset, offset + scale * (size - 1), size)
-    return si(axis)
+
+    #This is the interpolant function
+    si = interpolate.interp1d(original_axis, data, bounds_error=False,
+                              fill_value=fill_value, kind=kind)
+
+    #Evaluate interpolated data at shifted positions
+    return si(original_axis-shift)
 
 
 class Signal1D(BaseSignal, CommonSignal1D):

--- a/hyperspy/_signals/signal1d.py
+++ b/hyperspy/_signals/signal1d.py
@@ -242,16 +242,15 @@ def _estimate_shift1D(data, data_slice=slice(None), ref=None, ip=5,
 
 
 def _shift1D(data, **kwargs):
+    """Used to shift a data array by a specified amount in axes units. Axis must
+    be passed as a kwarg. """
     shift = kwargs.get('shift', 0.)
     original_axis = kwargs.get('original_axis', None)
     fill_value = kwargs.get('fill_value', np.nan)
     kind = kwargs.get('kind', 'linear')
-    offset = kwargs.get('offset', 0.)
-    scale = kwargs.get('scale', 1.)
-    size = kwargs.get('size', 2)
+
     if np.isnan(shift) or shift == 0:
         return data
-
 
     #This is the interpolant function
     si = sp.interpolate.interp1d(original_axis, data, bounds_error=False,
@@ -474,9 +473,6 @@ class Signal1D(BaseSignal, CommonSignal1D):
                  original_axis=axis.axis,
                  fill_value=fill_value,
                  kind=interpolation_method,
-                 offset=axis.offset,
-                 scale=axis.scale,
-                 size=axis.size,
                  show_progressbar=show_progressbar,
                  parallel=parallel,
                  max_workers=max_workers,

--- a/hyperspy/_signals/signal1d.py
+++ b/hyperspy/_signals/signal1d.py
@@ -254,7 +254,7 @@ def _shift1D(data, **kwargs):
 
 
     #This is the interpolant function
-    si = interpolate.interp1d(original_axis, data, bounds_error=False,
+    si = sp.interpolate.interp1d(original_axis, data, bounds_error=False,
                               fill_value=fill_value, kind=kind)
 
     #Evaluate interpolated data at shifted positions


### PR DESCRIPTION
### Description of the change
- Removed some unnecessary operations performed in `signal1d._shift1D`
- `axis` was computed twice without being used inbetween
- I replaced the function by a more compact and understandable line of code
- Change invisible to the user
- 30% speed gain in _shift1D execution

### Progress of the PR
- [x] Change implemented (can be split into several points),
- [x] ready for review.

There is room for more improvement by removing (offset,scale,size) kwargs, which are actually not needed.

### Minimal example of the bug fix or the new feature
```python
import hyperspy.api as hs
from hyperspy._signals.signal1d import _shift1D

s = hs.datasets.artificial_data.get_low_loss_eels_signal()

#Before the Change
%timeit _shift1D(s.data,shift=4.0,\
         original_axis=s.axes_manager[0].axis,\
         offset=s.axes_manager[0].offset,\
         scale =s.axes_manager[0].scale,\
         size  =s.axes_manager[0].size)
260 µs ± 6.44 µs per loop (mean ± std. dev. of 7 runs, 1000 loops each)

#After the change
%timeit _shift1D(s.data,shift=4.0,\
         original_axis=s.axes_manager[0].axis,\
         offset=s.axes_manager[0].offset,\
         scale =s.axes_manager[0].scale,\
         size  =s.axes_manager[0].size)
181 µs ± 2.36 µs per loop (mean ± std. dev. of 7 runs, 10000 loops each)

```