### PR TITLE
Update minimal requirement of importlib_metadata to 3.6

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -70,7 +70,7 @@ install_req = ['scipy>=1.1',
                'tifffile>=2018.10.18',
                'numba',
                 # included in stdlib since v3.8, but this required version requires Python 3.9
-               'importlib_metadata>=1.6.0',
+               'importlib_metadata>=3.6',
                ]
 
 extras_require = {

--- a/upcoming_changes/2793.bugfix.rst
+++ b/upcoming_changes/2793.bugfix.rst
@@ -1,0 +1,2 @@
+Update minimal requirement of dependency importlib_metadata from
+>= 1.6.0 to >= 3.6.


### PR DESCRIPTION
Signed-off-by: Håkon Wiik Ånes <hwaanes@gmail.com>

### Description of the change
* Update minimal requirement of dependency `importlib_metadata` from `>= 1.6.0` to `>= 3.6` so that passing argument `group` to `importlib_metadata.entry_points()` is allowed. Note that this is already done on `RELEASE_next_minor`.
* Fix #2792.

### Progress of the PR
- [x] Updated setup.py
- [x] add an changelog entry in the `upcoming_changes` folder (see [`upcoming_changes/README.rst`](https://github.com/hyperspy/hyperspy/blob/RELEASE_next_minor/upcoming_changes/README.rst)),
- [x] Check formatting changelog entry in the `readthedocs` doc build of this PR (link in github checks)
- [x] ready for review.