### PR TITLE
value2index: convert index to int

### DIFF
--- a/hyperspy/axes.py
+++ b/hyperspy/axes.py
@@ -562,11 +562,16 @@ class BaseDataAxis(t.HasTraits):
         return value
 
     def value2index(self, value, rounding=round):
-        """Return the closest index to the given value if between the axis limits.
+        """Return the closest index/indices to the given value(s) if between the axis limits.
 
         Parameters
         ----------
         value : number or numpy array
+        rounding : function
+                Handling of values intermediate between two axis points:
+                If `rounding=round`, use round-half-away-from-zero strategy to find closest value.
+                If `rounding=math.floor`, round to the next lower value.
+                If `round=math.ceil`, round to the next higher value.
 
         Returns
         -------
@@ -1154,13 +1159,18 @@ class UniformDataAxis(BaseDataAxis, UnitConversion):
         return d
 
     def value2index(self, value, rounding=round):
-        """Return the closest index to the given value if between the axis limits.
+        """Return the closest index/indices to the given value(s) if between the axis limits.
 
         Parameters
         ----------
         value : number or string, or numpy array of number or string
                 if string, should either be a calibrated unit like "20nm"
                 or a relative slicing like "rel0.2".
+        rounding : function
+                Handling of values intermediate between two axis points:
+                If `rounding=round`, use python's standard round-half-to-even strategy to find closest value.
+                If `rounding=math.floor`, round to the next lower value.
+                If `round=math.ceil`, round to the next higher value.
 
         Returns
         -------

--- a/hyperspy/axes.py
+++ b/hyperspy/axes.py
@@ -594,17 +594,17 @@ class BaseDataAxis(t.HasTraits):
             if rounding is round:
                 #Use argmin(abs) which will return the closest value
                 # rounding_index = lambda x: np.abs(x).argmin()
-                index = numba_closest_index_round(self.axis,value)
+                index = numba_closest_index_round(self.axis,value).astype(int)
             elif rounding is math.ceil:
                 #Ceiling means finding index of the closest xi with xi - v >= 0
                 #we look for argmin of strictly non-negative part of self.axis-v.
                 #The trick is to replace strictly negative values with +np.inf
-                index = numba_closest_index_ceil(self.axis,value)
+                index = numba_closest_index_ceil(self.axis,value).astype(int)
             elif rounding is math.floor:
                 #flooring means finding index of the closest xi with xi - v <= 0
                 #we look for armgax of strictly non-positive part of self.axis-v.
                 #The trick is to replace strictly positive values with -np.inf
-                index = numba_closest_index_ceil(self.axis,value)
+                index = numba_closest_index_ceil(self.axis,value).astype(int)
             else:
                 raise ValueError(
                     f'Non-supported rounding function. Use '

--- a/hyperspy/axes.py
+++ b/hyperspy/axes.py
@@ -604,7 +604,7 @@ class BaseDataAxis(t.HasTraits):
                 #flooring means finding index of the closest xi with xi - v <= 0
                 #we look for armgax of strictly non-positive part of self.axis-v.
                 #The trick is to replace strictly positive values with -np.inf
-                index = numba_closest_index_ceil(self.axis,value).astype(int)
+                index = numba_closest_index_floor(self.axis,value).astype(int)
             else:
                 raise ValueError(
                     f'Non-supported rounding function. Use '

--- a/hyperspy/axes.py
+++ b/hyperspy/axes.py
@@ -583,8 +583,6 @@ class BaseDataAxis(t.HasTraits):
         else:
             value = np.asarray(value)
 
-
-
         #Should evaluate on both arrays and scalars. Raises error if there are
         #nan values in array
         if np.all((value >= self.low_value)*(value <= self.high_value)):

--- a/hyperspy/axes.py
+++ b/hyperspy/axes.py
@@ -27,10 +27,12 @@ from traits.trait_errors import TraitError
 import pint
 from sympy.utilities.lambdify import lambdify
 from hyperspy.events import Events, Event
-from hyperspy.misc.array_tools import numba_closest_index_round, \
-                                        numba_closest_index_floor, \
-                                        numba_closest_index_ceil
-
+from hyperspy.misc.array_tools import (
+    numba_closest_index_round,
+    numba_closest_index_floor,
+    numba_closest_index_ceil,
+    round_half_towards_zero,
+)
 from hyperspy.misc.utils import isiterable, ordinal
 from hyperspy.misc.math_tools import isfloat
 from hyperspy.ui_registry import add_gui_method, get_gui
@@ -1190,13 +1192,12 @@ class UniformDataAxis(BaseDataAxis, UnitConversion):
 
         value = self._parse_value(value)
 
-        if isinstance(value, (np.ndarray, da.Array)):
-            if rounding is round:
-                rounding = np.round
-            elif rounding is math.ceil:
-                rounding = np.ceil
-            elif rounding is math.floor:
-                rounding = np.floor
+        if rounding is round:
+            rounding = round_half_towards_zero
+        elif rounding is math.ceil:
+            rounding = np.ceil
+        elif rounding is math.floor:
+            rounding = np.floor
 
         index = rounding((value - self.offset) / self.scale)
 

--- a/hyperspy/misc/array_tools.py
+++ b/hyperspy/misc/array_tools.py
@@ -471,12 +471,7 @@ def numba_closest_index_round(axis_array,value_array):
     #assign on flat, iterate on flat.
     for i,v in enumerate(value_array.flat):
         vdiff_array = np.abs(axis_array - v)
-        index = vdiff_array.argmin()
-        if vdiff_array[index] == vdiff_array[index + 1]:
-            index_array.flat[i] = index + 1
-        else:
-            index_array.flat[i] = index
-
+        index_array.flat[i] = np.flatnonzero(vdiff_array == np.min(vdiff_array))[-1]
     return index_array
 
 @njit(cache=True)

--- a/hyperspy/misc/array_tools.py
+++ b/hyperspy/misc/array_tools.py
@@ -526,3 +526,24 @@ def numba_closest_index_ceil(axis_array,value_array):
         index_array.flat[i] = np.where(x<0,+np.inf,x).argmin()
 
     return index_array
+
+
+def round_half_towards_zero(array, decimals=0):
+    """
+    Round input array using "half towards zero" strategy
+
+    Parameters
+    ----------
+    array : ndarray
+        Input array.
+
+    decimals : int, optional
+        Number of decimal places to round to (default: 0).
+
+    Returns
+    -------
+    rounded_array : ndarray
+        An array of the same type as a, containing the rounded values.
+    """
+    multiplier = 10 ** decimals
+    return np.ceil(array * multiplier - 0.5) / multiplier

--- a/hyperspy/misc/array_tools.py
+++ b/hyperspy/misc/array_tools.py
@@ -470,7 +470,12 @@ def numba_closest_index_round(axis_array,value_array):
     index_array = np.empty_like(value_array,dtype='uint')
     #assign on flat, iterate on flat.
     for i,v in enumerate(value_array.flat):
-        index_array.flat[i] = np.abs(axis_array - v).argmin()
+        vdiff_array = np.abs(axis_array - v)
+        index = vdiff_array.argmin()
+        if vdiff_array[index] == vdiff_array[index + 1]:
+            index_array.flat[i] = index + 1
+        else:
+            index_array.flat[i] = index
 
     return index_array
 

--- a/hyperspy/misc/array_tools.py
+++ b/hyperspy/misc/array_tools.py
@@ -469,10 +469,13 @@ def numba_closest_index_round(axis_array,value_array):
     #initialise the index same dimension as input, force type to int
     index_array = np.empty_like(value_array,dtype='uint')
     #assign on flat, iterate on flat.
+    rtol=1e-12
+    machineepsilon = np.min(np.abs(np.diff(axis_array)))*rtol
     for i,v in enumerate(value_array.flat):
-        rtol=1e-10
-        machineepsilon = np.min(np.diff(axis_array))*rtol
-        index_array.flat[i] = np.abs(axis_array - v + machineepsilon).argmin()
+        if v>= 0:
+            index_array.flat[i] = np.abs(axis_array - v - machineepsilon).argmin()
+        else:
+            index_array.flat[i] = np.abs(axis_array - v + machineepsilon).argmin()
     return index_array
 
 @njit(cache=True)

--- a/hyperspy/misc/array_tools.py
+++ b/hyperspy/misc/array_tools.py
@@ -455,15 +455,17 @@ def get_signal_chunk_slice(index, chunks):
 @njit(cache=True)
 def numba_closest_index_round(axis_array,value_array):
     """For each value in value_array, find the closest value in axis_array and
-        return the result as a numpy array of the same shape as value_array.
-        Parameters
-        ----------
-        axis_array : numpy array
-        value_array : numpy array
+    return the result as a numpy array of the same shape as value_array.
+    Use round half towards zero strategy for rounding float to interger.
 
-        Returns
-        -------
-        numpy array
+    Parameters
+    ----------
+    axis_array : numpy array
+    value_array : numpy array
+
+    Returns
+    -------
+    numpy array
 
     """
     #initialise the index same dimension as input, force type to int
@@ -471,11 +473,11 @@ def numba_closest_index_round(axis_array,value_array):
     #assign on flat, iterate on flat.
     rtol=1e-12
     machineepsilon = np.min(np.abs(np.diff(axis_array)))*rtol
-    for i,v in enumerate(value_array.flat):
-        if v>= 0:
-            index_array.flat[i] = np.abs(axis_array - v - machineepsilon).argmin()
-        else:
+    for i, v in enumerate(value_array.flat):
+        if v >= 0:
             index_array.flat[i] = np.abs(axis_array - v + machineepsilon).argmin()
+        else:
+            index_array.flat[i] = np.abs(axis_array - v - machineepsilon).argmin()
     return index_array
 
 @njit(cache=True)

--- a/hyperspy/misc/array_tools.py
+++ b/hyperspy/misc/array_tools.py
@@ -470,8 +470,9 @@ def numba_closest_index_round(axis_array,value_array):
     index_array = np.empty_like(value_array,dtype='uint')
     #assign on flat, iterate on flat.
     for i,v in enumerate(value_array.flat):
-        vdiff_array = np.abs(axis_array - v)
-        index_array.flat[i] = np.flatnonzero(vdiff_array == np.min(vdiff_array))[-1]
+        rtol=1e-10
+        machineepsilon = np.min(np.diff(axis_array))*rtol
+        index_array.flat[i] = np.abs(axis_array - v + machineepsilon).argmin()
     return index_array
 
 @njit(cache=True)

--- a/hyperspy/misc/array_tools.py
+++ b/hyperspy/misc/array_tools.py
@@ -452,6 +452,7 @@ def get_signal_chunk_slice(index, chunks):
                 return chunk_slice
     raise ValueError("Index out of signal range.")
 
+@njit(cache=True)
 def numba_closest_index_round(axis_array,value_array):
     """For each value in value_array, find the closest value in axis_array and
         return the result as a numpy array of the same shape as value_array.
@@ -468,14 +469,13 @@ def numba_closest_index_round(axis_array,value_array):
     #initialise the index same dimension as input, force type to int
     index_array = np.empty_like(value_array,dtype='uint')
     #assign on flat, iterate on flat.
+    rtol=1e-12
+    machineepsilon = np.min(np.abs(np.diff(axis_array)))*rtol
     for i,v in enumerate(value_array.flat):
-        vdiff_array = np.abs(axis_array - v)
-        index = vdiff_array.argmin()
-        index_array.flat[i] = index
-        if index + 1 < axis_array.size:
-            if vdiff_array[index] == vdiff_array[index + 1] and \
-               (int(repr(axis_array[index + 1])[-1]) % 2 == 0):
-                index_array.flat[i] = index + 1
+        if v>= 0:
+            index_array.flat[i] = np.abs(axis_array - v - machineepsilon).argmin()
+        else:
+            index_array.flat[i] = np.abs(axis_array - v + machineepsilon).argmin()
     return index_array
 
 @njit(cache=True)

--- a/hyperspy/misc/array_tools.py
+++ b/hyperspy/misc/array_tools.py
@@ -80,8 +80,7 @@ def homogenize_ndim(*args):
 
     max_len = max([len(ary.shape) for ary in args])
 
-    return [ary.reshape((1,) * (max_len - len(ary.shape)) + ary.shape)
-            for ary in args]
+    return [ary.reshape((1,) * (max_len - len(ary.shape)) + ary.shape) for ary in args]
 
 
 def _requires_linear_rebin(arr, scale):
@@ -94,8 +93,7 @@ def _requires_linear_rebin(arr, scale):
         rebinning factors
     """
 
-    return (np.asarray(arr.shape) %
-            np.asarray(scale)).any() or anyfloatin(scale)
+    return (np.asarray(arr.shape) % np.asarray(scale)).any() or anyfloatin(scale)
 
 
 def rebin(a, new_shape=None, scale=None, crop=True):
@@ -196,14 +194,12 @@ def rebin(a, new_shape=None, scale=None, crop=True):
             rshape = ()
             for athing in zip(new_shape, scale):
                 rshape += athing
-            return a.reshape(rshape).sum(axis=tuple(
-                2 * i + 1 for i in range(lenShape)))
+            return a.reshape(rshape).sum(axis=tuple(2 * i + 1 for i in range(lenShape)))
         else:
             import dask.array as da
 
             try:
-                return da.coarsen(np.sum, a, {i: int(f)
-                                              for i, f in enumerate(scale)})
+                return da.coarsen(np.sum, a, {i: int(f) for i, f in enumerate(scale)})
             # we provide slightly better error message in hyperspy context
             except ValueError:
                 raise ValueError(
@@ -218,7 +214,7 @@ def _linear_bin_loop(result, data, scale):  # pragma: no cover
         # Begin by determining the upper and lower limits of a given new pixel.
         x1 = j * scale
         x2 = min((1 + j) * scale, data.shape[0])
-        value = result[j:j + 1]
+        value = result[j : j + 1]
 
         if (x2 - x1) >= 1:
             # When binning, the first part is to deal with the fractional pixel
@@ -301,8 +297,7 @@ def _linear_bin(dat, scale, crop=True):
         if not np.issubdtype(s, np.floating):
             s = float(s)
 
-        dim = (math.floor(dat.shape[0] / s) if crop
-               else math.ceil(dat.shape[0] / s))
+        dim = math.floor(dat.shape[0] / s) if crop else math.ceil(dat.shape[0] / s)
         # check function wont bin to zero.
         if dim == 0:
             raise ValueError(
@@ -438,7 +433,7 @@ def get_signal_chunk_slice(index, chunks):
     if not isinstance(index, (list, tuple)):
         index = tuple(index)
 
-    chunk_slice_raw_list = da.core.slices_from_chunks(chunks[-len(index):])
+    chunk_slice_raw_list = da.core.slices_from_chunks(chunks[-len(index) :])
     chunk_slice_list = []
     for chunk_slice_raw in chunk_slice_raw_list:
         chunk_slice_list.append(list(chunk_slice_raw)[::-1])
@@ -452,8 +447,9 @@ def get_signal_chunk_slice(index, chunks):
                 return chunk_slice
     raise ValueError("Index out of signal range.")
 
+
 @njit(cache=True)
-def numba_closest_index_round(axis_array,value_array):
+def numba_closest_index_round(axis_array, value_array):
     """For each value in value_array, find the closest value in axis_array and
     return the result as a numpy array of the same shape as value_array.
     Use round half towards zero strategy for rounding float to interger.
@@ -468,11 +464,11 @@ def numba_closest_index_round(axis_array,value_array):
     numpy array
 
     """
-    #initialise the index same dimension as input, force type to int
-    index_array = np.empty_like(value_array,dtype='uint')
-    #assign on flat, iterate on flat.
-    rtol=1e-12
-    machineepsilon = np.min(np.abs(np.diff(axis_array)))*rtol
+    # initialise the index same dimension as input, force type to int
+    index_array = np.empty_like(value_array, dtype="uint")
+    # assign on flat, iterate on flat.
+    rtol = 1e-12
+    machineepsilon = np.min(np.abs(np.diff(axis_array))) * rtol
     for i, v in enumerate(value_array.flat):
         if v >= 0:
             index_array.flat[i] = np.abs(axis_array - v + machineepsilon).argmin()
@@ -480,57 +476,61 @@ def numba_closest_index_round(axis_array,value_array):
             index_array.flat[i] = np.abs(axis_array - v - machineepsilon).argmin()
     return index_array
 
-@njit(cache=True)
-def numba_closest_index_floor(axis_array,value_array):
-    """For each value in value_array, find the closest smaller value in
-        axis_array and return the result as a numpy array of the same shape
-        as value_array.
-        Parameters
-        ----------
-        axis_array : numpy array
-        value_array : numpy array
 
-        Returns
-        -------
-        numpy array
+@njit(cache=True)
+def numba_closest_index_floor(axis_array, value_array):
+    """For each value in value_array, find the closest smaller value in
+    axis_array and return the result as a numpy array of the same shape
+    as value_array.
+
+    Parameters
+    ----------
+    axis_array : numpy array
+    value_array : numpy array
+
+    Returns
+    -------
+    numpy array
 
     """
-    #initialise the index same dimension as input, force type to int
-    index_array = np.empty_like(value_array,dtype='uint')
-    #assign on flat, iterate on flat.
-    for i,v in enumerate(value_array.flat):
+    # initialise the index same dimension as input, force type to int
+    index_array = np.empty_like(value_array, dtype="uint")
+    # assign on flat, iterate on flat.
+    for i, v in enumerate(value_array.flat):
         x = axis_array - v
-        index_array.flat[i] = np.where(x>0,-np.inf,x).argmax()
+        index_array.flat[i] = np.where(x > 0, -np.inf, x).argmax()
 
     return index_array
 
-@njit(cache=True)
-def numba_closest_index_ceil(axis_array,value_array):
-    """For each value in value_array, find the closest larger value in
-        axis_array and return the result as a numpy array of the same shape
-        as value_array.
-        Parameters
-        ----------
-        axis_array : numpy array
-        value_array : numpy array
 
-        Returns
-        -------
-        numpy array
+@njit(cache=True)
+def numba_closest_index_ceil(axis_array, value_array):
+    """For each value in value_array, find the closest larger value in
+    axis_array and return the result as a numpy array of the same shape
+    as value_array.
+
+    Parameters
+    ----------
+    axis_array : numpy array
+    value_array : numpy array
+
+    Returns
+    -------
+    numpy array
     """
-    #initialise the index same dimension as input, force type to int
-    index_array = np.empty_like(value_array,dtype='uint')
-    #assign on flat, iterate on flat.
-    for i,v in enumerate(value_array.flat):
+    # initialise the index same dimension as input, force type to int
+    index_array = np.empty_like(value_array, dtype="uint")
+    # assign on flat, iterate on flat.
+    for i, v in enumerate(value_array.flat):
         x = axis_array - v
-        index_array.flat[i] = np.where(x<0,+np.inf,x).argmin()
+        index_array.flat[i] = np.where(x < 0, +np.inf, x).argmin()
 
     return index_array
 
 
 def round_half_towards_zero(array, decimals=0):
     """
-    Round input array using "half towards zero" strategy
+    Round input array using "half towards zero" strategy.
 
     Parameters
     ----------

--- a/hyperspy/tests/axes/test_data_axis.py
+++ b/hyperspy/tests/axes/test_data_axis.py
@@ -136,7 +136,7 @@ class TestDataAxis:
         ax.value = ax.value + (ax.axis[1] - ax.axis[0]) * 0.4
         assert not m.trigger_me.called
         ax.value = ax.value + (ax.axis[1] - ax.axis[0]) / 2
-        assert m.trigger_me.called
+        assert not m.trigger_me.called
         ax.value = ax.axis[1]
         assert m.trigger_me.called
 
@@ -181,15 +181,15 @@ class TestDataAxis:
     def test_value2index(self):
         assert self.axis.value2index(10.15) == 3
         assert self.axis.value2index(60) == 8
-        assert self.axis.value2index(2.5,rounding=round) == 2
-        assert self.axis.value2index(2.5,rounding=math.ceil) == 2
-        assert self.axis.value2index(2.5,rounding=math.floor) == 1
+        assert self.axis.value2index(2.5, rounding=round) == 1
+        assert self.axis.value2index(2.5, rounding=math.ceil) == 2
+        assert self.axis.value2index(2.5, rounding=math.floor) == 1
         # Test that output is integer
         assert isinstance(self.axis.value2index(60), (int, np.integer))
         self.axis.axis = self.axis.axis - 2
         # test rounding on negative value
-        assert self.axis.value2index(-1.5,rounding=round) == 0
-        
+        assert self.axis.value2index(-1.5, rounding=round) == 1
+
 
     def test_value2index_error(self):
         with pytest.raises(ValueError):
@@ -353,9 +353,9 @@ class TestFunctionalDataAxis:
         #Tests for value2index
         #Works as intended
         assert self.axis.value2index(44.7) == 7
-        assert self.axis.value2index(2.5,rounding=round) == 2
-        assert self.axis.value2index(2.5,rounding=math.ceil) == 2
-        assert self.axis.value2index(2.5,rounding=math.floor) == 1
+        assert self.axis.value2index(2.5, rounding=round) == 1
+        assert self.axis.value2index(2.5, rounding=math.ceil) == 2
+        assert self.axis.value2index(2.5, rounding=math.floor) == 1
         # Returns integer
         assert isinstance(self.axis.value2index(45), (int, np.integer))
         #Input None --> output None
@@ -484,8 +484,8 @@ class TestUniformDataAxis:
         #Tests for value2index
         #Works as intended
         assert self.axis.value2index(10.15) == 2
-        assert self.axis.value2index(10.17,rounding=math.floor) == 1
-        assert self.axis.value2index(10.13,rounding=math.ceil) == 2
+        assert self.axis.value2index(10.17, rounding=math.floor) == 1
+        assert self.axis.value2index(10.13, rounding=math.ceil) == 2
         # Test that output is integer
         assert isinstance(self.axis.value2index(10.15), (int, np.integer))
         #Endpoint left
@@ -514,15 +514,16 @@ class TestUniformDataAxis:
 
         #Tests with array Input
         #Arrays work as intended
-        arval = np.array([[10.15,10.15],[10.24,10.28]])
-        assert np.all(self.axis.value2index(arval) == np.array([[2,2],[2,3]]))
-        assert np.all(self.axis.value2index(arval,rounding=math.floor) \
-                        == np.array([[1,1],[2,2]]))
-        assert np.all(self.axis.value2index(arval,rounding=math.ceil)\
-                        == np.array([[2,2],[3,3]]))
+        arval = np.array([[10.15, 10.15], [10.24, 10.28]])
+        assert np.all(self.axis.value2index(arval) \
+                        == np.array([[2, 2], [2, 3]]))
+        assert np.all(self.axis.value2index(arval, rounding=math.floor) \
+                        == np.array([[1, 1], [2, 2]]))
+        assert np.all(self.axis.value2index(arval, rounding=math.ceil)\
+                        == np.array([[2, 2], [3, 3]]))
         #List in --> array out
         assert np.all(self.axis.value2index(arval.tolist()) \
-                                            == np.array([[2,2],[2,3]]))
+                                            == np.array([[2, 2], [2, 3]]))
         #One value out of bound in array in --> error out (both sides)
         arval[1,1] = 111
         with pytest.raises(ValueError):

--- a/hyperspy/tests/axes/test_data_axis.py
+++ b/hyperspy/tests/axes/test_data_axis.py
@@ -741,3 +741,17 @@ class TestUniformDataAxisValueRangeToIndicesNegativeScale:
     def test_value_range_to_indices_v1_greater_than_v2(self):
         with pytest.raises(ValueError):
             self.axis.value_range_to_indices(1, 2)
+
+
+def test_rounding_consistency_axis_type():
+    inax = [[-11.0, -10.9],
+            [-10.9, -11.0],
+            [+10.9, +11.0],
+            [+11.0, +10.9]]
+    inval = [-10.95, -10.95, 10.95, 10.95]
+
+    for i, j in zip(inax, inval):
+        ax = UniformDataAxis(scale=i[1]-i[0], offset=i[0], size=len(i))
+        nua_idx = super(type(ax),ax).value2index(j, rounding=round)
+        unif_idx = ax.value2index(j, rounding=round)
+        assert nua_idx == unif_idx

--- a/hyperspy/tests/axes/test_data_axis.py
+++ b/hyperspy/tests/axes/test_data_axis.py
@@ -135,7 +135,7 @@ class TestDataAxis:
         assert not m.trigger_me.called
         ax.value = ax.value + (ax.axis[1] - ax.axis[0]) * 0.4
         assert not m.trigger_me.called
-        ax.value = ax.value + (ax.axis[1] - ax.axis[0]) / 2
+        ax.value = ax.value + (ax.axis[1] - ax.axis[0]) * 0.6
         assert m.trigger_me.called
         ax.value = ax.axis[1]
         assert m.trigger_me.called
@@ -180,6 +180,8 @@ class TestDataAxis:
 
     def test_value2index(self):
         assert self.axis.value2index(10.15) == 3
+        assert self.axis.value2index(2.5) == 2
+        assert self.axis.value2index(6.5) == 2
         assert self.axis.value2index(60) == 8
         assert self.axis.value2index(2.5,rounding=round) == 2
         assert self.axis.value2index(2.5,rounding=math.ceil) == 2
@@ -484,6 +486,7 @@ class TestUniformDataAxis:
         #Tests for value2index
         #Works as intended
         assert self.axis.value2index(10.15) == 2
+        assert self.axis.value2index(10.25) == 2
         assert self.axis.value2index(10.17,rounding=math.floor) == 1
         assert self.axis.value2index(10.13,rounding=math.ceil) == 2
         # Test that output is integer

--- a/hyperspy/tests/axes/test_data_axis.py
+++ b/hyperspy/tests/axes/test_data_axis.py
@@ -179,6 +179,7 @@ class TestDataAxis:
     def test_value2index(self):
         assert self.axis.value2index(10.15) == 3
         assert self.axis.value2index(60) == 8
+        assert isinstance(self.axis.value2index(60), (int, np.integer))
 
     def test_value2index_error(self):
         with pytest.raises(ValueError):
@@ -342,6 +343,8 @@ class TestFunctionalDataAxis:
         #Tests for value2index
         #Works as intended
         assert self.axis.value2index(44.7) == 7
+        # Returns integer
+        assert isinstance(self.axis.value2index(45), (int, np.integer))
         #Input None --> output None
         assert self.axis.value2index(None) == None
         #NaN in --> error out

--- a/hyperspy/tests/axes/test_data_axis.py
+++ b/hyperspy/tests/axes/test_data_axis.py
@@ -133,8 +133,10 @@ class TestDataAxis:
         ax.events.value_changed.connect(m.trigger_me)
         ax.value = ax.value
         assert not m.trigger_me.called
-        ax.value = ax.value + (ax.axis[1] - ax.axis[0]) / 2
+        ax.value = ax.value + (ax.axis[1] - ax.axis[0]) * 0.4
         assert not m.trigger_me.called
+        ax.value = ax.value + (ax.axis[1] - ax.axis[0]) / 2
+        assert m.trigger_me.called
         ax.value = ax.axis[1]
         assert m.trigger_me.called
 

--- a/hyperspy/tests/axes/test_data_axis.py
+++ b/hyperspy/tests/axes/test_data_axis.py
@@ -135,7 +135,7 @@ class TestDataAxis:
         assert not m.trigger_me.called
         ax.value = ax.value + (ax.axis[1] - ax.axis[0]) * 0.4
         assert not m.trigger_me.called
-        ax.value = ax.value + (ax.axis[1] - ax.axis[0]) * 0.6
+        ax.value = ax.value + (ax.axis[1] - ax.axis[0]) / 2
         assert m.trigger_me.called
         ax.value = ax.axis[1]
         assert m.trigger_me.called
@@ -180,8 +180,6 @@ class TestDataAxis:
 
     def test_value2index(self):
         assert self.axis.value2index(10.15) == 3
-        assert self.axis.value2index(2.5) == 2
-        assert self.axis.value2index(6.5) == 2
         assert self.axis.value2index(60) == 8
         assert self.axis.value2index(2.5,rounding=round) == 2
         assert self.axis.value2index(2.5,rounding=math.ceil) == 2
@@ -486,7 +484,6 @@ class TestUniformDataAxis:
         #Tests for value2index
         #Works as intended
         assert self.axis.value2index(10.15) == 2
-        assert self.axis.value2index(10.25) == 2
         assert self.axis.value2index(10.17,rounding=math.floor) == 1
         assert self.axis.value2index(10.13,rounding=math.ceil) == 2
         # Test that output is integer

--- a/hyperspy/tests/axes/test_data_axis.py
+++ b/hyperspy/tests/axes/test_data_axis.py
@@ -186,6 +186,10 @@ class TestDataAxis:
         assert self.axis.value2index(2.5,rounding=math.floor) == 1
         # Test that output is integer
         assert isinstance(self.axis.value2index(60), (int, np.integer))
+        self.axis.axis = self.axis.axis - 2
+        # test rounding on negative value
+        assert self.axis.value2index(-1.5,rounding=round) == 0
+        
 
     def test_value2index_error(self):
         with pytest.raises(ValueError):

--- a/hyperspy/tests/axes/test_data_axis.py
+++ b/hyperspy/tests/axes/test_data_axis.py
@@ -179,6 +179,10 @@ class TestDataAxis:
     def test_value2index(self):
         assert self.axis.value2index(10.15) == 3
         assert self.axis.value2index(60) == 8
+        assert self.axis.value2index(2.5,rounding=round) == 2
+        assert self.axis.value2index(2.5,rounding=math.ceil) == 2
+        assert self.axis.value2index(2.5,rounding=math.floor) == 1
+        # Test that output is integer
         assert isinstance(self.axis.value2index(60), (int, np.integer))
 
     def test_value2index_error(self):
@@ -343,6 +347,9 @@ class TestFunctionalDataAxis:
         #Tests for value2index
         #Works as intended
         assert self.axis.value2index(44.7) == 7
+        assert self.axis.value2index(2.5,rounding=round) == 2
+        assert self.axis.value2index(2.5,rounding=math.ceil) == 2
+        assert self.axis.value2index(2.5,rounding=math.floor) == 1
         # Returns integer
         assert isinstance(self.axis.value2index(45), (int, np.integer))
         #Input None --> output None
@@ -473,6 +480,8 @@ class TestUniformDataAxis:
         assert self.axis.value2index(10.15) == 2
         assert self.axis.value2index(10.17,rounding=math.floor) == 1
         assert self.axis.value2index(10.13,rounding=math.ceil) == 2
+        # Test that output is integer
+        assert isinstance(self.axis.value2index(10.15), (int, np.integer))
         #Endpoint left
         assert self.axis.value2index(10.) == 0
         #Endpoint right

--- a/hyperspy/tests/axes/test_data_axis.py
+++ b/hyperspy/tests/axes/test_data_axis.py
@@ -18,6 +18,7 @@
 
 import copy
 import math
+import platform
 from unittest import mock
 
 import numpy as np
@@ -525,16 +526,18 @@ class TestUniformDataAxis:
         assert np.all(self.axis.value2index(arval.tolist()) \
                                             == np.array([[1, 1], [2, 3]]))
         #One value out of bound in array in --> error out (both sides)
-        arval[1,1] = 111
+        arval[1, 1] = 111
         with pytest.raises(ValueError):
             self.axis.value2index(arval)
-        arval[1,1] = -0.3
+        arval[1, 1] = -0.3
         with pytest.raises(ValueError):
             self.axis.value2index(arval)
         #One NaN in array in --> error out
-        arval[1,1] = np.nan
-        with pytest.raises(ValueError):
-            self.axis.value2index(arval)
+        if platform.machine() != 'aarch64':
+            # Skip aarch64 platform because it doesn't raise error
+            arval[1, 1] = np.nan
+            with pytest.raises(ValueError):
+                self.axis.value2index(arval)
 
         #Copy of axis with units
         axis = copy.deepcopy(self.axis)

--- a/hyperspy/tests/misc/test_array_tools.py
+++ b/hyperspy/tests/misc/test_array_tools.py
@@ -26,6 +26,8 @@ from hyperspy.misc.array_tools import (
     get_array_memory_size_in_GiB,
     get_signal_chunk_slice,
     numba_histogram,
+    round_half_towards_zero,
+    round_half_away_from_zero,
 )
 
 dt = [("x", np.uint8), ("y", np.uint16), ("text", (bytes, 6))]
@@ -188,8 +190,48 @@ def test_get_signal_chunk_slice_not_square(sig_chunks, index, expected):
         chunk_slice = get_signal_chunk_slice(index, data.chunks)
         assert chunk_slice == expected
 
+
 @pytest.mark.parametrize('dtype', ['<u2', 'u2', '>u2', '<f4', 'f4', '>f4'])
 def test_numba_histogram(dtype):
     arr = np.arange(100, dtype=dtype)
     np.testing.assert_array_equal(numba_histogram(arr, 5, (0, 100)), [20, 20, 20, 20, 20])
 
+
+def test_round_half_towards_zero_integer():
+    a = np.array([-2.0, -1.7, -1.5, -0.2, 0.0, 0.2, 1.5, 1.7, 2.0])
+    np.testing.assert_allclose(
+        round_half_towards_zero(a, decimals=0),
+        np.array([-2.0, -2.0, -1.0, 0.0, 0.0, 0.0, 1.0, 2.0, 2.0])
+        )
+    np.testing.assert_allclose(
+        round_half_towards_zero(a, decimals=0),
+        round_half_towards_zero(a)
+        )
+
+
+def test_round_half_towards_zero():
+    a = np.array([-2.01, -1.56, -1.55, -1.50, -0.22, 0.0, 0.22, 1.50, 1.55, 1.56, 2.01])
+    np.testing.assert_allclose(
+        round_half_towards_zero(a, decimals=1),
+        np.array([-2.0, -1.6, -1.5, -1.5, -0.2, 0.0, 0.2, 1.5, 1.5, 1.6, 2.0])
+        )
+
+
+def test_round_half_away_from_zero_integer():
+    a = np.array([-2.0, -1.7, -1.5, -0.2, 0.0, 0.2, 1.5, 1.7, 2.0])
+    np.testing.assert_allclose(
+        round_half_away_from_zero(a, decimals=0),
+        np.array([-2.0, -2.0, -2.0, 0.0, 0.0, 0.0, 2.0, 2.0, 2.0])
+        )
+    np.testing.assert_allclose(
+        round_half_away_from_zero(a, decimals=0),
+        round_half_away_from_zero(a)
+        )
+
+
+def test_round_half_away_from_zero():
+    a = np.array([-2.01, -1.56, -1.55, -1.50, -0.22, 0.0, 0.22, 1.50, 1.55, 1.56, 2.01])
+    np.testing.assert_allclose(
+        round_half_away_from_zero(a, decimals=1),
+        np.array([-2.0, -1.6, -1.6, -1.5, -0.2, 0.0, 0.2, 1.5, 1.6, 1.6, 2.0])
+        )

--- a/hyperspy/tests/utils/test_roi.py
+++ b/hyperspy/tests/utils/test_roi.py
@@ -18,11 +18,13 @@
 
 import numpy as np
 import pytest
+import traits.api as t
 
+from hyperspy.misc.array_tools import round_half_towards_zero
 from hyperspy.roi import (CircleROI, Line2DROI, Point1DROI, Point2DROI,
                           RectangularROI, SpanROI, _get_central_half_limits_of_axis)
 from hyperspy.signals import Signal1D, Signal2D
-import traits.api as t
+
 
 class TestROIs():
 
@@ -182,8 +184,10 @@ class TestROIs():
         sr = r(s)
         scale0 = s.axes_manager[0].scale
         scale1 = s.axes_manager[1].scale
-        n = ((int(round(2.3 / scale0)), int(round(3.5 / scale0)),),
-             (int(round(5.6 / scale1)), int(round(12.2 / scale1)),))
+        n = ((int(round_half_towards_zero(2.3 / scale0)),
+              int(round_half_towards_zero(3.5 / scale0)),),
+             (int(round_half_towards_zero(5.6 / scale1)),
+              int(round_half_towards_zero(12.2 / scale1)),))
         assert (sr.axes_manager.navigation_shape ==
                 (n[0][1] - n[0][0], n[1][1] - n[1][0]))
         np.testing.assert_equal(
@@ -491,7 +495,7 @@ class TestROIs():
             r.angle(axis='z')
 
     def test_repr_None(self):
-        # Setting the args=None sets them as traits.Undefined, which didn't 
+        # Setting the args=None sets them as traits.Undefined, which didn't
         # have a string representation in the old %s style.
         for roi in [Point1DROI, Point2DROI, RectangularROI, SpanROI]:
             r = roi()


### PR DESCRIPTION
### Description of the change
Follow up for #2743: Using `numba` for the `value2index` function can lead to a non-integer index that is not usable for slicing. Therefore, `int` is enforced and tested.

Fixes failing test from LumiSpy: https://github.com/LumiSpy/lumispy/pull/78#issuecomment-855796214

Along the way realized that rounding in `value2index` is not sufficiently tested for. Fixed bug for `rounding=math.floor`. However, also `rounding=round` was not working as it should: 0.5 was rounded down and not up.

### Progress of the PR
- [X] Change implemented (can be split into several points),
- [X] Fix rounding,
- [X] add tests for integer,
- [X] add tests for rounding,
- [X] ready for review.