### PR TITLE
fix complex rebin and add complex test

### DIFF
--- a/hyperspy/misc/array_tools.py
+++ b/hyperspy/misc/array_tools.py
@@ -310,12 +310,12 @@ def _linear_bin(dat, scale, crop=True):
                 "Re-adjust your scale values or run code with "
                 "crop=False to avoid this error."
             )
-        # Set up the result np.array to have a new axis[0] size for after
-        # cropping.
-        result = np.zeros((dim,) + dat.shape[1:])
         # Make sure that native endian is used
         if not dat.dtype.isnative:
             dat = dat.astype(dat.dtype.type)
+        # Set up the result np.array to have a new axis[0] size for after
+        # cropping.
+        result = np.zeros((dim,) + dat.shape[1:], dtype=dat.dtype)
         # Carry out binning over axis[0]
         _linear_bin_loop(result=result, data=dat, scale=s)
         # Swap axis[0] back to the original axis location.

--- a/hyperspy/tests/signals/test_linear_rebin.py
+++ b/hyperspy/tests/signals/test_linear_rebin.py
@@ -25,7 +25,7 @@ from hyperspy.signals import EDSTEMSpectrum
 
 class TestLinearRebin:
 
-    @pytest.mark.parametrize('dtype', ['<u2', 'u2', '>u2', '<f4', 'f4', '>f4'])
+    @pytest.mark.parametrize('dtype', ['<u2', 'u2', '>u2', '<f4', 'f4', '>f4', 'c8'])
     def test_linear_downsize(self, dtype):
         spectrum = EDSTEMSpectrum(np.ones([3, 5, 1], dtype=dtype))
         scale = (1.5, 2.5, 1)
@@ -36,7 +36,7 @@ class TestLinearRebin:
         res = spectrum.rebin(scale=scale, crop=False)
         np.testing.assert_allclose(res.data.sum(), spectrum.data.sum())
 
-    @pytest.mark.parametrize('dtype', ['<u2', 'u2', '>u2', '<f4', 'f4', '>f4'])
+    @pytest.mark.parametrize('dtype', ['<u2', 'u2', '>u2', '<f4', 'f4', '>f4', 'c8'])
     def test_linear_upsize(self, dtype):
         spectrum = EDSTEMSpectrum(np.ones([4, 5, 10], dtype=dtype))
         scale = [0.3, 0.2, 0.5]

--- a/upcoming_changes/2789.bugfix.rst
+++ b/upcoming_changes/2789.bugfix.rst
@@ -1,0 +1,1 @@
+ComplexSignals can now be rebinned without error


### PR DESCRIPTION
My second try to fix rebinning of complex signals, as suggested by @ericpre:

- I added a test for complex data types.
- I specified the data type during creation of the array that will receive the rebinned data.
- To pass the test I had to rearrange the endianness conversion (don't know what this is tbh).

See discussion in https://github.com/hyperspy/hyperspy/pull/2788.