### PR TITLE
added ValueError for unknown densities

### DIFF
--- a/hyperspy/misc/material.py
+++ b/hyperspy/misc/material.py
@@ -218,19 +218,23 @@ def _density_of_mixture(weight_percent,
         [elements_db[element]['Physical_properties']['density (g/cm^3)']
             for element in elements])
     sum_densities = np.zeros_like(weight_percent, dtype='float')
-    if mean == 'harmonic':
-        for i, weight in enumerate(weight_percent):
-            sum_densities[i] = weight / densities[i]
-        sum_densities = sum_densities.sum(axis=0)
-        density = np.sum(weight_percent, axis=0) / sum_densities
-        return np.where(sum_densities == 0.0, 0.0, density)
-    elif mean == 'weighted':
-        for i, weight in enumerate(weight_percent):
-            sum_densities[i] = weight * densities[i]
-        sum_densities = sum_densities.sum(axis=0)
-        sum_weight = np.sum(weight_percent, axis=0)
-        density = sum_densities / sum_weight
-        return np.where(sum_weight == 0.0, 0.0, density)
+    try : 
+        if mean == 'harmonic':
+            for i, weight in enumerate(weight_percent):
+                sum_densities[i] = weight / densities[i]
+            sum_densities = sum_densities.sum(axis=0)
+            density = np.sum(weight_percent, axis=0) / sum_densities
+            return np.where(sum_densities == 0.0, 0.0, density)
+        elif mean == 'weighted':
+            for i, weight in enumerate(weight_percent):
+                sum_densities[i] = weight * densities[i]
+            sum_densities = sum_densities.sum(axis=0)
+            sum_weight = np.sum(weight_percent, axis=0)
+            density = sum_densities / sum_weight
+            return np.where(sum_weight == 0.0, 0.0, density)
+    except TypeError : 
+        raise ValueError(
+            'The density of one of the elements is unknown (Probably At or Fr).')
 
 
 def density_of_mixture(weight_percent,

--- a/hyperspy/tests/utils/test_material.py
+++ b/hyperspy/tests/utils/test_material.py
@@ -17,6 +17,7 @@
 # along with  HyperSpy.  If not, see <http://www.gnu.org/licenses/>.
 
 import numpy as np
+import pytest
 
 import hyperspy.api as hs
 from hyperspy.misc.elements import elements_db
@@ -76,6 +77,12 @@ def test_density_of_mixture():
     wt = np.array([[[88] * 2] * 3, [[12] * 2] * 3])
     np.testing.assert_allclose(
         density, hs.material.density_of_mixture(wt, elements)[0, 0])
+
+    # Testing whether the correct exception is raised upon unknown density
+    elements = ("Cu", "Sn", "At")
+    wt = (87., 12., 1.)
+    with pytest.raises(ValueError):
+        hs.material.density_of_mixture(wt,elements)
 
 
 def test_mac():

--- a/upcoming_changes/2775.bugfix.rst
+++ b/upcoming_changes/2775.bugfix.rst
@@ -1,0 +1,1 @@
+:py:func:`~.misc.material.density_of_mixture` now throws a Value error when the density of an element is unknown


### PR DESCRIPTION
### Description of the change

Some entries of the elements database have unknown densities due to their very high radioactivity : Astate and Francium. When calling the function `_density_of_mixture` from `hyperspy.misc.material` with these elements it would raise a `TypeError` with a difficult to understand message.
With this PR, the function raises a `ValueError` with a more understandable error message.

### Progress of the PR
- [x] Change implemented 
- [x] ready for review.
- [x] make a test.
- [x] make a changelog entry.

### Minimal example of the bug fix or the new feature
```python
import hyperspy.misc.material as m
m._density_of_mixture([1.0],["At"])
```
#### New output
```
Traceback (most recent call last):
  File "/home/teurtrie/hyperspy/hyperspy/misc/material.py", line 224, in _density_of_mixture
    sum_densities[i] = weight / densities[i]
TypeError: unsupported operand type(s) for /: 'float' and 'numpy.str_'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/teurtrie/hyperspy/hyperspy/misc/material.py", line 236, in _density_of_mixture
    raise ValueError(
ValueError: The density of one of the elements is unknown (Probably At or Fr).
```

