### PR TITLE
non-uniform updates (NotImplementedErrors, tests, spelling, saving-fix)

### DIFF
--- a/hyperspy/component.py
+++ b/hyperspy/component.py
@@ -1245,7 +1245,7 @@ class Component(t.HasTraits):
 def _get_scaling_factor(signal, axis, parameter):
     """
     Convenience function to get the scaling factor required to take into
-    account binned and/or non uniform axes.
+    account binned and/or non-uniform axes.
 
     Parameters
     ----------

--- a/hyperspy/datasets/artificial_data.py
+++ b/hyperspy/datasets/artificial_data.py
@@ -452,10 +452,10 @@ def get_luminescence_signal(navigation_dimension=0,
     if add_baseline:
         data += 350.
 
-    #if not uniform, transformation into non-linear axis
+    #if not uniform, transformation into non-uniform axis
     if not uniform:
         hc = 1239.84198 #nm/eV
-        #converting to non uniform axis
+        #converting to non-uniform axis
         sig.axes_manager.signal_axes[0].convert_to_functional_data_axis(\
                                                               expression="a/x",
                                                               name='Energy',

--- a/hyperspy/io.py
+++ b/hyperspy/io.py
@@ -753,6 +753,7 @@ def save(filename, signal, overwrite=None, **kwds):
     # Check if the writer can write
     sd = signal.axes_manager.signal_dimension
     nd = signal.axes_manager.navigation_dimension
+    nua = signal.axes_manager.all_uniform
 
     if writer.writes is False:
         raise ValueError(
@@ -771,6 +772,14 @@ def save(filename, signal, overwrite=None, **kwds):
             f"Please try one of {strlist2enumeration(yes_we_can)}"
         )
 
+    if writer.non_uniform_axis is False and nua is False:
+        yes_we_can = [plugin.format_name for plugin in io_plugins
+                      if plugin.non_uniform_axis is True]
+        raise OSError("Writing to this format is not supported for "
+                      "non-uniform axes. Use one of the following "
+                      f"formats: {strlist2enumeration(yes_we_can)}"
+        )
+
     # Create the directory if it does not exist
     ensure_directory(filename.parent)
     is_file = filename.is_file()
@@ -782,40 +791,8 @@ def save(filename, signal, overwrite=None, **kwds):
     elif overwrite is False and is_file:
         write = False  # Don't write the file
     else:
-        # Check if the writer can write
-        sd = signal.axes_manager.signal_dimension
-        nd = signal.axes_manager.navigation_dimension
-        nua = signal.axes_manager.all_uniform
-        if writer.writes is False:
-            raise ValueError('Writing to this format is not '
-                             'supported, supported file extensions are: %s ' %
-                             strlist2enumeration(default_write_ext))
-        if writer.writes is not True and (sd, nd) not in writer.writes:
-            yes_we_can = [plugin.format_name for plugin in io_plugins
-                          if plugin.writes is True or
-                          plugin.writes is not False and
-                          (sd, nd) in plugin.writes]
-            raise IOError('This file format cannot write this data. '
-                          'The following formats can: %s' %
-                          strlist2enumeration(yes_we_can))
-        if writer.non_uniform_axis is False and nua is False:
-            yes_we_can = [plugin.format_name for plugin in io_plugins
-                          if plugin.non_uniform_axis is True]
-            raise OSError('Writing to this format is not supported for '
-                          'non-uniform axes.'
-                          'Use one of the following formats: %s' %
-                          strlist2enumeration(yes_we_can))
-        ensure_directory(filename)
-        is_file = os.path.isfile(filename)
-        if overwrite is None:
-            write = overwrite_method(filename)  # Ask what to do
-        elif overwrite is True or (overwrite is False and not is_file):
-            write = True  # Write the file
-        elif overwrite is False and is_file:
-            write = False  # Don't write the file
-        else:
-            raise ValueError("`overwrite` parameter can only be None, True or "
-                             "False.")
+        raise ValueError("`overwrite` parameter can only be None, True or "
+                         "False.")
     if write:
         # Pass as a string for now, pathlib.Path not
         # properly supported in io_plugins

--- a/hyperspy/io.py
+++ b/hyperspy/io.py
@@ -753,7 +753,6 @@ def save(filename, signal, overwrite=None, **kwds):
     # Check if the writer can write
     sd = signal.axes_manager.signal_dimension
     nd = signal.axes_manager.navigation_dimension
-    nua = signal.axes_manager.all_uniform
 
     if writer.writes is False:
         raise ValueError(
@@ -762,22 +761,22 @@ def save(filename, signal, overwrite=None, **kwds):
         )
 
     if writer.writes is not True and (sd, nd) not in writer.writes:
-        yes_we_can = [plugin.format_name for plugin in io_plugins
+        compatible_writers = [plugin.format_name for plugin in io_plugins
                       if plugin.writes is True or
                       plugin.writes is not False and
                       (sd, nd) in plugin.writes]
 
         raise IOError(
             "This file format does not support this data. "
-            f"Please try one of {strlist2enumeration(yes_we_can)}"
+            f"Please try one of {strlist2enumeration(compatible_writers)}"
         )
 
-    if writer.non_uniform_axis is False and nua is False:
-        yes_we_can = [plugin.format_name for plugin in io_plugins
+    if not writer.non_uniform_axis and not signal.axes_manager.all_uniform:
+        compatible_writers = [plugin.format_name for plugin in io_plugins
                       if plugin.non_uniform_axis is True]
-        raise OSError("Writing to this format is not supported for "
+        raise IOError("Writing to this format is not supported for "
                       "non-uniform axes. Use one of the following "
-                      f"formats: {strlist2enumeration(yes_we_can)}"
+                      f"formats: {strlist2enumeration(compatible_writers)}"
         )
 
     # Create the directory if it does not exist

--- a/hyperspy/io.py
+++ b/hyperspy/io.py
@@ -801,8 +801,8 @@ def save(filename, signal, overwrite=None, **kwds):
         if writer.non_uniform_axis is False and nua is False:
             yes_we_can = [plugin.format_name for plugin in io_plugins
                           if plugin.non_uniform_axis is True]
-            raise OSError('Writing to this format is not supported for non '
-                          'uniform axes.'
+            raise OSError('Writing to this format is not supported for '
+                          'non-uniform axes.'
                           'Use one of the following formats: %s' %
                           strlist2enumeration(yes_we_can))
         ensure_directory(filename)

--- a/hyperspy/io.py
+++ b/hyperspy/io.py
@@ -766,7 +766,7 @@ def save(filename, signal, overwrite=None, **kwds):
                       plugin.writes is not False and
                       (sd, nd) in plugin.writes]
 
-        raise IOError(
+        raise TypeError(
             "This file format does not support this data. "
             f"Please try one of {strlist2enumeration(compatible_writers)}"
         )
@@ -774,7 +774,7 @@ def save(filename, signal, overwrite=None, **kwds):
     if not writer.non_uniform_axis and not signal.axes_manager.all_uniform:
         compatible_writers = [plugin.format_name for plugin in io_plugins
                       if plugin.non_uniform_axis is True]
-        raise IOError("Writing to this format is not supported for "
+        raise TypeError("Writing to this format is not supported for "
                       "non-uniform axes. Use one of the following "
                       f"formats: {strlist2enumeration(compatible_writers)}"
         )

--- a/hyperspy/io_plugins/README
+++ b/hyperspy/io_plugins/README
@@ -21,8 +21,8 @@ All the read/write plugins must provide a python file containing:
         writes_images = <Bool>
         writes_spectrum = <Bool>
         writes_spectrum_image = <Bool>
-        # Support for non linear axis
-        non_linear_axis = <Bool>
+        # Support for non-uniform axis
+        non_uniform_axis = <Bool>
 
     - A function called file_reader with at least one attribute: filename
 

--- a/hyperspy/io_plugins/emd.py
+++ b/hyperspy/io_plugins/emd.py
@@ -684,7 +684,7 @@ class EMD_NCEM:
                                    simu_om.get('cellDimension', 0)[0])
                 if not math.isclose(total_thickness, len(array_list) * scale,
                                     rel_tol=1e-4):
-                    _logger.warning("Depth axis is non uniform and its offset "
+                    _logger.warning("Depth axis is non-uniform and its offset "
                                     "and scale can't be set accurately.")
                     # When non-uniform/non-linear axis are implemented, adjust
                     # the final depth to the "total_thickness"
@@ -798,7 +798,7 @@ class EMD_NCEM:
             offset, scale = axis_data[0], np.diff(axis_data).mean()
         else:
             # This is a string, return default values
-            # When non-linear axis is supported we should be able to parse
+            # When non-uniform axis is supported we should be able to parse
             # string
             offset, scale = 0, 1
         return offset, scale

--- a/hyperspy/io_plugins/hspy.py
+++ b/hyperspy/io_plugins/hspy.py
@@ -79,7 +79,7 @@ version = "3.1"
 # CHANGES
 #
 # v3.1
-# - add read support for non-linear DataAxis defined by 'axis' vector
+# - add read support for non-uniform DataAxis defined by 'axis' vector
 # - move metadata.Signal.binned attribute to axes.is_binned parameter
 #
 # v3.0

--- a/hyperspy/io_plugins/jeol.py
+++ b/hyperspy/io_plugins/jeol.py
@@ -42,6 +42,8 @@ reads_spectrum = True
 reads_spectrum_image = True
 # Writing capabilities
 writes = False
+non_uniform_axis = False
+# ----------------------
 
 
 jTYPE = {

--- a/hyperspy/models/model1d.py
+++ b/hyperspy/models/model1d.py
@@ -319,7 +319,7 @@ class Model1D(BaseModel):
                                  'navigation dimension as the core-loss.')
             if not value.axes_manager.signal_axes[0].is_uniform:
                 raise ValueError('Low loss convolution is not supported with '
-                                 'non linear signal axes.')
+                                 'non-uniform signal axes.')
             self._low_loss = value
             self.set_convolution_axis()
             self.convolved = True

--- a/hyperspy/signal_tools.py
+++ b/hyperspy/signal_tools.py
@@ -201,7 +201,7 @@ class Signal1DCalibration(SpanSelectorInSignal1D):
             raise SignalDimensionError(
                 signal.axes_manager.signal_dimension, 1)
         if not isinstance(self.axis, UniformDataAxis):
-            raise ValueError("The calibration tool supports only uniform axes.")
+            raise NotImplementedError("The calibration tool supports only uniform axes.")
         self.units = self.axis.units
         self.scale = self.axis.scale
         self.offset = self.axis.offset

--- a/hyperspy/tests/io/test_io.py
+++ b/hyperspy/tests/io/test_io.py
@@ -87,6 +87,10 @@ class TestIOOverwriting:
             self.new_s.save(FULLFILENAME)
             assert not self._check_file_is_written(FULLFILENAME)
 
+    def test_io_overwriting_invalid_parameter(self):
+        with pytest.raises(ValueError, match="parameter can only be"):
+            self.new_s.save(FULLFILENAME, overwrite="spam")
+
     def teardown_method(self, method):
         self._clean_file()
 
@@ -110,6 +114,17 @@ class TestNonUniformAxisCheck:
             except AttributeError:
                 print(plugin.format_name + ' IO-plugin is missing the '
                       'characteristic `non_uniform_axis`')
+
+    def test_nonuniform_error(self):
+        assert(self.s.axes_manager[0].is_uniform == False)
+        no_we_cant = [plugin.file_extensions[0] for plugin in io_plugins
+                      if (plugin.writes is True or plugin.writes is not False
+                      and (0, 1) in plugin.writes) and 
+                      plugin.non_uniform_axis is False]
+        for ext in no_we_cant:
+            with pytest.raises(OSError, match = "not supported for"):
+                filename = 'tmp.' + ext
+                self.s.save(filename, overwrite = True)
 
     def teardown_method(self):
         if os.path.exists('tmp.hspy'):

--- a/hyperspy/tests/io/test_io.py
+++ b/hyperspy/tests/io/test_io.py
@@ -104,7 +104,7 @@ class TestNonUniformAxisCheck:
     def test_io_nonuniform(self):
         assert(self.s.axes_manager[0].is_uniform == False)
         self.s.save('tmp.hspy', overwrite = True)
-        with pytest.raises(OSError):
+        with pytest.raises(IOError, match = "not supported for non-uniform"):
             self.s.save('tmp.msa', overwrite = True)
 
     def test_nonuniform_writer_characteristic(self):
@@ -117,12 +117,12 @@ class TestNonUniformAxisCheck:
 
     def test_nonuniform_error(self):
         assert(self.s.axes_manager[0].is_uniform == False)
-        no_we_cant = [plugin.file_extensions[plugin.default_extension] for
-                      plugin in io_plugins if (plugin.writes is True or
+        incompatible_writers = [plugin.file_extensions[plugin.default_extension]
+                      for plugin in io_plugins if (plugin.writes is True or
                       plugin.writes is not False and (1, 0) in plugin.writes)
                       and plugin.non_uniform_axis is False]
-        for ext in no_we_cant:
-            with pytest.raises(OSError, match = "not supported for"):
+        for ext in incompatible_writers:
+            with pytest.raises(IOError, match = "not supported for non-uniform"):
                 filename = 'tmp.' + ext
                 self.s.save(filename, overwrite = True)
 

--- a/hyperspy/tests/io/test_io.py
+++ b/hyperspy/tests/io/test_io.py
@@ -118,7 +118,7 @@ class TestNonUniformAxisCheck:
     def test_nonuniform_error(self):
         assert(self.s.axes_manager[0].is_uniform == False)
         no_we_cant = [plugin.file_extensions[plugin.default_extension] for
-                      plugin in io_pluginsif (plugin.writes is True or
+                      plugin in io_plugins if (plugin.writes is True or
                       plugin.writes is not False and (1, 0) in plugin.writes)
                       and plugin.non_uniform_axis is False]
         for ext in no_we_cant:

--- a/hyperspy/tests/io/test_io.py
+++ b/hyperspy/tests/io/test_io.py
@@ -117,10 +117,10 @@ class TestNonUniformAxisCheck:
 
     def test_nonuniform_error(self):
         assert(self.s.axes_manager[0].is_uniform == False)
-        no_we_cant = [plugin.file_extensions[0] for plugin in io_plugins
-                      if (plugin.writes is True or plugin.writes is not False
-                      and (0, 1) in plugin.writes) and 
-                      plugin.non_uniform_axis is False]
+        no_we_cant = [plugin.file_extensions[plugin.default_extension] for
+                      plugin in io_pluginsif (plugin.writes is True or
+                      plugin.writes is not False and (1, 0) in plugin.writes)
+                      and plugin.non_uniform_axis is False]
         for ext in no_we_cant:
             with pytest.raises(OSError, match = "not supported for"):
                 filename = 'tmp.' + ext

--- a/hyperspy/tests/io/test_io.py
+++ b/hyperspy/tests/io/test_io.py
@@ -104,7 +104,7 @@ class TestNonUniformAxisCheck:
     def test_io_nonuniform(self):
         assert(self.s.axes_manager[0].is_uniform == False)
         self.s.save('tmp.hspy', overwrite = True)
-        with pytest.raises(AttributeError):
+        with pytest.raises(OSError):
             self.s.save('tmp.msa', overwrite = True)
 
     def test_nonuniform_writer_characteristic(self):

--- a/hyperspy/tests/io/test_io.py
+++ b/hyperspy/tests/io/test_io.py
@@ -104,7 +104,7 @@ class TestNonUniformAxisCheck:
     def test_io_nonuniform(self):
         assert(self.s.axes_manager[0].is_uniform == False)
         self.s.save('tmp.hspy', overwrite = True)
-        with pytest.raises(IOError, match = "not supported for non-uniform"):
+        with pytest.raises(TypeError, match = "not supported for non-uniform"):
             self.s.save('tmp.msa', overwrite = True)
 
     def test_nonuniform_writer_characteristic(self):
@@ -122,7 +122,7 @@ class TestNonUniformAxisCheck:
                       plugin.writes is not False and (1, 0) in plugin.writes)
                       and plugin.non_uniform_axis is False]
         for ext in incompatible_writers:
-            with pytest.raises(IOError, match = "not supported for non-uniform"):
+            with pytest.raises(TypeError, match = "not supported for non-uniform"):
                 filename = 'tmp.' + ext
                 self.s.save(filename, overwrite = True)
 

--- a/hyperspy/tests/io/test_ripple.py
+++ b/hyperspy/tests/io/test_ripple.py
@@ -22,7 +22,7 @@ MYPATH = os.path.dirname(__file__)
 def test_write_unsupported_data_shape():
     data = np.arange(5 * 10 * 15 * 20).reshape((5, 10, 15, 20))
     s = signals.Signal1D(data)
-    with pytest.raises(IOError):
+    with pytest.raises(TypeError):
         s.save('test_write_unsupported_data_shape.rpl')
 
 

--- a/hyperspy/tests/signals/test_1D_tools.py
+++ b/hyperspy/tests/signals/test_1D_tools.py
@@ -210,31 +210,22 @@ class TestInterpolateInBetween:
         s.isig[8:12] = 0
         self.s = s
 
-    def test_single_spectrum(self):
+    @pytest.mark.parametrize('uniform', [True, False])
+    def test_single_spectrum(self, uniform):
         s = self.s.inav[0]
         m = mock.Mock()
         s.events.data_changed.connect(m.data_changed)
+        if not uniform:
+            s.axes_manager[-1].convert_to_non_uniform_axis()
         s.interpolate_in_between(8, 12)
         np.testing.assert_array_equal(s.data, np.arange(20))
         assert m.data_changed.called
 
-    def test_single_spectrum_nonuniform(self):
+    @pytest.mark.parametrize('uniform', [True, False])
+    def test_single_spectrum_in_units(self, uniform):
         s = self.s.inav[0]
-        m = mock.Mock()
-        s.events.data_changed.connect(m.data_changed)
-        s.axes_manager[-1].convert_to_non_uniform_axis()
-        s.interpolate_in_between(8, 12)
-        np.testing.assert_array_equal(s.data, np.arange(20))
-        assert m.data_changed.called
-
-    def test_single_spectrum_in_units(self):
-        s = self.s.inav[0]
-        s.interpolate_in_between(0.8, 1.2)
-        np.testing.assert_array_equal(s.data, np.arange(20))
-
-    def test_single_spectrum_in_units_nonuniform(self):
-        s = self.s.inav[0]
-        s.axes_manager[-1].convert_to_non_uniform_axis()
+        if not uniform:
+            s.axes_manager[-1].convert_to_non_uniform_axis()
         s.interpolate_in_between(0.8, 1.2)
         np.testing.assert_array_equal(s.data, np.arange(20))
 
@@ -254,27 +245,15 @@ class TestInterpolateInBetween:
         np.testing.assert_allclose(
             s.data[8:12], np.array([44., 95.4, 139.6, 155.]))
 
-    def test_delta_float(self):
+    @pytest.mark.parametrize('uniform', [True, False])
+    def test_delta_float(self, uniform):
         s = self.s.inav[0]
         s.change_dtype('float')
         tmp = np.zeros(s.data.shape)
         tmp[12] = s.data[12]
         s.data += tmp * 9.
-        s.interpolate_in_between(8, 12, delta=0.31, kind='cubic')
-        print(s.data[8:12])
-        np.testing.assert_allclose(
-            s.data[8:12], np.array([46.595205, 109.802805, 
-                                    164.512803, 178.615201]),
-            atol=1,
-        )
-
-    def test_delta_float_nonuniform(self):
-        s = self.s.inav[0]
-        s.change_dtype('float')
-        tmp = np.zeros(s.data.shape)
-        tmp[12] = s.data[12]
-        s.data += tmp * 9.
-        s.axes_manager[0].convert_to_non_uniform_axis()
+        if not uniform:
+            s.axes_manager[0].convert_to_non_uniform_axis()
         s.interpolate_in_between(8, 12, delta=0.31, kind='cubic')
         print(s.data[8:12])
         np.testing.assert_allclose(

--- a/hyperspy/tests/signals/test_1D_tools.py
+++ b/hyperspy/tests/signals/test_1D_tools.py
@@ -229,12 +229,12 @@ class TestInterpolateInBetween:
 
     def test_single_spectrum_in_units(self):
         s = self.s.inav[0]
-        s.axes_manager[-1].convert_to_non_uniform_axis()
         s.interpolate_in_between(0.8, 1.2)
         np.testing.assert_array_equal(s.data, np.arange(20))
 
     def test_single_spectrum_in_units_nonuniform(self):
         s = self.s.inav[0]
+        s.axes_manager[-1].convert_to_non_uniform_axis()
         s.interpolate_in_between(0.8, 1.2)
         np.testing.assert_array_equal(s.data, np.arange(20))
 

--- a/hyperspy/tests/signals/test_1D_tools.py
+++ b/hyperspy/tests/signals/test_1D_tools.py
@@ -218,7 +218,22 @@ class TestInterpolateInBetween:
         np.testing.assert_array_equal(s.data, np.arange(20))
         assert m.data_changed.called
 
+    def test_single_spectrum_nonuniform(self):
+        s = self.s.inav[0]
+        m = mock.Mock()
+        s.events.data_changed.connect(m.data_changed)
+        s.axes_manager[-1].convert_to_non_uniform_axis()
+        s.interpolate_in_between(8, 12)
+        np.testing.assert_array_equal(s.data, np.arange(20))
+        assert m.data_changed.called
+
     def test_single_spectrum_in_units(self):
+        s = self.s.inav[0]
+        s.axes_manager[-1].convert_to_non_uniform_axis()
+        s.interpolate_in_between(0.8, 1.2)
+        np.testing.assert_array_equal(s.data, np.arange(20))
+
+    def test_single_spectrum_in_units_nonuniform(self):
         s = self.s.inav[0]
         s.interpolate_in_between(0.8, 1.2)
         np.testing.assert_array_equal(s.data, np.arange(20))
@@ -248,8 +263,23 @@ class TestInterpolateInBetween:
         s.interpolate_in_between(8, 12, delta=0.31, kind='cubic')
         print(s.data[8:12])
         np.testing.assert_allclose(
-            s.data[8:12], np.array([45.09388598, 104.16170809,
-                                    155.48258721, 170.33564422]),
+            s.data[8:12], np.array([46.595205, 109.802805, 
+                                    164.512803, 178.615201]),
+            atol=1,
+        )
+
+    def test_delta_float_nonuniform(self):
+        s = self.s.inav[0]
+        s.change_dtype('float')
+        tmp = np.zeros(s.data.shape)
+        tmp[12] = s.data[12]
+        s.data += tmp * 9.
+        s.axes_manager[0].convert_to_non_uniform_axis()
+        s.interpolate_in_between(8, 12, delta=0.31, kind='cubic')
+        print(s.data[8:12])
+        np.testing.assert_allclose(
+            s.data[8:12], np.array([46.595205, 109.802805, 
+                                    164.512803, 178.615201]),
             atol=1,
         )
 

--- a/hyperspy/tests/test_non-uniform_not-implemented.py
+++ b/hyperspy/tests/test_non-uniform_not-implemented.py
@@ -42,7 +42,11 @@ def test_signal1d():
     s = Signal1D((1))
     s.axes_manager[0].convert_to_non_uniform_axis()
     with pytest.raises(NotImplementedError):
+        s.calibrate()
+    with pytest.raises(NotImplementedError):
         s.shift1D([1])
+    with pytest.raises(NotImplementedError):
+        s.estimate_shift1D([1])
     with pytest.raises(NotImplementedError):
         s.smooth_savitzky_golay()
     with pytest.raises(NotImplementedError):


### PR DESCRIPTION
### Description of the change
- Replace remaining mentions of 'non-linear' instead of 'non-uniform' axis
- Replace remaining misspellings of 'non uniform' instead of 'non-uniform' axis
- Add missing catches for non-uniform axis  few sentences and/or a bulleted list to describe and motivate the change:
- Implement `interpolate_in_between` for non-uniform axis with `delta` being `float`
- fix error in io-save-code introduced by some merge of RnM: https://github.com/hyperspy/hyperspy/pull/2399/files#r629224770

### Progress of the PR
- [x] Changes implemented (can be split into several points),
- [x] add tests,
- [x] ready for review.
