### PR TITLE
Fix warning when build doc and formatting user guide

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -25,19 +25,19 @@ Bug Fixes
 
 * Fix disconnect event when closing navigator only plot (fixes `#996 <https://github.com/hyperspy/hyperspy/issues/996>`_), (`#2631 <https://github.com/hyperspy/hyperspy/pull/2631>`_)
 * Fix incorrect chunksize when saving EMD NCEM file and specifying chunks (`#2629 <https://github.com/hyperspy/hyperspy/pull/2629>`_)
-* Fix ``find_peaks`` GUIs call with laplacian/difference of gaussian methods (`#2622 <https://github.com/hyperspy/hyperspy/issues/2622>`_ and `#2647 <https://github.com/hyperspy/hyperspy/pull/2647>`_)
+* Fix :py:meth:`~._signals.signal2d.Signal2D.find_peaks` GUIs call with laplacian/difference of gaussian methods (`#2622 <https://github.com/hyperspy/hyperspy/issues/2622>`_ and `#2647 <https://github.com/hyperspy/hyperspy/pull/2647>`_)
 * Fix various bugs with ``CircleWidget`` and ``Line2DWidget`` (`#2625 <https://github.com/hyperspy/hyperspy/pull/2625>`_)
 * Fix setting signal range of model with negative axis scales (`#2656 <https://github.com/hyperspy/hyperspy/pull/2656>`_)
 * Fix and improve mask handling in lazy decomposition; Close `#2605 <https://github.com/hyperspy/hyperspy/issues/2605>`_ (`#2657 <https://github.com/hyperspy/hyperspy/pull/2657>`_)
 * Plot scalebar when the axis scales have different sign, fixes `#2557 <https://github.com/hyperspy/hyperspy/issues/2557>`_ (`#2657 <https://github.com/hyperspy/hyperspy/pull/2657>`_)
-* Fix align1D returning zeros shifts (`#2675 <https://github.com/hyperspy/hyperspy/pull/2675>`_)
+* Fix :py:meth:`~._signals.signal1d.Signal1D.align1D` returning zeros shifts (`#2675 <https://github.com/hyperspy/hyperspy/pull/2675>`_)
 * Fix finding dataset path for EMD NCEM file containing more than one dataset in a  group (`#2673 <https://github.com/hyperspy/hyperspy/pull/2673>`_)
 * Fix squeeze function for multiple zero-dimensional entries, improved docstring, added to user guide. (`#2676 <https://github.com/hyperspy/hyperspy/pull/2676>`_)
 * Fix error in Cliff-Lorimer quantification using absorption correction (`#2681 <https://github.com/hyperspy/hyperspy/pull/2681>`_)
 * Fix ``navigation_mask`` bug in decomposition when provided as numpy array (`#2679 <https://github.com/hyperspy/hyperspy/pull/2679>`_)
 * Fix closing image contrast tool and setting vmin/vmax values (`#2684 <https://github.com/hyperspy/hyperspy/pull/2684>`_)
 * Fix range widget with matplotlib 3.4 (`#2684 <https://github.com/hyperspy/hyperspy/pull/2684>`_)
-* Fix bug in `hs.interactive` with function returning `None`. Improve user guide example. (`#2686 <https://github.com/hyperspy/hyperspy/pull/2686>`_)
+* Fix bug in :py:func:`~.interactive.interactive` with function returning `None`. Improve user guide example. (`#2686 <https://github.com/hyperspy/hyperspy/pull/2686>`_)
 * Fix broken events when changing signal type `#2683 <https://github.com/hyperspy/hyperspy/pull/2683>`_
 * Fix setting offset in rebin: the offset was changed in the wrong axis (`#2690 <https://github.com/hyperspy/hyperspy/pull/2690>`_)
 * Fix reading XRF bruker file, close `#2689 <https://github.com/hyperspy/hyperspy/issues/2689>`_ (`#2694 <https://github.com/hyperspy/hyperspy/pull/2694>`_)
@@ -51,7 +51,7 @@ Enhancements
 * Improve error message when file not found (`#2597 <https://github.com/hyperspy/hyperspy/pull/2597>`_)
 * Add update instructions to user guide (`#2621 <https://github.com/hyperspy/hyperspy/pull/2621>`_)
 * Improve plotting navigator of lazy signals, add ``navigator`` setter to lazy signals (`#2631 <https://github.com/hyperspy/hyperspy/pull/2631>`_)
-* Use 'dask_auto' when rechunk=True in ``change_dtype`` for lazy signal (`#2645 <https://github.com/hyperspy/hyperspy/pull/2645>`_)
+* Use ``'dask_auto'`` when rechunk=True in :py:meth:`~._signals.lazy.LazySignal.change_dtype` for lazy signal (`#2645 <https://github.com/hyperspy/hyperspy/pull/2645>`_)
 * Use dask chunking when saving lazy signal instead of rechunking and leave the user to decide what is the suitable chunking (`#2629 <https://github.com/hyperspy/hyperspy/pull/2629>`_)
 * Added lazy reading support for FFT and DPC datasets in FEI emd datasets (`#2651 <https://github.com/hyperspy/hyperspy/pull/2651>`_).
 * Improve error message when initialising SpanROI with left >= right (`#2604 <https://github.com/hyperspy/hyperspy/pull/2604>`_)
@@ -59,8 +59,8 @@ Enhancements
 * Add Releasing guide (`#2595 <https://github.com/hyperspy/hyperspy/pull/2595>`_)
 * Add support for python 3.9, fix deprecation warning with matplotlib 3.4.0 and bump minimum requirement to numpy 1.17.1 and dask 2.1.0. (`#2663 <https://github.com/hyperspy/hyperspy/pull/2663>`_)
 * Use native endianess in numba jitted functions. (`#2678 <https://github.com/hyperspy/hyperspy/pull/2678>`_)
-* Add option not to snap ROI when calling the `interactive` method of a ROI (`#2686 <https://github.com/hyperspy/hyperspy/pull/2686>`_)
-* Make DictionaryTreeBrowser lazy by default - see `#368 <https://github.com/hyperspy/hyperspy/issues/368>`_ (`#2623 <https://github.com/hyperspy/hyperspy/pull/2623>`_)
+* Add option not to snap ROI when calling the :py:meth:`~.roi.BaseInteractiveROI.interactive` method of a ROI (`#2686 <https://github.com/hyperspy/hyperspy/pull/2686>`_)
+* Make :py:class:`~.misc.utils.DictionaryTreeBrowser` lazy by default - see `#368 <https://github.com/hyperspy/hyperspy/issues/368>`_ (`#2623 <https://github.com/hyperspy/hyperspy/pull/2623>`_)
 * Speed up setting CI on azure pipeline (`#2694 <https://github.com/hyperspy/hyperspy/pull/2694>`_)
 * Improve performance issue with the map method of lazy signal (`#2617 <https://github.com/hyperspy/hyperspy/pull/2617>`_)
 * Add option to copy/load original metadata in ``hs.stack`` and ``hs.load`` to avoid large ``original_metadata`` which can slowdown processing. Close `#1398 <https://github.com/hyperspy/hyperspy/issues/1398>`_, `#2045 <https://github.com/hyperspy/hyperspy/issues/2045>`_, `#2536 <https://github.com/hyperspy/hyperspy/issues/2536>`_ and `#1568 <https://github.com/hyperspy/hyperspy/issues/1568>`_. (`#2691 <https://github.com/hyperspy/hyperspy/pull/2691>`_)
@@ -74,7 +74,7 @@ Maintenance
 * Run test suite against upstream dependencies (numpy, scipy, scikit-learn and scikit-image) (`#2616 <https://github.com/hyperspy/hyperspy/pull/2616>`_)
 * Update external links in the loading data section of the user guide (`#2627 <https://github.com/hyperspy/hyperspy/pull/2627>`_)
 * Fix various future and deprecation warnings from numpy and scikit-learn (`#2646 <https://github.com/hyperspy/hyperspy/pull/2646>`_)
-* Fix ``iterpath`` VisibleDeprecationWarning when using ``fit_component`` (`#2654 <https://github.com/hyperspy/hyperspy/pull/2654>`_)
+* Fix ``iterpath`` VisibleDeprecationWarning when using :py:meth:`~.models.model1d.Model1D.fit_component` (`#2654 <https://github.com/hyperspy/hyperspy/pull/2654>`_)
 * Add integration test suite documentation in the developer guide. (`#2663 <https://github.com/hyperspy/hyperspy/pull/2663>`_)
 * Fix SkewNormal component compatibility with sympy 1.8 (`#2701 <https://github.com/hyperspy/hyperspy/pull/2701>`_)
 
@@ -106,7 +106,7 @@ NEW
   * :ref:`usid-format`
   * :ref:`empad-format`
   * Prismatic EMD format, see :ref:`emd-format`
-* :meth:`~._signals.eels.EELSSpectrum_mixin.print_edges_near_energy` method
+* :meth:`~._signals.eels.EELSSpectrum.print_edges_near_energy` method
   that, if the `hyperspy-gui-ipywidgets package
   <https://github.com/hyperspy/hyperspy_gui_ipywidgets>`_
   is installed, includes an
@@ -130,12 +130,12 @@ Enhancements
 * Further improvements to the contrast adjustment tool.
   Test it by pressing the ``h`` key on any image.
 * The following components have been rewritten using
-  :py:class:`hyperspy._components.expression.Expression`, boosting their
+  :py:class:`~._components.expression.Expression`, boosting their
   speeds among other benefits.
 
-  * :py:class:`hyperspy._components.arctan.Arctan`
-  * :py:class:`hyperspy._components.voigt.Voigt`
-  * :py:class:`hyperspy._components.heaviside.HeavisideStep`
+  * :py:class:`~._components.arctan.Arctan`
+  * :py:class:`~._components.voigt.Voigt`
+  * :py:class:`~._components.heaviside.HeavisideStep`
 * The model fitting :py:meth:`~.model.BaseModel.fit` and
   :py:meth:`~.model.BaseModel.multifit` methods have been vastly improved. See
   :ref:`model.fitting` and the API changes section below.
@@ -152,7 +152,7 @@ Enhancements
   scikit-learn like algorithms, better API and much improved documentation.
   See :ref:`ml-label` and the API changes section below.
 * Add option to calculate the absolute thickness to the EELS
-  :meth:`~._signals.eels.EELSSpectrum_mixin.estimate_thickness` method.
+  :meth:`~._signals.eels.EELSSpectrum.estimate_thickness` method.
   See :ref:`eels_thickness-label`.
 * Vastly improved performance and memory footprint of the
   :py:meth:`~._signals.signal2d.Signal2D.estimate_shift2D` method.
@@ -1222,8 +1222,8 @@ Major bugs fixed
 
 API changes
 -----------
-* EELSSPectrum.find_low_loss_centre was renamed to estimate_zero_loss_peak_centre.
-* EELSSPectrum.calculate_FWHM was renamed to estimate_FWHM.
+* EELSSpectrum.find_low_loss_centre was renamed to estimate_zero_loss_peak_centre.
+* EELSSpectrum.calculate_FWHM was renamed to estimate_FWHM.
 
 .. _changes_0.5:
 

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -13,7 +13,6 @@
 
 from hyperspy import Release
 import sys
-import os
 from datetime import datetime
 
 sys.path.append('../')
@@ -271,9 +270,10 @@ def run_apidoc(_):
     cur_dir = os.path.normpath(os.path.dirname(__file__))
     output_path = os.path.join(cur_dir, 'api')
     modules = os.path.normpath(os.path.join(cur_dir, "../hyperspy"))
-    exclude_pattern = "../hyperspy/tests"
-    exclude_pattern2 = "../hyperspy/external"
-    main(['-e', '-f', '-P', '-o', output_path, modules, exclude_pattern, exclude_pattern2])
+    exclude_pattern = ["../hyperspy/tests",
+                       "../hyperspy/external",
+                       "../hyperspy/io_plugins/unbcf_fast.pyx"]
+    main(['-e', '-f', '-P', '-o', output_path, modules, *exclude_pattern])
 
 
 def setup(app):

--- a/doc/user_guide/eds.rst
+++ b/doc/user_guide/eds.rst
@@ -122,7 +122,7 @@ You can also set these parameters directly:
     >>> s.metadata.Acquisition_instrument.SEM.beam_energy = 30
 
 or by using the
-:py:meth:`~._signals.eds_tem.EDSTEM_mixin.set_microscope_parameters` method:
+:py:meth:`~._signals.eds_tem.EDSTEMSpectrum.set_microscope_parameters` method:
 
 .. code-block:: python
 
@@ -197,7 +197,7 @@ Copying spectrum calibration
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 All of the above parameters can be copied from one spectrum to another
-with the :py:meth:`~._signals.eds_tem.EDSTEM_mixin.get_calibration_from`
+with the :py:meth:`~._signals.eds_tem.EDSTEMSpectrum.get_calibration_from`
 method.
 
 .. code-block:: python
@@ -241,8 +241,8 @@ Elements
 ^^^^^^^^
 
 The elements present in the sample can be defined using the
-:py:meth:`~._signals.eds.EDS_mixin.set_elements`  and
-:py:meth:`~._signals.eds.EDS_mixin.add_elements` methods.  Only element
+:py:meth:`~._signals.eds.EDSSpectrum.set_elements`  and
+:py:meth:`~._signals.eds.EDSSpectrum.add_elements` methods.  Only element
 abbreviations are accepted:
 
 .. code-block:: python
@@ -257,8 +257,8 @@ X-ray lines
 ^^^^^^^^^^^
 
 Similarly, the X-ray lines can be defined using the
-:py:meth:`~._signals.eds.EDS_mixin.set_lines` and
-:py:meth:`~._signals.eds.EDS_mixin.add_lines` methods. The corresponding
+:py:meth:`~._signals.eds.EDSSpectrum.set_lines` and
+:py:meth:`~._signals.eds.EDSSpectrum.add_lines` methods. The corresponding
 elements will be added automatically.
 Several lines per element can be defined at once.
 
@@ -364,7 +364,7 @@ Plotting
 --------
 
 You can visualize an EDS spectrum using the
-:py:meth:`~._signals.eds.EDS_mixin.plot` method (see
+:py:meth:`~._signals.eds.EDSSpectrum.plot` method (see
 :ref:`visualisation<visualization-label>`). For example:
 
 .. code-block:: python
@@ -388,9 +388,9 @@ Plotting X-ray lines
 ^^^^^^^^^^^^^^^^^^^^
 
 X-ray lines can be added as plot labels with
-:py:meth:`~._signals.eds.EDS_mixin.plot`. The lines are either retrieved
+:py:meth:`~._signals.eds.EDSSpectrum.plot`. The lines are either retrieved
 from `metadata.Sample.Xray_lines`, or selected with the same method as
-:py:meth:`~._signals.eds.EDS_mixin.add_lines` using the elements in
+:py:meth:`~._signals.eds.EDSSpectrum.add_lines` using the elements in
 `metadata.Sample.elements`.
 
 .. code-block:: python
@@ -471,7 +471,7 @@ for more information in setting plotting parameters.
    :width:   500
 
 Finally, the windows of integration can be visualised using
-:py:meth:`~._signals.eds.EDS_mixin.plot` method:
+:py:meth:`~._signals.eds.EDSSpectrum.plot` method:
 
 .. code-block:: python
 
@@ -491,12 +491,12 @@ Background subtraction
 ^^^^^^^^^^^^^^^^^^^^^^
 
 The background can be subtracted from the X-ray intensities with
-:py:meth:`~._signals.eds.EDS_mixin.get_lines_intensity`.
+:py:meth:`~._signals.eds.EDSSpectrum.get_lines_intensity`.
 The background value is obtained by averaging the intensity in two
 windows on each side of the X-ray line.
 The position of the windows can be estimated using
-:py:meth:`~._signals.eds.EDS_mixin.estimate_background_windows`, and
-can be plotted using :py:meth:`~._signals.eds.EDS_mixin.plot`:
+:py:meth:`~._signals.eds.EDSSpectrum.estimate_background_windows`, and
+can be plotted using :py:meth:`~._signals.eds.EDSSpectrum.plot`:
 
 .. code-block:: python
 
@@ -531,7 +531,7 @@ set the beam energy:
     >>> s.set_microscope_parameters(beam_energy=10)
 
 Next, the model is created with
-:py:meth:`~._signals.eds_sem.EDSSEM_mixin.create_model`. One Gaussian is
+:py:meth:`~._signals.eds_sem.EDSSEMSpectrum.create_model`. One Gaussian is
 automatically created per X-ray line, along with a polynomial for the
 background.
 
@@ -664,9 +664,9 @@ absorption correction:
 * Ionization cross sections
 
 Quantification must be applied to the background-subtracted intensities, which
-can be found using :py:meth:`~._signals.eds.EDS_mixin.get_lines_intensity`.
+can be found using :py:meth:`~._signals.eds.EDSSpectrum.get_lines_intensity`.
 The quantification of these intensities can then be calculated using
-:py:meth:`~._signals.eds_tem.EDSTEM_mixin.quantification`.
+:py:meth:`~._signals.eds_tem.EDSTEMSpectrum.quantification`.
 
 The quantification method needs be specified as either 'CL', 'zeta', or
 'cross_section'. If no method is specified, the function will raise an
@@ -674,7 +674,7 @@ exception.
 
 A list of factors or cross sections should be supplied in the same order as
 the listed intensities (please note that HyperSpy intensities in
-:py:meth:`~._signals.eds.EDS_mixin.get_lines_intensity` are in alphabetical
+:py:meth:`~._signals.eds.EDSSpectrum.get_lines_intensity` are in alphabetical
 order).
 
 A set of k-factors can be usually found in the EDS manufacturer software
@@ -708,7 +708,7 @@ out as follows:
 
 The obtained composition is in atomic percent, by default. However, it can be
 transformed into weight percent either with the option
-:py:meth:`~._signals.eds_tem.EDSTEM_mixin.quantification`:
+:py:meth:`~._signals.eds_tem.EDSTEMSpectrum.quantification`:
 
 .. code-block:: python
 

--- a/doc/user_guide/eels.rst
+++ b/doc/user_guide/eels.rst
@@ -30,7 +30,7 @@ Elemental composition of the sample
 It can be useful to define the elemental composition of the sample for
 archiving purposes or to use some feature (e.g. curve fitting) that requires
 this information.  The elemental composition of the sample can be declared
-using :py:meth:`~._signals.eels.EELSSpectrum_mixin.add_elements`. The
+using :py:meth:`~._signals.eels.EELSSpectrum.add_elements`. The
 information is stored in the :py:attr:`~.signal.BaseSignal.metadata`
 attribute (see :ref:`metadata_structure`). This information is saved to file
 when saving in the hspy format (HyperSpy's HDF5 specification).
@@ -54,7 +54,7 @@ they are arranged in the order closest to 849 eV.
 
 
 `
-The static method :py:meth:`~._signals.eels.EELSSpectrum_mixin.print_edges_near_energy`
+The static method :py:meth:`~._signals.eels.EELSSpectrum.print_edges_near_energy`
 in :py:class:`~._signals.eels.EELSSpectrum` will print out a table containing
 more information about the edges.
 
@@ -74,7 +74,7 @@ more information about the edges.
     | Cd_M4 |       411.0       |   Major   |       Delayed maximum       |
     +-------+-------------------+-----------+-----------------------------+
 
-The method :py:meth:`~._signals.eels.EELSSpectrum_mixin.edges_at_energy` allows
+The method :py:meth:`~._signals.eels.EELSSpectrum.edges_at_energy` allows
 inspecting different sections of the signal for interactive edge 
 identification (the default). A region can be selected by dragging the mouse 
 across the signal and after clicking the `Update` button, edges with onset 
@@ -105,7 +105,7 @@ Thickness estimation
     Option to compute the absolute thickness, including the angular corrections
     and mean free path estimation.
 
-The :py:meth:`~._signals.eels.EELSSpectrum_mixin.estimate_thickness` method can
+The :py:meth:`~._signals.eels.EELSSpectrum.estimate_thickness` method can
 estimate the thickness from a low-loss EELS spectrum using the log-ratio
 method. If the beam energy, collection angle, convergence angle and sample
 density are known, the absolute thickness is computed using the method in
@@ -119,12 +119,12 @@ Zero-loss peak centre and alignment
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 The
-:py:meth:`~._signals.eels.EELSSpectrum_mixin.estimate_zero_loss_peak_centre`
+:py:meth:`~._signals.eels.EELSSpectrum.estimate_zero_loss_peak_centre`
 can be used to estimate the position of the zero-loss peak. The method assumes
 that the ZLP is the most intense feature in the spectra. For a more general
 approach see :py:meth:`~.signal.Signal1DTools.find_peaks1D_ohaver`.
 
-The :py:meth:`~._signals.eels.EELSSpectrum_mixin.align_zero_loss_peak` can
+The :py:meth:`~._signals.eels.EELSSpectrum.align_zero_loss_peak` can
 align the ZLP with subpixel accuracy. It is more robust and easy to use than
 :py:meth:`~.signal.Signal1DTools.align1D` for the task. Note that it is
 possible to apply the same alignment to other spectra using the `also_align`
@@ -138,23 +138,23 @@ Deconvolutions
 
 Three deconvolution methods are currently available:
 
-* :py:meth:`~._signals.eels.EELSSpectrum_mixin.fourier_log_deconvolution`
-* :py:meth:`~._signals.eels.EELSSpectrum_mixin.fourier_ratio_deconvolution`
-* :py:meth:`~._signals.eels.EELSSpectrum_mixin.richardson_lucy_deconvolution`
+* :py:meth:`~._signals.eels.EELSSpectrum.fourier_log_deconvolution`
+* :py:meth:`~._signals.eels.EELSSpectrum.fourier_ratio_deconvolution`
+* :py:meth:`~._signals.eels.EELSSpectrum.richardson_lucy_deconvolution`
 
 Estimate elastic scattering intensity
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 The
-:py:meth:`~._signals.eels.EELSSpectrum_mixin.estimate_elastic_scattering_intensity`
+:py:meth:`~._signals.eels.EELSSpectrum.estimate_elastic_scattering_intensity`
 can be used to calculate the integral of the zero loss peak (elastic intensity)
 from EELS low-loss spectra containing the zero loss peak using the
 (rudimentary) threshold method. The threshold can be global or spectrum-wise.
 If no threshold is provided it is automatically calculated using
-:py:meth:`~._signals.eels.EELSSpectrum_mixin.estimate_elastic_scattering_threshold`
+:py:meth:`~._signals.eels.EELSSpectrum.estimate_elastic_scattering_threshold`
 with default values.
 
-:py:meth:`~._signals.eels.EELSSpectrum_mixin.estimate_elastic_scattering_threshold`
+:py:meth:`~._signals.eels.EELSSpectrum.estimate_elastic_scattering_threshold`
 can be used to  calculate separation point between elastic and inelastic
 scattering on EELS low-loss spectra. This algorithm calculates the derivative
 of the signal and assigns the inflexion point to the first point below a
@@ -171,7 +171,7 @@ Kramers-Kronig Analysis
 
 The single-scattering EEL spectrum is approximately related to the complex
 permittivity of the sample and can be estimated by Kramers-Kronig analysis.
-The :py:meth:`~._signals.eels.EELSSpectrum_mixin.kramers_kronig_analysis`
+The :py:meth:`~._signals.eels.EELSSpectrum.kramers_kronig_analysis`
 method implements the Kramers-Kronig FFT method as in
 :ref:`[Egerton2011] <Egerton2011>` to estimate the complex dielectric function
 from a low-loss EELS spectrum. In addition, it can estimate the thickness if
@@ -222,7 +222,7 @@ Define the chemical composition of the sample
     >>> s.add_elements(('B', 'N'))
 
 
-In order to include the effect of plural scattering, the model is convolved with the loss loss spectrum in which case the low loss spectrum needs to be provided to :py:meth:`~._signals.eels.EELSSpectrum_mixin.create_model`:
+In order to include the effect of plural scattering, the model is convolved with the loss loss spectrum in which case the low loss spectrum needs to be provided to :py:meth:`~._signals.eels.EELSSpectrum.create_model`:
 
 .. code-block:: python
 

--- a/doc/user_guide/electron_holography.rst
+++ b/doc/user_guide/electron_holography.rst
@@ -38,7 +38,7 @@ Fourier based reconstruction of off-axis holograms (includes
 finding a side band in FFT, isolating and filtering it, recenter and
 calculate inverse Fourier transform) can be performed using the
 :meth:`~._signals.hologram_image.HologramImage.reconstruct_phase` method
-which returns a :py:class:`~._signals.complex_signal2d.Complex2D` class,
+which returns a :py:class:`~._signals.complex_signal2d.ComplexSignal2D` class,
 containing the reconstructed electron wave.
 The :meth:`~._signals.hologram_image.HologramImage.reconstruct_phase` method
 takes sideband position and size as parameters:
@@ -86,7 +86,7 @@ hologram should be provided to the method either as Hyperspy's
 Using the reconstructed wave, one can access its amplitude and phase (also
 unwrapped phase) using
 ``amplitude`` and ``phase`` properties
-(also the :meth:`~._signals.complex_signal.ComplexSignal_mixin.unwrapped_phase`
+(also the :meth:`~._signals.complex_signal.ComplexSignal.unwrapped_phase`
 method):
 
 .. code-block:: python

--- a/doc/user_guide/io.rst
+++ b/doc/user_guide/io.rst
@@ -352,7 +352,7 @@ The change of type is done using numpy "safe" rules, so no information is lost,
 as numbers are represented to full machine precision.
 
 This feature is particularly useful when using
-:py:meth:`~hyperspy._signals.eds.EDS_mixin.get_lines_intensity`:
+:py:meth:`~hyperspy._signals.eds.EDSSpectrum.get_lines_intensity`:
 
 .. code-block:: python
 

--- a/doc/user_guide/signal.rst
+++ b/doc/user_guide/signal.rst
@@ -1149,7 +1149,7 @@ in the example above by using the ``power_spectum`` argument:
     >>> fft.plot(True)
 
 Where ``power_spectum`` is set to ``True`` since it is the first argument of the
-:py:meth:`~._signals.complex_signal.ComplexSignal_mixin.plot` method for complex signal.
+:py:meth:`~._signals.complex_signal.ComplexSignal.plot` method for complex signal.
 When ``power_spectrum=True``, the plot will be displayed on a log scale by default.
 
 

--- a/doc/user_guide/signal.rst
+++ b/doc/user_guide/signal.rst
@@ -224,7 +224,7 @@ Note that, if you have :ref:`packages that extend HyperSpy
 <hyperspy_extensions-label>` installed in your system, there may
 be more specialised signals available to you. To print all available specialised
 :py:class:`~.signal.BaseSignal` subclasses installed in your system call the
-:py:func:`hyperspy.utils.print_known_signal_types`
+:py:func:`~.utils.print_known_signal_types`
 function as in the following example:
 
 .. code-block:: python
@@ -304,7 +304,7 @@ following table:
     +---------------------------------------------------------------+--------+
     |           :py:class:`~._signals.eds_sem.EDSSEMSpectrum`       | True   |
     +---------------------------------------------------------------+--------+
-    |           :py:class:`~._signals.eds_tem.EDSTEM`               | True   |
+    |           :py:class:`~._signals.eds_tem.EDSTEMSpectrum`       | True   |
     +---------------------------------------------------------------+--------+
     |              :py:class:`~._signals.signal2d.Signal2D`         | False  |
     +---------------------------------------------------------------+--------+
@@ -312,7 +312,7 @@ following table:
     +---------------------------------------------------------------+--------+
     |    :py:class:`~._signals.complex_signal1d.ComplexSignal1D`    | False  |
     +---------------------------------------------------------------+--------+
-    |    :py:class:`~._signals.complex_signal2d.Complex2Dmixin`     | False  |
+    |    :py:class:`~._signals.complex_signal2d.ComplexSignal2D`    | False  |
     +---------------------------------------------------------------+--------+
 
 
@@ -1586,10 +1586,10 @@ operation.
 Handling complex data
 ---------------------
 
-The HyperSpy :py:class:`~.hyperspy.signals.ComplexSignal` signal class and its
-subclasses for 1-dimensional and 2-dimensional data allow the user to access
-complex properties like the `real` and `imag` parts of the data or the
-`amplitude` (also known as the modulus) and `phase` (also known as angle or
+The HyperSpy :py:class:`~._signals.complex_signal.ComplexSignal` signal class
+and its subclasses for 1-dimensional and 2-dimensional data allow the user to
+access complex properties like the ``real`` and ``imag`` parts of the data or the
+``amplitude`` (also known as the modulus) and ``phase`` (also known as angle or
 argument) directly. Getting and setting those properties can be done as
 follows:
 
@@ -1612,31 +1612,32 @@ To transform a real signal into a complex one use:
 
     >>> s.change_dtype(complex)
 
-Changing the `dtype` of a complex signal to something real is not clearly
-defined and thus not directly possible. Use the `real`, `imag`, `amplitude`
-or `phase` properties instead to extract the real data that is desired.
+Changing the ``dtype`` of a complex signal to something real is not clearly
+defined and thus not directly possible. Use the ``real``, ``imag``,
+``amplitude`` or ``phase`` properties instead to extract the real data that is
+desired.
 
 
 Calculate the angle / phase / argument
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-The :py:func:`~hyperspy.signals.ComplexSignal.angle` function can be used to
-calculate the angle, which is equivalent to using the `phase` property if no
-argument is used. If the data is real, the angle will be 0 for positive
-values and 2$\pi$ for negative values. If the `deg` parameter is set to
-`True`, the result will be given in degrees, otherwise in rad (default). The
-underlying function is the :py:func:`~numpy.angle` function.
-:py:func:`~hyperspy.signals.ComplexSignal.angle` will return an appropriate
-HyperSpy signal.
+The :py:meth:`~._signals.complex_signal.ComplexSignal.angle` function
+can be used to calculate the angle, which is equivalent to using the ``phase``
+property if no argument is used. If the data is real, the angle will be 0 for
+positive values and 2$\pi$ for negative values. If the `deg` parameter is set
+to ``True``, the result will be given in degrees, otherwise in rad (default).
+The underlying function is the :py:func:`numpy.angle` function.
+:py:meth:`~._signals.complex_signal.ComplexSignal.angle` will return
+an appropriate HyperSpy signal.
 
 
 Phase unwrapping
 ^^^^^^^^^^^^^^^^
 
-With the :py:func:`~hyperspy.signals.ComplexSignal.unwrapped_phase` method the
-complex phase of a signal can be unwrapped and returned as a new signal. The
-underlying method is :py:func:`~skimage.restoration.unwrap`, which uses the
-algorithm described in :ref:`[Herraez] <Herraez>`.
+With the :py:meth:`~._signals.complex_signal.ComplexSignal.unwrapped_phase`
+method the complex phase of a signal can be unwrapped and returned as a new signal.
+The underlying method is :py:func:`skimage.restoration.unwrap_phase`, which
+uses the algorithm described in :ref:`[Herraez] <Herraez>`.
 
 
 .. _complex.argand:
@@ -1646,13 +1647,12 @@ Calculate and display Argand diagram
 
 Sometimes it is convenient to visualize a complex signal as a plot of its
 imaginary part versus real one. In this case so called Argand diagrams can
-be calculated using :py:func:`~hyperspy.signals.ComplexSignal.argand_diagram`
-method, which returns the plot as a
-:py:class:`~._signals.complex_signal.Signal2D`. Optional arguments ``size``
-and ``display_range`` can be used to change the size (and therefore
-resolution) of the plot and to change the range for the display of the
-plot respectively. The last one is especially useful in order to zoom
-into specific regions of the plot or to limit the plot in case of noisy
+be calculated using :py:meth:`~hyperspy.signals.ComplexSignal.argand_diagram`
+method, which returns the plot as a :py:class:`~._signals.signal2d.Signal2D`.
+Optional arguments ``size`` and ``display_range`` can be used to change the
+size (and therefore resolution) of the plot and to change the range for the
+display of the plot respectively. The last one is especially useful in order to
+zoom into specific regions of the plot or to limit the plot in case of noisy
 data points.
 
 An example of calculation of Aragand diagram is :ref:`shown for electron
@@ -1663,9 +1663,9 @@ Add a linear phase ramp
 
 For 2-dimensional complex images, a linear phase ramp can be added to the
 signal via the
-:py:func:`~._signals.complex_signal2d.Complex2Dmixin.add_phase_ramp` method.
-The parameters `ramp_x` and `ramp_y` dictate the slope of the ramp in `x`-
-and `y` direction, while the offset is determined by the `offset` parameter.
+:py:meth:`~._signals.complex_signal2d.ComplexSignal2D.add_phase_ramp` method.
+The parameters ``ramp_x`` and ``ramp_y`` dictate the slope of the ramp in `x`-
+and `y` direction, while the offset is determined by the ``offset`` parameter.
 The fulcrum of the linear ramp is at the origin and the slopes are given in
 units of the axis with the according scale taken into account. Both are
 available via the :py:class:`~.axes.AxesManager` of the signal.

--- a/doc/user_guide/visualisation.rst
+++ b/doc/user_guide/visualisation.rst
@@ -450,7 +450,7 @@ used for this purpose.
 
 In the following example we also use `scikit-image <http://scikit-image.org/>`_
 for noise reduction. More details about
-:py:meth:`~._signals.eds.EDS_mixin.get_lines_intensity` method can be
+:py:meth:`~._signals.eds.EDSSpectrum.get_lines_intensity` method can be
 found in :ref:`EDS lines intensity<get_lines_intensity>`.
 
 .. code-block:: python
@@ -636,7 +636,7 @@ which is used to call subplots_adjust method of matplotlib
   :width:   500
 
   Using :py:func:`~.drawing.utils.plot_images` to plot the output of
-  :py:meth:`~._signals.eds.EDS_mixin.get_lines_intensity`.
+  :py:meth:`~._signals.eds.EDSSpectrum.get_lines_intensity`.
 
 .. |subplots_adjust| image:: images/plot_images_subplots.png
 
@@ -665,7 +665,7 @@ generator:
   :width:   500
 
   Using :py:func:`~.drawing.utils.plot_images` to plot the output of
-  :py:meth:`~._signals.eds.EDS_mixin.get_lines_intensity` using a unique
+  :py:meth:`~._signals.eds.EDSSpectrum.get_lines_intensity` using a unique
   colormap for each image.
 
 The ``cmap`` argument can also be given as ``'mpl_colors'``, and as a result,

--- a/doc/user_guide/visualisation.rst
+++ b/doc/user_guide/visualisation.rst
@@ -738,7 +738,7 @@ __ plot.spectra_
     ``button_press_event`` in the figure canvas is being used.
 
 It is also possible to plot multiple images overlayed on the same figure by 
-passing the argument `overlay=True` to the 
+passing the argument ``overlay=True`` to the 
 :py:func:`~.drawing.utils.plot_images` function. This should only be done when
 images have the same scale (eg. for elemental maps from the same dataset).
 Using the same data as above, the Fe and Pt signals can be plotted using

--- a/hyperspy/_components/gaussian2d.py
+++ b/hyperspy/_components/gaussian2d.py
@@ -63,8 +63,6 @@ class Gaussian2D(Expression):
     fwhm_x, fwhm_y : float
         Convenience attributes to get and set the full width at half maximum along
         the two axes.
-    height : float
-        Convenience attribute to get height of the Gaussian.
     """
 
     def __init__(self, A=1., sigma_x=1., sigma_y=1., centre_x=0.,

--- a/hyperspy/_signals/common_signal1d.py
+++ b/hyperspy/_signals/common_signal1d.py
@@ -21,7 +21,7 @@ from hyperspy.exceptions import DataDimensionError
 from hyperspy.docstrings.signal import OPTIMIZE_ARG
 
 
-class CommonSignal1D(object):
+class CommonSignal1D:
 
     """Common functions for 1-dimensional signals."""
 

--- a/hyperspy/_signals/common_signal2d.py
+++ b/hyperspy/_signals/common_signal2d.py
@@ -20,7 +20,7 @@
 from hyperspy.docstrings.signal import OPTIMIZE_ARG
 
 
-class CommonSignal2D(object):
+class CommonSignal2D:
 
     """Common functions for 2-dimensional signals."""
 

--- a/hyperspy/_signals/complex_signal.py
+++ b/hyperspy/_signals/complex_signal.py
@@ -156,7 +156,7 @@ class ComplexSignal(BaseSignal):
         if np.issubdtype(dtype, np.complexfloating):
             self.data = self.data.astype(dtype)
         else:
-            raise AttributeError(
+            raise ValueError(
                 'Complex data can only be converted into other complex dtypes!')
 
     def unwrapped_phase(self, wrap_around=False, seed=None,

--- a/hyperspy/_signals/complex_signal.py
+++ b/hyperspy/_signals/complex_signal.py
@@ -19,7 +19,6 @@
 from functools import wraps
 
 import numpy as np
-import dask.array as da
 
 from hyperspy.signal import BaseSignal
 from hyperspy._signals.signal2d import Signal2D
@@ -31,6 +30,13 @@ from hyperspy.docstrings.signal import SHOW_PROGRESSBAR_ARG, PARALLEL_ARG, MAX_W
 from hyperspy.misc.utils import parse_quantity
 
 
+ERROR_MESSAGE_SETTER = ('Setting the {} with a complex signal is ambiguous, '
+                        'use a numpy array or a real signal.')
+
+
+PROPERTY_DOCSTRING_TEMPLATE = """Get/set the {} of the data."""
+
+
 def format_title(thing):
     def title_decorator(func):
         @wraps(func)
@@ -40,61 +46,17 @@ def format_title(thing):
                 title = signal.metadata.General.title
             else:
                 title = 'Untitled Signal'
-            signal.metadata.General.title = thing + '({})'.format(title)
+            signal.metadata.General.title = f'{thing}({title})'
             return signal
         return signal_wrapper
     return title_decorator
 
 
-class ComplexSignal_mixin:
+class ComplexSignal(BaseSignal):
 
     """BaseSignal subclass for complex data."""
 
     _dtype = "complex"
-
-    @format_title('real')
-    def _get_real(self):
-        real = self._deepcopy_with_new_data(self.data.real)
-        real._assign_subclass()
-        return real
-
-    real = property(lambda s: s._get_real(),
-                    lambda s, v: s._set_real(v),
-                    doc="""Get/set the real part of the data. Returns an
-                    appropriate HyperSpy signal."""
-                    )
-
-    @format_title('imag')
-    def _get_imag(self):
-        imag = self._deepcopy_with_new_data(self.data.imag)
-        imag._assign_subclass()
-        return imag
-
-    imag = property(lambda s: s._get_imag(),
-                    lambda s, v: s._set_imag(v),
-                    doc="""Get/set imaginary part of the data. Returns an
-                    appropriate HyperSpy signal."""
-                    )
-
-    def _get_amplitude(self, amplitude):
-        amplitude._assign_subclass()
-        return amplitude
-
-    amplitude = property(lambda s: s._get_amplitude(),
-                         lambda s, v: s._set_amplitude(v),
-                         doc="""Get/set the amplitude of the data. Returns an
-                         appropriate HyperSpy signal.""")
-
-    @format_title('phase')
-    def _get_phase(self, phase):
-        phase._assign_subclass()
-        return phase
-
-    phase = property(lambda s: s._get_phase(),
-                     lambda s, v: s._set_phase(v),
-                     doc="""Get/set the phase of the data. Returns an appropriate
-                     HyperSpy signal."""
-                     )
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
@@ -104,6 +66,82 @@ class ComplexSignal_mixin:
         self._plot_kwargs = {}
         if not np.issubdtype(self.data.dtype, np.complexfloating):
             self.data = self.data.astype(np.complex128)
+
+    @format_title('real')
+    def _get_real(self):
+        real = self._deepcopy_with_new_data(self.data.real)
+        real._assign_subclass()
+        return real
+
+    real = property(lambda s: s._get_real(),
+                    lambda s, v: s._set_real(v),
+                    doc=PROPERTY_DOCSTRING_TEMPLATE.format('real part')
+                    )
+
+    def _set_real(self, real):
+        if isinstance(real, self.__class__):
+            raise TypeError(ERROR_MESSAGE_SETTER.format('real part'))
+        elif isinstance(real, BaseSignal):
+            real = real.data
+        self.data = real + 1j * self.data.imag
+        self.events.data_changed.trigger(self)
+
+    @format_title('imag')
+    def _get_imag(self):
+        imag = self._deepcopy_with_new_data(self.data.imag)
+        imag._assign_subclass()
+        return imag
+
+    imag = property(lambda s: s._get_imag(),
+                    lambda s, v: s._set_imag(v),
+                    doc=PROPERTY_DOCSTRING_TEMPLATE.format('imaginary part')
+                    )
+
+    def _set_imag(self, imag):
+        if isinstance(imag, self.__class__):
+            raise TypeError(ERROR_MESSAGE_SETTER.format('imaginary part'))
+        elif isinstance(imag, BaseSignal):
+            imag = imag.data
+        self.data = self.data.real + 1j * imag
+        self.events.data_changed.trigger(self)
+
+    @format_title('amplitude')
+    def _get_amplitude(self):
+        amplitude = self._deepcopy_with_new_data(abs(self.data))
+        amplitude._assign_subclass()
+        return amplitude
+
+    amplitude = property(lambda s: s._get_amplitude(),
+                         lambda s, v: s._set_amplitude(v),
+                         doc=PROPERTY_DOCSTRING_TEMPLATE.format('amplitude')
+                         )
+
+    def _set_amplitude(self, amplitude):
+        if isinstance(amplitude, self.__class__):
+            raise TypeError(ERROR_MESSAGE_SETTER.format('amplitude'))
+        elif isinstance(amplitude, BaseSignal):
+            amplitude = amplitude.data.real
+        self.data = amplitude * np.exp(1j * np.angle(self.data))
+        self.events.data_changed.trigger(self)
+
+    @format_title('phase')
+    def _get_phase(self):
+        phase = self._deepcopy_with_new_data(np.angle(self.data))
+        phase._assign_subclass()
+        return phase
+
+    phase = property(lambda s: s._get_phase(),
+                     lambda s, v: s._set_phase(v),
+                     doc=PROPERTY_DOCSTRING_TEMPLATE.format('phase')
+                     )
+
+    def _set_phase(self, phase):
+        if isinstance(phase, self.__class__):
+            raise TypeError(ERROR_MESSAGE_SETTER.format('phase'))
+        elif isinstance(phase, BaseSignal):
+            phase = phase.data
+        self.data = abs(self.data) * np.exp(1j * phase)
+        self.events.data_changed.trigger(self)
 
     def change_dtype(self, dtype):
         """Change the data type.
@@ -120,26 +158,6 @@ class ComplexSignal_mixin:
         else:
             raise AttributeError(
                 'Complex data can only be converted into other complex dtypes!')
-
-    @format_title('angle')
-    def angle(self, angle, deg=False):
-        r"""Return the angle (also known as phase or argument). If the data is real, the angle is 0
-        for positive values and :math:`2\pi` for negative values.
-
-        Parameters
-        ----------
-        deg : bool, optional
-            Return angle in degrees if True, radians if False (default).
-
-        Returns
-        -------
-        angle : HyperSpy signal
-            The counterclockwise angle from the positive real axis on the complex plane,
-            with dtype as numpy.float64.
-
-        """
-        angle.set_signal_type('')
-        return angle
 
     def unwrapped_phase(self, wrap_around=False, seed=None,
                         show_progressbar=None, parallel=None, max_workers=None):
@@ -179,8 +197,7 @@ class ComplexSignal_mixin:
         phase.map(unwrap_phase, wrap_around=wrap_around, seed=seed,
                   show_progressbar=show_progressbar, ragged=False,
                   parallel=parallel, max_workers=max_workers)
-        phase.metadata.General.title = 'unwrapped {}'.format(
-            phase.metadata.General.title)
+        phase.metadata.General.title = f'unwrapped {phase.metadata.General.title}'
         return phase  # Now unwrapped!
 
     unwrapped_phase.__doc__ %= (SHOW_PROGRESSBAR_ARG, PARALLEL_ARG, MAX_WORKERS_ARG)
@@ -233,8 +250,8 @@ class ComplexSignal_mixin:
                 self.amplitude.plot(**kwargs)
                 self.phase.plot(**kwargs)
         else:
-            raise ValueError('{}'.format(representation) +
-                             'is not a valid input for representation (use "cartesian" or "polar")!')
+            raise ValueError(f'{representation} is not a valid input for '
+                             'representation (use "cartesian" or "polar")!')
 
         self._plot_kwargs = {'power_spectrum': power_spectrum,
                              'representation': representation,
@@ -244,49 +261,27 @@ class ComplexSignal_mixin:
     plot.__doc__ %= (BASE_PLOT_DOCSTRING, COMPLEX_DOCSTRING,
                      BASE_PLOT_DOCSTRING_PARAMETERS, PLOT2D_KWARGS_DOCSTRING)
 
-
-class ComplexSignal(ComplexSignal_mixin, BaseSignal):
-
-    def _get_phase(self):
-        phase = self._deepcopy_with_new_data(np.angle(self.data))
-        return super()._get_phase(phase)
-
-    def _get_amplitude(self):
-        amplitude = np.abs(self)
-        return super()._get_amplitude(amplitude)
-
-    def _set_real(self, real):
-        if isinstance(real, BaseSignal):
-            self.real.isig[:] = real
-        else:
-            self.data.real[:] = real
-        self.events.data_changed.trigger(self)
-
-    def _set_imag(self, imag):
-        if isinstance(imag, BaseSignal):
-            self.imag.isig[:] = imag
-        else:
-            self.data.imag[:] = imag
-        self.events.data_changed.trigger(self)
-
-    def _set_amplitude(self, amplitude):
-        if isinstance(amplitude, BaseSignal):
-            self.isig[:] = amplitude * np.exp(self.angle() * 1j)
-        else:
-            self.data[:] = amplitude * np.exp(1j * np.angle(self.data))
-        self.events.data_changed.trigger(self)
-
-    def _set_phase(self, phase):
-        if isinstance(phase, BaseSignal):
-            self.isig[:] = np.abs(self) * np.exp(phase * 1j)
-        else:
-            self.data[:] = np.abs(self.data) * np.exp(1j * phase)
-        self.events.data_changed.trigger(self)
-
+    @format_title('angle')
     def angle(self, deg=False):
+        r"""Return the angle (also known as phase or argument). If the data is real, the angle is 0
+        for positive values and :math:`2\pi` for negative values.
+
+        Parameters
+        ----------
+        deg : bool, optional
+            Return angle in degrees if True, radians if False (default).
+
+        Returns
+        -------
+        angle : HyperSpy signal
+            The counterclockwise angle from the positive real axis on the complex plane,
+            with dtype as numpy.float64.
+
+        """
         angle = self._deepcopy_with_new_data(np.angle(self.data, deg))
-        return super().angle(angle, deg=deg)
-    angle.__doc__ = ComplexSignal_mixin.angle.__doc__
+        angle.set_signal_type('')
+        
+        return angle
 
     def argand_diagram(self, size=[256, 256], range=None):
         """
@@ -317,6 +312,12 @@ class ComplexSignal(ComplexSignal_mixin, BaseSignal):
         >>> w.argand_diagram(range=[-3, 3]).plot()
 
         """
+        if self._lazy:
+            raise NotImplementedError(
+                "Argand diagram is not implemented for lazy signals. Use "
+                "`compute()` to convert the signal to a regular one."
+                )
+
         im = self.imag.data.ravel()
         re = self.real.data.ravel()
 
@@ -330,7 +331,7 @@ class ComplexSignal(ComplexSignal_mixin, BaseSignal):
         argand_diagram, real_edges, imag_edges = np.histogram2d(re, im, bins=size, range=range)
         argand_diagram = Signal2D(argand_diagram.T)
         argand_diagram.metadata = self.metadata.deepcopy()
-        argand_diagram.metadata.General.title = 'Argand diagram of {}'.format(self.metadata.General.title)
+        argand_diagram.metadata.General.title = f'Argand diagram of {self.metadata.General.title}'
 
         if self.real.metadata.Signal.has_item('quantity'):
             quantity_real, units_real = parse_quantity(self.real.metadata.Signal.quantity)
@@ -359,46 +360,4 @@ class ComplexSignal(ComplexSignal_mixin, BaseSignal):
 
 class LazyComplexSignal(ComplexSignal, LazySignal):
 
-    @format_title('absolute')
-    def _get_amplitude(self):
-        amplitude = abs(self)
-        return super(ComplexSignal, self)._get_amplitude(amplitude)
-
-    def _get_phase(self):
-        phase = self._deepcopy_with_new_data(da.angle(self.data))
-        return super(ComplexSignal, self)._get_phase(phase)
-
-    def _set_real(self, real):
-        if isinstance(real, BaseSignal):
-            real = real.data.real
-        self.data = 1j * self.data.imag + real
-        self.events.data_changed.trigger(self)
-
-    def _set_imag(self, imag):
-        if isinstance(imag, BaseSignal):
-            imag = imag.data.real
-        self.data = self.data.real + 1j * imag
-        self.events.data_changed.trigger(self)
-
-    def _set_amplitude(self, amplitude):
-        if isinstance(amplitude, BaseSignal):
-            amplitude = amplitude.data.real
-        self.data = amplitude * da.exp(1j * da.angle(self.data))
-        self.events.data_changed.trigger(self)
-
-    def _set_phase(self, phase):
-        if isinstance(phase, BaseSignal):
-            phase = phase.data.real
-        self.data = abs(self.data) * \
-            da.exp(1j * phase)
-        self.events.data_changed.trigger(self)
-
-    def angle(self, deg=False):
-        angle = self._deepcopy_with_new_data(da.angle(self.data, deg))
-        return super(ComplexSignal, self).angle(angle, deg=deg)
-    angle.__doc__ = ComplexSignal_mixin.angle.__doc__
-
-    def argand_diagram(self, *args, **kwargs):
-        raise NotImplementedError("Argand diagram is not implemented for lazy "
-                                  "signals. Use `compute()` to convert the "
-                                  "signal to a regular one.")
+    pass

--- a/hyperspy/_signals/complex_signal1d.py
+++ b/hyperspy/_signals/complex_signal1d.py
@@ -31,17 +31,10 @@ class ComplexSignal1D(ComplexSignal, CommonSignal1D):
         super().__init__(*args, **kwargs)
         if self.axes_manager.signal_dimension != 1:
             self.axes_manager.set_signal_dimension(1)
-        self.axes_manager.signal_axes[0].is_binned = False
 
 
 class LazyComplexSignal1D(ComplexSignal1D, LazyComplexSignal):
 
     """BaseSignal subclass for lazy complex 1-dimensional data."""
 
-    _signal_dimension = 1
-
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-        if self.axes_manager.signal_dimension != 1:
-            self.axes_manager.set_signal_dimension(1)
-        self.axes_manager.signal_axes[0].is_binned = False
+    pass

--- a/hyperspy/_signals/complex_signal2d.py
+++ b/hyperspy/_signals/complex_signal2d.py
@@ -120,4 +120,5 @@ class ComplexSignal2D(ComplexSignal, CommonSignal2D):
 class LazyComplexSignal2D(ComplexSignal2D, LazyComplexSignal):
 
     """BaseSignal subclass for lazy complex 2-dimensional data."""
+
     pass

--- a/hyperspy/_signals/complex_signal2d.py
+++ b/hyperspy/_signals/complex_signal2d.py
@@ -24,7 +24,7 @@ from hyperspy.docstrings.plot import (
     COMPLEX_DOCSTRING, PLOT2D_KWARGS_DOCSTRING)
 
 
-class Complex2Dmixin:
+class ComplexSignal2D(ComplexSignal, CommonSignal2D):
 
     """BaseSignal subclass for complex 2-dimensional data."""
 
@@ -115,12 +115,6 @@ class Complex2Dmixin:
     plot.__doc__ %= (BASE_PLOT_DOCSTRING, COMPLEX_DOCSTRING,
                      BASE_PLOT_DOCSTRING_PARAMETERS,
                      PLOT2D_DOCSTRING, PLOT2D_KWARGS_DOCSTRING)
-
-
-class ComplexSignal2D(Complex2Dmixin, ComplexSignal, CommonSignal2D):
-
-    """BaseSignal subclass for complex 2-dimensional data."""
-    pass
 
 
 class LazyComplexSignal2D(ComplexSignal2D, LazyComplexSignal):

--- a/hyperspy/_signals/dielectric_function.py
+++ b/hyperspy/_signals/dielectric_function.py
@@ -25,7 +25,7 @@ from hyperspy._signals.complex_signal1d import (ComplexSignal1D,
 from hyperspy.misc.eels.tools import eels_constant
 
 
-class DielectricFunction_mixin:
+class DielectricFunction(ComplexSignal1D):
 
     _signal_type = "DielectricFunction"
     _alias_signal_types = ["dielectric function"]
@@ -120,10 +120,6 @@ class DielectricFunction_mixin:
         s.metadata.General.title = ("EELS calculated from " +
                                     self.metadata.General.title)
         return s
-
-
-class DielectricFunction(DielectricFunction_mixin, ComplexSignal1D):
-    pass
 
 
 class LazyDielectricFunction(DielectricFunction, LazyComplexSignal1D):

--- a/hyperspy/_signals/eds.py
+++ b/hyperspy/_signals/eds.py
@@ -37,7 +37,7 @@ from hyperspy.docstrings.plot import (BASE_PLOT_DOCSTRING_PARAMETERS,
 _logger = logging.getLogger(__name__)
 
 
-class EDS_mixin:
+class EDSSpectrum(Signal1D):
 
     _signal_type = "EDS"
 
@@ -1111,10 +1111,6 @@ class EDS_mixin:
             self.add_marker(line, render_figure=False)
         if render_figure:
             self._render_figure(plot=['signal_plot'])
-
-
-class EDSSpectrum(EDS_mixin, Signal1D):
-    pass
 
 
 class LazyEDSSpectrum(EDSSpectrum, LazySignal1D):

--- a/hyperspy/_signals/eds_sem.py
+++ b/hyperspy/_signals/eds_sem.py
@@ -57,7 +57,7 @@ class EDSSEMParametersUI(BaseSetMetadataItems):
         'energy_resolution_MnKa', }
 
 
-class EDSSEM_mixin:
+class EDSSEMSpectrum(EDSSpectrum):
 
     _signal_type = "EDS_SEM"
 
@@ -295,10 +295,6 @@ class EDSSEM_mixin:
                             auto_add_lines=auto_add_lines,
                             *args, **kwargs)
         return model
-
-
-class EDSSEMSpectrum(EDSSEM_mixin, EDSSpectrum):
-    pass
 
 
 class LazyEDSSEMSpectrum(EDSSEMSpectrum, LazyEDSSpectrum):

--- a/hyperspy/_signals/eds_tem.py
+++ b/hyperspy/_signals/eds_tem.py
@@ -77,7 +77,7 @@ class EDSTEMParametersUI(BaseSetMetadataItems):
         'real_time', }
 
 
-class EDSTEM_mixin:
+class EDSTEMSpectrum(EDSSpectrum):
 
     _signal_type = "EDS_TEM"
 
@@ -923,10 +923,6 @@ class EDSTEM_mixin:
             elemental_mt = element_composition * thickness_map * density * 1E-8
             mass_thickness += elemental_mt
         return mass_thickness
-
-
-class EDSTEMSpectrum(EDSTEM_mixin, EDSSpectrum):
-    pass
 
 
 class LazyEDSTEMSpectrum(EDSTEMSpectrum, LazyEDSSpectrum):

--- a/hyperspy/_signals/eels.py
+++ b/hyperspy/_signals/eels.py
@@ -71,7 +71,7 @@ class EELSTEMParametersUI(BaseSetMetadataItems):
     }
 
 
-class EELSSpectrum_mixin:
+class EELSSpectrum(Signal1D):
 
     _signal_type = "EELS"
     _alias_signal_types = ["TEM EELS"]
@@ -1830,11 +1830,6 @@ class EELSSpectrum_mixin:
             mask.data = binary_erosion(mask.data, border_value=1)
             mask.data = binary_dilation(mask.data, border_value=0)
         return mask
-
-
-class EELSSpectrum(EELSSpectrum_mixin, Signal1D):
-
-    pass
 
 
 class LazyEELSSpectrum(EELSSpectrum, LazySignal1D):

--- a/hyperspy/io_plugins/unbcf_fast.pyx
+++ b/hyperspy/io_plugins/unbcf_fast.pyx
@@ -299,8 +299,21 @@ cdef void unpack16bit(channel_t[:, :, :] dest, int x, int y,
 #the main function:
 
 def parse_to_numpy(virtual_file, shape, dtype, downsample=1):
-    """parse the hyperspectral cube from brukers bcf binary file
-    and return it as numpy array"""
+    """Parse the hyperspectral cube from brukers bcf binary file
+    and return it as numpy array
+    
+    Parameters
+    ----------
+    virtual_file : SFSTreeItem
+        Virtual file handle returned by SFS_reader instance.
+    shape : tuple
+        Shape of the dataset.
+    dtype : numpy.dtype
+        Data type of the dataset.
+    downsample : int, optional
+        Value for downsampling in navigation space. Default is 1.
+        
+    """
     blocks, block_size = virtual_file.get_iter_and_properties()[:2]
     map_depth = shape[2]
     hypermap = np.zeros(shape, dtype=dtype)

--- a/hyperspy/misc/utils.py
+++ b/hyperspy/misc/utils.py
@@ -1185,30 +1185,29 @@ def process_function_blockwise(data,
                                arg_keys=None,
                                **kwargs):
     """
-    Function for processing the function blockwise...
-    This gets passed to map_blocks so that the function
-    only gets applied to the signal axes.
+    Convenience function for processing a function blockwise. By design, its
+    output is used as an argument of the dask ``map_blocks`` so that the
+    function only gets applied to the signal axes.
 
-    Parameters:
-    ------------
-    data: np.array
+    Parameters
+    ----------
+    data : np.ndarray
         The data for one chunk
-    *args: tuple
-        Any signal the is iterated alongside the data in. In the
-        form ((key1, value1),(key2,value2)...)
-    function: function
+    *args : tuple
+        Any signal the is iterated alongside the data in. In the form
+        ((key1, value1), (key2, value2))
+    function : function
         The function to applied to the signal axis
-    nav_indexes: tuple
+    nav_indexes : tuple
         The indexes of the navigation axes for the dataset.
     output_signal_shape: tuple
-        The shape of the output signal.  For a ragged signal
-        this is equal to 1.
-    block_info: dict
-        The block info as described by the `dask.array.map_blocks` function
-    arg_keys: tuple
+        The shape of the output signal. For a ragged signal, this is equal to 1
+    block_info : dict
+        The block info as described by the ``dask.array.map_blocks`` function
+    arg_keys : tuple
         The list of keys for the passed arguments (args).  Together this makes
         a set of key:value pairs to be passed to the function.
-    **kwargs: dict
+    **kwargs : dict
         Any additional key value pairs to be used by the function
         (Note that these are the constants that are applied.)
 
@@ -1251,11 +1250,12 @@ def guess_output_signal_size(test_signal,
     the resulting signal shape and datatype.
 
     Parameters
+    ----------
     test_signal: BaseSignal
         A test signal for the function to be applied to. A signal
         with 0 navigation dimensions
     function: function
-        The function to be applied to the dataset
+        The function to be applied to the data
     ragged: bool
         If the data is ragged then the output signal size is () and the
         data type is 'object'

--- a/hyperspy/tests/drawing/test_plot_signal.py
+++ b/hyperspy/tests/drawing/test_plot_signal.py
@@ -314,3 +314,15 @@ def test_plot_autoscale(sdim):
 
     s.change_dtype(bool)
     s.plot()
+
+
+def test_plot_complex_representation():
+    real_ref = np.arange(9).reshape((3, 3))
+    imag_ref = np.arange(9).reshape((3, 3)) + 9
+    comp_ref = real_ref + 1j * imag_ref
+    s = hs.signals.ComplexSignal1D(comp_ref)
+    s.plot(representation='polar', same_axes=True)
+    s.plot(representation='polar', same_axes=False)
+    with pytest.raises(ValueError):
+        s.plot(representation='unsupported_argument')
+    

--- a/hyperspy/tests/signals/test_complex_signal.py
+++ b/hyperspy/tests/signals/test_complex_signal.py
@@ -31,7 +31,7 @@ class TestComplexProperties:
     imag_ref = np.arange(9).reshape((3, 3)) + 9
     comp_ref = real_ref + 1j * imag_ref
     phase_ref = np.angle(comp_ref)
-    amplitude_ref = np.abs(comp_ref)
+    amplitude_ref = abs(comp_ref)
 
     def setup_method(self, method):
         test = self.real_ref + 1j * self.imag_ref
@@ -43,32 +43,72 @@ class TestComplexProperties:
 
     def test_set_real(self):
         real = np.random.random((3, 3))
-        self.s.real = real
-        np.testing.assert_allclose(self.s.real.data, real)
+        s = self.s
+        # Set with numpy array
+        s.real = real
+        np.testing.assert_allclose(s.real.data, real)
+        # Set with BaseSignal
+        s2 = hs.signals.ComplexSignal(self.comp_ref)
+        s2.real = s.real
+        np.testing.assert_allclose(s2.real.data, real)
+        np.testing.assert_allclose(s2.imag.data, self.imag_ref)
+        # Set with ComplexSignal
+        with pytest.raises(TypeError):
+            s2.real = s
 
     def test_get_imag(self):
         np.testing.assert_allclose(self.s.imag.data, self.imag_ref)
 
     def test_set_imag(self):
         imag = np.random.random((3, 3))
-        self.s.imag = imag
+        s = self.s
+        # Set with numpy array
+        s.imag = imag
         np.testing.assert_allclose(self.s.imag.data, imag)
+        # Set with BaseSignal
+        s2 = hs.signals.ComplexSignal(self.comp_ref)
+        s2.imag = s.imag
+        np.testing.assert_allclose(s2.imag.data, imag)
+        np.testing.assert_allclose(s2.real.data, self.real_ref)
+        # Set with ComplexSignal
+        with pytest.raises(TypeError):
+            s2.imag = s
 
     def test_get_amplitude(self):
         np.testing.assert_allclose(self.s.amplitude.data, self.amplitude_ref)
 
     def test_set_amplitude(self):
         amplitude = np.random.random((3, 3))
-        self.s.amplitude = amplitude
-        np.testing.assert_allclose(self.s.amplitude, amplitude)
+        s = self.s
+        # Set with numpy array
+        s.amplitude = amplitude
+        np.testing.assert_allclose(s.amplitude, amplitude)
+        # Set with BaseSignal
+        s2 = hs.signals.ComplexSignal(self.comp_ref)
+        s2.amplitude = s.amplitude
+        np.testing.assert_allclose(s2.amplitude.data, amplitude)
+        np.testing.assert_allclose(s2.phase.data, self.phase_ref)
+        # Set with ComplexSignal
+        with pytest.raises(TypeError):
+            s2.amplitude = s
 
     def test_get_phase(self):
         np.testing.assert_allclose(self.s.phase.data, self.phase_ref)
 
     def test_set_phase(self):
         phase = np.random.random((3, 3))
-        self.s.phase = phase
-        np.testing.assert_allclose(self.s.phase, phase)
+        s = self.s
+        # Set with numpy array
+        s.phase = phase
+        np.testing.assert_allclose(s.phase, phase)
+        # Set with BaseSignal
+        s2 = hs.signals.ComplexSignal(self.comp_ref)
+        s2.phase = s.phase
+        np.testing.assert_allclose(s2.phase.data, phase)
+        np.testing.assert_allclose(s2.amplitude.data, self.amplitude_ref)
+        # Set with ComplexSignal
+        with pytest.raises(TypeError):
+            s2.phase = s
 
     def test_angle(self):
         np.testing.assert_allclose(self.s.angle(deg=False), self.phase_ref)

--- a/hyperspy/tests/signals/test_complex_signal.py
+++ b/hyperspy/tests/signals/test_complex_signal.py
@@ -211,3 +211,15 @@ def test_argand_diagram():
     with pytest.raises(NotImplementedError):
         s1d = s1d.as_lazy()
         s1d.argand_diagram()
+
+
+def test_change_dtype():
+    real_ref = np.arange(9).reshape((3, 3))
+    imag_ref = np.arange(9).reshape((3, 3)) + 9
+    comp_ref = real_ref + 1j * imag_ref
+    s = hs.signals.ComplexSignal(comp_ref)
+    
+    s.change_dtype(np.complex64)
+    assert s.data.dtype is np.dtype(np.complex64)
+    with pytest.raises(ValueError):
+        s.change_dtype(float)      

--- a/upcoming_changes/1412.new.rst
+++ b/upcoming_changes/1412.new.rst
@@ -1,1 +1,1 @@
-Add `filter_zero_loss_peak` argument to the `spikes_removal_tool` method
+Add ``filter_zero_loss_peak`` argument to the :py:meth:`~._signals.eels.EELSSpectrum.spikes_removal_tool` method

--- a/upcoming_changes/2183.new.rst
+++ b/upcoming_changes/2183.new.rst
@@ -1,1 +1,1 @@
-Add `vacuum_mask` method for EELSSpectrum
+Add :py:meth:`~._signals.eels.EELSSpectrum.vacuum_mask` method to :py:class:`~._signals.eels.EELSSpectrum` signal

--- a/upcoming_changes/2341.enhancements.rst
+++ b/upcoming_changes/2341.enhancements.rst
@@ -1,0 +1,1 @@
+:ref:`Region of Interest (ROI)<roi-label>` can now be created without specifying values

--- a/upcoming_changes/2386.new.rst
+++ b/upcoming_changes/2386.new.rst
@@ -1,1 +1,1 @@
-Support for relative slicing
+Support for :ref:`relative slicing <signal.indexing>`

--- a/upcoming_changes/2488.new.rst
+++ b/upcoming_changes/2488.new.rst
@@ -1,1 +1,1 @@
-Support for reading JEOL EDS data
+Support for reading :ref:`JEOL EDS data<jeol_format-label>`

--- a/upcoming_changes/2599.new.rst
+++ b/upcoming_changes/2599.new.rst
@@ -1,1 +1,1 @@
-Plot overlayed images
+Plot overlayed images - see :ref:`plotting several images<plot.images>`

--- a/upcoming_changes/2652.api.rst
+++ b/upcoming_changes/2652.api.rst
@@ -1,1 +1,1 @@
-`metadata.Signal.binned` is replaced by an axis parameter, e.g. `axes_manager[-1].is_binned`
+``metadata.Signal.binned`` is replaced by an axis parameter, e. g. ``axes_manager[-1].is_binned``

--- a/upcoming_changes/2688.new.rst
+++ b/upcoming_changes/2688.new.rst
@@ -1,1 +1,1 @@
-Add `height` property to the `Gaussian2D` component
+Add ``height`` property to the :py:class:`~._components.gaussian2d.Gaussian2D` component

--- a/upcoming_changes/2722.maintenance.rst
+++ b/upcoming_changes/2722.maintenance.rst
@@ -1,1 +1,1 @@
-Fix test suite to support dask 2021.4.1
+Fix test suite to support ``dask`` 2021.4.1

--- a/upcoming_changes/2725.enhancements.rst
+++ b/upcoming_changes/2725.enhancements.rst
@@ -1,1 +1,1 @@
-NeXus file with more options when reading and writing
+:ref:`NeXus<nexus-format>` file with more options when reading and writing

--- a/upcoming_changes/2760.bugfix.rst
+++ b/upcoming_changes/2760.bugfix.rst
@@ -1,1 +1,1 @@
-Fix unclear error message when reading a hspy file saved using blosc compression and `hdf5plugin` hasn't been imported previously
+Fix unclear error message when reading a hspy file saved using blosc compression and ``hdf5plugin`` hasn't been imported previously

--- a/upcoming_changes/2762.maintenance.rst
+++ b/upcoming_changes/2762.maintenance.rst
@@ -1,0 +1,1 @@
+Fix warning when build doc and formatting user guide

--- a/upcoming_changes/README.rst
+++ b/upcoming_changes/README.rst
@@ -23,7 +23,8 @@ changelog using that instead.
 If you are not sure what issue type to use, don't hesitate to ask in your PR.
 
 ``towncrier`` preserves multiple paragraphs and formatting (code blocks, lists, and so on), but for entries
-other than ``new`` it is usually better to stick to a single paragraph to keep it concise.
+other than ``new`` it is usually better to stick to a single paragraph to keep it concise. For ``new``,
+it is recommended to add hyperlink to the user guide.
 
 
 To previous a draft of the changelog, run from the command line:


### PR DESCRIPTION
This PR was a bit of rabbit hole effort... I simply wanted to fix a few warning when building the doc and improve the formatting of the changelog, but the hyperlinking to the API wasn't working properly and I ended up removing unnecessary mixin classes.

### Progress of the PR
- [x] Remove mixin classes for signals class: we don't need them and it simplifies the structure of the signal classes. It also fixes the API doc,
- [x] simplify the complex signal classes: thanks to the numpy array protocol, some code of lazy signal can be removed,
- [x] fix formatting changelog,
- [x] fix API doc,
- [x] add an changelog entry in the `upcoming_changes` folder (see [`upcoming_changes/README.rst`](https://github.com/hyperspy/hyperspy/blob/RELEASE_next_minor/upcoming_changes/README.rst)),
- [x] Check formatting changelog entry in the `readthedocs` doc build of this PR (link in github checks)
- [x] add tests,
- [x] ready for review.


