### PR TITLE
Add ``set()`` and ``get`` methods to ``AxesManager``'s ``signal_axes`` and ``navigation_axes``

### DIFF
--- a/doc/reference/utils/index.rst
+++ b/doc/reference/utils/index.rst
@@ -8,7 +8,10 @@ signals.
 .. currentmodule:: hyperspy.misc.utils
 
 .. autoclass:: DictionaryTreeBrowser
-   :members: 
+   :members:
+
+.. autoclass:: TupleSA
+   :members:
 
 .. currentmodule:: hyperspy.misc.export_dictionary
 

--- a/doc/user_guide/axes.rst
+++ b/doc/user_guide/axes.rst
@@ -107,6 +107,17 @@ attributes, e.g.:
     >>> s.axes_manager[0]
     <X axis, size: 20, index: 0>
 
+.. version_added:: 2.2
+    `set` method for `navigation_axes` and `signal_axes`.
+
+It is also possible to set multiple attributes of multiple axes at once, using the :meth:`~.misc.utils.TupleSA.set`
+of the `navigation_axes` and `signal_axes` attributes.
+For example:
+
+.. code-block:: python
+
+    >>> s.axes_manager.navigation_axes.set(name=("X", "Y"), offset=10, units="nm")
+
 
 Once the name of an axis has been defined it is possible to request it by its
 name e.g.:
@@ -118,6 +129,8 @@ name e.g.:
     >>> s.axes_manager["X"].scale = 0.2
     >>> s.axes_manager["X"].units = "nm"
     >>> s.axes_manager["X"].offset = 100
+
+The 
 
 
 It is also possible to set the axes properties using a GUI by calling the

--- a/doc/user_guide/axes.rst
+++ b/doc/user_guide/axes.rst
@@ -111,7 +111,7 @@ attributes, e.g.:
     :meth:`~.misc.utils.TupleSA.set` method for :attr:`~.axes.AxesManager.navigation_axes` and :attr:`~.axes.AxesManager.signal_axes`.
 
 It is also possible to set multiple attributes of multiple axes at once, using the :meth:`~.misc.utils.TupleSA.set`
-of the `navigation_axes` and `signal_axes` attributes.
+of the :attr:`~.axes.AxesManager.navigation_axes` and :attr:`~.axes.AxesManager.signal_axes` attributes.
 For example:
 
 .. code-block:: python

--- a/doc/user_guide/axes.rst
+++ b/doc/user_guide/axes.rst
@@ -107,7 +107,7 @@ attributes, e.g.:
     >>> s.axes_manager[0]
     <X axis, size: 20, index: 0>
 
-.. version_added:: 2.2
+.. versionadded:: 2.2
     `set` method for `navigation_axes` and `signal_axes`.
 
 It is also possible to set multiple attributes of multiple axes at once, using the :meth:`~.misc.utils.TupleSA.set`

--- a/doc/user_guide/axes.rst
+++ b/doc/user_guide/axes.rst
@@ -130,7 +130,6 @@ name e.g.:
     >>> s.axes_manager["X"].units = "nm"
     >>> s.axes_manager["X"].offset = 100
 
-The 
 
 
 It is also possible to set the axes properties using a GUI by calling the

--- a/doc/user_guide/axes.rst
+++ b/doc/user_guide/axes.rst
@@ -108,15 +108,18 @@ attributes, e.g.:
     <X axis, size: 20, index: 0>
 
 .. versionadded:: 2.2
-    :meth:`~.misc.utils.TupleSA.set` method for :attr:`~.axes.AxesManager.navigation_axes` and :attr:`~.axes.AxesManager.signal_axes`.
+    :meth:`~.misc.utils.TupleSA.set` and :meth:`~.misc.utils.TupleSA.get` methods for :attr:`~.axes.AxesManager.navigation_axes`
+    and :attr:`~.axes.AxesManager.signal_axes`.
 
 It is also possible to set multiple attributes of multiple axes at once, using the :meth:`~.misc.utils.TupleSA.set`
 of the :attr:`~.axes.AxesManager.navigation_axes` and :attr:`~.axes.AxesManager.signal_axes` attributes.
-For example:
+The :meth:`~.misc.utils.TupleSA.get` returns a dictionary of the attributes.  For example:
 
 .. code-block:: python
 
     >>> s.axes_manager.navigation_axes.set(name=("X", "Y"), offset=10, units="nm")
+    >>> s.axes_manager.navigation_axes.get("name", "offset", "units")
+    {"name" : ("X", "Y"), "offset" : (10, 10), "units" : ("nm", "nm")}
 
 
 Once the name of an axis has been defined it is possible to request it by its

--- a/doc/user_guide/axes.rst
+++ b/doc/user_guide/axes.rst
@@ -108,7 +108,7 @@ attributes, e.g.:
     <X axis, size: 20, index: 0>
 
 .. versionadded:: 2.2
-    `set` method for `navigation_axes` and `signal_axes`.
+    :meth:`~.misc.utils.TupleSA.set` method for :attr:`~.axes.AxesManager.navigation_axes` and :attr:`~.axes.AxesManager.signal_axes`.
 
 It is also possible to set multiple attributes of multiple axes at once, using the :meth:`~.misc.utils.TupleSA.set`
 of the `navigation_axes` and `signal_axes` attributes.

--- a/hyperspy/axes.py
+++ b/hyperspy/axes.py
@@ -43,7 +43,7 @@ from hyperspy.misc.array_tools import (
     round_half_towards_zero,
 )
 from hyperspy.misc.math_tools import isfloat
-from hyperspy.misc.utils import isiterable, ordinal
+from hyperspy.misc.utils import isiterable, ordinal, TupleSA
 from hyperspy.ui_registry import add_gui_method, get_gui
 
 _logger = logging.getLogger(__name__)

--- a/hyperspy/axes.py
+++ b/hyperspy/axes.py
@@ -2121,12 +2121,12 @@ class AxesManager(t.HasTraits):
     @property
     def signal_axes(self):
         """The signal axes as a tuple."""
-        return self._signal_axes
+        return TupleSA(self._signal_axes)
 
     @property
     def navigation_axes(self):
         """The navigation axes as a tuple."""
-        return self._navigation_axes
+        return TupleSA(self._navigation_axes)
 
     @property
     def signal_shape(self):
@@ -2580,3 +2580,4 @@ def _parse_axis_attribute(value):
         return None
     else:
         return value
+

--- a/hyperspy/axes.py
+++ b/hyperspy/axes.py
@@ -43,7 +43,7 @@ from hyperspy.misc.array_tools import (
     round_half_towards_zero,
 )
 from hyperspy.misc.math_tools import isfloat
-from hyperspy.misc.utils import isiterable, ordinal, TupleSA
+from hyperspy.misc.utils import TupleSA, isiterable, ordinal
 from hyperspy.ui_registry import add_gui_method, get_gui
 
 _logger = logging.getLogger(__name__)
@@ -2120,12 +2120,20 @@ class AxesManager(t.HasTraits):
 
     @property
     def signal_axes(self):
-        """The signal axes as a tuple."""
+        """The signal axes as a TupleSA.
+
+        A TupleSA object is a tuple with a `set` method
+        to easily set the attributes of its items.
+        """
         return TupleSA(self._signal_axes)
 
     @property
     def navigation_axes(self):
-        """The navigation axes as a tuple."""
+        """The navigation axes as a TupleSA.
+
+        A TupleSA object is a tuple with a `set` method
+        to easily set the attributes of its items.
+        """
         return TupleSA(self._navigation_axes)
 
     @property
@@ -2580,4 +2588,3 @@ def _parse_axis_attribute(value):
         return None
     else:
         return value
-

--- a/hyperspy/misc/utils.py
+++ b/hyperspy/misc/utils.py
@@ -1645,7 +1645,11 @@ class TupleSA(tuple):
     """A tuple that can set the attributes of its items
     """
     def __getitem__(self, *args, **kwargs):
-        return type(self)(super().__getitem__(*args, **kwargs))
+        item = super().__getitem__(*args, **kwargs)
+        try:
+            return type(self)(item)
+        except TypeError:
+            return item
 
     def __setattr__(self, name, value):
         no_name = [item

--- a/hyperspy/misc/utils.py
+++ b/hyperspy/misc/utils.py
@@ -1655,8 +1655,12 @@ class TupleSA(tuple):
             raise AttributeError(
                 f"'The items {no_name} have not attribute '{name}'")
         else:
-            for item in self:
-                setattr(item, name, value)
+            if isiterable(value) and not isinstance(value, str):
+                for item, value_ in zip(self, value):
+                    setattr(item, name, value_)
+            else:
+                for item in self:
+                    setattr(item, name, value)
 
     def __add__(self, *args, **kwargs):
         return type(self)(super().__add__(*args, **kwargs))

--- a/hyperspy/misc/utils.py
+++ b/hyperspy/misc/utils.py
@@ -1657,3 +1657,9 @@ class TupleSA(tuple):
         else:
             for item in self:
                 setattr(item, name, value)
+
+    def __add__(self, *args, **kwargs):
+        return type(self)(super().__add__(*args, **kwargs))
+
+    def __mul__(self, *args, **kwargs):
+        return type(self)(super().__mul__(*args, **kwargs))

--- a/hyperspy/misc/utils.py
+++ b/hyperspy/misc/utils.py
@@ -1645,7 +1645,7 @@ class TupleSA(tuple):
     """A tuple that can set the attributes of its items
     """
     def __getitem__(self, *args, **kwargs):
-        return TupleSI(super().__getitem__(*args, **kwargs))
+        return type(self)(super().__getitem__(*args, **kwargs))
 
     def __setattr__(self, name, value):
         no_name = [item

--- a/hyperspy/misc/utils.py
+++ b/hyperspy/misc/utils.py
@@ -1544,6 +1544,7 @@ def is_cupy_array(array):
     """
     Convenience function to determine if an array is a cupy array
 
+<<<<<<< HEAD
     Parameters
     ----------
     array : array
@@ -1639,3 +1640,20 @@ def display(obj):
         display.display(obj)
     except ImportError:
         print(obj)
+
+class TupleSA(tuple):
+    """A tuple that can set the attributes of its items
+    """
+    def __getitem__(self, *args, **kwargs):
+        return TupleSI(super().__getitem__(*args, **kwargs))
+
+    def __setattr__(self, name, value):
+        no_name = [item
+                   for item in self
+                   if not hasattr(item, name)]
+        if no_name:
+            raise AttributeError(
+                f"'The items {no_name} have not attribute '{name}'")
+        else:
+            for item in self:
+                setattr(item, name, value)

--- a/hyperspy/misc/utils.py
+++ b/hyperspy/misc/utils.py
@@ -1651,6 +1651,14 @@ class TupleSA(tuple):
             return item
 
     def set(self, **kwargs):
+        """Set the attributes of its items
+
+        Parameters
+        ----------
+        kwargs : dict
+            The name of the attributes and their values. If a value is iterable,
+            then attribute of each item of the tuple will be set to each of the values.
+        """
         for key, value in kwargs.items():
             no_name = [item
                     for item in self

--- a/hyperspy/misc/utils.py
+++ b/hyperspy/misc/utils.py
@@ -1650,20 +1650,21 @@ class TupleSA(tuple):
         except TypeError:
             return item
 
-    def __setattr__(self, name, value):
-        no_name = [item
-                   for item in self
-                   if not hasattr(item, name)]
-        if no_name:
-            raise AttributeError(
-                f"'The items {no_name} have not attribute '{name}'")
-        else:
-            if isiterable(value) and not isinstance(value, str):
-                for item, value_ in zip(self, value):
-                    setattr(item, name, value_)
+    def set(self, **kwargs):
+        for key, value in kwargs.items():
+            no_name = [item
+                    for item in self
+                    if not hasattr(item, key)]
+            if no_name:
+                raise AttributeError(
+                    f"'The items {no_name} have not attribute '{key}'")
             else:
-                for item in self:
-                    setattr(item, name, value)
+                if isiterable(value) and not isinstance(value, str):
+                    for item, value_ in zip(self, value):
+                        setattr(item, key, value_)
+                else:
+                    for item in self:
+                        setattr(item, key, value)
 
     def __add__(self, *args, **kwargs):
         return type(self)(super().__add__(*args, **kwargs))

--- a/hyperspy/misc/utils.py
+++ b/hyperspy/misc/utils.py
@@ -1648,6 +1648,7 @@ class TupleSA(tuple):
         try:
             return type(self)(item)
         except TypeError:
+            # When indexing, the returned object is not a tuple
             return item
 
     def set(self, **kwargs):
@@ -1690,12 +1691,12 @@ class TupleSA(tuple):
         output = dict()
         for key in args:
             values = list()
-            for axis in self:
-                if not hasattr(axis, key):
+            for item in self:
+                if not hasattr(item, key):
                     raise AttributeError(
-                        f"'The item {axis} has not attribute '{key}'")
+                        f"'The item {item} has not attribute '{key}'")
                 else:
-                    values.append(getattr(axis, key))
+                    values.append(getattr(item, key))
             output[key] = tuple(values)
         return output
 

--- a/hyperspy/misc/utils.py
+++ b/hyperspy/misc/utils.py
@@ -1544,7 +1544,6 @@ def is_cupy_array(array):
     """
     Convenience function to determine if an array is a cupy array
 
-<<<<<<< HEAD
     Parameters
     ----------
     array : array

--- a/hyperspy/misc/utils.py
+++ b/hyperspy/misc/utils.py
@@ -1640,9 +1640,10 @@ def display(obj):
     except ImportError:
         print(obj)
 
+
 class TupleSA(tuple):
-    """A tuple that can set the attributes of its items
-    """
+    """A tuple that can set the attributes of its items"""
+
     def __getitem__(self, *args, **kwargs):
         item = super().__getitem__(*args, **kwargs)
         try:
@@ -1661,12 +1662,9 @@ class TupleSA(tuple):
             then attribute of each item of the tuple will be set to each of the values.
         """
         for key, value in kwargs.items():
-            no_name = [item
-                    for item in self
-                    if not hasattr(item, key)]
+            no_name = [item for item in self if not hasattr(item, key)]
             if no_name:
-                raise AttributeError(
-                    f"'The items {no_name} have not attribute '{key}'")
+                raise AttributeError(f"'The items {no_name} have not attribute '{key}'")
             else:
                 if isiterable(value) and not isinstance(value, str):
                     for item, value_ in zip(self, value):
@@ -1693,8 +1691,7 @@ class TupleSA(tuple):
             values = list()
             for item in self:
                 if not hasattr(item, key):
-                    raise AttributeError(
-                        f"'The item {item} has not attribute '{key}'")
+                    raise AttributeError(f"'The item {item} has not attribute '{key}'")
                 else:
                     values.append(getattr(item, key))
             output[key] = tuple(values)

--- a/hyperspy/misc/utils.py
+++ b/hyperspy/misc/utils.py
@@ -1674,6 +1674,31 @@ class TupleSA(tuple):
                     for item in self:
                         setattr(item, key, value)
 
+    def get(self, *args):
+        """Get the attributes of its items
+
+        Parameters
+        ----------
+        args : list
+            The names of the attributes to get.
+
+        Returns
+        -------
+        output : dict
+            The name of the attributes and their values.
+        """
+        output = dict()
+        for key in args:
+            values = list()
+            for axis in self:
+                if not hasattr(axis, key):
+                    raise AttributeError(
+                        f"'The item {axis} has not attribute '{key}'")
+                else:
+                    values.append(getattr(axis, key))
+            output[key] = tuple(values)
+        return output
+
     def __add__(self, *args, **kwargs):
         return type(self)(super().__add__(*args, **kwargs))
 

--- a/hyperspy/tests/axes/test_axes_manager.py
+++ b/hyperspy/tests/axes/test_axes_manager.py
@@ -137,7 +137,9 @@ class TestAxesManager:
         assert am.navigation_axes[0].units == "nm"
         assert am.navigation_axes[1].units == "nm"
         with pytest.raises(AttributeError):
-            am.signal_axes.set(names=("kx", "kx"), offset=(1, 2), scale=3, units="nm^{-1}")
+            am.signal_axes.set(
+                names=("kx", "kx"), offset=(1, 2), scale=3, units="nm^{-1}"
+            )
 
     def test_all_uniform(self):
         assert self.am.all_uniform is True

--- a/hyperspy/tests/axes/test_axes_manager.py
+++ b/hyperspy/tests/axes/test_axes_manager.py
@@ -116,6 +116,29 @@ class TestAxesManager:
         assert am[-2].offset == am[-1].offset
         assert am[-2].scale == am[-1].scale
 
+    def test_set_attributes(self):
+        am = self.am
+        am.signal_axes.set(name=("kx", "ky"), offset=(1, 2), scale=3, units="nm^{-1}")
+        assert am.signal_axes[0].name == "kx"
+        assert am.signal_axes[1].name == "ky"
+        assert am.signal_axes[0].offset == 1
+        assert am.signal_axes[1].offset == 2
+        assert am.signal_axes[0].scale == 3
+        assert am.signal_axes[1].scale == 3
+        assert am.signal_axes[0].units == "nm^{-1}"
+        assert am.signal_axes[1].units == "nm^{-1}"
+        am.navigation_axes.set(name=("x", "y"), offset=10, scale=(10, 20), units="nm")
+        assert am.navigation_axes[0].name == "x"
+        assert am.navigation_axes[1].name == "y"
+        assert am.navigation_axes[0].offset == 10
+        assert am.navigation_axes[1].offset == 10
+        assert am.navigation_axes[0].scale == 10
+        assert am.navigation_axes[1].scale == 20
+        assert am.navigation_axes[0].units == "nm"
+        assert am.navigation_axes[1].units == "nm"
+        with pytest.raises(AttributeError):
+            am.signal_axes.set(names=("kx", "kx"), offset=(1, 2), scale=3, units="nm^{-1}")
+
     def test_all_uniform(self):
         assert self.am.all_uniform is True
         self.am[-1].convert_to_non_uniform_axis()

--- a/hyperspy/tests/misc/test_utils.py
+++ b/hyperspy/tests/misc/test_utils.py
@@ -196,6 +196,7 @@ class TestTupleSA:
         assert t[1].attribute1 == "value3"
         assert t[0].attribute2 == 0
         assert t[1].attribute2 == 1
+
     @staticmethod
     def test_tuple_sa_set_attribute_error():
         t = TupleSA((1, 2, 3))
@@ -204,7 +205,11 @@ class TestTupleSA:
 
     def test_tuple_sa_get_attribute(self):
         t = self.tuple
-        assert t.get("attribute1", "attribute2") == {"attribute1": ("value1", "value1"), "attribute2": ("value2", "value2")}
+        assert t.get("attribute1", "attribute2") == {
+            "attribute1": ("value1", "value1"),
+            "attribute2": ("value2", "value2"),
+        }
+
     @staticmethod
     def test_tuple_sa_get_attribute_error():
         t = TupleSA((1, 2, 3))

--- a/hyperspy/tests/misc/test_utils.py
+++ b/hyperspy/tests/misc/test_utils.py
@@ -16,12 +16,15 @@
 # You should have received a copy of the GNU General Public License
 # along with HyperSpy. If not, see <https://www.gnu.org/licenses/#GPL>.
 
+from unittest.mock import Mock
+
 import dask.array as da
 import numpy as np
 import pytest
 
 from hyperspy import signals
 from hyperspy.misc.utils import (
+    TupleSA,
     closest_power_of_two,
     fsdict,
     get_array_module,
@@ -174,3 +177,40 @@ def test_get_array_module():
 def test_get_array_module_cupy():
     cp_array = cp.array([0, 1, 2])
     assert get_array_module(cp_array) == cp
+
+
+class TestTupleSA:
+    def setup_method(self, method):
+        item1 = Mock()
+        item1.attribute1 = "value1"
+        item1.attribute2 = "value2"
+        item2 = Mock()
+        item2.attribute1 = "value1"
+        item2.attribute2 = "value2"
+        self.tuple = TupleSA((item1, item2))
+
+    def test_tuple_sa_set_attribute(self):
+        t = self.tuple
+        t.set(attribute1="value3", attribute2=(0, 1))
+        assert t[0].attribute1 == "value3"
+        assert t[1].attribute1 == "value3"
+        assert t[0].attribute2 == 0
+        assert t[1].attribute2 == 1
+
+    def test_tuple_sa_set_attribute_error(self):
+        t = TupleSA((1, 2, 3))
+        with pytest.raises(AttributeError):
+            t.set(a=4, b=5, c=6, d=7)
+
+    @staticmethod
+    def test_tuple_sa_add():
+        t1 = TupleSA((1, 2, 3))
+        t2 = TupleSA((4, 5, 6))
+        t3 = t1 + t2
+        assert isinstance(t3, TupleSA)
+
+    @staticmethod
+    def test_tuple_sa_mul():
+        t1 = TupleSA((1, 2, 3))
+        t2 = t1 * 2
+        assert isinstance(t2, TupleSA)

--- a/hyperspy/tests/misc/test_utils.py
+++ b/hyperspy/tests/misc/test_utils.py
@@ -196,11 +196,20 @@ class TestTupleSA:
         assert t[1].attribute1 == "value3"
         assert t[0].attribute2 == 0
         assert t[1].attribute2 == 1
-
-    def test_tuple_sa_set_attribute_error(self):
+    @staticmethod
+    def test_tuple_sa_set_attribute_error():
         t = TupleSA((1, 2, 3))
         with pytest.raises(AttributeError):
             t.set(a=4, b=5, c=6, d=7)
+
+    def test_tuple_sa_get_attribute(self):
+        t = self.tuple
+        assert t.get("attribute1", "attribute2") == {"attribute1": ("value1", "value1"), "attribute2": ("value2", "value2")}
+    @staticmethod
+    def test_tuple_sa_get_attribute_error():
+        t = TupleSA((1, 2, 3))
+        with pytest.raises(AttributeError):
+            t.get("a", "b")
 
     @staticmethod
     def test_tuple_sa_add():

--- a/upcoming_changes/2756.enhancements.rst
+++ b/upcoming_changes/2756.enhancements.rst
@@ -1,2 +1,2 @@
 New :attr:`~.axes.AxesManager.signal_axes` and :attr:`~.axes.AxesManager.navigation_axes` :meth:`~.misc.utils.TupleSA.set` method 
-to set multiple attributes of multiple axes at once. See :ref:`_Setting_axis_properties`.
+to set multiple attributes of multiple axes at once. See :ref:`Setting_axis_properties`.

--- a/upcoming_changes/2756.enhancements.rst
+++ b/upcoming_changes/2756.enhancements.rst
@@ -1,2 +1,2 @@
-New :attr:`~.axes.AxesManager.signal_axes` and :attr:`~.axes.AxesManager.navigation_axes` :meth:`~.misc.utils.TupleSA.set` method 
-to set multiple attributes of multiple axes at once. See :ref:`Setting_axis_properties`.
+New :attr:`~.axes.AxesManager.signal_axes` and :attr:`~.axes.AxesManager.navigation_axes` :meth:`~.misc.utils.TupleSA.set`
+and :meth:`~.misc.utils.TupleSA.get` methods to set/get multiple attributes of multiple axes at once. See :ref:`Setting_axis_properties`.

--- a/upcoming_changes/2756.enhancements.rst
+++ b/upcoming_changes/2756.enhancements.rst
@@ -1,0 +1,2 @@
+New :attr:`~.axes.AxesManager.signal_axes` and :attr:`~.axes.AxesManager.navigation_axes` :meth:`~.misc.utils.TupleSA.set` method 
+to set multiple attributes of multiple axes at once. See :ref:`_Setting_axis_properties`.


### PR DESCRIPTION
The goal is to ease the task of setting up the axes attributes, see below for an example. 

The syntax is inspired by (but different from) https://matplotlib.org/stable/users/whats_new.html#axes-spines-access-shortcuts

### Progress of the PR
- [x] Change implemented (can be split into several points),
- [x] update docstring (if appropriate),
- [x] update user guide (if appropriate),
- [x] add an changelog entry in the `upcoming_changes` folder (see [`upcoming_changes/README.rst`](https://github.com/hyperspy/hyperspy/blob/RELEASE_next_minor/upcoming_changes/README.rst)),
- [x] add tests,
- [x] ready for review.

### Minimal example of the bug fix or the new feature
```python
>>> import hyperspy.api as hs
>>> import numpy as np
>>> s = hs.signals.Signal1D(np.random.random((10, 20, 30)))
>>> s.axes_manager.navigation_axes.set(name=("x", "y"), scale=1e-3, units="nm")
>>> s.axes_manager.signal_axes.set(name="Energy loss", offset=300, units="eV")
>>> s.axes_manager.navigation_axes.get("name", "offset")
{'name': ('x', 'y'), 'offset': (0.0, 0.0)}
>>> s.axes_manger
<Axes manager, axes: (20, 10|30)>
            Name |   size |  index |  offset |   scale |  units 
================ | ====== | ====== | ======= | ======= | ====== 
               x |     20 |      0 |       0 |   0.001 |     nm 
               y |     10 |      0 |       0 |   0.001 |     nm 
---------------- | ------ | ------ | ------- | ------- | ------ 
     Energy loss |     30 |        |   3e+02 |       1 |     eV
```


