### PR TITLE
Fix parsing EELS aperture label with unexpected value

### DIFF
--- a/hyperspy/io_plugins/digital_micrograph.py
+++ b/hyperspy/io_plugins/digital_micrograph.py
@@ -798,14 +798,14 @@ class ImageObject(object):
             dt = dateutil.parser.parse(time)
             return dt.time().isoformat()
         except BaseException:
-            _logger.warning("Time string, %s,  could not be parsed", time)
+            _logger.warning(f"Time string '{time}' could not be parsed.")
 
     def _get_date(self, date):
         try:
             dt = dateutil.parser.parse(date)
             return dt.date().isoformat()
         except BaseException:
-            _logger.warning("Date string, %s,  could not be parsed", date)
+            _logger.warning(f"Date string '{date}' could not be parsed.")
 
     def _get_microscope_name(self, ImageTags):
         locations = (
@@ -820,9 +820,20 @@ class ImageObject(object):
         _logger.info("Microscope name not present")
         return None
 
-    def _parse_string(self, tag):
+    def _parse_string(self, tag, convert_to_float=False, tag_name=None):
         if len(tag) == 0:
             return None
+        elif convert_to_float:
+            try:
+                return float(tag)
+            # In case the string can't be converted to float
+            except BaseException:
+                if tag_name is None:
+                    warning = "Metadata could not be parsed."
+                else:
+                    warning = f"Metadata '{tag_name}' could not be parsed."
+                _logger.warning(warning)
+                return None
         else:
             return tag
 
@@ -952,7 +963,9 @@ class ImageObject(object):
                     None),
                 "{}.EELS_Spectrometer.Aperture_label".format(tags_path): (
                     "Acquisition_instrument.TEM.Detector.EELS.aperture_size",
-                    lambda string: float(string.replace('mm', ''))),
+                    lambda string: self._parse_string(string.replace('mm', ''),
+                                                      convert_to_float=True,
+                                                      tag_name='Aperture_label')),
                 "{}.EELS Spectrometer.Instrument name".format(tags_path): (
                     "Acquisition_instrument.TEM.Detector.EELS.spectrometer",
                     None),

--- a/hyperspy/tests/io/test_dm3.py
+++ b/hyperspy/tests/io/test_dm3.py
@@ -70,6 +70,11 @@ class TestImageObject():
         assert self.imageobject._parse_string("") is None
         assert self.imageobject._parse_string("string") == "string"
 
+    def test_parse_string_convert_float(self):
+        assert self.imageobject._parse_string("5", False) == '5'
+        assert self.imageobject._parse_string("5", True) == 5
+        assert self.imageobject._parse_string("Imaging", True) == None
+
 
 def test_missing_tag():
     fname = os.path.join(MY_PATH, "dm3_2D_data",

--- a/upcoming_changes/2772.bugfix.rst
+++ b/upcoming_changes/2772.bugfix.rst
@@ -1,0 +1,1 @@
+Fix parsing EELS aperture label with unexpected value, for example 'Imaging' instead of '5 mm'


### PR DESCRIPTION
Fix #2769. When acquiring EELS spectrum, the tag `aperture label` should contain a number but it is possible that this value is `Imaging` when the "wrong" aperture is used.

### Progress of the PR
- [x] Catch `ValueError` and raise a warning instead,
- [x] add an changelog entry in the `upcoming_changes` folder (see [`upcoming_changes/README.rst`](https://github.com/hyperspy/hyperspy/blob/RELEASE_next_minor/upcoming_changes/README.rst)),
- [x] Check formatting changelog entry in the `readthedocs` doc build of this PR (link in github checks)
- [x] add tests,
- [x] ready for review.


