### PR TITLE
Fix `add_widget` for undefined roi

### DIFF
--- a/hyperspy/drawing/_widgets/line2d.py
+++ b/hyperspy/drawing/_widgets/line2d.py
@@ -162,7 +162,7 @@ class Line2DWidget(ResizableDraggableWidgetBase):
         # _set_axes overwrites self._size so we back it up
         size = self._size
         position = self._pos
-        super(Line2DWidget, self)._set_axes(axes)
+        super()._set_axes(axes)
         # Restore self._size
         self._size = size
         self._pos = position

--- a/hyperspy/roi.py
+++ b/hyperspy/roi.py
@@ -406,9 +406,7 @@ class BaseInteractiveROI(BaseROI):
                     'fft_shift', False):
                 raise NotImplementedError('ROIs are not supported when data '
                                           'are shifted during plotting.')
-        # Undefined if roi initialised without specifying parameters
-        if t.Undefined in tuple(self):
-            self._set_default_values(signal)
+
         if isinstance(navigation_signal, str) and navigation_signal == "same":
             navigation_signal = signal
         if navigation_signal is not None:
@@ -484,6 +482,10 @@ class BaseInteractiveROI(BaseROI):
         kwargs:
             All keyword argument are passed to the widget constructor.
         """
+        # Undefined if roi initialised without specifying parameters
+        if t.Undefined in tuple(self):
+            self._set_default_values(signal)
+
         axes = self._parse_axes(axes, signal.axes_manager,)
         if widget is None:
             widget = self._get_widget_type(

--- a/hyperspy/tests/utils/test_roi.py
+++ b/hyperspy/tests/utils/test_roi.py
@@ -157,18 +157,21 @@ class TestROIs():
         r = SpanROI(15, 30)
         assert tuple(r) == (15, 30)
 
-    def test_widget_initialisation(self):
-        self.s_s.plot()
-        for roi in [Point1DROI, Point2DROI, RectangularROI, SpanROI, Line2DROI, CircleROI]:
-            r = roi()
-            r._set_default_values(self.s_s)
-            r.add_widget(self.s_s)
-
-    def test_add_widget_ROI_undefined(self):
+    @pytest.mark.parametrize('axes', [None, 'signal'])
+    def test_add_widget_ROI_undefined(self, axes):
         s = self.s_i
         s.plot()
-        line = Line2DROI()
-        line.add_widget(s)
+        if axes == 'signal':
+            axes = s.axes_manager.signal_axes
+        for roi in [Point1DROI, Point2DROI, RectangularROI, SpanROI, Line2DROI,
+                    CircleROI]:
+            r = roi()
+            r.add_widget(s, axes=axes)
+            if axes is None:
+                expected_axes = s.axes_manager.navigation_axes
+            else:
+                expected_axes = axes
+            r.signal_map[s][1][0] in expected_axes
 
     def test_span_spectrum_sig(self):
         s = self.s_s
@@ -527,10 +530,19 @@ class TestROIs():
                 r(self.s_s)
 
     def test_default_values_call(self):
-        for roi in [Point1DROI, Point2DROI, RectangularROI, SpanROI, Line2DROI, CircleROI]:
+        for roi in [Point1DROI, Point2DROI, RectangularROI, SpanROI, Line2DROI,
+                    CircleROI]:
             r = roi()
             r._set_default_values(self.s_s)
             r(self.s_s)
+
+    def test_default_values_call_specify_signal_axes(self):
+        s = self.s_i
+        for roi in [Point1DROI, Point2DROI, RectangularROI, SpanROI, Line2DROI,
+                    CircleROI]:
+            r = roi()
+            r._set_default_values(s, axes=s.axes_manager.signal_axes)
+            r(s)
 
     def test_get_central_half_limits(self):
         ax = self.s_s.axes_manager[0]

--- a/hyperspy/tests/utils/test_roi.py
+++ b/hyperspy/tests/utils/test_roi.py
@@ -164,6 +164,12 @@ class TestROIs():
             r._set_default_values(self.s_s)
             r.add_widget(self.s_s)
 
+    def test_add_widget_ROI_undefined(self):
+        s = self.s_i
+        s.plot()
+        line = Line2DROI()
+        line.add_widget(s)
+
     def test_span_spectrum_sig(self):
         s = self.s_s
         r = SpanROI(1, 3)
@@ -491,7 +497,7 @@ class TestROIs():
             r.angle(axis='z')
 
     def test_repr_None(self):
-        # Setting the args=None sets them as traits.Undefined, which didn't 
+        # Setting the args=None sets them as traits.Undefined, which didn't
         # have a string representation in the old %s style.
         for roi in [Point1DROI, Point2DROI, RectangularROI, SpanROI]:
             r = roi()


### PR DESCRIPTION
Improvement of #2341.

### Progress of the PR
- [x] Add support for "undefined" ROI in `add_widget`
- [x] add tests,
- [x] ready for review.

### Minimal example of the bug fix or the new feature
```python
import hyperspy.api as hs

im = hs.datasets.example_signals.object_hologram()
im.plot()

roi = hs.roi.Line2DROI()
roi.add_widget(im)
```
Previously, only `roi.interactive(s)` would work.
