### PR TITLE
Output size save image

### DIFF
--- a/doc/user_guide/io.rst
+++ b/doc/user_guide/io.rst
@@ -599,6 +599,16 @@ documentation for more information.
     >>> s.save('file.jpg', scalebar=True)
     >>> s.save('file.jpg', scalebar=True, scalebar_kwds={'location':'lower right'})
 
+In the example above, the image is created using
+:py:func:`~.matplotlib.pyplot.imshow`, and additional keyword arguments can be
+pass to this function using ``imshow_kwds``. For example, this can be used to
+save an image displayed using a matplotlib colormap:
+
+.. code-block:: python
+
+    >>> s.save('file.jpg', imshow_kwds=dict(cmap='viridis'))
+
+
 The number of pixel of the exported image can be adjusted:
 
 .. code-block:: python
@@ -828,10 +838,10 @@ Extra saving arguments
 - ``intensity_scaling`` : in case the dataset that needs to be saved does not
   have the `np.uint8` data type, casting to this datatype without intensity
   rescaling results in overflow errors (default behavior). This option allows
-  you to perform linear intensity scaling of the images prior to saving the 
+  you to perform linear intensity scaling of the images prior to saving the
   data. The options are:
-  
-  - `'dtype'`: the limits of the datatype of the dataset, e.g. 0-65535 for 
+
+  - `'dtype'`: the limits of the datatype of the dataset, e.g. 0-65535 for
     `np.uint16`, are mapped onto 0-255 respectively. Does not work for `float`
     data types.
   - `'minmax'`: the minimum and maximum in the dataset are mapped to 0-255.
@@ -841,7 +851,7 @@ Extra saving arguments
 - ``navigator_signal``: the BLO file also stores a virtual bright field (VBF) image which
   behaves like a navigation signal in the ASTAR software. By default this is
   set to `'navigator'`, which results in the default :py:attr:`navigator` signal to be used.
-  If this signal was not calculated before (e.g. by calling :py:meth:`~.signal.BaseSignal.plot`), it is 
+  If this signal was not calculated before (e.g. by calling :py:meth:`~.signal.BaseSignal.plot`), it is
   calculated when :py:meth:`~.signal.BaseSignal.save` is called, which can be time consuming.
   Alternatively, setting the argument to `None` will result in a correctly sized
   zero array to be used. Finally, a custom ``Signal2D`` object can be passed,

--- a/doc/user_guide/io.rst
+++ b/doc/user_guide/io.rst
@@ -603,17 +603,17 @@ Extra saving arguments
   scalebar. Useful to set formattiong, location, etc. of the scalebar. See the
   `matplotlib-scalebar <https://pypi.org/project/matplotlib-scalebar/>`_
   documentation for more information.
-- ``output_size`` : (int, tuple of length 2 or None): the output size of the
-  image in pixels:
+- ``output_size`` : (int, tuple of length 2 or None, optional): the output size 
+  of the image in pixels:
 
   * if ``int``, defines the width of the image, the height is
-    determined from the aspec ratio of the image
+    determined from the aspect ratio of the image.
   * if ``tuple`` of length 2, defines the width and height of the
     image. Padding with white pixels is used to maintain the aspect
     ratio of the image.
   * if ``None``, the size of the data is used.
 
-  For output size larger than the data size, "nearest" interpolation is
+  For output sizes larger than the data size, "nearest" interpolation is
   used by default and this behaviour can be changed through the
   ``imshow_kwds`` dictionary.
 
@@ -646,7 +646,7 @@ to save an image displayed using a matplotlib colormap:
     >>> s.save('file.jpg', imshow_kwds=dict(cmap='viridis'))
 
 
-The number of pixels of the exported image can be adjusted:
+The resolution of the exported image can be adjusted:
 
 .. code-block:: python
 

--- a/doc/user_guide/io.rst
+++ b/doc/user_guide/io.rst
@@ -603,8 +603,7 @@ The number of pixel of the exported image can be adjusted:
 
 .. code-block:: python
 
-    >>> s.save('file.jpg', scalebar=True)
-    >>> s.save('file.jpg', scalebar=True, output_size=512)
+    >>> s.save('file.jpg', output_size=512)
 
 When saving an image, keyword arguments can be passed to the corresponding
 pillow file writer.

--- a/doc/user_guide/io.rst
+++ b/doc/user_guide/io.rst
@@ -599,6 +599,13 @@ documentation for more information.
     >>> s.save('file.jpg', scalebar=True)
     >>> s.save('file.jpg', scalebar=True, scalebar_kwds={'location':'lower right'})
 
+The number of pixel of the exported image can be adjusted:
+
+.. code-block:: python
+
+    >>> s.save('file.jpg', scalebar=True)
+    >>> s.save('file.jpg', scalebar=True, output_size=512)
+
 When saving an image, keyword arguments can be passed to the corresponding
 pillow file writer.
 

--- a/doc/user_guide/io.rst
+++ b/doc/user_guide/io.rst
@@ -588,11 +588,48 @@ HyperSpy can read and write data to `all the image formats
 <https://imageio.readthedocs.io/en/stable/formats.html>`_ supported by
 `imageio`, which uses the Python Image Library  (PIL/pillow).
 This includes png, pdf, gif, etc.
+It is important to note that these image formats only support 8-bit files, and
+therefore have an insufficient dynamic range for most scientific applications.
+It is therefore highly discouraged to use any general image format (with the
+exception of :ref:`tiff-format` which uses another library) to store data for
+analysis purposes.
+
+Extra saving arguments
+^^^^^^^^^^^^^^^^^^^^^^
+
+- ``scalebar`` (bool, optional): Export the image with a scalebar. Default
+  is False.
+- ``scalebar_kwds`` (dict, optional): dictionary of keyword arguments for the
+  scalebar. Useful to set formattiong, location, etc. of the scalebar. See the
+  `matplotlib-scalebar <https://pypi.org/project/matplotlib-scalebar/>`_
+  documentation for more information.
+- ``output_size`` : (int, tuple of length 2 or None): the output size of the
+  image in pixels:
+
+  * if ``int``, defines the width of the image, the height is
+    determined from the aspec ratio of the image
+  * if ``tuple`` of length 2, defines the width and height of the
+    image. Padding with white pixels is used to maintain the aspect
+    ratio of the image.
+  * if ``None``, the size of the data is used.
+
+  For output size larger than the data size, "nearest" interpolation is
+  used by default and this behaviour can be changed through the
+  ``imshow_kwds`` dictionary.
+
+- ``imshow_kwds`` (dict, optional):  Keyword arguments dictionary for
+  :py:func:`~.matplotlib.pyplot.imshow`.
+- ``**kwds`` : keyword arguments supported by the individual file
+  writers as documented at
+  https://imageio.readthedocs.io/en/stable/formats.html when exporting
+  an image without scalebar. When exporting with a scalebar, the keyword
+  arguments are passed to the `pil_kwargs` dictionary of
+  :py:func:`matplotlib.pyplot.savefig`
+
 
 When saving an image, a scalebar can be added to the image and the formatting,
-location, etc. of the scalebar can be set using the ``scalebar_kwds`` arguments
-- see the `matplotlib-scalebar <https://pypi.org/project/matplotlib-scalebar/>`_
-documentation for more information.
+location, etc. of the scalebar can be set using the ``scalebar_kwds``
+arguments:
 
 .. code-block:: python
 
@@ -615,14 +652,6 @@ The number of pixels of the exported image can be adjusted:
 
     >>> s.save('file.jpg', output_size=512)
 
-When saving an image, keyword arguments can be passed to the corresponding
-pillow file writer.
-
-It is important to note that these image formats only support 8-bit files, and
-therefore have an insufficient dynamic range for most scientific applications.
-It is therefore highly discouraged to use any general image format (with the
-exception of :ref:`tiff-format` which uses another library) to store data for
-analysis purposes.
 
 .. _tiff-format:
 

--- a/doc/user_guide/io.rst
+++ b/doc/user_guide/io.rst
@@ -601,15 +601,15 @@ documentation for more information.
 
 In the example above, the image is created using
 :py:func:`~.matplotlib.pyplot.imshow`, and additional keyword arguments can be
-pass to this function using ``imshow_kwds``. For example, this can be used to
-save an image displayed using a matplotlib colormap:
+passed to this function using ``imshow_kwds``. For example, this can be used
+to save an image displayed using a matplotlib colormap:
 
 .. code-block:: python
 
     >>> s.save('file.jpg', imshow_kwds=dict(cmap='viridis'))
 
 
-The number of pixel of the exported image can be adjusted:
+The number of pixels of the exported image can be adjusted:
 
 .. code-block:: python
 

--- a/hyperspy/datasets/artificial_data.py
+++ b/hyperspy/datasets/artificial_data.py
@@ -41,11 +41,8 @@ def get_low_loss_eels_signal(add_noise=True, random_state=None):
     Parameters
     ----------
     %s
-    %s
 
-    Returns
-    -------
-    artificial_low_loss_signal : :py:class:`~hyperspy._signals.eels.EELSSpectrum`
+    %s
 
     Example
     -------
@@ -84,7 +81,8 @@ get_low_loss_eels_signal.__doc__ %= (ADD_NOISE_DOCSTRING,
                                      RETURNS_DOCSTRING)
 
 
-def get_core_loss_eels_signal(add_powerlaw=False, add_noise=True, random_state=None):
+def get_core_loss_eels_signal(add_powerlaw=False, add_noise=True,
+                              random_state=None):
     """Get an artificial core loss electron energy loss spectrum.
 
     Similar to a Mn-L32 edge from a perovskite oxide.
@@ -209,7 +207,8 @@ get_low_loss_eels_line_scan_signal.__doc__ %= (ADD_NOISE_DOCSTRING,
                                                RETURNS_DOCSTRING)
 
 
-def get_core_loss_eels_line_scan_signal(add_powerlaw=False, add_noise=True, random_state=None):
+def get_core_loss_eels_line_scan_signal(add_powerlaw=False, add_noise=True,
+                                        random_state=None):
     """Get an artificial core loss electron energy loss line scan spectrum.
 
     Similar to a Mn-L32 and Fe-L32 edge from a perovskite oxide.
@@ -279,7 +278,8 @@ get_core_loss_eels_line_scan_signal.__doc__ %= (ADD_POWERLAW_DOCSTRING,
                                                 RETURNS_DOCSTRING)
 
 
-def get_core_loss_eels_model(add_powerlaw=False, add_noise=True, random_state=None):
+def get_core_loss_eels_model(add_powerlaw=False, add_noise=True,
+                             random_state=None):
     """Get an artificial core loss electron energy loss model.
 
     Similar to a Mn-L32 edge from a perovskite oxide.
@@ -364,12 +364,10 @@ def get_luminescence_signal(navigation_dimension=0,
     uniform: bool.
         return uniform (wavelength) or non-uniform (energy) spectrum
     add_baseline : bool
-            If true, adds a constant baseline to the spectrum. Conversion to
-            energy representation will turn the constant baseline into inverse
-            powerlaw.
+        If true, adds a constant baseline to the spectrum. Conversion to
+        energy representation will turn the constant baseline into inverse
+        powerlaw.
     %s
-    random_state: None or int
-        initialise state of the random number generator
 
     Example
     -------

--- a/hyperspy/io_plugins/image.py
+++ b/hyperspy/io_plugins/image.py
@@ -63,9 +63,19 @@ def file_writer(filename, signal, scalebar=False, scalebar_kwds=None,
         formattiong, location, etc. of the scalebar. See the documentation of
         the 'matplotlib-scalebar' library for more information.
     output_size : {tuple of length 2, int, None}, optional
-        The output size of the image in pixels (width, height). If int, defines 
-        the width of the image. If None, the size of the data is used. Default is 
-        None.
+        The output size of the image in pixels (width, height):
+
+            * if *int*, defines the width of the image, the height is
+              determined from the aspec ratio of the image
+            * if *tuple of length 2*, defines the width and height of the
+              image. Padding with white pixels is used to maintain the aspect
+              ratio of the image.
+            * if *None*, the size of the data is used.
+
+        For output size larger than the data size, "nearest" interpolation is
+        used by default and this behaviour can be changed through the
+        *imshow_kwds* dictionary. Default is None.
+
     imshow_kwds : dict, optional
         Keyword arguments dictionary for :py:func:`~.matplotlib.pyplot.imshow`.
     **kwds : keyword arguments, optional
@@ -74,7 +84,7 @@ def file_writer(filename, signal, scalebar=False, scalebar_kwds=None,
         https://imageio.readthedocs.io/en/stable/formats.html when exporting
         an image without scalebar. When exporting with a scalebar, the keyword
         arguments are passed to the `pil_kwargs` dictionary of
-        :py:func:`matplotlib.pyplot.savefig`
+        :py:func:`~matplotlib.pyplot.savefig`
 
     """
     data = signal.data

--- a/hyperspy/io_plugins/image.py
+++ b/hyperspy/io_plugins/image.py
@@ -45,7 +45,9 @@ _logger = logging.getLogger(__name__)
 
 def file_writer(filename, signal, scalebar=False, scalebar_kwds=None,
                 output_size=None, **kwds):
-    """Writes data to any format supported by PIL
+    """Writes data to any format supported by pillow. When ``output_size``
+    or ``scalebar`` is used, :py:func:`~.matplotlib.pyplot.imshow` is used to
+    generate a figure.
 
     Parameters
     ----------
@@ -62,7 +64,7 @@ def file_writer(filename, signal, scalebar=False, scalebar_kwds=None,
         the 'matplotlib-scalebar' library for more information.
     output_size : tuple of length 2 or int
         The output size of the image in pixel, if None, the size of the data
-        is used. Default is None.
+        is used. If int, define the width of the image. Default is None.
     **kwds : keyword arguments
         Allows to pass keyword arguments supported by the individual file
         writers as documented at
@@ -99,7 +101,8 @@ def file_writer(filename, signal, scalebar=False, scalebar_kwds=None,
             # fall back to image size
             output_size = [axis.size for axis in axes]
         elif isinstance(output_size, (int, float)):
-            output_size = [output_size]*2
+            aspect_ratio = data.shape[0] / data.shape[1]
+            output_size = [output_size, output_size * aspect_ratio]
 
         fig = Figure(figsize=[size / dpi for size in output_size], dpi=dpi)
 

--- a/hyperspy/io_plugins/image.py
+++ b/hyperspy/io_plugins/image.py
@@ -57,21 +57,21 @@ def file_writer(filename, signal, scalebar=False, scalebar_kwds=None,
         the file extension that is any one supported by imageio.
     signal: a Signal instance
     scalebar : bool, optional
-        Export the image with a scalebar. Default is False
+        Export the image with a scalebar. Default is False.
     scalebar_kwds : dict, optional
         Dictionary of keyword arguments for the scalebar. Useful to set
         formattiong, location, etc. of the scalebar. See the documentation of
         the 'matplotlib-scalebar' library for more information.
     output_size : tuple of length 2 or int
-        The output size of the image in pixel, if None, the size of the data
-        is used. If int, define the width of the image. Default is None.
+        The output size of the image in pixels, if None, the size of the data
+        is used. If int, defines the width of the image. Default is None.
     imshow_kwds : dict, optional
         Keyword arguments dictionary for :py:func:`~.matplotlib.pyplot.imshow`.
     **kwds : keyword arguments
         Allows to pass keyword arguments supported by the individual file
         writers as documented at
         https://imageio.readthedocs.io/en/stable/formats.html when exporting
-        image without scalebar. When exporting with a scalebar, the keyword
+        an image without scalebar. When exporting with a scalebar, the keyword
         arguments are passed to the `pil_kwargs` dictionary of
         :py:func:`matplotlib.pyplot.savefig`
 
@@ -131,7 +131,7 @@ def file_writer(filename, signal, scalebar=False, scalebar_kwds=None,
                                  f"with {', '.join(supported_format)}.")
 
     if scalebar:
-        # Sanety check of the axes
+        # Sanity check of the axes
         # This plugin doesn't support non-uniform axes, we don't need to check
         # if the axes have a scale attribute
         if axes[0].scale != axes[1].scale or axes[0].units != axes[1].units:

--- a/hyperspy/io_plugins/image.py
+++ b/hyperspy/io_plugins/image.py
@@ -62,12 +62,13 @@ def file_writer(filename, signal, scalebar=False, scalebar_kwds=None,
         Dictionary of keyword arguments for the scalebar. Useful to set
         formattiong, location, etc. of the scalebar. See the documentation of
         the 'matplotlib-scalebar' library for more information.
-    output_size : tuple of length 2 or int
-        The output size of the image in pixels, if None, the size of the data
-        is used. If int, defines the width of the image. Default is None.
+    output_size : {tuple of length 2, int, None}, optional
+        The output size of the image in pixels (width, height). If int, defines 
+        the width of the image. If None, the size of the data is used. Default is 
+        None.
     imshow_kwds : dict, optional
         Keyword arguments dictionary for :py:func:`~.matplotlib.pyplot.imshow`.
-    **kwds : keyword arguments
+    **kwds : keyword arguments, optional
         Allows to pass keyword arguments supported by the individual file
         writers as documented at
         https://imageio.readthedocs.io/en/stable/formats.html when exporting

--- a/hyperspy/io_plugins/image.py
+++ b/hyperspy/io_plugins/image.py
@@ -46,8 +46,8 @@ _logger = logging.getLogger(__name__)
 def file_writer(filename, signal, scalebar=False, scalebar_kwds=None,
                 output_size=None, imshow_kwds=None, **kwds):
     """Writes data to any format supported by pillow. When ``output_size``
-    or ``scalebar`` is used, :py:func:`~.matplotlib.pyplot.imshow` is used to
-    generate a figure.
+    or ``scalebar`` or ``imshow_kwds`` is used,
+    :py:func:`~.matplotlib.pyplot.imshow` is used to generate a figure.
 
     Parameters
     ----------
@@ -83,10 +83,6 @@ def file_writer(filename, signal, scalebar=False, scalebar_kwds=None,
     scalebar_kwds.setdefault('box_alpha', 0.75)
     scalebar_kwds.setdefault('location', 'lower left')
 
-    if imshow_kwds is None:
-        imshow_kwds = dict()
-    imshow_kwds.setdefault('cmap', 'gray')
-
     if rgb_tools.is_rgbx(data):
         data = rgb_tools.rgbx2regular_array(data)
 
@@ -98,8 +94,12 @@ def file_writer(filename, signal, scalebar=False, scalebar_kwds=None,
             _logger.warning("Exporting image with scalebar requires the "
                             "matplotlib-scalebar library.")
 
-    if scalebar or output_size:
+    if scalebar or output_size or imshow_kwds:
         dpi = 100
+
+        if imshow_kwds is None:
+            imshow_kwds = dict()
+        imshow_kwds.setdefault('cmap', 'gray')
 
         if len(signal.axes_manager.signal_axes) == 2:
             axes = signal.axes_manager.signal_axes

--- a/hyperspy/io_plugins/image.py
+++ b/hyperspy/io_plugins/image.py
@@ -35,7 +35,7 @@ file_extensions = ['png', 'bmp', 'dib', 'gif', 'jpeg', 'jpe', 'jpg',
                    'msp', 'pcx', 'ppm', "pbm", "pgm", 'xbm', 'spi', ]
 default_extension = 0  # png
 # Writing capabilities
-writes = [(2, 0), ]
+writes = [(2, 0), (0, 2)]
 non_uniform_axis = False
 # ----------------------
 
@@ -92,10 +92,8 @@ def file_writer(filename, signal, scalebar=False, scalebar_kwds=None,
         if len(signal.axes_manager.signal_axes) == 2:
             axes = signal.axes_manager.signal_axes
         elif len(signal.axes_manager.navigation_axes) == 2:
-            # Try to use navigation axes
+            # Use navigation axes
             axes = signal.axes_manager.navigation_axes
-        else:
-            raise ValueError("Data not compatible with saving scale bar.")
 
         if output_size is None:
             # fall back to image size

--- a/hyperspy/tests/io/test_image.py
+++ b/hyperspy/tests/io/test_image.py
@@ -187,6 +187,21 @@ def test_export_output_size_non_square(output_size, tmp_path):
     assert s_reload.data.shape == output_size
 
 
+@pytest.mark.parametrize('output_size', (None, 512))
+@pytest.mark.parametrize('aspect', (1, 0.5))
+def test_export_output_size_aspect(aspect, output_size, tmp_path):
+    pixels = (256, 256)
+    s = hs.signals.Signal2D(np.arange(np.multiply(*pixels)).reshape(pixels))
+
+    fname = tmp_path / 'test_export_size_non_square_aspect.jpg'
+    s.save(fname, scalebar=True, output_size=output_size, imshow_kwds=dict(aspect=aspect))
+    s_reload = hs.load(fname)
+
+    if output_size is None:
+        output_size = s.data.shape[0]
+    assert s_reload.data.shape == (output_size * aspect, output_size)
+
+
 def test_save_image_navigation():
     pixels = 16
     s = hs.signals.Signal2D(np.arange(pixels**2).reshape((pixels, pixels)))

--- a/hyperspy/tests/io/test_image.py
+++ b/hyperspy/tests/io/test_image.py
@@ -170,3 +170,11 @@ def test_export_output_size(output_size):
         s.save(filename, scalebar=True, output_size=output_size)
         s_reload = hs.load(filename)
         assert s_reload.data.shape == (512, 512)
+
+
+def test_save_image_navigation():
+    pixels = 16
+    s = hs.signals.Signal2D(np.arange(pixels**2).reshape((pixels, pixels)))
+    with tempfile.TemporaryDirectory() as tmpdir:
+        filename = os.path.join(tmpdir, 'test_save_image_navigation.jpg')
+        s.T.save(filename, scalebar=True)

--- a/hyperspy/tests/io/test_image.py
+++ b/hyperspy/tests/io/test_image.py
@@ -16,9 +16,6 @@
 # You should have received a copy of the GNU General Public License
 # along with  HyperSpy.  If not, see <http://www.gnu.org/licenses/>.
 
-import os
-import tempfile
-
 import numpy as np
 import pytest
 
@@ -34,18 +31,18 @@ except ImportError:  # pragma: no cover
 
 @pytest.mark.parametrize(("dtype"), ['uint8', 'uint32'])
 @pytest.mark.parametrize(("ext"), ['png', 'bmp', 'gif', 'jpg'])
-def test_save_load_cycle_grayscale(dtype, ext):
+def test_save_load_cycle_grayscale(dtype, ext, tmp_path):
     s = hs.signals.Signal2D(np.arange(128*128).reshape(128, 128).astype(dtype))
-    with tempfile.TemporaryDirectory() as tmpdir:
-        print('Saving-loading cycle for the extension:', ext)
-        filename = os.path.join(tmpdir, 'test_image.'+ext)
-        s.save(filename)
-        hs.load(filename)
+
+    print('Saving-loading cycle for the extension:', ext)
+    filename = tmp_path / f'test_image.{ext}'
+    s.save(filename)
+    hs.load(filename)
 
 
 @pytest.mark.parametrize(("color"), ['rgb8', 'rgba8', 'rgb16', 'rgba16'])
 @pytest.mark.parametrize(("ext"), ['png', 'bmp', 'gif', 'jpeg'])
-def test_save_load_cycle_color(color, ext):
+def test_save_load_cycle_color(color, ext, tmp_path):
     dim = 4 if "rgba" in color else 3
     dtype = 'uint8' if "8" in color else 'uint16'
     if dim == 4 and ext == 'jpeg':
@@ -54,122 +51,116 @@ def test_save_load_cycle_color(color, ext):
     print('color:', color, '; dim:', dim, '; dtype:', dtype)
     s = hs.signals.Signal1D(np.arange(128*128*dim).reshape(128, 128, dim).astype(dtype))
     s.change_dtype(color)
-    with tempfile.TemporaryDirectory() as tmpdir:
-        print('Saving-loading cycle for the extension:', ext)
-        filename = os.path.join(tmpdir, 'test_image.'+ext)
-        s.save(filename)
-        hs.load(filename)
+
+    print('Saving-loading cycle for the extension:', ext)
+    filename = tmp_path / f'test_image.{ext}'
+    s.save(filename)
+    hs.load(filename)
 
 
 @pytest.mark.parametrize(("dtype"), ['uint8', 'uint32'])
 @pytest.mark.parametrize(("ext"), ['png', 'bmp', 'gif', 'jpg'])
-def test_save_load_cycle_kwds(dtype, ext):
+def test_save_load_cycle_kwds(dtype, ext, tmp_path):
     s = hs.signals.Signal2D(np.arange(128*128).reshape(128, 128).astype(dtype))
-    with tempfile.TemporaryDirectory() as tmpdir:
-        print('Saving-loading cycle for the extension:', ext)
-        filename = os.path.join(tmpdir, 'test_image.'+ext)
-        if ext == 'png':
-            if dtype == 'uint32':
-                kwds = {'bits': 32}
-            else:
-                kwds = {'optimize': True}
-        elif ext == 'jpg':
-            kwds = {'quality': 100, 'optimize': True}
-        elif ext == 'gif':
-            kwds = {'subrectangles': 'True', 'palettesize': 128}
+
+    print('Saving-loading cycle for the extension:', ext)
+    filename = tmp_path / f'test_image.{ext}'
+    if ext == 'png':
+        if dtype == 'uint32':
+            kwds = {'bits': 32}
         else:
-            kwds = {}
-        s.save(filename, **kwds)
-        hs.load(filename, pilmode='L', as_grey=True)
+            kwds = {'optimize': True}
+    elif ext == 'jpg':
+        kwds = {'quality': 100, 'optimize': True}
+    elif ext == 'gif':
+        kwds = {'subrectangles': 'True', 'palettesize': 128}
+    else:
+        kwds = {}
+    s.save(filename, **kwds)
+    hs.load(filename, pilmode='L', as_grey=True)
 
 
 @pytest.mark.parametrize(("ext"), ['png', 'bmp', 'gif', 'jpg'])
-def test_export_scalebar(ext):
+def test_export_scalebar(ext, tmp_path):
     data = np.arange(1E6).reshape((1000, 1000))
     s = hs.signals.Signal2D(data)
     s.axes_manager[0].units = 'nm'
     s.axes_manager[1].units = 'nm'
-    with tempfile.TemporaryDirectory() as tmpdir:
-        filename = os.path.join(tmpdir, f'test_scalebar_export.{ext}')
-        if ext in ['bmp', 'gif'] and matplotlib_scalebar_installed:
-            with pytest.raises(ValueError):
-                s.save(filename, scalebar=True)
-            with pytest.raises(ValueError):
-                s.save(filename, output_size=512)
-            s.save(filename)
-        else:
+
+    filename = tmp_path / f'test_scalebar_export.{ext}'
+    if ext in ['bmp', 'gif'] and matplotlib_scalebar_installed:
+        with pytest.raises(ValueError):
             s.save(filename, scalebar=True)
-        s_reload = hs.load(filename)
-        assert s.data.shape == s_reload.data.shape
+        with pytest.raises(ValueError):
+            s.save(filename, output_size=512)
+        s.save(filename)
+    else:
+        s.save(filename, scalebar=True)
+    s_reload = hs.load(filename)
+    assert s.data.shape == s_reload.data.shape
 
 
-def test_export_scalebar_reciprocal():
+def test_export_scalebar_reciprocal(tmp_path):
     pixels = 512
     s = hs.signals.Signal2D(np.arange(pixels**2).reshape((pixels, pixels)))
     for axis in s.axes_manager.signal_axes:
         axis.units = '1/nm'
         axis.scale = 0.1
 
-    with tempfile.TemporaryDirectory() as tmpdir:
-        filename = os.path.join(tmpdir, 'test_scalebar_export.jpg')
-        s.save(filename, scalebar=True, scalebar_kwds={'location':'lower right'})
-        s_reload = hs.load(filename)
-        assert s.data.shape == s_reload.data.shape
+    filename = tmp_path / 'test_scalebar_export.jpg'
+    s.save(filename, scalebar=True, scalebar_kwds={'location':'lower right'})
+    s_reload = hs.load(filename)
+    assert s.data.shape == s_reload.data.shape
 
 
-def test_export_scalebar_undefined_units():
+def test_export_scalebar_undefined_units(tmp_path):
     pixels = 512
     s = hs.signals.Signal2D(np.arange(pixels**2).reshape((pixels, pixels)))
 
-    with tempfile.TemporaryDirectory() as tmpdir:
-        filename = os.path.join(tmpdir, 'test_scalebar_export.jpg')
-        s.save(filename, scalebar=True, scalebar_kwds={'location':'lower right'})
-        s_reload = hs.load(filename)
-        assert s.data.shape == s_reload.data.shape
+    filename = tmp_path / 'test_scalebar_export.jpg'
+    s.save(filename, scalebar=True, scalebar_kwds={'location':'lower right'})
+    s_reload = hs.load(filename)
+    assert s.data.shape == s_reload.data.shape
 
 
-def test_non_uniform():
+def test_non_uniform(tmp_path):
     pixels = 16
     s = hs.signals.Signal2D(np.arange(pixels**2).reshape((pixels, pixels)))
     s.axes_manager[0].convert_to_non_uniform_axis()
 
-    with tempfile.TemporaryDirectory() as tmpdir:
-        filename = os.path.join(tmpdir, 'test_export_size.jpg')
-        with pytest.raises(TypeError):
-            s.save(filename)
+    filename = tmp_path / 'test_export_size.jpg'
+    with pytest.raises(TypeError):
+        s.save(filename)
 
 
 @pytest.mark.skipif(not matplotlib_scalebar_installed,
                     reason='matplotlib_scalebar is not installed')
-def test_export_scalebar_different_scale_units():
+def test_export_scalebar_different_scale_units(tmp_path):
     pixels = 16
     s = hs.signals.Signal2D(np.arange(pixels**2).reshape((pixels, pixels)))
     s.axes_manager[0].scale = 2
 
-    with tempfile.TemporaryDirectory() as tmpdir:
-        filename = os.path.join(tmpdir, 'test_export_size.jpg')
-        with pytest.raises(ValueError):
-            s.save(filename, scalebar=True)
+    filename = tmp_path / 'test_export_size.jpg'
+    with pytest.raises(ValueError):
+        s.save(filename, scalebar=True)
 
     s = hs.signals.Signal2D(np.arange(pixels**2).reshape((pixels, pixels)))
     s.axes_manager[0].units = 'nm'
 
-    with tempfile.TemporaryDirectory() as tmpdir:
-        filename = os.path.join(tmpdir, 'test_export_size.jpg')
-        with pytest.raises(ValueError):
-            s.save(filename, scalebar=True)
+    filename = tmp_path / 'test_export_size.jpg'
+    with pytest.raises(ValueError):
+        s.save(filename, scalebar=True)
 
 
 @pytest.mark.parametrize('output_size', (512, [512, 512]))
-def test_export_output_size(output_size):
+def test_export_output_size(output_size, tmp_path):
     pixels = 16
     s = hs.signals.Signal2D(np.arange(pixels**2).reshape((pixels, pixels)))
 
-    with tempfile.TemporaryDirectory() as tmpdir:
-        filename = os.path.join(tmpdir, 'test_export_size.jpg')
-        s.save(filename, scalebar=True, output_size=output_size)
-        s_reload = hs.load(filename)
-        assert s_reload.data.shape == (512, 512)
+    fname = tmp_path / 'test_export_size.jpg'
+    s.save(fname, scalebar=True, output_size=output_size)
+    s_reload = hs.load(fname)
+    assert s_reload.data.shape == (512, 512)
 
 
 @pytest.mark.parametrize('output_size', (512, (512, 512)))
@@ -202,9 +193,9 @@ def test_export_output_size_aspect(aspect, output_size, tmp_path):
     assert s_reload.data.shape == (output_size * aspect, output_size)
 
 
-def test_save_image_navigation():
+def test_save_image_navigation(tmp_path):
     pixels = 16
     s = hs.signals.Signal2D(np.arange(pixels**2).reshape((pixels, pixels)))
-    with tempfile.TemporaryDirectory() as tmpdir:
-        filename = os.path.join(tmpdir, 'test_save_image_navigation.jpg')
-        s.T.save(filename, scalebar=True)
+
+    fname = tmp_path / 'test_save_image_navigation.jpg'
+    s.T.save(fname, scalebar=True)

--- a/hyperspy/tests/io/test_image.py
+++ b/hyperspy/tests/io/test_image.py
@@ -172,6 +172,21 @@ def test_export_output_size(output_size):
         assert s_reload.data.shape == (512, 512)
 
 
+@pytest.mark.parametrize('output_size', (512, (512, 512)))
+def test_export_output_size_non_square(output_size, tmp_path):
+    pixels = (8, 16)
+    s = hs.signals.Signal2D(np.arange(np.multiply(*pixels)).reshape(pixels))
+
+    fname = tmp_path / 'test_export_size_non_square.jpg'
+    s.save(fname, output_size=output_size)
+    s_reload = hs.load(fname)
+
+    if isinstance(output_size, int):
+       output_size = (output_size * np.divide(*pixels), output_size)
+
+    assert s_reload.data.shape == output_size
+
+
 def test_save_image_navigation():
     pixels = 16
     s = hs.signals.Signal2D(np.arange(pixels**2).reshape((pixels, pixels)))

--- a/upcoming_changes/2399.new.rst
+++ b/upcoming_changes/2399.new.rst
@@ -1,1 +1,1 @@
-Implement non-uniform axes, not all hyperspy functionalities support non-uniform axes, see this [tracking issue](https://github.com/hyperspy/hyperspy/issues/2398) for progress.
+Implement non-uniform axes, not all hyperspy functionalities support non-uniform axes, see this `tracking issue <https://github.com/hyperspy/hyperspy/issues/2398>`_ for progress.

--- a/upcoming_changes/2791.enhancements.rst
+++ b/upcoming_changes/2791.enhancements.rst
@@ -1,0 +1,1 @@
+Add option to set output size when :ref:`exporting images<image-format>`


### PR DESCRIPTION
### Progress of the PR
- [x] Add argument to set output size when saving image,
- [x] update docstring (if appropriate),
- [x] update user guide (if appropriate),
- [x] add an changelog entry in the `upcoming_changes` folder (see [`upcoming_changes/README.rst`](https://github.com/hyperspy/hyperspy/blob/RELEASE_next_minor/upcoming_changes/README.rst)),
- [x] Check formatting changelog entry in the `readthedocs` doc build of this PR (link in github checks)
- [x] add tests,
- [x] ready for review.

### Minimal example of the bug fix or the new feature
```python
import hyperspy.api as hs
import numpy as np

pixels = 16
s = hs.signals.Signal2D(np.arange(pixels**2).reshape((pixels, pixels)))
s.save('test.jpg', output_size=512)
s.save('test-with_scalebar.jpg', output_size=512, scalebar=True)
```
