### PR TITLE
Add `dtype` to rebin

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -25,7 +25,8 @@ jobs:
             PYTHON_VERSION: 3.6
             OLDEST_SUPPORTED_VERSION: true
             DEPENDENCIES: matplotlib==3.1.0 numpy==1.17.1 scipy==1.1 imagecodecs==2019.12.3 dask==2.1.0
-            PIP_SELECTOR: '[all, tests]'
+            PIP_SELECTOR: '[all, tests, coverage]'
+            PYTEST_ARGS_COVERAGE: --cov=. --cov-report=xml
             LABEL: -oldest
           # test minimum requirement
           - os: ubuntu

--- a/doc/user_guide/signal.rst
+++ b/doc/user_guide/signal.rst
@@ -1023,6 +1023,35 @@ cannot be performed lazily:
     NotImplementedError: Lazy rebin requires scale to be integer and divisor of the original signal shape
 
 
+The ``dtype``  argument can be used to specify the ``dtype`` of the returned
+signal:
+
+.. code-block:: python
+
+    >>> s = hs.signals.Signal1D(np.ones((2, 5, 10), dtype=np.uint8)
+    >>> print(s)
+    <Signal1D, title: , dimensions: (5, 2|10)>
+    >>> print(s.data.dtype)
+    uint8
+
+    # Use dtype=np.unit16 to specify a dtype
+    >>> s2 = s.rebin(scale=(5, 2, 1), dtype=np.uint16)
+    >>> print(s2.data.dtype)
+    uint16
+
+    # Use dtype="same" to keep the same dtype
+    >>> s3 = s.rebin(scale=(5, 2, 1), dtype="same")
+    >>> print(s3.data.dtype)
+    uint8
+
+    # By default `dtype=None`, the dtype is determined by the behaviour of
+    # numpy.sum, in this case, unsigned integer of the same precision as the 
+    # platform interger
+    >>> s4 = s.rebin(scale=(5, 2, 1))
+    >>> print(s4.data.dtype)
+    uint64
+
+
 .. _squeeze-label:
 
 Squeezing

--- a/hyperspy/_signals/eds.py
+++ b/hyperspy/_signals/eds.py
@@ -188,11 +188,13 @@ class EDS_mixin:
             return s
     sum.__doc__ = Signal1D.sum.__doc__
 
-    def rebin(self, new_shape=None, scale=None, crop=True, out=None):
+    def rebin(self, new_shape=None, scale=None, crop=True, dtype=None,
+              out=None):
         factors = self._validate_rebin_args_and_get_factors(
             new_shape=new_shape,
             scale=scale,)
-        m = super().rebin(new_shape=new_shape, scale=scale, crop=crop, out=out)
+        m = super().rebin(new_shape=new_shape, scale=scale, crop=crop,
+                          dtype=dtype, out=out)
         m = out or m
         time_factor = np.prod([factors[axis.index_in_array]
                                for axis in m.axes_manager.navigation_axes])

--- a/hyperspy/_signals/eels.py
+++ b/hyperspy/_signals/eels.py
@@ -1763,11 +1763,13 @@ class EELSSpectrum_mixin:
 
         return complmt_edges
 
-    def rebin(self, new_shape=None, scale=None, crop=True, out=None):
+    def rebin(self, new_shape=None, scale=None, crop=True, dtype=None,
+              out=None):
         factors = self._validate_rebin_args_and_get_factors(
             new_shape=new_shape,
             scale=scale)
-        m = super().rebin(new_shape=new_shape, scale=scale, crop=crop, out=out)
+        m = super().rebin(new_shape=new_shape, scale=scale, crop=crop,
+                          dtype=dtype, out=out)
         m = out or m
         time_factor = np.prod([factors[axis.index_in_array]
                                for axis in m.axes_manager.navigation_axes])

--- a/hyperspy/_signals/lazy.py
+++ b/hyperspy/_signals/lazy.py
@@ -361,7 +361,7 @@ class LazySignal(BaseSignal):
             return s
 
     def rebin(self, new_shape=None, scale=None,
-              crop=False, out=None, rechunk=True):
+              crop=False, dtype=None, out=None, rechunk=True):
         factors = self._validate_rebin_args_and_get_factors(
             new_shape=new_shape,
             scale=scale)
@@ -378,8 +378,8 @@ class LazySignal(BaseSignal):
         axis = {ax.index_in_array: ax
                 for ax in self.axes_manager._axes}[factors.argmax()]
         self._make_lazy(axis=axis, rechunk=rechunk)
-        return super().rebin(new_shape=new_shape,
-                             scale=scale, crop=crop, out=out)
+        return super().rebin(new_shape=new_shape, scale=scale, crop=crop,
+                             dtype=dtype, out=out)
     rebin.__doc__ = BaseSignal.rebin.__doc__
 
     def __array__(self, dtype=None):

--- a/hyperspy/docstrings/utils.py
+++ b/hyperspy/docstrings/utils.py
@@ -31,7 +31,32 @@ STACK_METADATA_ARG = \
         If False, the ``metadata`` and ``original_metadata`` are not copied."""
 
 
-REBIN_DTYPE_ARG = \
-    """dtype : {None, numpy.dtype, "same"}, default None
-        Specify the dtype of the output. If None, the dtype will be determined
-        by :py:func:`numpy.dtype`, if "same", the dtype will be kept the same."""
+REBIN_ARGS = \
+    """new_shape : list (of floats or integer) or None
+            For each dimension specify the new_shape. This will internally be
+            converted into a ``scale`` parameter.
+        scale : list (of floats or integer) or None
+            For each dimension, specify the new:old pixel ratio, e.g. a ratio
+            of 1 is no binning and a ratio of 2 means that each pixel in the new
+            spectrum is twice the size of the pixels in the old spectrum.
+            The length of the list should match the dimension of the
+            Signal's underlying data array.
+            *Note : Only one of `scale` or `new_shape` should be specified,
+            otherwise the function will not run*
+        crop : bool
+            Whether or not to crop the resulting rebinned data (default is
+            ``True``). When binning by a non-integer number of
+            pixels it is likely that the final row in each dimension will
+            contain fewer than the full quota to fill one pixel. For example, 
+            a 5*5 array binned by 2.1 will produce two rows containing
+            2.1 pixels and one row containing only 0.8 pixels. Selection of
+            ``crop=True`` or ``crop=False`` determines whether or not this
+            `"black"` line is cropped from the final binned array or not.
+            *Please note that if ``crop=False`` is used, the final row in each
+            dimension may appear black if a fractional number of pixels are left
+            over. It can be removed but has been left to preserve total counts
+            before and after binning.*
+        dtype : {None, numpy.dtype, "same"}
+            Specify the dtype of the output. If None, the dtype will be
+            determined by the behaviour of :py:func:`numpy.sum`, if "same",
+            the dtype will be kept the same. Default is None."""

--- a/hyperspy/docstrings/utils.py
+++ b/hyperspy/docstrings/utils.py
@@ -29,3 +29,9 @@ STACK_METADATA_ARG = \
         returned signal. In this case, the ``metadata`` are copied from the
         first signal in the list.
         If False, the ``metadata`` and ``original_metadata`` are not copied."""
+
+
+REBIN_DTYPE_ARG = \
+    """dtype : {None, numpy.dtype, "same"}, default None
+        Specify the dtype of the output. If None, the dtype will be determined
+        by :py:func:`numpy.dtype`, if "same", the dtype will be kept the same."""

--- a/hyperspy/misc/array_tools.py
+++ b/hyperspy/misc/array_tools.py
@@ -28,7 +28,7 @@ from numba import njit
 
 
 from hyperspy.misc.math_tools import anyfloatin
-from hyperspy.docstrings.utils import REBIN_DTYPE_ARG
+from hyperspy.docstrings.utils import REBIN_ARGS
 
 
 _logger = logging.getLogger(__name__)
@@ -102,39 +102,14 @@ def _requires_linear_rebin(arr, scale):
 
 
 def rebin(a, new_shape=None, scale=None, crop=True, dtype=None):
-    """Rebin array.
-
-    rebin ndarray data into a smaller or larger array based on a linear
-    interpolation. Specify either a new_shape or a scale. Scale of 1== no
+    """Rebin data into a smaller or larger array based on a linear
+    interpolation. Specify either a new_shape or a scale. Scale of 1 means no
     binning. Scale less than one results in up-sampling.
 
     Parameters
     ----------
     a : numpy array
-    new_shape : a list of floats or integer, default None
-        For each dimension specify the new_shape of the np.array. This will
-        then be converted into a scale.
-    scale : a list of floats or integer, default None
-        For each dimension specify the new:old pixel ratio, e.g. a ratio of 1
-        is no binning and a ratio of 2 means that each pixel in the new
-        spectrum is twice the size of the pixels in the old spectrum.
-        The length of the list should match the dimension of the numpy array.
-        ***Note : Only one of scale or new_shape should be specified otherwise
-        the function will not run***
-    crop: bool, default True
-        When binning by a non-integer number of pixels it is likely that
-        the final row in each dimension contains less than the full quota to
-        fill one pixel.
-
-        e.g. 5*5 array binned by 2.1 will produce two rows containing 2.1
-        pixels and one row containing only 0.8 pixels worth. Selection of
-        crop='True' or crop='False' determines whether or not this
-        'black' line is cropped from the final binned array or not.
-
-        *Please note that if crop=False is used, the final row in each
-        dimension may appear black, if a fractional number of pixels are left
-        over. It can be removed but has been left to preserve total counts
-        before and after binning.*
+        The array to rebin.
     %s
 
     Returns
@@ -227,7 +202,8 @@ def rebin(a, new_shape=None, scale=None, crop=True, dtype=None):
                     "Rebin fewer dimensions at a time to avoid this error"
                 )
 
-rebin.__doc__ %= REBIN_DTYPE_ARG
+# Replacing space is necessary to get the correct indentation
+rebin.__doc__ %= REBIN_ARGS.replace("        ", "    ")
 
 
 @njit(cache=True)
@@ -317,7 +293,7 @@ def _linear_bin(dat, scale, crop=True, dtype=None):
 
     if dtype_str_same_integer or dtype_interger:
         raise ValueError(
-            "Linear interpolation requires `float` dtype, change the "
+            "Linear interpolation requires float dtype, change the "
             "dtype argument."
             )
 

--- a/hyperspy/signal.py
+++ b/hyperspy/signal.py
@@ -59,6 +59,7 @@ from hyperspy.docstrings.signal import (
 from hyperspy.docstrings.plot import (BASE_PLOT_DOCSTRING, PLOT1D_DOCSTRING,
                                       BASE_PLOT_DOCSTRING_PARAMETERS,
                                       PLOT2D_KWARGS_DOCSTRING)
+from hyperspy.docstrings.utils import REBIN_DTYPE_ARG
 from hyperspy.events import Events, Event
 from hyperspy.interactive import interactive
 from hyperspy.misc.signal_tools import (are_signals_aligned,
@@ -3037,7 +3038,8 @@ class BaseSignal(FancySlicing,
                                 for axis in self.axes_manager._axes])
         return factors  # Factors are in array order
 
-    def rebin(self, new_shape=None, scale=None, crop=True, out=None):
+    def rebin(self, new_shape=None, scale=None, crop=True, dtype=None,
+              out=None):
         """
         Rebin the signal into a smaller or larger shape, based on linear
         interpolation. Specify **either** `new_shape` or `scale`.
@@ -3072,6 +3074,7 @@ class BaseSignal(FancySlicing,
             over. It can be removed but has been left to preserve total counts
             before and after binning.
         %s
+        %s
 
         Returns
         -------
@@ -3099,7 +3102,7 @@ class BaseSignal(FancySlicing,
             scale=scale,)
         s = out or self._deepcopy_with_new_data(None, copy_variance=True)
         data = hyperspy.misc.array_tools.rebin(
-            self.data, scale=factors, crop=crop)
+            self.data, scale=factors, crop=crop, dtype=dtype)
 
         if out:
             if out._lazy:
@@ -3119,13 +3122,14 @@ class BaseSignal(FancySlicing,
                           BaseSignal):
                 var = s.metadata.Signal.Noise_properties.variance
                 s.metadata.Signal.Noise_properties.variance = var.rebin(
-                    new_shape=new_shape, scale=scale, crop=crop, out=out)
+                    new_shape=new_shape, scale=scale, crop=crop, out=out,
+                    dtype=dtype)
         if out is None:
             return s
         else:
             out.events.data_changed.trigger(obj=out)
 
-    rebin.__doc__ %= (OUT_ARG)
+    rebin.__doc__ %= (REBIN_DTYPE_ARG, OUT_ARG)
 
     def split(self,
               axis='auto',

--- a/hyperspy/signal.py
+++ b/hyperspy/signal.py
@@ -59,7 +59,7 @@ from hyperspy.docstrings.signal import (
 from hyperspy.docstrings.plot import (BASE_PLOT_DOCSTRING, PLOT1D_DOCSTRING,
                                       BASE_PLOT_DOCSTRING_PARAMETERS,
                                       PLOT2D_KWARGS_DOCSTRING)
-from hyperspy.docstrings.utils import REBIN_DTYPE_ARG
+from hyperspy.docstrings.utils import REBIN_ARGS
 from hyperspy.events import Events, Event
 from hyperspy.interactive import interactive
 from hyperspy.misc.signal_tools import (are_signals_aligned,
@@ -3042,37 +3042,11 @@ class BaseSignal(FancySlicing,
               out=None):
         """
         Rebin the signal into a smaller or larger shape, based on linear
-        interpolation. Specify **either** `new_shape` or `scale`.
+        interpolation. Specify **either** `new_shape` or `scale`. Scale of 1
+        means no binning and scale less than one results in up-sampling.
 
         Parameters
         ----------
-        new_shape : list (of floats or integer) or None
-            For each dimension specify the new_shape. This will internally be
-            converted into a `scale` parameter.
-        scale : list (of floats or integer) or None
-            For each dimension, specify the new:old pixel ratio, e.g. a ratio
-            of 1 is no binning and a ratio of 2 means that each pixel in the new
-            spectrum is twice the size of the pixels in the old spectrum.
-            The length of the list should match the dimension of the
-            Signal's underlying data array.
-            *Note : Only one of `scale` or `new_shape` should be specified,
-            otherwise the function will not run*
-        crop : bool
-            Whether or not to crop the resulting rebinned data (default is
-            ``True``). When binning by a non-integer number of
-            pixels it is likely that the final row in each dimension will
-            contain fewer than the full quota to fill one pixel.
-
-                - e.g. a 5*5 array binned by 2.1 will produce two rows
-                  containing 2.1 pixels and one row containing only 0.8
-                  pixels. Selection of ``crop=True`` or ``crop=False``
-                  determines whether or not this `"black"` line is cropped
-                  from the final binned array or not.
-
-            Please note that if ``crop=False`` is used, the final row in each
-            dimension may appear black if a fractional number of pixels are left
-            over. It can be removed but has been left to preserve total counts
-            before and after binning.
         %s
         %s
 
@@ -3129,7 +3103,7 @@ class BaseSignal(FancySlicing,
         else:
             out.events.data_changed.trigger(obj=out)
 
-    rebin.__doc__ %= (REBIN_DTYPE_ARG, OUT_ARG)
+    rebin.__doc__ %= (REBIN_ARGS, OUT_ARG)
 
     def split(self,
               axis='auto',

--- a/hyperspy/signal.py
+++ b/hyperspy/signal.py
@@ -3063,12 +3063,39 @@ class BaseSignal(FancySlicing,
         <EDXTEMSpectrum, title: dimensions: (4, 4|10)>
         >>> print ('Sum = ', sum(sum(sum(spectrum.data))))
         Sum = 164.0
+
         >>> scale = [2, 2, 5]
         >>> test = spectrum.rebin(scale)
         >>> print(test)
         <EDSTEMSpectrum, title: dimensions (2, 2|2)>
         >>> print('Sum = ', sum(sum(sum(test.data))))
         Sum =  164.0
+
+        >>> s = hs.signals.Signal1D(np.ones((2, 5, 10), dtype=np.uint8)
+        >>> print(s)
+        <Signal1D, title: , dimensions: (5, 2|10)>
+        >>> print(s.data.dtype)
+        uint8
+
+        Use dtype=np.unit16 to specify a dtype
+
+        >>> s2 = s.rebin(scale=(5, 2, 1), dtype=np.uint16)
+        >>> print(s2.data.dtype)
+        uint16
+
+        Use dtype="same" to keep the same dtype
+
+        >>> s3 = s.rebin(scale=(5, 2, 1), dtype="same")
+        >>> print(s3.data.dtype)
+        uint8
+
+        By default `dtype=None`, the dtype is determined by the behaviour of
+        numpy.sum, in this case, unsigned integer of the same precision as
+        the platform interger
+
+        >>> s4 = s.rebin(scale=(5, 2, 1))
+        >>> print(s4.data.dtype)
+        uint64
 
         """
         factors = self._validate_rebin_args_and_get_factors(

--- a/hyperspy/tests/signals/test_3D.py
+++ b/hyperspy/tests/signals/test_3D.py
@@ -141,10 +141,24 @@ class Test3D:
         new_s = self.signal.rebin(scale=(2, 2, 1))
         assert new_s.metadata.Signal.Noise_properties.variance == 0.3
 
-    def test_rebin_dtype(self):
+    def test_rebin_dtype_interpolation(self):
         s = Signal1D(np.arange(1000).reshape(10, 10, 10))
         s.change_dtype(np.uint8)
         s2 = s.rebin(scale=(3, 3, 1), crop=False)
+        assert s2.data.dtype == np.dtype('float')
+        assert s.sum() == s2.sum()
+
+    @pytest.mark.parametrize('dtype', [None, 'same', np.uint16])
+    def test_rebin_dtype(self, dtype):
+        s = Signal1D(np.arange(100).reshape(2, 5, 10))
+        s.change_dtype(np.uint8)
+        s2 = s.rebin(scale=(5, 2, 1), crop=False, dtype=dtype)
+        if dtype == None:
+            # np.sum default uses platform (un)signed interger (input dependent)
+            dtype = np.uint
+        elif dtype == 'same':
+            dtype = s.data.dtype
+        assert s2.data.dtype == dtype
         assert s.sum() == s2.sum()
 
     def test_rebin_errors(self):

--- a/hyperspy/tests/signals/test_3D.py
+++ b/hyperspy/tests/signals/test_3D.py
@@ -319,7 +319,7 @@ class TestRebinDtype:
         if s._lazy:
             with pytest.raises(NotImplementedError):
                 _ = s.rebin(scale=(3, 3, 1), dtype=dtype)
-            # exit test
+            # exit to skip the rest of the test
             return
         s.change_dtype(np.uint8)
         with pytest.raises(ValueError):
@@ -333,9 +333,14 @@ class TestRebinDtype:
     @pytest.mark.parametrize('dtype', [None, 'same', np.uint16])
     def test_rebin_dtype(self, dtype):
         s = self.s
-        if s._lazy and LooseVersion(dask.__version__) < LooseVersion("2.11.0"):
-            pytest.skip('dtype argument not supported with dask < 2.11.0')
         s.change_dtype(np.uint8)
+        if s._lazy and LooseVersion(dask.__version__) < LooseVersion("2.11.0"):
+            if dtype is not None:
+                with pytest.raises(ValueError):
+                    _ = s.rebin(scale=(5, 2, 1), dtype=dtype)
+            # exit to skip the rest of the test
+            return
+
         s2 = s.rebin(scale=(5, 2, 1), dtype=dtype)
         if dtype == None:
             # np.sum default uses platform (un)signed interger (input dependent)

--- a/hyperspy/tests/signals/test_3D.py
+++ b/hyperspy/tests/signals/test_3D.py
@@ -318,12 +318,17 @@ class TestRebinDtype:
         s = self.s
         if s._lazy:
             with pytest.raises(NotImplementedError):
-                s2 = s.rebin(scale=(3, 3, 1), crop=False, dtype=dtype)
+                _ = s.rebin(scale=(3, 3, 1), dtype=dtype)
             # exit test
             return
         s.change_dtype(np.uint8)
         with pytest.raises(ValueError):
-            s2 = s.rebin(scale=(3, 3, 1), crop=False, dtype=dtype)
+            _ = s.rebin(scale=(3, 3, 1), dtype=dtype)
+
+    def test_rebin_invalid_dtype_args(self):
+        s = self.s
+        with pytest.raises(ValueError):
+            _ = s.rebin(scale=(5, 2, 1), dtype='invalid_string')
 
     @pytest.mark.parametrize('dtype', [None, 'same', np.uint16])
     def test_rebin_dtype(self, dtype):
@@ -331,7 +336,7 @@ class TestRebinDtype:
         if s._lazy and LooseVersion(dask.__version__) < LooseVersion("2.11.0"):
             pytest.skip('dtype argument not supported with dask < 2.11.0')
         s.change_dtype(np.uint8)
-        s2 = s.rebin(scale=(5, 2, 1), crop=False, dtype=dtype)
+        s2 = s.rebin(scale=(5, 2, 1), dtype=dtype)
         if dtype == None:
             # np.sum default uses platform (un)signed interger (input dependent)
             dtype = np.uint

--- a/upcoming_changes/2764.enhancements.rst
+++ b/upcoming_changes/2764.enhancements.rst
@@ -1,0 +1,1 @@
+Add ``dtype`` argument to :py:meth:`~.signal.BaseSignal.rebin`


### PR DESCRIPTION
### Progress of the PR
- [x] Add `dtype` to rebin,
- [x] update docstring,
- [x] update user guide,
- [x] add an changelog entry in the `upcoming_changes` folder (see [`upcoming_changes/README.rst`](https://github.com/hyperspy/hyperspy/blob/RELEASE_next_minor/upcoming_changes/README.rst)),
- [x] Check formatting changelog entry in the `readthedocs` doc build of this PR (link in github checks)
- [x] add tests,
- [x] ready for review.

### Minimal example of the bug fix or the new feature
```python
import hyperspy.api as hs
import numpy as np
 
s = hs.signals.Signal1D(np.arange(100, dtype=np.uint8).reshape(2, 5, 10))
s2 = s.rebin(scale=(5, 2, 1), dtype='same')
print(s2.data.dtype)

s3 = s.rebin(scale=(5, 2, 1))
print(s3.data.dtype)
```
