### PR TITLE
Fix blo writing for lazy datasets + other improvements

### DIFF
--- a/doc/user_guide/io.rst
+++ b/doc/user_guide/io.rst
@@ -813,6 +813,14 @@ Extra saving arguments
   - `'crop'`: everything below 0 and above 255 is set to 0 and 255 respectively
   - 2-tuple of `floats` or `ints`: the intensities between these values are
     scaled between 0-255, everything below is 0 and everything above is 255.
+- ``navigator_signal``: the BLO file also stores a virtual bright field (VBF) image which
+  behaves like a navigation signal in the ASTAR software. By default this is
+  set to `'navigator'`, which results in the default :py:attr:`navigator` signal to be used.
+  If this signal was not calculated before (e.g. by calling :py:meth:`~.signal.BaseSignal.plot`), it is 
+  calculated when :py:meth:`~.signal.BaseSignal.save` is called, which can be time consuming.
+  Alternatively, setting the argument to `None` will result in a correctly sized
+  zero array to be used. Finally, a custom ``Signal2D`` object can be passed,
+  but the shape must match the navigation dimensions.
 
 .. _dens-format:
 

--- a/doc/user_guide/io.rst
+++ b/doc/user_guide/io.rst
@@ -797,6 +797,23 @@ loading the file using a different mode. However, note that lazy loading
 does not support in-place writing (i.e lazy loading and the "r+" mode
 are incompatible).
 
+Extra saving arguments
+^^^^^^^^^^^^^^^^^^^^^^
+
+- ``intensity_scaling`` : in case the dataset that needs to be saved does not
+  have the `np.uint8` data type, casting to this datatype without intensity
+  rescaling results in overflow errors (default behavior). This option allows
+  you to perform linear intensity scaling of the images prior to saving the 
+  data. The options are:
+  
+  - `'dtype'`: the limits of the datatype of the dataset, e.g. 0-65535 for 
+    `np.uint16`, are mapped onto 0-255 respectively. Does not work for `float`
+    data types.
+  - `'minmax'`: the minimum and maximum in the dataset are mapped to 0-255.
+  - `'crop'`: everything below 0 and above 255 is set to 0 and 255 respectively
+  - 2-tuple of `floats` or `ints`: the intensities between these values are
+    scaled between 0-255, everything below is 0 and everything above is 255.
+
 .. _dens-format:
 
 DENS heater log

--- a/hyperspy/io_plugins/blockfile.py
+++ b/hyperspy/io_plugins/blockfile.py
@@ -117,7 +117,7 @@ def get_header_from_signal(signal, endianess='<'):
         axes_manager.convert_units('signal', 'cm')
     except Exception:
         warnings.warn("Could not convert between units, scales in the "
-                      "blo file may be incorrect")
+                      "blo file may be incorrect", UserWarning)
 
     if axes_manager.navigation_dimension == 2:
         NX, NY = axes_manager.navigation_shape
@@ -172,7 +172,8 @@ def file_reader(filename, endianess='<', mmap_mode=None,
     header = np.fromfile(f, dtype=get_header_dtype_list(endianess), count=1)
     if header['MAGIC'][0] not in magics:
         warnings.warn("Blockfile has unrecognized header signature. "
-                      "Will attempt to read, but correcteness not guaranteed!")
+                      "Will attempt to read, but correcteness not guaranteed!",
+                      UserWarning)
     header = sarray2dict(header)
     note = f.read(header['Data_offset_1'] - f.tell())
     # It seems it uses "\x00" for padding, so we remove it
@@ -289,7 +290,8 @@ def file_writer(filename, signal, **kwds):
         if signal.data.dtype != "u1":
             warnings.warn("Data does not have uint8 dtype: values outside the "
                           "range 0-255 may result in overflow. To avoid this "
-                          "use the 'intensity_scaling' keyword argument.")
+                          "use the 'intensity_scaling' keyword argument.",
+                          UserWarning)
     elif scale_strategy == "dtype":
         original_scale = dtype_limits(signal.data)
         if original_scale[1] == 1.:

--- a/hyperspy/io_plugins/blockfile.py
+++ b/hyperspy/io_plugins/blockfile.py
@@ -116,8 +116,7 @@ def get_header_from_signal(signal, endianess='<'):
         axes_manager.convert_units('navigation', 'nm')
         axes_manager.convert_units('signal', 'cm')
     except Exception:
-        warnings.warn("Could not convert between units, scales in the "
-                      "blo file may be incorrect", UserWarning)
+        warnings.warn("Could not convert between units, scales in the blo file may be incorrect", UserWarning)
 
     if axes_manager.navigation_dimension == 2:
         NX, NY = axes_manager.navigation_shape

--- a/hyperspy/io_plugins/blockfile.py
+++ b/hyperspy/io_plugins/blockfile.py
@@ -262,13 +262,27 @@ def file_reader(filename, endianess='<', mmap_mode=None,
 
 
 def file_writer(filename, signal, **kwds):
+    """
+    Write signal to blockfile.
+
+    Parameters
+    ----------
+    file : str
+        Filename of the file to write to
+    signal : instance of hyperspy Signal2D
+        The signal to save.
+    endianess : str
+        '<' (default) or '>' determining how the bits are written to the file
+    intensity_scaling : str or 2-Tuple of float/int
+        If the signal datatype is not uint8 this argument provides intensity
+        linear scaling strategies. If 'dtype', the entire dtype range is mapped
+        to 0-255, if 'minmax' the range between the minimum and maximum intensity is
+        mapped to 0-255, if 'crop' the range between 0-255 is conserved without
+        overflow, if a tuple of values the values between this range is mapped
+        to 0-255. If None (default) no rescaling is performed and overflow is
+        permitted.
+    """
     endianess = kwds.pop('endianess', '<')
-    # intensity_scaling can be:
-    # None (default) = do not rescale, accept overflow but warn user if dtype != uint8
-    # "dtype" = take the extremes of the signal dtype and map linearly to 0-255. Warn for floats.
-    # "minmax" = calculate minimum and maximum of dataset to map linearly to 0 - 255
-    # "crop" = everything above 255 and below 0 gets set to 255 and 0 resp
-    # tuple of values = values in input image mapped linearly to 0 and 255
     scale_strategy = kwds.pop("intensity_scaling", None)
     if scale_strategy is None:
         # to distinguish from the tuple case

--- a/hyperspy/io_plugins/blockfile.py
+++ b/hyperspy/io_plugins/blockfile.py
@@ -315,7 +315,7 @@ def file_writer(filename, signal, **kwds):
         overflow, if a tuple of values the values between this range is mapped
         to 0-255. If None (default) no rescaling is performed and overflow is
         permitted.
-    vbf : str or Signal2D
+    navigator_signal : str or Signal2D
         A blo file also saves a virtual bright field image for navigation.
         This option determines what kind of data is stored for this image.
         The default option "navigator" uses the navigator image if it was
@@ -326,7 +326,7 @@ def file_writer(filename, signal, **kwds):
     """
     endianess = kwds.pop("endianess", "<")
     scale_strategy = kwds.pop("intensity_scaling", None)
-    vbf_strategy = kwds.pop("vbf", "navigator")
+    vbf_strategy = kwds.pop("navigator_signal", "navigator")
     show_progressbar = kwds.pop("show_progressbar", None)
     if scale_strategy is None:
         # to distinguish from the tuple case

--- a/hyperspy/io_plugins/blockfile.py
+++ b/hyperspy/io_plugins/blockfile.py
@@ -221,11 +221,10 @@ def file_reader(filename, endianess="<", mmap_mode=None, lazy=False, **kwds):
 
     # Get data:
 
-    # A Virtual BF/DF is stored first
-    #    offset1 = header['Data_offset_1']
-    #    f.seek(offset1)
-    #    data_pre = np.array(f.read(NX*NY), dtype=endianess+'u1'
-    #        ).squeeze().reshape((NX, NY), order='C').T
+    # TODO A Virtual BF/DF is stored first, may be loaded as navigator in future
+    # offset1 = header['Data_offset_1']
+    # f.seek(offset1)
+    # navigator = np.fromfile(f, dtype=endianess+"u1", shape=(NX, NY)).T
 
     # Then comes actual blockfile
     offset2 = header["Data_offset_2"]
@@ -367,8 +366,8 @@ def file_writer(filename, signal, **kwds):
         np.zeros((zero_pad,), np.byte).tofile(f)
         # Write virtual bright field
         if vbf_strategy is None:
-            vbf = np.zeros(signal.data.shape[0], signal.data.shape[1])
-        elif vbf_strategy == "navigator":
+            vbf = np.zeros((signal.data.shape[0], signal.data.shape[1]))
+        elif isinstance(vbf_strategy, str) and (vbf_strategy == "navigator"):
             if signal.navigator is not None:
                 vbf = signal.navigator.data
             else:
@@ -382,11 +381,7 @@ def file_writer(filename, signal, **kwds):
         else:
             vbf = vbf_strategy.data
             # check that the shape is ok
-            if vbf.shape[::-1] == signal.axes_manager.navigation_shape or (
-                vbf.shape[::-1] == (1,) and signal.axes_manager.navigation_shape == ()
-            ):
-                pass
-            else:
+            if vbf.shape != signal.data.shape[:-2]:
                 raise ValueError(
                     "Size of the provided VBF does not match the "
                     "navigation dimensions of the dataset."

--- a/hyperspy/io_plugins/blockfile.py
+++ b/hyperspy/io_plugins/blockfile.py
@@ -19,6 +19,8 @@
 import os
 from traits.api import Undefined
 import numpy as np
+import dask
+from dask.diagnostics import ProgressBar
 from skimage.exposure import rescale_intensity
 from skimage import dtype_limits
 from tqdm import tqdm
@@ -28,18 +30,23 @@ import datetime
 import dateutil
 
 from hyperspy.misc.array_tools import sarray2dict, dict2sarray
-from hyperspy.misc.date_time_tools import serial_date_to_ISO_format, datetime_to_serial_date
+from hyperspy.misc.date_time_tools import (
+    serial_date_to_ISO_format,
+    datetime_to_serial_date,
+)
+from hyperspy.misc.utils import dummy_context_manager
+from hyperspy.defaults_parser import preferences
 
 _logger = logging.getLogger(__name__)
 
 
 # Plugin characteristics
 # ----------------------
-format_name = 'Blockfile'
-description = 'Read/write support for ASTAR blockfiles'
+format_name = "Blockfile"
+description = "Read/write support for ASTAR blockfiles"
 full_support = False
 # Recognised file extension
-file_extensions = ['blo', 'BLO']
+file_extensions = ["blo", "BLO"]
 default_extension = 0
 # Writing capabilities:
 writes = [(2, 2), (2, 1), (2, 0)]
@@ -47,76 +54,88 @@ magics = [0x0102]
 
 
 mapping = {
-    'blockfile_header.Beam_energy':
-    ("Acquisition_instrument.TEM.beam_energy", lambda x: x * 1e-3),
-    'blockfile_header.Camera_length':
-    ("Acquisition_instrument.TEM.camera_length", lambda x: x * 1e-4),
-    'blockfile_header.Scan_rotation':
-    ("Acquisition_instrument.TEM.rotation", lambda x: x * 1e-2),
+    "blockfile_header.Beam_energy": (
+        "Acquisition_instrument.TEM.beam_energy",
+        lambda x: x * 1e-3,
+    ),
+    "blockfile_header.Camera_length": (
+        "Acquisition_instrument.TEM.camera_length",
+        lambda x: x * 1e-4,
+    ),
+    "blockfile_header.Scan_rotation": (
+        "Acquisition_instrument.TEM.rotation",
+        lambda x: x * 1e-2,
+    ),
 }
 
 
-def get_header_dtype_list(endianess='<'):
+def get_header_dtype_list(endianess="<"):
     end = endianess
-    dtype_list = \
+    dtype_list = (
         [
-            ('ID', (bytes, 6)),
-            ('MAGIC', end + 'u2'),
-            ('Data_offset_1', end + 'u4'),      # Offset VBF
-            ('Data_offset_2', end + 'u4'),      # Offset DPs
-            ('UNKNOWN1', end + 'u4'),           # Flags for ASTAR software?
-            ('DP_SZ', end + 'u2'),              # Pixel dim DPs
-            ('DP_rotation', end + 'u2'),        # [degrees ( * 100 ?)]
-            ('NX', end + 'u2'),                 # Scan dim 1
-            ('NY', end + 'u2'),                 # Scan dim 2
-            ('Scan_rotation', end + 'u2'),      # [100 * degrees]
-            ('SX', end + 'f8'),                 # Pixel size [nm]
-            ('SY', end + 'f8'),                 # Pixel size [nm]
-            ('Beam_energy', end + 'u4'),        # [V]
-            ('SDP', end + 'u2'),                # Pixel size [100 * ppcm]
-            ('Camera_length', end + 'u4'),      # [10 * mm]
-            ('Acquisition_time', end + 'f8'),   # [Serial date]
-        ] + [
-            ('Centering_N%d' % i, 'f8') for i in range(8)
-        ] + [
-            ('Distortion_N%02d' % i, 'f8') for i in range(14)
+            ("ID", (bytes, 6)),
+            ("MAGIC", end + "u2"),
+            ("Data_offset_1", end + "u4"),  # Offset VBF
+            ("Data_offset_2", end + "u4"),  # Offset DPs
+            ("UNKNOWN1", end + "u4"),  # Flags for ASTAR software?
+            ("DP_SZ", end + "u2"),  # Pixel dim DPs
+            ("DP_rotation", end + "u2"),  # [degrees ( * 100 ?)]
+            ("NX", end + "u2"),  # Scan dim 1
+            ("NY", end + "u2"),  # Scan dim 2
+            ("Scan_rotation", end + "u2"),  # [100 * degrees]
+            ("SX", end + "f8"),  # Pixel size [nm]
+            ("SY", end + "f8"),  # Pixel size [nm]
+            ("Beam_energy", end + "u4"),  # [V]
+            ("SDP", end + "u2"),  # Pixel size [100 * ppcm]
+            ("Camera_length", end + "u4"),  # [10 * mm]
+            ("Acquisition_time", end + "f8"),  # [Serial date]
         ]
+        + [("Centering_N%d" % i, "f8") for i in range(8)]
+        + [("Distortion_N%02d" % i, "f8") for i in range(14)]
+    )
 
     return dtype_list
 
 
-def get_default_header(endianess='<'):
-    """Returns a header pre-populated with default values.
-    """
+def get_default_header(endianess="<"):
+    """Returns a header pre-populated with default values."""
     dt = np.dtype(get_header_dtype_list())
     header = np.zeros((1,), dtype=dt)
-    header['ID'][0] = 'IMGBLO'.encode()
-    header['MAGIC'][0] = magics[0]
-    header['Data_offset_1'][0] = 0x1000     # Always this value observed
-    header['UNKNOWN1'][0] = 131141          # Very typical value (always?)
-    header['Acquisition_time'][0] = datetime_to_serial_date(
-        datetime.datetime.fromtimestamp(86400, dateutil.tz.tzutc()))
+    header["ID"][0] = "IMGBLO".encode()
+    header["MAGIC"][0] = magics[0]
+    header["Data_offset_1"][0] = 0x1000  # Always this value observed
+    header["UNKNOWN1"][0] = 131141  # Very typical value (always?)
+    header["Acquisition_time"][0] = datetime_to_serial_date(
+        datetime.datetime.fromtimestamp(86400, dateutil.tz.tzutc())
+    )
     # Default to UNIX epoch + 1 day
     # Have to add 1 day, as dateutil's timezones dont work before epoch
     return header
 
 
-def get_header_from_signal(signal, endianess='<'):
+def get_header_from_signal(signal, endianess="<"):
     header = get_default_header(endianess)
-    if 'blockfile_header' in signal.original_metadata:
-        header = dict2sarray(signal.original_metadata['blockfile_header'],
-                             sarray=header)
-        note = signal.original_metadata['blockfile_header']['Note']
+    if "blockfile_header" in signal.original_metadata:
+        header = dict2sarray(
+            signal.original_metadata["blockfile_header"], sarray=header
+        )
+        note = signal.original_metadata["blockfile_header"]["Note"]
     else:
-        note = ''
+        note = ""
     # The navigation and signal units are 'nm' and 'cm', respectively, so we
     # convert the units accordingly before saving the signal
     axes_manager = signal.axes_manager.deepcopy()
     try:
-        axes_manager.convert_units('navigation', 'nm')
-        axes_manager.convert_units('signal', 'cm')
+        axes_manager.convert_units("navigation", "nm")
+        axes_manager.convert_units("signal", "cm")
     except Exception:
-        warnings.warn("Could not convert between units, scales in the blo file may be incorrect", UserWarning)
+        warnings.warn(
+            "BLO file expects cm units in signal dimensions and nm in navigation dimensions. "
+            "Existing units could not be converted; saving "
+            "axes scales as is. Beware that scales "
+            "will likely be incorrect in the file.",
+            UserWarning,
+        )
 
     if axes_manager.navigation_dimension == 2:
         NX, NY = axes_manager.navigation_shape
@@ -132,133 +151,149 @@ def get_header_from_signal(signal, endianess='<'):
 
     DP_SZ = axes_manager.signal_shape
     if DP_SZ[0] != DP_SZ[1]:
-        raise ValueError('Blockfiles require signal shape to be square!')
+        raise ValueError("Blockfiles require signal shape to be square!")
     DP_SZ = DP_SZ[0]
-    SDP = 100. / axes_manager.signal_axes[0].scale
+    SDP = 100.0 / axes_manager.signal_axes[0].scale
 
-    offset2 = NX * NY + header['Data_offset_1']
+    offset2 = NX * NY + header["Data_offset_1"]
     # Based on inspected files, the DPs are stored at 16-bit boundary...
     # Normally, you'd expect word alignment (32-bits) ¯\_(°_o)_/¯
     offset2 += offset2 % 16
 
-    header = dict2sarray({
-        'NX': NX, 'NY': NY,
-        'DP_SZ': DP_SZ,
-        'SX': SX, 'SY': SY,
-        'SDP': SDP,
-        'Data_offset_2': offset2,
-    }, sarray=header)
+    header = dict2sarray(
+        {
+            "NX": NX,
+            "NY": NY,
+            "DP_SZ": DP_SZ,
+            "SX": SX,
+            "SY": SY,
+            "SDP": SDP,
+            "Data_offset_2": offset2,
+        },
+        sarray=header,
+    )
     return header, note
 
 
-def file_reader(filename, endianess='<', mmap_mode=None,
-                lazy=False, **kwds):
+def file_reader(filename, endianess="<", mmap_mode=None, lazy=False, **kwds):
     _logger.debug("Reading blockfile: %s" % filename)
     metadata = {}
     if mmap_mode is None:
-        mmap_mode = 'r' if lazy else 'c'
+        mmap_mode = "r" if lazy else "c"
     # Makes sure we open in right mode:
-    if '+' in mmap_mode or ('write' in mmap_mode and
-                            'copyonwrite' != mmap_mode):
+    if "+" in mmap_mode or ("write" in mmap_mode and "copyonwrite" != mmap_mode):
         if lazy:
             raise ValueError("Lazy loading does not support in-place writing")
-        f = open(filename, 'r+b')
+        f = open(filename, "r+b")
     else:
-        f = open(filename, 'rb')
+        f = open(filename, "rb")
     _logger.debug("File opened")
 
     # Get header
     header = np.fromfile(f, dtype=get_header_dtype_list(endianess), count=1)
-    if header['MAGIC'][0] not in magics:
-        warnings.warn("Blockfile has unrecognized header signature. "
-                      "Will attempt to read, but correcteness not guaranteed!",
-                      UserWarning)
+    if header["MAGIC"][0] not in magics:
+        warnings.warn(
+            "Blockfile has unrecognized header signature. "
+            "Will attempt to read, but correcteness not guaranteed!",
+            UserWarning,
+        )
     header = sarray2dict(header)
-    note = f.read(header['Data_offset_1'] - f.tell())
+    note = f.read(header["Data_offset_1"] - f.tell())
     # It seems it uses "\x00" for padding, so we remove it
     try:
-        header['Note'] = note.decode("latin1").strip("\x00")
+        header["Note"] = note.decode("latin1").strip("\x00")
     except BaseException:
         # Not sure about the encoding so, if it fails, we carry on
         _logger.warning(
             "Reading the Note metadata of this file failed. "
             "You can help improving "
             "HyperSpy by reporting the issue in "
-            "https://github.com/hyperspy/hyperspy")
+            "https://github.com/hyperspy/hyperspy"
+        )
     _logger.debug("File header: " + str(header))
-    NX, NY = int(header['NX']), int(header['NY'])
-    DP_SZ = int(header['DP_SZ'])
-    if header['SDP']:
-        SDP = 100. / header['SDP']
+    NX, NY = int(header["NX"]), int(header["NY"])
+    DP_SZ = int(header["DP_SZ"])
+    if header["SDP"]:
+        SDP = 100.0 / header["SDP"]
     else:
         SDP = Undefined
-    original_metadata = {'blockfile_header': header}
+    original_metadata = {"blockfile_header": header}
 
     # Get data:
 
     # A Virtual BF/DF is stored first
-#    offset1 = header['Data_offset_1']
-#    f.seek(offset1)
-#    data_pre = np.array(f.read(NX*NY), dtype=endianess+'u1'
-#        ).squeeze().reshape((NX, NY), order='C').T
+    #    offset1 = header['Data_offset_1']
+    #    f.seek(offset1)
+    #    data_pre = np.array(f.read(NX*NY), dtype=endianess+'u1'
+    #        ).squeeze().reshape((NX, NY), order='C').T
 
     # Then comes actual blockfile
-    offset2 = header['Data_offset_2']
+    offset2 = header["Data_offset_2"]
     if not lazy:
         f.seek(offset2)
-        data = np.fromfile(f, dtype=endianess + 'u1')
+        data = np.fromfile(f, dtype=endianess + "u1")
     else:
-        data = np.memmap(f, mode=mmap_mode, offset=offset2,
-                         dtype=endianess + 'u1')
+        data = np.memmap(f, mode=mmap_mode, offset=offset2, dtype=endianess + "u1")
     try:
         data = data.reshape((NY, NX, DP_SZ * DP_SZ + 6))
     except ValueError:
         warnings.warn(
-            'Blockfile header dimensions larger than file size! '
-            'Will attempt to load by zero padding incomplete frames.')
+            "Blockfile header dimensions larger than file size! "
+            "Will attempt to load by zero padding incomplete frames."
+        )
         # Data is stored DP by DP:
         pw = [(0, NX * NY * (DP_SZ * DP_SZ + 6) - data.size)]
-        data = np.pad(data, pw, mode='constant')
+        data = np.pad(data, pw, mode="constant")
         data = data.reshape((NY, NX, DP_SZ * DP_SZ + 6))
 
     # Every frame is preceeded by a 6 byte sequence (AA 55, and then a 4 byte
     # integer specifying frame number)
     data = data[:, :, 6:]
-    data = data.reshape((NY, NX, DP_SZ, DP_SZ), order='C').squeeze()
+    data = data.reshape((NY, NX, DP_SZ, DP_SZ), order="C").squeeze()
 
-    units = ['nm', 'nm', 'cm', 'cm']
-    names = ['y', 'x', 'dy', 'dx']
-    scales = [header['SY'], header['SX'], SDP, SDP]
-    date, time, time_zone = serial_date_to_ISO_format(
-        header['Acquisition_time'])
-    metadata = {'General': {'original_filename': os.path.split(filename)[1],
-                            'date': date,
-                            'time': time,
-                            'time_zone': time_zone,
-                            'notes': header['Note']},
-                "Signal": {'signal_type': "diffraction",
-                           'record_by': 'image', },
-                }
+    units = ["nm", "nm", "cm", "cm"]
+    names = ["y", "x", "dy", "dx"]
+    scales = [header["SY"], header["SX"], SDP, SDP]
+    date, time, time_zone = serial_date_to_ISO_format(header["Acquisition_time"])
+    metadata = {
+        "General": {
+            "original_filename": os.path.split(filename)[1],
+            "date": date,
+            "time": time,
+            "time_zone": time_zone,
+            "notes": header["Note"],
+        },
+        "Signal": {
+            "signal_type": "diffraction",
+            "record_by": "image",
+        },
+    }
     # Create the axis objects for each axis
     dim = data.ndim
     axes = [
         {
-            'size': data.shape[i],
-            'index_in_array': i,
-            'name': names[i],
-            'scale': scales[i],
-            'offset': 0.0,
-            'units': units[i], }
-        for i in range(dim)]
+            "size": data.shape[i],
+            "index_in_array": i,
+            "name": names[i],
+            "scale": scales[i],
+            "offset": 0.0,
+            "units": units[i],
+        }
+        for i in range(dim)
+    ]
 
-    dictionary = {'data': data,
-                  'axes': axes,
-                  'metadata': metadata,
-                  'original_metadata': original_metadata,
-                  'mapping': mapping, }
+    dictionary = {
+        "data": data,
+        "axes": axes,
+        "metadata": metadata,
+        "original_metadata": original_metadata,
+        "mapping": mapping,
+    }
 
     f.close()
-    return [dictionary, ]
+    return [
+        dictionary,
+    ]
 
 
 def file_writer(filename, signal, **kwds):
@@ -281,26 +316,37 @@ def file_writer(filename, signal, **kwds):
         overflow, if a tuple of values the values between this range is mapped
         to 0-255. If None (default) no rescaling is performed and overflow is
         permitted.
+    vbf : str or Signal2D
+        A blo file also saves a virtual bright field image for navigation.
+        This option determines what kind of data is stored for this image.
+        The default option "navigator" uses the navigator image if it was
+        previously calculated, else it is calculated here which can take
+        some time for large datasets. Alternatively, a Signal2D of the right
+        shape may also be provided. If set to None, a zero array is stored
+        in the file.
     """
-    endianess = kwds.pop('endianess', '<')
+    endianess = kwds.pop("endianess", "<")
     scale_strategy = kwds.pop("intensity_scaling", None)
+    vbf_strategy = kwds.pop("vbf", "navigator")
+    show_progressbar = kwds.pop("show_progressbar", None)
     if scale_strategy is None:
         # to distinguish from the tuple case
         if signal.data.dtype != "u1":
-            warnings.warn("Data does not have uint8 dtype: values outside the "
-                          "range 0-255 may result in overflow. To avoid this "
-                          "use the 'intensity_scaling' keyword argument.",
-                          UserWarning)
+            warnings.warn(
+                "Data does not have uint8 dtype: values outside the "
+                "range 0-255 may result in overflow. To avoid this "
+                "use the 'intensity_scaling' keyword argument.",
+                UserWarning,
+            )
     elif scale_strategy == "dtype":
         original_scale = dtype_limits(signal.data)
-        if original_scale[1] == 1.:
+        if original_scale[1] == 1.0:
             raise ValueError("Signals with float dtype can not use 'dtype'")
     elif scale_strategy == "minmax":
         minimum = signal.data.min()
         maximum = signal.data.max()
         if signal._lazy:
-            minimum = minimum.compute()
-            maximum = maximum.compute()
+            minimum, maximum = dask.compute(minimum, maximum)
         original_scale = (minimum, maximum)
     elif scale_strategy == "crop":
         original_scale = (0, 255)
@@ -309,46 +355,85 @@ def file_writer(filename, signal, **kwds):
         original_scale = scale_strategy
 
     header, note = get_header_from_signal(signal, endianess=endianess)
-    with open(filename, 'wb') as f:
+    with open(filename, "wb") as f:
         # Write header
         header.tofile(f)
         # Write header note field:
-        if len(note) > int(header['Data_offset_1']) - f.tell():
-            note = note[:int(header['Data_offset_1']) - f.tell() - len(note)]
+        if len(note) > int(header["Data_offset_1"]) - f.tell():
+            note = note[: int(header["Data_offset_1"]) - f.tell() - len(note)]
         f.write(note.encode())
         # Zero pad until next data block
-        zero_pad = int(header['Data_offset_1']) - f.tell()
+        zero_pad = int(header["Data_offset_1"]) - f.tell()
         np.zeros((zero_pad,), np.byte).tofile(f)
         # Write virtual bright field
-        vbf = signal.mean(
-            signal.axes_manager.signal_axes[
-                :2])
-        if signal._lazy:
-            vbf.compute()
-        vbf = vbf.data
+        if vbf_strategy is None:
+            vbf = np.zeros(signal.data.shape[0], signal.data.shape[1])
+        elif vbf_strategy == "navigator":
+            if signal.navigator is not None:
+                vbf = signal.navigator.data
+            else:
+                if signal._lazy:
+                    signal.compute_navigator()
+                    vbf = signal.navigator.data
+                else:
+                    # TODO workaround for non-lazy datasets
+                    sigints = signal.axes_manager.signal_indices_in_array[:2]
+                    vbf = signal.mean(axis=sigints).data
+        else:
+            vbf = vbf_strategy.data
+            # check that the shape is ok
+            if vbf.shape[::-1] == signal.axes_manager.navigation_shape or (
+                vbf.shape[::-1] == (1,) and signal.axes_manager.navigation_shape == ()
+            ):
+                pass
+            else:
+                raise ValueError(
+                    "Size of the provided VBF does not match the "
+                    "navigation dimensions of the dataset."
+                )
         if scale_strategy is not None:
             vbf = rescale_intensity(vbf, in_range=original_scale, out_range=np.uint8)
-        vbf = vbf.astype(endianess + 'u1')
+        vbf = vbf.astype(endianess + "u1")
         vbf.tofile(f)
         # Zero pad until next data block
-        if f.tell() > int(header['Data_offset_2']):
-            raise ValueError("Signal navigation size does not match "
-                             "data dimensions.")
-        zero_pad = int(header['Data_offset_2']) - f.tell()
+        if f.tell() > int(header["Data_offset_2"]):
+            raise ValueError(
+                "Signal navigation size does not match " "data dimensions."
+            )
+        zero_pad = int(header["Data_offset_2"]) - f.tell()
         np.zeros((zero_pad,), np.byte).tofile(f)
+        file_location = f.tell()
 
-        # Write full data stack:
-        # We need to pad each image with magic 'AA55', then a u32 serial
-        dp_head = np.zeros((1,), dtype=[('MAGIC', endianess + 'u2'),
-                                        ('ID', endianess + 'u4')])
-        dp_head['MAGIC'] = 0x55AA
-        # Write by loop:
-        for img in tqdm(signal._iterate_signal(),
-                        total=signal.data.shape[0] * signal.data.shape[1]):
-            # to ensure dask datasets, get a tofile method
-            dp_head.tofile(f)
-            img = np.array(img)
-            if scale_strategy is not None:
-                img = rescale_intensity(img, in_range=original_scale, out_range=np.uint8)
-            img.astype(endianess + 'u1').tofile(f)
-            dp_head['ID'] += 1
+    if scale_strategy is not None:
+        signal = signal.map(
+            rescale_intensity,
+            in_range=original_scale,
+            out_range=np.uint8,
+            inplace=False,
+        )
+    array_data = signal.data.astype(endianess + "u1")
+    # Write full data stack:
+    # We need to pad each image with magic 'AA55', then a u32 serial
+    pixels = array_data.shape[-2:]
+    records = array_data.shape[:-2]
+    record_dtype = [
+        ("MAGIC", endianess + "u2"),
+        ("ID", endianess + "u4"),
+        ("IMG", endianess + "u1", pixels),
+    ]
+    magics = np.full(records, 0x55AA, dtype=endianess + "u2")
+    ids = np.arange(np.product(records), dtype=endianess + "u4").reshape(records)
+    file_memmap = np.memmap(
+        filename, dtype=record_dtype, mode="r+", offset=file_location, shape=records
+    )
+    file_memmap["MAGIC"] = magics
+    file_memmap["ID"] = ids
+    if signal._lazy:
+        if show_progressbar is None:
+            show_progressbar = preferences.General.show_progressbar
+        cm = ProgressBar if show_progressbar else dummy_context_manager
+        with cm():
+            signal.data.store(file_memmap["IMG"])
+    else:
+        file_memmap["IMG"] = signal.data
+    file_memmap.flush()

--- a/hyperspy/tests/io/test_blockfile.py
+++ b/hyperspy/tests/io/test_blockfile.py
@@ -348,6 +348,31 @@ def test_lazy_save(save_path, fake_signal):
     np.testing.assert_allclose(sig_reload.data, compare)
 
 
+@pytest.mark.parametrize(
+    "vbf",
+    [
+        None,
+        "navigator",
+        hs.signals.Signal2D(np.zeros((3, 4))),
+    ],
+)
+def test_vbfs(save_path, fake_signal, vbf):
+    fake_signal = fake_signal.as_lazy()
+    if vbf == "navigator":
+        fake_signal.compute_navigator()
+    fake_signal.save(save_path, intensity_scaling=None, vbf=vbf, overwrite=True)
+    sig_reload = hs.load(save_path)
+    compare = (fake_signal.data % 256).astype(np.uint8)
+    np.testing.assert_allclose(sig_reload.data, compare)
+
+
+def test_invalid_vbf(save_path, fake_signal):
+    with pytest.raises(ValueError):
+        fake_signal.save(
+            save_path, vbf=hs.signals.Signal2D(np.zeros((10, 10))), overwrite=True
+        )
+
+
 def test_default_header():
     # Simply check that no exceptions are raised
     header = get_default_header()

--- a/hyperspy/tests/io/test_blockfile.py
+++ b/hyperspy/tests/io/test_blockfile.py
@@ -286,8 +286,8 @@ def test_different_x_y_scale_units(save_path):
 
 
 def test_inconvertible_units(save_path, fake_signal):
-    fake_signal.axes_manager[2].units = "bla"
-    fake_signal.axes_manager[3].units = "bla"
+    fake_signal.axes_manager[2].units = "1/A"
+    fake_signal.axes_manager[3].units = "1/A"
     fake_signal.change_dtype(np.uint8)
     with pytest.warns(UserWarning):
         fake_signal.save(save_path, overwrite=True)
@@ -308,6 +308,12 @@ def test_dtype_lims(save_path, fake_signal):
     np.testing.assert_allclose(
         sig_reload.data, (fake_signal.data / 65535 * 255).astype(np.uint8)
     )
+
+
+def test_dtype_float_fail(save_path, fake_signal):
+    fake_signal.change_dtype(np.float32)
+    with pytest.raises(ValueError):
+        fake_signal.save(save_path, intensity_scaling="dtype", overwrite=True)
 
 
 def test_minmax_lims(save_path, fake_signal):
@@ -332,6 +338,13 @@ def test_tuple_limits(save_path, fake_signal):
     sig_reload = hs.load(save_path)
     compare = rescale_intensity(fake_signal.data, in_range=(5, 200), out_range=np.uint8)
     np.testing.assert_allclose(sig_reload.data, compare)
+
+
+def test_lazy_save(save_path, fake_signal):
+    fake_signal = fake_signal.as_lazy()
+    fake_signal.save(save_path, overwrite=True)
+    sig_reload = hs.load(save_path)
+    np.testing.assert_allclose(sig_reload.data, fake_signal.data % 256)
 
 
 def test_default_header():

--- a/hyperspy/tests/io/test_blockfile.py
+++ b/hyperspy/tests/io/test_blockfile.py
@@ -342,9 +342,10 @@ def test_tuple_limits(save_path, fake_signal):
 
 def test_lazy_save(save_path, fake_signal):
     fake_signal = fake_signal.as_lazy()
-    fake_signal.save(save_path, overwrite=True)
+    fake_signal.save(save_path, intensity_scaling="minmax", overwrite=True)
     sig_reload = hs.load(save_path)
-    np.testing.assert_allclose(sig_reload.data, fake_signal.data % 256)
+    compare = (fake_signal.data / fake_signal.data.max() * 255).astype(np.uint8)
+    np.testing.assert_allclose(sig_reload.data, compare)
 
 
 def test_default_header():

--- a/hyperspy/tests/io/test_blockfile.py
+++ b/hyperspy/tests/io/test_blockfile.py
@@ -39,108 +39,186 @@ except NameError:
 
 
 DIRPATH = os.path.dirname(__file__)
-FILE1 = os.path.join(DIRPATH, 'blockfile_data', 'test1.blo')
-FILE2 = os.path.join(DIRPATH, 'blockfile_data', 'test2.blo')
+FILE1 = os.path.join(DIRPATH, "blockfile_data", "test1.blo")
+FILE2 = os.path.join(DIRPATH, "blockfile_data", "test2.blo")
+
 
 @pytest.fixture()
 def fake_signal():
     fake_data = np.arange(300).reshape(3, 4, 5, 5)
     fake_signal = hs.signals.Signal2D(fake_data)
-    fake_signal.axes_manager[0].scale_as_quantity = '1 mm'
-    fake_signal.axes_manager[1].scale_as_quantity = '1 mm'
-    fake_signal.axes_manager[2].scale_as_quantity = '1 mm'
-    fake_signal.axes_manager[3].scale_as_quantity = '1 mm'
+    fake_signal.axes_manager[0].scale_as_quantity = "1 mm"
+    fake_signal.axes_manager[1].scale_as_quantity = "1 mm"
+    fake_signal.axes_manager[2].scale_as_quantity = "1 mm"
+    fake_signal.axes_manager[3].scale_as_quantity = "1 mm"
     return fake_signal
 
 
 @pytest.fixture()
 def save_path():
     with tempfile.TemporaryDirectory() as tmp:
-        filepath = os.path.join(tmp, 'blockfile_data', 'save_temp.blo')
+        filepath = os.path.join(tmp, "blockfile_data", "save_temp.blo")
         yield filepath
         # Force files release (required in Windows)
         gc.collect()
 
 
 ref_data2 = np.array(
-    [[[[20, 23, 25, 25, 27],
-       [29, 23, 23, 0, 29],
-       [24, 0, 0, 22, 18],
-       [0, 14, 19, 17, 26],
-       [19, 21, 22, 27, 20]],
-
-      [[28, 25, 29, 15, 29],
-       [12, 15, 12, 25, 24],
-       [25, 26, 26, 18, 27],
-       [19, 18, 20, 23, 28],
-       [28, 18, 22, 25, 0]],
-
-      [[21, 29, 25, 19, 18],
-       [30, 15, 20, 22, 26],
-       [23, 18, 26, 15, 25],
-       [22, 25, 24, 15, 20],
-       [22, 15, 15, 21, 23]]],
-
-
-     [[[28, 25, 26, 24, 26],
-       [26, 17, 0, 24, 12],
-       [17, 18, 21, 19, 21],
-       [21, 24, 19, 17, 0],
-       [17, 14, 25, 15, 26]],
-
-      [[25, 18, 20, 15, 24],
-       [19, 13, 23, 18, 11],
-       [0, 25, 0, 0, 14],
-       [26, 22, 22, 11, 14],
-       [21, 0, 15, 13, 19]],
-
-      [[24, 18, 20, 22, 21],
-       [13, 25, 20, 28, 29],
-       [15, 17, 24, 23, 23],
-       [22, 21, 21, 22, 18],
-       [24, 25, 18, 18, 27]]]], dtype=np.uint8)
+    [
+        [
+            [
+                [20, 23, 25, 25, 27],
+                [29, 23, 23, 0, 29],
+                [24, 0, 0, 22, 18],
+                [0, 14, 19, 17, 26],
+                [19, 21, 22, 27, 20],
+            ],
+            [
+                [28, 25, 29, 15, 29],
+                [12, 15, 12, 25, 24],
+                [25, 26, 26, 18, 27],
+                [19, 18, 20, 23, 28],
+                [28, 18, 22, 25, 0],
+            ],
+            [
+                [21, 29, 25, 19, 18],
+                [30, 15, 20, 22, 26],
+                [23, 18, 26, 15, 25],
+                [22, 25, 24, 15, 20],
+                [22, 15, 15, 21, 23],
+            ],
+        ],
+        [
+            [
+                [28, 25, 26, 24, 26],
+                [26, 17, 0, 24, 12],
+                [17, 18, 21, 19, 21],
+                [21, 24, 19, 17, 0],
+                [17, 14, 25, 15, 26],
+            ],
+            [
+                [25, 18, 20, 15, 24],
+                [19, 13, 23, 18, 11],
+                [0, 25, 0, 0, 14],
+                [26, 22, 22, 11, 14],
+                [21, 0, 15, 13, 19],
+            ],
+            [
+                [24, 18, 20, 22, 21],
+                [13, 25, 20, 28, 29],
+                [15, 17, 24, 23, 23],
+                [22, 21, 21, 22, 18],
+                [24, 25, 18, 18, 27],
+            ],
+        ],
+    ],
+    dtype=np.uint8,
+)
 
 axes1 = {
-    'axis-0': {
-        'name': 'y', 'navigate': True, 'offset': 0.0,
-        'scale': 12.8, 'size': 3, 'units': 'nm'},
-    'axis-1': {
-        'name': 'x', 'navigate': True, 'offset': 0.0,
-        'scale': 12.8, 'size': 2, 'units': 'nm'},
-    'axis-2': {
-        'name': 'dy', 'navigate': False, 'offset': 0.0,
-        'scale': 0.016061676839061997, 'size': 144, 'units': 'cm'},
-    'axis-3': {
-        'name': 'dx', 'navigate': False, 'offset': 0.0,
-        'scale': 0.016061676839061997, 'size': 144, 'units': 'cm'}}
+    "axis-0": {
+        "name": "y",
+        "navigate": True,
+        "offset": 0.0,
+        "scale": 12.8,
+        "size": 3,
+        "units": "nm",
+    },
+    "axis-1": {
+        "name": "x",
+        "navigate": True,
+        "offset": 0.0,
+        "scale": 12.8,
+        "size": 2,
+        "units": "nm",
+    },
+    "axis-2": {
+        "name": "dy",
+        "navigate": False,
+        "offset": 0.0,
+        "scale": 0.016061676839061997,
+        "size": 144,
+        "units": "cm",
+    },
+    "axis-3": {
+        "name": "dx",
+        "navigate": False,
+        "offset": 0.0,
+        "scale": 0.016061676839061997,
+        "size": 144,
+        "units": "cm",
+    },
+}
 
 axes2 = {
-    'axis-0': {
-        'name': 'y', 'navigate': True, 'offset': 0.0,
-        'scale': 64.0, 'size': 2, 'units': 'nm'},
-    'axis-1': {
-        'name': 'x', 'navigate': True, 'offset': 0.0,
-        'scale': 64.0, 'size': 3, 'units': 'nm'},
-    'axis-2': {
-        'name': 'dy', 'navigate': False, 'offset': 0.0,
-        'scale': 0.016061676839061997, 'size': 5, 'units': 'cm'},
-    'axis-3': {
-        'name': 'dx', 'navigate': False, 'offset': 0.0,
-        'scale': 0.016061676839061997, 'size': 5, 'units': 'cm'}}
+    "axis-0": {
+        "name": "y",
+        "navigate": True,
+        "offset": 0.0,
+        "scale": 64.0,
+        "size": 2,
+        "units": "nm",
+    },
+    "axis-1": {
+        "name": "x",
+        "navigate": True,
+        "offset": 0.0,
+        "scale": 64.0,
+        "size": 3,
+        "units": "nm",
+    },
+    "axis-2": {
+        "name": "dy",
+        "navigate": False,
+        "offset": 0.0,
+        "scale": 0.016061676839061997,
+        "size": 5,
+        "units": "cm",
+    },
+    "axis-3": {
+        "name": "dx",
+        "navigate": False,
+        "offset": 0.0,
+        "scale": 0.016061676839061997,
+        "size": 5,
+        "units": "cm",
+    },
+}
 
 axes2_converted = {
-    'axis-0': {
-        'name': 'y', 'navigate': True, 'offset': 0.0,
-        'scale': 64.0, 'size': 2, 'units': 'nm'},
-    'axis-1': {
-        'name': 'x', 'navigate': True, 'offset': 0.0,
-        'scale': 64.0, 'size': 3, 'units': 'nm'},
-    'axis-2': {
-        'name': 'dy', 'navigate': False, 'offset': 0.0,
-        'scale': 160.61676839061997, 'size': 5, 'units': 'µm'},
-    'axis-3': {
-        'name': 'dx', 'navigate': False, 'offset': 0.0,
-        'scale': 160.61676839061997, 'size': 5, 'units': 'µm'}}
+    "axis-0": {
+        "name": "y",
+        "navigate": True,
+        "offset": 0.0,
+        "scale": 64.0,
+        "size": 2,
+        "units": "nm",
+    },
+    "axis-1": {
+        "name": "x",
+        "navigate": True,
+        "offset": 0.0,
+        "scale": 64.0,
+        "size": 3,
+        "units": "nm",
+    },
+    "axis-2": {
+        "name": "dy",
+        "navigate": False,
+        "offset": 0.0,
+        "scale": 160.61676839061997,
+        "size": 5,
+        "units": "µm",
+    },
+    "axis-3": {
+        "name": "dx",
+        "navigate": False,
+        "offset": 0.0,
+        "scale": 160.61676839061997,
+        "size": 5,
+        "units": "µm",
+    },
+}
 
 
 def test_load1():
@@ -162,32 +240,35 @@ def test_load2(convert_units):
 def test_save_load_cycle(save_path, convert_units):
     sig_reload = None
     signal = hs.load(FILE2, convert_units=convert_units)
-    serial = signal.original_metadata['blockfile_header']['Acquisition_time']
+    serial = signal.original_metadata["blockfile_header"]["Acquisition_time"]
     date, time, timezone = serial_date_to_ISO_format(serial)
-    assert signal.metadata.General.original_filename == 'test2.blo'
+    assert signal.metadata.General.original_filename == "test2.blo"
     assert signal.metadata.General.date == date
     assert signal.metadata.General.time == time
     assert signal.metadata.General.time_zone == timezone
     assert (
-        signal.metadata.General.notes ==
-        "Precession angle : \r\nPrecession Frequency : \r\nCamera gamma : on")
+        signal.metadata.General.notes
+        == "Precession angle : \r\nPrecession Frequency : \r\nCamera gamma : on"
+    )
     signal.save(save_path, overwrite=True)
     sig_reload = hs.load(save_path, convert_units=convert_units)
     np.testing.assert_equal(signal.data, sig_reload.data)
-    assert (signal.axes_manager.as_dictionary() ==
-            sig_reload.axes_manager.as_dictionary())
-    assert (signal.original_metadata.as_dictionary() ==
-            sig_reload.original_metadata.as_dictionary())
+    assert (
+        signal.axes_manager.as_dictionary() == sig_reload.axes_manager.as_dictionary()
+    )
+    assert (
+        signal.original_metadata.as_dictionary()
+        == sig_reload.original_metadata.as_dictionary()
+    )
     # change original_filename to make the metadata of both signals equals
-    sig_reload.metadata.General.original_filename = signal.metadata.General.original_filename
-    assert_deep_almost_equal(signal.metadata.as_dictionary(),
-                             sig_reload.metadata.as_dictionary())
-    assert (
-        signal.metadata.General.date ==
-        sig_reload.metadata.General.date)
-    assert (
-        signal.metadata.General.time ==
-        sig_reload.metadata.General.time)
+    sig_reload.metadata.General.original_filename = (
+        signal.metadata.General.original_filename
+    )
+    assert_deep_almost_equal(
+        signal.metadata.as_dictionary(), sig_reload.metadata.as_dictionary()
+    )
+    assert signal.metadata.General.date == sig_reload.metadata.General.date
+    assert signal.metadata.General.time == sig_reload.metadata.General.time
     assert isinstance(signal, hs.signals.Signal2D)
     # Delete reference to close memmap file!
     del sig_reload
@@ -199,12 +280,9 @@ def test_different_x_y_scale_units(save_path):
     signal.axes_manager[0].scale = 50.0
     signal.save(save_path, overwrite=True)
     sig_reload = hs.load(save_path)
-    np.testing.assert_allclose(sig_reload.axes_manager[0].scale, 50.0,
-                    rtol=1E-5)
-    np.testing.assert_allclose(sig_reload.axes_manager[1].scale, 64.0,
-                    rtol=1E-5)
-    np.testing.assert_allclose(sig_reload.axes_manager[2].scale, 0.0160616,
-                    rtol=1E-5)
+    np.testing.assert_allclose(sig_reload.axes_manager[0].scale, 50.0, rtol=1e-5)
+    np.testing.assert_allclose(sig_reload.axes_manager[1].scale, 64.0, rtol=1e-5)
+    np.testing.assert_allclose(sig_reload.axes_manager[2].scale, 0.0160616, rtol=1e-5)
 
 
 def test_inconvertible_units(save_path, fake_signal):
@@ -219,22 +297,26 @@ def test_overflow(save_path, fake_signal):
     with pytest.warns(UserWarning):
         fake_signal.save(save_path, overwrite=True)
     sig_reload = hs.load(save_path)
-    np.testing.assert_allclose(sig_reload.data,
-                              fake_signal.data.astype(np.uint8))
+    np.testing.assert_allclose(sig_reload.data, fake_signal.data.astype(np.uint8))
 
 
 def test_dtype_lims(save_path, fake_signal):
+    fake_signal.data = fake_signal.data * 100
     fake_signal.change_dtype(np.uint16)
     fake_signal.save(save_path, intensity_scaling="dtype", overwrite=True)
     sig_reload = hs.load(save_path)
-    np.testing.assert_allclose(sig_reload.data, fake_signal.data/65535)
+    np.testing.assert_allclose(
+        sig_reload.data, (fake_signal.data / 65535 * 255).astype(np.uint8)
+    )
 
 
 def test_minmax_lims(save_path, fake_signal):
     fake_signal.save(save_path, intensity_scaling="minmax", overwrite=True)
     sig_reload = hs.load(save_path)
-    np.testing.assert_allclose(sig_reload.data,
-                               fake_signal.data/fake_signal.data.max())
+    np.testing.assert_allclose(
+        sig_reload.data,
+        (fake_signal.data / fake_signal.data.max() * 255).astype(np.uint8),
+    )
 
 
 def test_crop_lims(save_path, fake_signal):
@@ -243,7 +325,7 @@ def test_crop_lims(save_path, fake_signal):
     compare = fake_signal.data
     compare[compare > 255] = 255
     np.testing.assert_allclose(sig_reload.data, compare)
-    
+
 
 def test_tuple_limits(save_path, fake_signal):
     fake_signal.save(save_path, intensity_scaling=(5, 200), overwrite=True)
@@ -259,14 +341,14 @@ def test_default_header():
 
 
 def test_non_square(save_path):
-    signal = hs.signals.Signal2D((255 * np.random.rand(10, 3, 5, 6)
-                                  ).astype(np.uint8))
+    signal = hs.signals.Signal2D((255 * np.random.rand(10, 3, 5, 6)).astype(np.uint8))
     with pytest.raises(ValueError):
         signal.save(save_path, overwrite=True)
 
 
 def test_load_lazy():
     from dask.array import Array
+
     s = hs.load(FILE2, lazy=True)
     assert isinstance(s.data, Array)
 
@@ -279,9 +361,12 @@ def test_load_to_memory():
 
 def test_load_readonly():
     s = hs.load(FILE2, lazy=True)
-    k = next(filter(lambda x: isinstance(x, str) and
-                    x.startswith("array-original"),
-                    s.data.dask.keys()))
+    k = next(
+        filter(
+            lambda x: isinstance(x, str) and x.startswith("array-original"),
+            s.data.dask.keys(),
+        )
+    )
     mm = s.data.dask[k]
     assert isinstance(mm, np.memmap)
     assert not mm.flags["WRITEABLE"]
@@ -289,57 +374,54 @@ def test_load_readonly():
 
 def test_load_inplace():
     with pytest.raises(ValueError):
-        hs.load(FILE2, lazy=True, mmap_mode='r+')
+        hs.load(FILE2, lazy=True, mmap_mode="r+")
 
 
 def test_write_fresh(save_path):
-    signal = hs.signals.Signal2D((255 * np.random.rand(10, 3, 5, 5)
-                                  ).astype(np.uint8))
+    signal = hs.signals.Signal2D((255 * np.random.rand(10, 3, 5, 5)).astype(np.uint8))
     signal.save(save_path, overwrite=True)
     sig_reload = hs.load(save_path)
     np.testing.assert_equal(signal.data, sig_reload.data)
     header = sarray2dict(get_default_header())
-    header.update({
-        'NX': 3, 'NY': 10,
-        'DP_SZ': 5,
-        'SX': 1, 'SY': 1,
-        'SDP': 100,
-        'Data_offset_2': 10 * 3 + header['Data_offset_1'],
-        'Note': '',
-    })
-    header['Data_offset_2'] += header['Data_offset_2'] % 16
-    assert (
-        sig_reload.original_metadata.blockfile_header.as_dictionary() ==
-        header)
+    header.update(
+        {
+            "NX": 3,
+            "NY": 10,
+            "DP_SZ": 5,
+            "SX": 1,
+            "SY": 1,
+            "SDP": 100,
+            "Data_offset_2": 10 * 3 + header["Data_offset_1"],
+            "Note": "",
+        }
+    )
+    header["Data_offset_2"] += header["Data_offset_2"] % 16
+    assert sig_reload.original_metadata.blockfile_header.as_dictionary() == header
 
 
 def test_write_data_line(save_path):
-    signal = hs.signals.Signal2D((255 * np.random.rand(3, 5, 5)
-                                  ).astype(np.uint8))
+    signal = hs.signals.Signal2D((255 * np.random.rand(3, 5, 5)).astype(np.uint8))
     signal.save(save_path, overwrite=True)
     sig_reload = hs.load(save_path)
     np.testing.assert_equal(signal.data, sig_reload.data)
 
 
 def test_write_data_single(save_path):
-    signal = hs.signals.Signal2D((255 * np.random.rand(5, 5)
-                                  ).astype(np.uint8))
+    signal = hs.signals.Signal2D((255 * np.random.rand(5, 5)).astype(np.uint8))
     signal.save(save_path, overwrite=True)
     sig_reload = hs.load(save_path)
     np.testing.assert_equal(signal.data, sig_reload.data)
 
 
 def test_write_data_am_mismatch(save_path):
-    signal = hs.signals.Signal2D((255 * np.random.rand(10, 3, 5, 5)
-                                  ).astype(np.uint8))
+    signal = hs.signals.Signal2D((255 * np.random.rand(10, 3, 5, 5)).astype(np.uint8))
     signal.axes_manager.navigation_axes[1].size = 4
     with pytest.raises(ValueError):
         signal.save(save_path, overwrite=True)
 
 
 def test_write_cutoff(save_path):
-    signal = hs.signals.Signal2D((255 * np.random.rand(10, 3, 5, 5)
-                                  ).astype(np.uint8))
+    signal = hs.signals.Signal2D((255 * np.random.rand(10, 3, 5, 5)).astype(np.uint8))
     signal.axes_manager.navigation_axes[0].size = 20
     # Test that it raises a warning
     signal.save(save_path, overwrite=True)
@@ -348,26 +430,24 @@ def test_write_cutoff(save_path):
         sig_reload = hs.load(save_path)
         # There can be other warnings so >=
         assert len(w) >= 1
-        warning_blockfile = ["Blockfile header" in str(warning.message)
-                             for warning in w]
+        warning_blockfile = [
+            "Blockfile header" in str(warning.message) for warning in w
+        ]
         assert True in warning_blockfile
-        assert issubclass(w[warning_blockfile.index(True)].category,
-                          UserWarning)
+        assert issubclass(w[warning_blockfile.index(True)].category, UserWarning)
     cut_data = signal.data.flatten()
     pw = [(0, 17 * 10 * 5 * 5)]
-    cut_data = np.pad(cut_data, pw, mode='constant')
+    cut_data = np.pad(cut_data, pw, mode="constant")
     cut_data = cut_data.reshape((10, 20, 5, 5))
     np.testing.assert_equal(cut_data, sig_reload.data)
 
 
 def test_crop_notes(save_path):
     note_len = 0x1000 - 0xF0
-    note = 'test123' * 1000     # > note_len
-    signal = hs.signals.Signal2D((255 * np.random.rand(2, 3, 2, 2)
-                                  ).astype(np.uint8))
-    signal.original_metadata.add_node('blockfile_header.Note')
+    note = "test123" * 1000  # > note_len
+    signal = hs.signals.Signal2D((255 * np.random.rand(2, 3, 2, 2)).astype(np.uint8))
+    signal.original_metadata.add_node("blockfile_header.Note")
     signal.original_metadata.blockfile_header.Note = note
     signal.save(save_path, overwrite=True)
     sig_reload = hs.load(save_path)
-    assert (sig_reload.original_metadata.blockfile_header.Note ==
-            note[:note_len])
+    assert sig_reload.original_metadata.blockfile_header.Note == note[:note_len]

--- a/upcoming_changes/2774.bugfix.rst
+++ b/upcoming_changes/2774.bugfix.rst
@@ -1,0 +1,1 @@
+Lazy datasets can now be saved out as blockfiles (blo).

--- a/upcoming_changes/2774.enhancements.rst
+++ b/upcoming_changes/2774.enhancements.rst
@@ -1,3 +1,4 @@
-When saving a dataset with a dtype other than `uint8` to a blockfile (blo) 
-it is now possible to provide the argument `intensity_scaling` to map the
-intensity values to the reduced range.
+When saving a dataset with a dtype other than
+`uint8<https://numpy.org/doc/stable/user/basics.types.html>`_ to a blockfile
+(blo) it is now possible to provide the argument ``intensity_scaling`` to map
+the intensity values to the reduced range.

--- a/upcoming_changes/2774.enhancements.rst
+++ b/upcoming_changes/2774.enhancements.rst
@@ -1,0 +1,3 @@
+When saving a dataset with a dtype other than `uint8` to a blockfile (blo) 
+it is now possible to provide the argument `intensity_scaling` to map the
+intensity values to the reduced range.

--- a/upcoming_changes/2774.enhancements.rst
+++ b/upcoming_changes/2774.enhancements.rst
@@ -1,4 +1,4 @@
 When saving a dataset with a dtype other than
-`uint8<https://numpy.org/doc/stable/user/basics.types.html>`_ to a blockfile
+`uint8 <https://numpy.org/doc/stable/user/basics.types.html>`_ to a blockfile
 (blo) it is now possible to provide the argument ``intensity_scaling`` to map
 the intensity values to the reduced range.


### PR DESCRIPTION
### Description of the change
As discussed in #2774 the BLO writer doesn't work for lazy datasets and throws errors when the diffraction patterns have weird units like 1/angstrom. This PR:

- Fixes the option to write lazy datasets
- Puts the conversion of units into a `try` block and warns the users if unit conversion was unsuccessful

In addition, since 4D-STEM data may be collected at dtypes > uint8, the default writer can easily cause overflow errors. I added an extra kwarg to the writer that allows the images to be rescaled to an appropriate range before conversion to 8-bit. A number of ways to do this are possible, the options I included are:

- `None` (default): current behavior, no rescaling and allow overflow. However, I added a warning in case the dtype is not uint8 that users may want to use the `intensity_scaling` argument in `save`.
- `'dtype'`: use the min and max value of the signal dtype range. Nonsensical for floats so throws an error.
- `'minmax'`: calculate the minimum and maximum of the dataset and map those onto 0 and 255 resp.
- `'crop'`: everything below 0 and above 255 is set to 0 and 255 resp.
- a 2-tuple of floats/ints: these intensity values are scaled linearly to 0 and 255

In addition, since the process in the loop can be quite slow for large datasets I added a tqdm progressbar.

Still needs more testing and possibly user guide additions, just posting this up here in case someone already wants to have a look.

### Progress of the PR
- [x] Change implemented (can be split into several points),
- [x] update docstring (if appropriate),
- [x] update user guide (if appropriate),
- [x] add an changelog entry in the `upcoming_changes` folder (see [`upcoming_changes/README.rst`](https://github.com/hyperspy/hyperspy/blob/RELEASE_next_minor/upcoming_changes/README.rst)),
- [x] Check formatting changelog entry in the `readthedocs` doc build of this PR (link in github checks)
- [x] add tests,
- [x] ready for review.

### Minimal example of the bug fix or the new feature
```python
import hyperspy.api as hs
import numpy as np
s = hs.signals.Signal2D(np.arange(25).reshape(1, 1, 5, 5).astype(np.float64)*1000, lazy=True)
s.save("test.blo", intensity_scaling="minmax")
```
Note that this example can be useful to update the user guide.

