### PR TITLE
Use mamba and conda-forge channel on azure pipeline

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -21,36 +21,45 @@ resources:
       # For more details on service connection endpoint, see
       # https://docs.microsoft.com/en-us/azure/devops/pipelines/library/service-endpoints
       endpoint: hyperspy # Azure DevOps service connection
+      ref: use_mamba
 
 strategy:
   matrix:
     Linux_Python38:
       vmImage: 'ubuntu-latest'
       PYTHON_VERSION: '3.8'
+      MAMBAFORGE_PATH: $(Agent.BuildDirectory)/mambaforge
     Linux_Python37:
       vmImage: 'ubuntu-latest'
       PYTHON_VERSION: '3.7'
+      MAMBAFORGE_PATH: $(Agent.BuildDirectory)/mambaforge
     Linux_Python36:
       vmImage: 'ubuntu-latest'
       PYTHON_VERSION: '3.6'
+      MAMBAFORGE_PATH: $(Agent.BuildDirectory)/mambaforge
     MacOS_Python38:
       vmImage: 'macOS-latest'
       PYTHON_VERSION: '3.8'
+      MAMBAFORGE_PATH: $(Agent.BuildDirectory)/mambaforge
     MacOS_Python37:
       vmImage: 'macOS-latest'
       PYTHON_VERSION: '3.7'
+      MAMBAFORGE_PATH: $(Agent.BuildDirectory)/mambaforge
     Windows_Python38:
       vmImage: 'windows-latest'
       PYTHON_VERSION: '3.8'
+      MAMBAFORGE_PATH: $(Agent.BuildDirectory)\mambaforge
     Windows_Python36:
       vmImage: 'windows-latest'
       PYTHON_VERSION: '3.6'
+      MAMBAFORGE_PATH: $(Agent.BuildDirectory)\mambaforge
 
 pool:
   vmImage: '$(vmImage)'
 
 steps:
 - template: azure_pipelines/clone_ci-scripts_repo.yml@templates
+- template: azure_pipelines/install_mambaforge.yml@templates
 - template: azure_pipelines/activate_conda.yml@templates
 - template: azure_pipelines/setup_anaconda_packages.yml@templates
 

--- a/conda_environment.yml
+++ b/conda_environment.yml
@@ -1,6 +1,5 @@
 name: test_env
 channels:
-- defaults
 - conda-forge
 dependencies:
 - dask-core >2.0

--- a/conda_environment.yml
+++ b/conda_environment.yml
@@ -15,7 +15,6 @@ dependencies:
 - numpy
 - pint
 - prettytable
-- python
 - python-dateutil
 - pyyaml
 - requests

--- a/conda_environment_dev.yml
+++ b/conda_environment_dev.yml
@@ -1,6 +1,5 @@
 name: test_env
 channels:
-- defaults
 - conda-forge
 dependencies:
 # We pin freetype and matplotlib for the image comparison

--- a/doc/dev_guide/testing.rst
+++ b/doc/dev_guide/testing.rst
@@ -177,9 +177,8 @@ The testing matrix is as follows:
   See ``.github/workflows/tests.yml`` in the HyperSpy repository for further details.
 - **Azure Pipeline**: test a range of Python versions on Linux, MacOS and Windows;
   all dependencies are installed from `Anaconda Cloud <https://anaconda.org/>`_
-  using the `Anaconda "defaults" <https://anaconda.org/anaconda>`_ and the
-  `"conda-forge" <https://anaconda.org/conda-forge>`_ channel (in this order of
-  priority). See ``azure-pipelines.yml`` in the HyperSpy repository for further details.
+  using the `"conda-forge" <https://anaconda.org/conda-forge>`_ channel.
+  See ``azure-pipelines.yml`` in the HyperSpy repository for further details.
 
 This testing matrix has been designed to be simple and easy to maintain, whilst
 ensuring that packages from PyPI and Anaconda cloud are not mixed in order to

--- a/upcoming_changes/2759.maintenance.rst
+++ b/upcoming_changes/2759.maintenance.rst
@@ -1,0 +1,1 @@
+Use mamba and conda-forge channel on azure pipeline


### PR DESCRIPTION
The azure pipeline builds have been failing regularly in the last few months and are currently failing on windows... This was because of broken packages on anaconda defaults channels.

### Progress of the PR
- [x] Use conda-forge channel instead of defaults,
- [x] use mamba to install packages (conda is too slow with conda-forge channels, because of the larger number of packages on conda-forge)
- [x] update dev guide,
- [x] add an changelog entry in the `upcoming_changes` folder (see [`upcoming_changes/README.rst`](https://github.com/hyperspy/hyperspy/blob/RELEASE_next_minor/upcoming_changes/README.rst)),
- [x] ready for review.

