### PR TITLE
Release 1.6.3

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,6 +10,8 @@ on:
 
 jobs:
   create_release:
+    permissions:
+      contents: write
     name: Create Release
     runs-on: ubuntu-latest
     outputs: 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -15,7 +15,7 @@ Bug Fixes
 ---------
 
 - Fix ROI snapping regression (`#2720 <https://github.com/hyperspy/hyperspy/issues/2720>`_)
-- Fix :py:meth:`~._signals.signal1d.Signal1D.shift1D` regression with navigation dimension larger than one (`#2729 <https://github.com/hyperspy/hyperspy/issues/2729>`_)
+- Fix :py:meth:`~._signals.signal1d.Signal1D.shift1D`, :py:meth:`~._signals.signal1d.Signal1D.align1D` and :py:meth:`~._signals.eels.EELSSpectrum.align_zero_loss_peak` regression with navigation dimension larger than one (`#2729 <https://github.com/hyperspy/hyperspy/issues/2729>`_)
 - Fix disconnecting events when closing figure and :py:meth:`~._signals.signal1d.Signal1D.remove_background` is active (`#2734 <https://github.com/hyperspy/hyperspy/issues/2734>`_)
 - Fix :py:meth:`~.signal.BaseSignal.map` regression of lazy signal with navigation chunks of size of 1 (`#2748 <https://github.com/hyperspy/hyperspy/issues/2748>`_)
 - Fix unclear error message when reading a hspy file saved using blosc compression and `hdf5plugin` hasn't been imported previously (`#2760 <https://github.com/hyperspy/hyperspy/issues/2760>`_)

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,6 +8,43 @@ https://hyperspy.readthedocs.io/en/latest/user_guide/changes.html
 
 .. towncrier release notes start
 
+Hyperspy 1.6.3 (2021-06-10)
+===========================
+
+Bug Fixes
+---------
+
+- Fix ROI snapping regression (`#2720 <https://github.com/hyperspy/hyperspy/issues/2720>`_)
+- Fix :py:meth:`~._signals.signal1d.Signal1D.shift1D` regression with navigation dimension larger than one (`#2729 <https://github.com/hyperspy/hyperspy/issues/2729>`_)
+- Fix disconnecting events when closing figure and :py:meth:`~._signals.signal1d.Signal1D.remove_background` is active (`#2734 <https://github.com/hyperspy/hyperspy/issues/2734>`_)
+- Fix :py:meth:`~.signal.BaseSignal.map` regression of lazy signal with navigation chunks of size of 1 (`#2748 <https://github.com/hyperspy/hyperspy/issues/2748>`_)
+- Fix unclear error message when reading a hspy file saved using blosc compression and `hdf5plugin` hasn't been imported previously (`#2760 <https://github.com/hyperspy/hyperspy/issues/2760>`_)
+- Fix saving ``navigator`` of lazy signal (`#2763 <https://github.com/hyperspy/hyperspy/issues/2763>`_)
+
+
+Enhancements
+------------
+
+- Use ``importlib_metadata`` instead of ``pkg_resources`` for extensions
+  registration to speed up the import process and making it possible to install
+  extensions and use them without restarting the python session (`#2709 <https://github.com/hyperspy/hyperspy/issues/2709>`_)
+- Don't import hyperspy extensions when registering extensions (`#2711 <https://github.com/hyperspy/hyperspy/issues/2711>`_)
+- Improve docstrings of various fitting methods (`#2724 <https://github.com/hyperspy/hyperspy/issues/2724>`_)
+- Improve speed of :py:meth:`~._signals.signal1d.Signal1D.shift1D` (`#2750 <https://github.com/hyperspy/hyperspy/issues/2750>`_)
+- Add support for recent EMPAD file; scanning size wasn't parsed. (`#2757 <https://github.com/hyperspy/hyperspy/issues/2757>`_)
+
+
+Maintenance
+-----------
+
+- Add drone CI to test arm64 platform (`#2713 <https://github.com/hyperspy/hyperspy/issues/2713>`_)
+- Fix latex doc build on github actions (`#2714 <https://github.com/hyperspy/hyperspy/issues/2714>`_)
+- Use towncrier to generate changelog automatically (`#2717 <https://github.com/hyperspy/hyperspy/issues/2717>`_)
+- Fix test suite to support dask 2021.4.1 (`#2722 <https://github.com/hyperspy/hyperspy/issues/2722>`_)
+- Generate changelog when building doc to keep the changelog of the development doc up to date on https://hyperspy.readthedocs.io/en/latest (`#2758 <https://github.com/hyperspy/hyperspy/issues/2758>`_)
+- Use mamba and conda-forge channel on azure pipeline (`#2759 <https://github.com/hyperspy/hyperspy/issues/2759>`_)
+
+
 .. _changes_1.6.2:
 
 v1.6.2

--- a/hyperspy/Release.py
+++ b/hyperspy/Release.py
@@ -25,7 +25,7 @@ name = 'hyperspy'
 # When running setup.py the ".dev" string will be replaced (if possible)
 # by the output of "git describe" if git is available or the git
 # hash if .git is present.
-version = "1.6.3.dev0"
+version = "1.6.3"
 description = "Multidimensional data analysis toolbox"
 license = 'GPL v3'
 

--- a/hyperspy/Release.py
+++ b/hyperspy/Release.py
@@ -25,7 +25,7 @@ name = 'hyperspy'
 # When running setup.py the ".dev" string will be replaced (if possible)
 # by the output of "git describe" if git is available or the git
 # hash if .git is present.
-version = "1.6.3"
+version = "1.6.4.dev0"
 description = "Multidimensional data analysis toolbox"
 license = 'GPL v3'
 

--- a/upcoming_changes/2709.enhancements.rst
+++ b/upcoming_changes/2709.enhancements.rst
@@ -1,3 +1,0 @@
-Use ``importlib_metadata`` instead of ``pkg_resources`` for extensions
-registration to speed up the import process and making it possible to install
-extensions and use them without restarting the python session

--- a/upcoming_changes/2711.enhancements.rst
+++ b/upcoming_changes/2711.enhancements.rst
@@ -1,1 +1,0 @@
-Don't import hyperspy extensions when registering extensions

--- a/upcoming_changes/2713.maintenance.rst
+++ b/upcoming_changes/2713.maintenance.rst
@@ -1,1 +1,0 @@
-Add drone CI to test arm64 platform

--- a/upcoming_changes/2714.maintenance.rst
+++ b/upcoming_changes/2714.maintenance.rst
@@ -1,1 +1,0 @@
-Fix latex doc build on github actions

--- a/upcoming_changes/2717.maintenance.rst
+++ b/upcoming_changes/2717.maintenance.rst
@@ -1,1 +1,0 @@
-Use towncrier to generate changelog automatically

--- a/upcoming_changes/2720.bugfix.rst
+++ b/upcoming_changes/2720.bugfix.rst
@@ -1,1 +1,0 @@
-Fix ROI snapping regression 

--- a/upcoming_changes/2722.maintenance.rst
+++ b/upcoming_changes/2722.maintenance.rst
@@ -1,1 +1,0 @@
-Fix test suite to support dask 2021.4.1

--- a/upcoming_changes/2724.enhancements.rst
+++ b/upcoming_changes/2724.enhancements.rst
@@ -1,1 +1,0 @@
-Improve docstrings of various fitting methods

--- a/upcoming_changes/2729.bugfix.rst
+++ b/upcoming_changes/2729.bugfix.rst
@@ -1,1 +1,0 @@
-Fix :py:meth:`~._signals.signal1d.Signal1D.shift1D` regression with navigation dimension larger than one

--- a/upcoming_changes/2734.bugfix.rst
+++ b/upcoming_changes/2734.bugfix.rst
@@ -1,1 +1,0 @@
-Fix disconnecting events when closing figure and :py:meth:`~._signals.signal1d.Signal1D.remove_background` is active

--- a/upcoming_changes/2748.bugfix.rst
+++ b/upcoming_changes/2748.bugfix.rst
@@ -1,1 +1,0 @@
-Fix :py:meth:`~.signal.BaseSignal.map` regression of lazy signal with navigation chunks of size of 1

--- a/upcoming_changes/2750.enhancements.rst
+++ b/upcoming_changes/2750.enhancements.rst
@@ -1,1 +1,0 @@
-Improve speed of :py:meth:`~._signals.signal1d.Signal1D.shift1D`

--- a/upcoming_changes/2757.enhancements.rst
+++ b/upcoming_changes/2757.enhancements.rst
@@ -1,1 +1,0 @@
-Add support for recent EMPAD file; scanning size wasn't parsed.

--- a/upcoming_changes/2758.maintenance.rst
+++ b/upcoming_changes/2758.maintenance.rst
@@ -1,1 +1,0 @@
-Generate changelog when building doc to keep the changelog of the development doc up to date on https://hyperspy.readthedocs.io/en/latest

--- a/upcoming_changes/2759.maintenance.rst
+++ b/upcoming_changes/2759.maintenance.rst
@@ -1,1 +1,0 @@
-Use mamba and conda-forge channel on azure pipeline

--- a/upcoming_changes/2760.bugfix.rst
+++ b/upcoming_changes/2760.bugfix.rst
@@ -1,1 +1,0 @@
-Fix unclear error message when reading a hspy file saved using blosc compression and `hdf5plugin` hasn't been imported previously

--- a/upcoming_changes/2763.bugfix.rst
+++ b/upcoming_changes/2763.bugfix.rst
@@ -1,1 +1,0 @@
-Fix saving ``navigator`` of lazy signal


### PR DESCRIPTION
Since https://github.com/hyperspy/hyperspy/issues/2726 and https://github.com/hyperspy/hyperspy/pull/2731 is a bad regression and that releasing is much easier now, I suggest that we do 1.6.3?

Is there any other issue which should be included in the next patch release?

Release test workflow in my fork: https://github.com/ericpre/hyperspy/actions/runs/924627005

Releasing guide: https://github.com/hyperspy/hyperspy/blob/RELEASE_next_minor/releasing_guide.md

### Progress of the PR
- [x] bump version number,
- [x] update changelog: run `towncrier build`
- [x] Check formatting changelog entry in the `readthedocs` doc build of this PR (link in github checks)
- [x] ready for review.

