### PR TITLE
Fix is binned gui

### DIFF
--- a/hyperspy/axes.py
+++ b/hyperspy/axes.py
@@ -265,7 +265,7 @@ class BaseDataAxis(t.HasTraits):
     high_index = t.Int()
     slice = t.Instance(slice)
     navigate = t.Bool(t.Undefined)
-    is_binnned = t.Bool(t.Undefined)
+    is_binned = t.Bool(t.Undefined)
     index = t.Range('low_index', 'high_index')
     axis = t.Array()
 
@@ -313,7 +313,6 @@ class BaseDataAxis(t.HasTraits):
         self.units = units
         self.low_index = 0
         self.on_trait_change(self._update_slice, 'navigate')
-        self.on_trait_change(self._update_slice, 'is_binned')
         self.on_trait_change(self.update_index_bounds, 'size')
         self.on_trait_change(self._update_bounds, 'axis')
 

--- a/hyperspy/axes.py
+++ b/hyperspy/axes.py
@@ -241,6 +241,7 @@ class UnitConversion:
         self._units = s
 
 
+@add_gui_method(toolkey="hyperspy.DataAxis")
 class BaseDataAxis(t.HasTraits):
     """Parent class defining common attributes for all DataAxis classes.
 
@@ -1316,6 +1317,7 @@ def _flyback_iter(shape):
             return self._it.multi_index[::-1]
 
     return ndindex_reversed(shape)
+
 
 @add_gui_method(toolkey="hyperspy.AxesManager")
 class AxesManager(t.HasTraits):


### PR DESCRIPTION
Close #2751

@LMSC-NTappy, this was indeed a typo, which was preventing/neutralising another bug! The trait `is_binned` was wrongly connected to a listener (or callback) and fixing the typo was calling the `BaseDataAxis._update_slice` with the new value of the `is_binned` argument, which then cause the issue.

### Progress of the PR
- [x] fix `is_binned` typo and connection to callback,
- [x] add gui toolkey to `BaseDataAxis` to enable the axis GUI for all type of axis, 
- [x] ready for review.


