### PR TITLE
Fix error message when reading hspy compressed using blosc

### DIFF
--- a/hyperspy/io_plugins/hspy.py
+++ b/hyperspy/io_plugins/hspy.py
@@ -126,6 +126,11 @@ def file_reader(filename, backing_store=False,
         Load image lazily using dask
     **kwds, optional
     """
+    try:
+        # in case blosc compression is used
+        import hdf5plugin
+    except ImportError:
+        pass
     mode = kwds.pop('mode', 'r')
     f = h5py.File(filename, mode=mode, **kwds)
     # Getting the format version here also checks if it is a valid HSpy

--- a/upcoming_changes/2760.bugfix.rst
+++ b/upcoming_changes/2760.bugfix.rst
@@ -1,0 +1,1 @@
+Fix unclear error message when reading a hspy file saved using blosc compression and `hdf5plugin` hasn't been imported previously


### PR DESCRIPTION
When reading a hspy file saved using blosc compression, an unclear error message is raised if `hdf5plugin` hasn't been imported previously - see https://github.com/silx-kit/hdf5plugin/issues/69#issuecomment-618953846.

### Progress of the PR
- [x] Try to import hdf5plugin when reading hspy file to avoid unclear error message,
- [x] add an changelog entry in the `upcoming_changes` folder (see [`upcoming_changes/README.rst`](https://github.com/hyperspy/hyperspy/blob/RELEASE_next_minor/upcoming_changes/README.rst)),
- [x] ready for review.

### Minimal example of the bug fix or the new feature
Create a signal and save it using blosc compression
```python
import hdf5plugin
import hyperspy.api as hs
import numpy as np

s = hs.signals.Signal1D(np.random.random(10*10).reshape((10, 10)))
s.save('test.hspy', compression=hdf5plugin.Blosc(cname='blosclz', clevel=9, shuffle=hdf5plugin.Blosc.SHUFFLE))
```
Try to open it in a new python process
```python
import hyperspy.api as hs

s = hs.load('test.hspy')
```
It gives the following error message:
```python
ERROR:hyperspy.io:If this file format is supported, please report this error to the HyperSpy developers.
Traceback (most recent call last):

  File "<ipython-input-3-bed9dafb25ee>", line 1, in <module>
    s = hs.load('test.hspy')

  File "/home/eric/Dev/hyperspy/hyperspy/io.py", line 423, in load
    objects = [load_single_file(filename, lazy=lazy, **kwds) for filename in filenames]

  File "/home/eric/Dev/hyperspy/hyperspy/io.py", line 423, in <listcomp>
    objects = [load_single_file(filename, lazy=lazy, **kwds) for filename in filenames]

  File "/home/eric/Dev/hyperspy/hyperspy/io.py", line 476, in load_single_file
    return load_with_reader(filename=filename, reader=reader, **kwds)

  File "/home/eric/Dev/hyperspy/hyperspy/io.py", line 496, in load_with_reader
    file_data_list = reader.file_reader(filename, **kwds)

  File "/home/eric/Dev/hyperspy/hyperspy/io_plugins/hspy.py", line 180, in file_reader
    exp = hdfgroup2signaldict(exg, lazy)

  File "/home/eric/Dev/hyperspy/hyperspy/io_plugins/hspy.py", line 237, in hdfgroup2signaldict
    data = np.asanyarray(data)

  File "/opt/miniconda3/lib/python3.8/site-packages/numpy/core/_asarray.py", line 171, in asanyarray
    return array(a, dtype, copy=False, order=order, subok=True)

  File "h5py/_objects.pyx", line 54, in h5py._objects.with_phil.wrapper

  File "h5py/_objects.pyx", line 55, in h5py._objects.with_phil.wrapper

  File "/opt/miniconda3/lib/python3.8/site-packages/h5py/_hl/dataset.py", line 1012, in __array__
    self.read_direct(arr)

  File "/opt/miniconda3/lib/python3.8/site-packages/h5py/_hl/dataset.py", line 973, in read_direct
    self.id.read(mspace, fspace, dest, dxpl=self._dxpl)

  File "h5py/_objects.pyx", line 54, in h5py._objects.with_phil.wrapper

  File "h5py/_objects.pyx", line 55, in h5py._objects.with_phil.wrapper

  File "h5py/h5d.pyx", line 192, in h5py.h5d.DatasetID.read

  File "h5py/_proxy.pyx", line 112, in h5py._proxy.dset_rw

OSError: Can't read data (can't open directory: /opt/miniconda3/lib/hdf5/plugin)
```

