### PR TITLE
Handle polynomial with order >10 for estimate_parameters

### DIFF
--- a/hyperspy/_components/polynomial.py
+++ b/hyperspy/_components/polynomial.py
@@ -33,7 +33,7 @@ class Polynomial(Expression):
     """n-order polynomial component.
 
     Polynomial component consisting of order + 1 parameters.
-    The parameters are named "a" followed by the corresponding order, 
+    The parameters are named "a" followed by the corresponding order,
     i.e.
 
     .. math::
@@ -60,10 +60,10 @@ class Polynomial(Expression):
             raise ValueError("Polynomial of order 0 is not supported.")
         coeff_list = ['{}'.format(o).zfill(len(list(str(order)))) for o in
                       range(order, -1, -1)]
-        expr = "+".join(["a{}*x**{}".format(c, o) for c, o in 
+        expr = "+".join(["a{}*x**{}".format(c, o) for c, o in
                          zip(coeff_list, range(order, -1, -1))])
         name = "{} order Polynomial".format(ordinal(order))
-        super().__init__(expression=expr, name=name, module=module, 
+        super().__init__(expression=expr, name=name, module=module,
              autodoc=False, **kwargs)
         self._id_name = "eab91275-88db-4855-917a-cdcbe7209592"
 
@@ -107,7 +107,7 @@ class Polynomial(Expression):
                     para.value = estim
             return True
         else:
-            if self.a0.map is None:
+            if self.parameters[0].map is None:
                 self._create_arrays()
 
             nav_shape = signal.axes_manager._navigation_shape_in_array
@@ -142,7 +142,7 @@ def convert_to_polynomial(poly_dict):
     """
     _logger.info("Converting the polynomial to the new definition")
     poly_order = poly_dict['order']
-    coeff_list = ['{}'.format(o).zfill(len(list(str(poly_dict['order'])))) 
+    coeff_list = ['{}'.format(o).zfill(len(list(str(poly_dict['order']))))
                   for o in range(poly_dict['order'], -1, -1)]
     poly2_dict = dict(poly_dict)
     coefficient_dict = poly_dict['parameters'][0]

--- a/hyperspy/tests/component/test_components.py
+++ b/hyperspy/tests/component/test_components.py
@@ -308,16 +308,17 @@ class TestPolynomial:
         m_2d.multifit(iterpath='serpentine', grad='analytical')
         np.testing.assert_allclose(m_2d.red_chisq.data.sum(), 0.0, atol=1E-7)
 
+    @pytest.mark.parametrize(("order"), (2, 12))
     @pytest.mark.parametrize(("only_current", "binned"), TRUE_FALSE_2_TUPLE)
-    def test_estimate_parameters(self,  only_current, binned):
+    def test_estimate_parameters(self,  only_current, binned, order):
         self.m.signal.metadata.Signal.binned = binned
         s = self.m.as_signal()
         s.metadata.Signal.binned = binned
-        p = hs.model.components1D.Polynomial(order=2, legacy=False)
+        p = hs.model.components1D.Polynomial(order=order, legacy=False)
         p.estimate_parameters(s, None, None, only_current=only_current)
-        np.testing.assert_allclose(p.a2.value, 0.5)
-        np.testing.assert_allclose(p.a1.value, 2)
-        np.testing.assert_allclose(p.a0.value, 3)
+        np.testing.assert_allclose(p.parameters[2].value, 0.5)
+        np.testing.assert_allclose(p.parameters[1].value, 2)
+        np.testing.assert_allclose(p.parameters[0].value, 3)
 
     def test_zero_order(self):
         m = self.m_offset

--- a/upcoming_changes/2790.bugfix.rst
+++ b/upcoming_changes/2790.bugfix.rst
@@ -1,0 +1,2 @@
+Method `estimate_parameters` in `Polynomial` component now supports order
+greater than 10.


### PR DESCRIPTION
### Description of the change
This short PR fixes the issue for `estimate_parameters` in the `Polynomial` component if someone wants to use a polynomial with an order greater than 10. This allows the usage of, such as `remove_background` in non-interactive mode, with a polynomial order greater than 10, if one desires.

### Progress of the PR
- [x] Change implemented,
- [x] modify tests,
- [x] ready for review.

### Minimal example of the bug fix
This works after the fix:
```python
import numpy as np
import hyperspy.api as hs
s = hs.signals.Signal1D(np.random.random((4,4,32)))
s.remove_background(signal_range=(None, None), background_type='Polynomial', polynomial_order=12)
```