### PR TITLE
Fix loading duplicated dataset for NeXus file loader

### DIFF
--- a/hyperspy/io_plugins/nexus.py
+++ b/hyperspy/io_plugins/nexus.py
@@ -311,6 +311,16 @@ def _extract_hdf_dataset(group, dataset, lazy=False):
     """
 
     data = group[dataset]
+
+    # exclude the dataset tagged by the signal attribute to avoid extracting
+    # duplicated dataset, which is already loaded when loading NeXus data
+    if 'signal' in data.parent.attrs.keys():
+        data_key = data.parent.attrs['signal']
+        if isinstance(data_key, bytes):
+            data_key = data_key.decode()
+        if dataset.split('/')[-1] == data_key:
+            return
+
     nav_list = _get_nav_list(data, data.parent)
 
     if lazy:
@@ -535,6 +545,7 @@ def file_reader(filename, lazy=False, dataset_key=None, dataset_path=None,
                 hdf_data_paths = []
                 nexus_data_paths = [nxpath for nxpath in nexus_data_paths
                                     if nxdata in nxpath]
+
     # if no default found then search for the data as normal
     if not nexus_data_paths and not hdf_data_paths:
         nexus_data_paths, hdf_data_paths = \

--- a/hyperspy/tests/io/test_nexus_hdf.py
+++ b/hyperspy/tests/io/test_nexus_hdf.py
@@ -66,9 +66,9 @@ class TestDLSNexus():
         if nxdata_only and hardlinks_only:
             assert not isinstance(s, list)
         if nxdata_only is False and hardlinks_only:
-            assert len(s) == 12
+            assert len(s) == 11
         if nxdata_only is False and not hardlinks_only:
-            assert len(s) == 16
+            assert len(s) == 14
 
     @pytest.mark.parametrize("metadata_key", ["m1_y", "xxxx"])
     def test_metadata_keys(self, metadata_key):
@@ -105,12 +105,12 @@ class TestDLSNexus():
             pytest.fail("unexpected error saving hdf5")
 
     @pytest.mark.parametrize("dataset_path",
-                             ('/entry1/testdata/nexustest/data',
-                               ['/entry1/testdata/nexustest/data', 'wrong']))
+                             ('/entry1/testdata/nexustest',
+                               ['/entry1/testdata/nexustest', 'wrong']))
     def test_dataset_paths(self, dataset_path):
         s = load(self.file, dataset_path=dataset_path)
         title = s.metadata.General.title
-        assert title == 'entry1_testdata_nexustest_data'
+        assert title == 'nexustest'
 
     def test_skip_load_array_metadata(self):
         s = load(self.file, nxdata_only=True, hardlinks_only=True,


### PR DESCRIPTION
### Description of the change
This fixes #2779, which avoid loading duplicated dataset for the NeXus file loader when `nxdata_only=False`.

### Progress of the PR
- [x] Change implemented
- [x] updated tests,
- [x] ready for review.

### Minimal example of the bug fix
```python
import hyperspy.api as hs
import numpy as np
s = hs.signals.Signal1D(np.random.random((20, 1000)))
s.save("test_duplicated_load.nxs")
s_load = hs.load("test_duplicated_load.nxs")
```

s_load is `<Signal1D, title: unnamed__0, dimensions: (20|1000)>`.