### PR TITLE
Fix saving navigator

### DIFF
--- a/hyperspy/_signals/lazy.py
+++ b/hyperspy/_signals/lazy.py
@@ -1192,7 +1192,7 @@ class LazySignal(BaseSignal):
         axes = [axis.index_in_array for axis in self.axes_manager.signal_axes]
         navigator = self.isig[isig_slice].sum(axes)
         navigator.compute(show_progressbar=show_progressbar)
-        navigator.original_metadata.set_item('sum_from', isig_slice)
+        navigator.original_metadata.set_item('sum_from', str(isig_slice))
 
         self.navigator = navigator.T
 

--- a/hyperspy/tests/drawing/test_plot_lazy.py
+++ b/hyperspy/tests/drawing/test_plot_lazy.py
@@ -48,7 +48,7 @@ def test_plot_lazy_chunks(plot_kwargs):
     s.data = s.data.rechunk(("auto", "auto", 5))
     s.plot(**plot_kwargs)
     assert s.navigator.data.shape == tuple([N]*(dim-1))
-    assert s.navigator.original_metadata.sum_from == [slice(5, 10, None)]
+    assert s.navigator.original_metadata.sum_from == '[slice(5, 10, None)]'
 
 
 def test_compute_navigator():
@@ -56,7 +56,7 @@ def test_compute_navigator():
     dim = 3
     s = hs.signals.Signal1D(da.arange(N**dim).reshape([N]*dim)).as_lazy()
     s.compute_navigator(chunks_number=3)
-    assert s.navigator.original_metadata.sum_from == [slice(5, 10, None)]
+    assert s.navigator.original_metadata.sum_from == '[slice(5, 10, None)]'
 
     # change the navigator and check it is used when plotting
     s.navigator = s.navigator / s.navigator.mean()
@@ -107,22 +107,22 @@ def test_compute_navigator_index():
         ax.offset = -0.75
 
     s.compute_navigator(index=0.0, chunks_number=3)
-    assert s.navigator.original_metadata.sum_from ==  [slice(5, 10, None), slice(5, 10, None)]
+    assert s.navigator.original_metadata.sum_from ==  '[slice(5, 10, None), slice(5, 10, None)]'
 
     s.compute_navigator(index=0, chunks_number=3)
-    assert s.navigator.original_metadata.sum_from == [slice(0, 5, None), slice(0, 5, None)]
+    assert s.navigator.original_metadata.sum_from == '[slice(0, 5, None), slice(0, 5, None)]'
 
     s.compute_navigator(index=-0.7, chunks_number=3)
-    assert s.navigator.original_metadata.sum_from == [slice(0, 5, None), slice(0, 5, None)]
+    assert s.navigator.original_metadata.sum_from == '[slice(0, 5, None), slice(0, 5, None)]'
 
     s.compute_navigator(index=[-0.7, 0.0], chunks_number=3)
-    assert s.navigator.original_metadata.sum_from ==  [slice(0, 5, None), slice(5, 10, None)]
+    assert s.navigator.original_metadata.sum_from ==  '[slice(0, 5, None), slice(5, 10, None)]'
 
     s.compute_navigator(index=0.0, chunks_number=[3, 5])
-    assert s.navigator.original_metadata.sum_from ==  [slice(5, 10, None), slice(6, 9, None)]
+    assert s.navigator.original_metadata.sum_from ==  '[slice(5, 10, None), slice(6, 9, None)]'
 
     s.compute_navigator(index=[0.7, -0.7], chunks_number=[3, 5])
-    assert s.navigator.original_metadata.sum_from ==  [slice(10, 15, None), slice(0, 3, None)]
+    assert s.navigator.original_metadata.sum_from ==  '[slice(10, 15, None), slice(0, 3, None)]'
 
 
 def test_plot_navigator_signal():

--- a/upcoming_changes/2763.bugfix.rst
+++ b/upcoming_changes/2763.bugfix.rst
@@ -1,0 +1,1 @@
+Fix saving ``navigator`` of lazy signal


### PR DESCRIPTION
Follow up of #2631.
Convert slice to string in original_metadata of the navigator when calculating navigator to avoid saving error with h5py.

### Progress of the PR
- [x] Convert `slice` to string so that it can be used by h5py,
- [x] add an changelog entry in the `upcoming_changes` folder (see [`upcoming_changes/README.rst`](https://github.com/hyperspy/hyperspy/blob/RELEASE_next_minor/upcoming_changes/README.rst)),
- [x] Check formatting changelog entry in the `readthedocs` doc build of this PR (link in github checks)
- [x] update tests,
- [x] ready for review.

### Minimal example of the bug fix or the new feature
```python
import dask.array as da
import hyperspy.api as hs

dim = 3
N = 10    
s = hs.signals.Signal1D(da.arange(N**dim).reshape([N]*dim)).as_lazy()
s.plot()
s.save('test.hspy')
s.navigator.original_metadata
s2 = hs.load('test.hspy')
```
would give the following error:
```python
ERROR:hyperspy.io_plugins.hspy:The hdf5 writer could not write the following information in the file: 0 : slice(0, 10, None)
Traceback (most recent call last):
  File "/home/eric/Dev/hyperspy/hyperspy/io_plugins/hspy.py", line 502, in dict2hdfgroup
    group.attrs[key] = value
  File "h5py/_objects.pyx", line 54, in h5py._objects.with_phil.wrapper
  File "h5py/_objects.pyx", line 55, in h5py._objects.with_phil.wrapper
  File "/opt/miniconda3/lib/python3.8/site-packages/h5py/_hl/attrs.py", line 103, in __setitem__
    self.create(name, data=value)
  File "/opt/miniconda3/lib/python3.8/site-packages/h5py/_hl/attrs.py", line 180, in create
    htype = h5t.py_create(original_dtype, logical=True)
  File "h5py/h5t.pyx", line 1629, in h5py.h5t.py_create
  File "h5py/h5t.pyx", line 1653, in h5py.h5t.py_create
  File "h5py/h5t.pyx", line 1713, in h5py.h5t.py_create
TypeError: Object dtype dtype('O') has no native HDF5 equivalent
```

