### PR TITLE
Add context manager to switch iterpath

### DIFF
--- a/doc/user_guide/axes.rst
+++ b/doc/user_guide/axes.rst
@@ -55,7 +55,7 @@ Setting axis properties
 The axes are managed and stored by the :py:class:`~.axes.AxesManager` class
 that is stored in the :py:attr:`~.signal.BaseSignal.axes_manager` attribute of
 the signal class. The individual axes can be accessed by indexing the
-AxesManager, e.g.:
+:py:class:`~.axes.AxesManager`, e.g.:
 
 .. code-block:: python
 
@@ -434,14 +434,14 @@ Adding/Removing axes to/from a signal
 
 Usually, the axes are directly added to a signal during :ref:`signal 
 initialization<signal_initialization>`. However, you may wish to add/remove
-axes from the `AxesManager` of a signal.
+axes from the :py:class:`~.axes.AxesManager` of a signal.
 
 Note that there is currently no consistency check whether a signal object has
 the right number of axes of the right dimensions. Most functions will however
 fail if you pass a signal object where the axes do not match the data 
 dimensions and shape.
 
-You can *add a set of axes* to the `AxesManager` by passing either a list of
+You can *add a set of axes* to the :py:class:`~.axes.AxesManager` by passing either a list of
 axes dictionaries to ``axes_manager.create_axes()``:
 
 .. code-block:: python
@@ -459,7 +459,7 @@ or a list of axes objects:
     >>> axis1 = DataAxis(axis=np.arange(12)**2)
     >>> s.axes_manager.create_axes([axis0,axis1])
 
-*Remove an axis* from the `AxesManager` using ``remove()``, e.g. for the last axis:
+*Remove an axis* from the :py:class:`~.axes.AxesManager` using ``remove()``, e.g. for the last axis:
 
 .. code-block:: python
 
@@ -586,7 +586,12 @@ fast.
 
 Iterating over the AxesManager
 ------------------------------
-One can iterate over the AxesManager to produce indices to the navigation axes. Each iteration will yield a new tuple of indices, sorted according to the iteration path specified in :py:attr:`~.axes.AxesManager.iterpath`. Setting the :py:attr:`~.axes.AxesManager.indices` property to a new index will update the accompanying signal so that signal methods that operate at a specific navigation index will now use that index, like ``s.plot()``.
+One can iterate over the :py:class:`~.axes.AxesManager` to produce indices to
+the navigation axes. Each iteration will yield a new tuple of indices, sorted
+according to the iteration path specified in :py:attr:`~.axes.AxesManager.iterpath`.
+Setting the :py:attr:`~.axes.AxesManager.indices` property to a new index will
+update the accompanying signal so that signal methods that operate at a specific
+navigation index will now use that index, like ``s.plot()``.
 
 .. code-block:: python
 
@@ -604,7 +609,16 @@ One can iterate over the AxesManager to produce indices to the navigation axes. 
     (2, 1)
 
 
-The ``AxesManager.iterpath`` specifies the strategy that the AxesManager should use to iterate over the navigation axes. Two built-in strategies exist: ``'flyback'`` and ``'serpentine'``. The flyback strategy starts at (0,0), continues down the row until the final column, "flies back" to the first column, and continues from (1,0). The serpentine strategy begins the same way, but when it reaches the final column (of index N), it continues from (1, N) along the next row, in the same way that a snake might slither, left and right.
+The :py:attr:`~.axes.AxesManager.iterpath` attribute specifies the strategy that
+the :py:class:`~.axes.AxesManager` should use to iterate over the navigation axes.
+Two built-in strategies exist:
+
+- ``'flyback'``: starts at (0, 0), continues down the row until the final
+  column, "flies back" to the first column, and continues from (1, 0)
+- ``'serpentine'``: starts at (0, 0), but when it reaches the final column
+  (of index N), it continues from (1, N) along the next row, in the same way
+  that a snake might slither, left and right.
+
 
 .. code-block:: python
 
@@ -613,7 +627,21 @@ The ``AxesManager.iterpath`` specifies the strategy that the AxesManager should 
     >>> for index in s.axes_manager:
     ...     print(index)
 
-The iterpath can also be set to be a specific list of indices, like [(0,0), (0,1)], but can also be any generator of indices. Storing a high-dimensional set of indices as a list or array can take a significant amount of memory. By using a generator instead, one almost entirely removes such a memory footprint:
+The :py:attr:`~.axes.AxesManager.iterpath` can also be set using the
+:py:meth:`~.axes.AxesManager.switch_iterpath` context manager:
+
+.. code-block:: python
+
+    >>> s = hs.signals.Signal1D(np.zeros((2,3,10)))
+    >>> with s.axes_manager.switch_iterpath('serpentine'):
+    >>>     for index in s.axes_manager:
+    ...         print(index)
+
+
+The :py:attr:`~.axes.AxesManager.iterpath` can also be set to be a specific list of indices, like [(0,0), (0,1)],
+but can also be any generator of indices. Storing a high-dimensional set of
+indices as a list or array can take a significant amount of memory. By using a
+generator instead, one almost entirely removes such a memory footprint:
 
 .. code-block:: python
 
@@ -640,10 +668,14 @@ The iterpath can also be set to be a specific list of indices, like [(0,0), (0,1
     (0, 0)
 
 
-Since generators do not have a defined length, and does not need to include all navigation indices, a progressbar will be unable to determine how long it needs to be. To resolve this, a helper class can be imported that takes both a generator and a manually specified length as inputs:
+Since generators do not have a defined length, and does not need to include all
+navigation indices, a progressbar will be unable to determine how long it needs
+to be. To resolve this, a helper class can be imported that takes both a generator
+and a manually specified length as inputs:
 
 .. code-block:: python
 
->>> from hyperspy.axes import GeneratorLen
->>> gen = GeneratorLen(reverse_flyback_generator(), 6)
->>> s.axes_manager.iterpath = gen
+    >>> from hyperspy.axes import GeneratorLen
+    >>> gen = GeneratorLen(reverse_flyback_generator(), 6)
+    >>> s.axes_manager.iterpath = gen
+

--- a/hyperspy/_signals/lazy.py
+++ b/hyperspy/_signals/lazy.py
@@ -686,22 +686,6 @@ class LazySignal(BaseSignal):
             sig.get_dimensions_from_data()
         return sig
 
-    def _iterate_signal(self):
-        if self.axes_manager.navigation_size < 2:
-            yield self()
-            return
-        nav_dim = self.axes_manager.navigation_dimension
-        sig_dim = self.axes_manager.signal_dimension
-        nav_indices = self.axes_manager.navigation_indices_in_array[::-1]
-        nav_lengths = np.atleast_1d(
-            np.array(self.data.shape)[list(nav_indices)])
-        getitem = [slice(None)] * (nav_dim + sig_dim)
-        data = self._lazy_data()
-        for indices in product(*[range(l) for l in nav_lengths]):
-            for res, ind in zip(indices, nav_indices):
-                getitem[ind] = res
-            yield data[tuple(getitem)]
-
     def _block_iterator(self,
                         flat_signal=True,
                         get=dask.threaded.get,

--- a/hyperspy/_signals/signal1d.py
+++ b/hyperspy/_signals/signal1d.py
@@ -516,7 +516,7 @@ class Signal1D(BaseSignal, CommonSignal1D):
             The limits of the interval. If int, they are taken as the
             axis index. If float, they are taken as the axis value.
         delta : int or float
-            The windows around the (start, end) to use for interpolation. If 
+            The windows around the (start, end) to use for interpolation. If
             int, they are taken as index steps. If float, they are taken in
             units of the axis value.
         %s
@@ -691,7 +691,8 @@ class Signal1D(BaseSignal, CommonSignal1D):
                 fill_value=np.nan,
                 also_align=None,
                 mask=None,
-                show_progressbar=None):
+                show_progressbar=None,
+                iterpath="flyback"):
         """Estimate the shifts in the signal axis using
         cross-correlation and use the estimation to align the data in place.
         This method can only estimate the shift by comparing
@@ -765,23 +766,24 @@ class Signal1D(BaseSignal, CommonSignal1D):
                             'appropriately), which might take a long time. '
                             'Use expand=False to only pass through the data '
                             'once.')
-        shift_array = self.estimate_shift1D(
-            start=start,
-            end=end,
-            reference_indices=reference_indices,
-            max_shift=max_shift,
-            interpolate=interpolate,
-            number_of_interpolation_points=number_of_interpolation_points,
-            mask=mask,
-            show_progressbar=show_progressbar)
-        signals_to_shift = [self] + also_align
-        for signal in signals_to_shift:
-            signal.shift1D(shift_array=shift_array,
-                           interpolation_method=interpolation_method,
-                           crop=crop,
-                           fill_value=fill_value,
-                           expand=expand,
-                           show_progressbar=show_progressbar)
+        with self.axes_manager.switch_iterpath(iterpath):
+            shift_array = self.estimate_shift1D(
+                start=start,
+                end=end,
+                reference_indices=reference_indices,
+                max_shift=max_shift,
+                interpolate=interpolate,
+                number_of_interpolation_points=number_of_interpolation_points,
+                mask=mask,
+                show_progressbar=show_progressbar)
+            signals_to_shift = [self] + also_align
+            for signal in signals_to_shift:
+                signal.shift1D(shift_array=shift_array,
+                               interpolation_method=interpolation_method,
+                               crop=crop,
+                               fill_value=fill_value,
+                               expand=expand,
+                               show_progressbar=show_progressbar)
     align1D.__doc__ %= (CROP_PARAMETER_DOC, SHOW_PROGRESSBAR_ARG)
 
     def integrate_in_range(self, signal_range='interactive',

--- a/hyperspy/axes.py
+++ b/hyperspy/axes.py
@@ -1131,17 +1131,19 @@ class UniformDataAxis(BaseDataAxis, UnitConversion):
         self._is_uniform = True
         self.on_trait_change(self.update_axis, ["scale", "offset", "size"])
 
-    def _slice_me(self, slice_):
+    def _slice_me(self, _slice):
         """Returns a slice to slice the corresponding data axis and
         change the offset and scale of the UniformDataAxis accordingly.
+
         Parameters
         ----------
-        slice_ : {float, int, slice}
+        _slice : {float, int, slice}
+
         Returns
         -------
         my_slice : slice
         """
-        my_slice = self._get_array_slices(slice_)
+        my_slice = self._get_array_slices(_slice)
         start, step = my_slice.start, my_slice.step
 
         if start is None:
@@ -1388,20 +1390,10 @@ class AxesManager(t.HasTraits):
 
     Attributes
     ----------
-    coordinates : tuple
-        Get and set the current coordinates, if the navigation dimension
-        is not 0. If the navigation dimension is 0, it raises
-        AttributeError when attempting to set its value.
-    indices : tuple
-        Get and set the current indices, if the navigation dimension
-        is not 0. If the navigation dimension is 0, it raises
-        AttributeError when attempting to set its value.
     signal_axes, navigation_axes : list
         Contain the corresponding DataAxis objects
-    iterpath : string or iterable
-        Sets the order of iterating through the indices in the navigation dimension.
-        Can be either "flyback" or "serpentine", or an iterable
-        of hyperspy navigation indices.
+
+    coordinates, indices, iterpath
 
     Examples
     --------
@@ -1711,7 +1703,10 @@ class AxesManager(t.HasTraits):
 
     @property
     def iterpath(self):
-        "Sets or returns the current iteration path through the axes indices"
+        """Sets the order of iterating through the indices in the navigation
+        dimension. Can be either "flyback" or "serpentine", or an iterable
+        of navigation indices.
+        """
         return self._iterpath
 
     @iterpath.setter
@@ -2259,7 +2254,11 @@ class AxesManager(t.HasTraits):
 
     @property
     def coordinates(self):
-        # See class docstring
+        """
+        Get and set the current coordinates, if the navigation dimension
+        is not 0. If the navigation dimension is 0, it raises
+        AttributeError when attempting to set its value.
+        """
         return tuple([axis.value for axis in self.navigation_axes])
 
     @coordinates.setter
@@ -2281,7 +2280,11 @@ class AxesManager(t.HasTraits):
 
     @property
     def indices(self):
-        # See class docstring
+        """
+        Get and set the current indices, if the navigation dimension
+        is not 0. If the navigation dimension is 0, it raises
+        AttributeError when attempting to set its value.
+        """
         return tuple([axis.index for axis in self.navigation_axes])
 
     @indices.setter
@@ -2392,18 +2395,19 @@ class AxesManager(t.HasTraits):
         """
 
 class GeneratorLen:
-    """Helper class for creating a generator-like object with a known length.
+    """
+    Helper class for creating a generator-like object with a known length.
     Useful when giving a generator as input to the AxesManager iterpath, so that the
     length is known for the progressbar.
 
     Found at: https://stackoverflow.com/questions/7460836/how-to-lengenerator/7460986
 
     Parameters
-        ----------
-        gen : generator
-            The Generator containing hyperspy navigation indices.
-        length : int
-            The manually-specified length of the generator.
+    ----------
+    gen : generator
+        The Generator containing hyperspy navigation indices.
+    length : int
+        The manually-specified length of the generator.
     """
     def __init__(self, gen, length):
         self.gen = gen

--- a/hyperspy/axes.py
+++ b/hyperspy/axes.py
@@ -1817,9 +1817,16 @@ class AxesManager(t.HasTraits):
         iterpath : str, optional
             The iterpath to use. The default is None.
 
-        Returns
-        -------
+        Yields
+        ------
         None.
+
+        Examples
+        --------
+        >>> s = hs.signals.Signal1D(np.arange(2*3*4).reshape([3, 2, 4]))
+        >>> with s.axes_manager.switch_iterpath('serpentine'):
+        >>>     for indices in s.axes_manager:
+        >>>         print(indices)
 
         """
         if iterpath is not None:

--- a/hyperspy/axes.py
+++ b/hyperspy/axes.py
@@ -16,6 +16,7 @@
 # You should have received a copy of the GNU General Public License
 # along with  HyperSpy.  If not, see <http://www.gnu.org/licenses/>.
 
+from contextlib import contextmanager
 import copy
 import math
 import logging
@@ -1804,6 +1805,33 @@ class AxesManager(t.HasTraits):
         # is created before data shape is known
         self.iterpath = self._iterpath
         return self
+
+    @contextmanager
+    def switch_iterpath(self, iterpath=None):
+        """
+        Context manager to change iterpath. The original iterpath is restored
+        when exiting the context.
+
+        Parameters
+        ----------
+        iterpath : str, optional
+            The iterpath to use. The default is None.
+
+        Returns
+        -------
+        None.
+
+        """
+        if iterpath is not None:
+            original_iterpath = self._iterpath
+            self._iterpath = iterpath
+        try:
+            yield
+        finally:
+            # if an error is raised when using this context manager, we
+            # reset the original value of _iterpath
+            if iterpath is not None:
+                self.iterpath = original_iterpath
 
     def _append_axis(self, **kwargs):
         axis = create_axis(**kwargs)

--- a/hyperspy/datasets/artificial_data.py
+++ b/hyperspy/datasets/artificial_data.py
@@ -352,59 +352,59 @@ def get_luminescence_signal(navigation_dimension=0,
                             add_noise=True,
                             random_state=None):
     """Get an artificial luminescence signal in wavelength scale (nm, uniform) or
-        energy scale (eV, non-uniform), simulating luminescence data recorded with a
-        diffracting spectrometer. Some random noise is also added to the spectrum,
-        to simulate experimental noise.
+    energy scale (eV, non-uniform), simulating luminescence data recorded with a
+    diffracting spectrometer. Some random noise is also added to the spectrum,
+    to simulate experimental noise.
 
-        Parameters
-        ----------
-        navigation_dimension: positive int.
-            The navigation dimension(s) of the signal. 0 = single spectrum,
-            1 = linescan, 2 = spectral map etc...
-        uniform: bool.
-            return uniform (wavelength) or non-uniform (energy) spectrum
-        add_baseline : bool
-                If true, adds a constant baseline to the spectrum. Conversion to
-                energy representation will turn the constant baseline into inverse
-                powerlaw.
-        %s
-        random_state: None or int
-            initialise state of the random number generator
+    Parameters
+    ----------
+    navigation_dimension: positive int.
+        The navigation dimension(s) of the signal. 0 = single spectrum,
+        1 = linescan, 2 = spectral map etc...
+    uniform: bool.
+        return uniform (wavelength) or non-uniform (energy) spectrum
+    add_baseline : bool
+            If true, adds a constant baseline to the spectrum. Conversion to
+            energy representation will turn the constant baseline into inverse
+            powerlaw.
+    %s
+    random_state: None or int
+        initialise state of the random number generator
 
-        Example
-        -------
-        >>> import hyperspy.datasets.artificial_data as ad
-        >>> s = ad.get_luminescence_signal()
-        >>> s.plot()
+    Example
+    -------
+    >>> import hyperspy.datasets.artificial_data as ad
+    >>> s = ad.get_luminescence_signal()
+    >>> s.plot()
 
-        With constant baseline
+    With constant baseline
 
-        >>> s = ad.get_luminescence_signal(uniform=True, add_baseline=True)
-        >>> s.plot()
+    >>> s = ad.get_luminescence_signal(uniform=True, add_baseline=True)
+    >>> s.plot()
 
-        To make the noise the same for multiple spectra, which can
-        be useful for testing fitting routines
+    To make the noise the same for multiple spectra, which can
+    be useful for testing fitting routines
 
-        >>> s1 = ad.get_luminescence_signal(random_state=10)
-        >>> s2 = ad.get_luminescence_signal(random_state=10)
-        >>> (s1.data == s2.data).all()
-        True
+    >>> s1 = ad.get_luminescence_signal(random_state=10)
+    >>> s2 = ad.get_luminescence_signal(random_state=10)
+    >>> (s1.data == s2.data).all()
+    True
 
-        2D map
+    2D map
 
-        >>> s = ad.get_luminescence_signal(navigation_dimension=2)
-        >>> s.plot()
+    >>> s = ad.get_luminescence_signal(navigation_dimension=2)
+    >>> s.plot()
 
-        See also
-        --------
-        get_low_loss_eels_signal,
-        get_core_loss_eels_signal,
-        get_low_loss_eels_line_scan_signal,
-        get_core_loss_eels_line_scan_signal,
-        get_core_loss_eels_model,
-        get_atomic_resolution_tem_signal2d,
+    See also
+    --------
+    get_low_loss_eels_signal,
+    get_core_loss_eels_signal,
+    get_low_loss_eels_line_scan_signal,
+    get_core_loss_eels_line_scan_signal,
+    get_core_loss_eels_model,
+    get_atomic_resolution_tem_signal2d,
 
-        """
+    """
 
     #Initialisation of random number generator
     random_state = check_random_state(random_state)

--- a/hyperspy/signal.py
+++ b/hyperspy/signal.py
@@ -3498,7 +3498,8 @@ class BaseSignal(FancySlicing,
 
     def _iterate_signal(self, iterpath=None):
         """Iterates over the signal data. It is faster than using the signal
-        iterator.
+        iterator, because it avoids making deepcopy of metadata and other
+        attributes.
 
         Parameters
         ----------

--- a/hyperspy/tests/axes/test_axes_manager.py
+++ b/hyperspy/tests/axes/test_axes_manager.py
@@ -18,7 +18,7 @@
 
 from unittest import mock
 
-from numpy import array, arange, zeros
+import numpy as np
 
 from hyperspy.axes import AxesManager, _serpentine_iter, _flyback_iter, GeneratorLen
 from hyperspy.defaults_parser import preferences
@@ -29,7 +29,7 @@ import pytest
 def generator():
     for i in range(3):
         yield((0,0,i))
-        
+
 class TestAxesManager:
     def setup_method(self, method):
         axes_list = [
@@ -117,14 +117,14 @@ class TestAxesManager:
 
 class TestAxesManagerScaleOffset:
     def test_low_high_value(self):
-        data = arange(11)
+        data = np.arange(11)
         s = BaseSignal(data)
         axes = s.axes_manager[0]
         assert axes.low_value == data[0]
         assert axes.high_value == data[-1]
 
     def test_change_scale(self):
-        data = arange(132)
+        data = np.arange(132)
         s = BaseSignal(data)
         axes = s.axes_manager[0]
         scale_value_list = [0.07, 76, 1]
@@ -134,7 +134,7 @@ class TestAxesManagerScaleOffset:
             assert axes.high_value == data[-1] * scale_value
 
     def test_change_offset(self):
-        data = arange(81)
+        data = np.arange(81)
         s = BaseSignal(data)
         axes = s.axes_manager[0]
         offset_value_list = [12, -216, 1, 0]
@@ -144,7 +144,7 @@ class TestAxesManagerScaleOffset:
             assert axes.high_value == (data[-1] + offset_value)
 
     def test_change_offset_scale(self):
-        data = arange(11)
+        data = np.arange(11)
         s = BaseSignal(data)
         axes = s.axes_manager[0]
         scale, offset = 0.123, -314
@@ -156,7 +156,7 @@ class TestAxesManagerScaleOffset:
 
 class TestAxesManagerExtent:
     def test_1d_basesignal(self):
-        s = BaseSignal(arange(10))
+        s = BaseSignal(np.arange(10))
         assert len(s.axes_manager.signal_extent) == 2
         signal_axis = s.axes_manager.signal_axes[0]
         signal_extent = (signal_axis.low_value, signal_axis.high_value)
@@ -165,7 +165,7 @@ class TestAxesManagerExtent:
         assert () == s.axes_manager.navigation_extent
 
     def test_1d_signal1d(self):
-        s = Signal1D(arange(10))
+        s = Signal1D(np.arange(10))
         assert len(s.axes_manager.signal_extent) == 2
         signal_axis = s.axes_manager.signal_axes[0]
         signal_extent = (signal_axis.low_value, signal_axis.high_value)
@@ -174,7 +174,7 @@ class TestAxesManagerExtent:
         assert () == s.axes_manager.navigation_extent
 
     def test_2d_signal1d(self):
-        s = Signal1D(arange(100).reshape(10, 10))
+        s = Signal1D(np.arange(100).reshape(10, 10))
         assert len(s.axes_manager.signal_extent) == 2
         signal_axis = s.axes_manager.signal_axes[0]
         signal_extent = (signal_axis.low_value, signal_axis.high_value)
@@ -185,7 +185,7 @@ class TestAxesManagerExtent:
         assert nav_extent == s.axes_manager.navigation_extent
 
     def test_3d_signal1d(self):
-        s = Signal1D(arange(1000).reshape(10, 10, 10))
+        s = Signal1D(np.arange(1000).reshape(10, 10, 10))
         assert len(s.axes_manager.signal_extent) == 2
         signal_axis = s.axes_manager.signal_axes[0]
         signal_extent = (signal_axis.low_value, signal_axis.high_value)
@@ -202,7 +202,7 @@ class TestAxesManagerExtent:
         assert nav_extent == s.axes_manager.navigation_extent
 
     def test_2d_signal2d(self):
-        s = Signal2D(arange(100).reshape(10, 10))
+        s = Signal2D(np.arange(100).reshape(10, 10))
         assert len(s.axes_manager.signal_extent) == 4
         signal_axis0 = s.axes_manager.signal_axes[0]
         signal_axis1 = s.axes_manager.signal_axes[1]
@@ -217,7 +217,7 @@ class TestAxesManagerExtent:
         assert () == s.axes_manager.navigation_extent
 
     def test_3d_signal2d(self):
-        s = Signal2D(arange(1000).reshape(10, 10, 10))
+        s = Signal2D(np.arange(1000).reshape(10, 10, 10))
         assert len(s.axes_manager.signal_extent) == 4
         signal_axis0 = s.axes_manager.signal_axes[0]
         signal_axis1 = s.axes_manager.signal_axes[1]
@@ -234,7 +234,7 @@ class TestAxesManagerExtent:
         assert nav_extent == s.axes_manager.navigation_extent
 
     def test_changing_scale_offset(self):
-        s = Signal2D(arange(100).reshape(10, 10))
+        s = Signal2D(np.arange(100).reshape(10, 10))
         signal_axis0 = s.axes_manager.signal_axes[0]
         signal_axis1 = s.axes_manager.signal_axes[1]
         signal_extent = (
@@ -265,7 +265,7 @@ class TestAxesManagerExtent:
 
 
 def test_setting_indices_coordinates():
-    s = Signal1D(arange(1000).reshape(10, 10, 10))
+    s = Signal1D(np.arange(1000).reshape(10, 10, 10))
 
     m = mock.Mock()
     s.axes_manager.events.indices_changed.connect(m, [])
@@ -313,7 +313,7 @@ def test_setting_indices_coordinates():
 
 class TestAxesHotkeys:
     def setup_method(self, method):
-        s = Signal1D(zeros(7 * (5,)))
+        s = Signal1D(np.zeros(7 * (5,)))
         self.am = s.axes_manager
 
     def test_hotkeys_in_six_dimensions(self):
@@ -371,7 +371,7 @@ class TestAxesHotkeys:
 
 class TestIterPathScanPattern:
     def setup_method(self, method):
-        s = Signal1D(zeros((3, 3, 3, 2)))
+        s = Signal1D(np.zeros((3, 3, 3, 2)))
         self.am = s.axes_manager
 
     def test_iterpath_property(self):
@@ -380,7 +380,7 @@ class TestIterPathScanPattern:
 
         with pytest.raises(ValueError):
             self.am.iterpath = "blahblah" # w/o underscore
-        
+
         path = "flyback"
         self.am.iterpath = path
         assert self.am.iterpath == path
@@ -390,7 +390,7 @@ class TestIterPathScanPattern:
         self.am.iterpath = path
         assert self.am.iterpath == path
         assert self.am._iterpath == path
-            
+
     def test_wrong_iterpath(self):
         with pytest.raises(ValueError):
             self.am.iterpath = ""
@@ -457,7 +457,7 @@ class TestIterPathScanPattern:
             if i == 1:
                 assert self.am.indices == (0,0,1)
             break
-        
+
     def test_get_iterpath_size1(self):
         assert self.am._get_iterpath_size() == self.am.navigation_size
         assert self.am._get_iterpath_size(masked_elements = 1) == self.am.navigation_size - 1
@@ -482,10 +482,12 @@ class TestIterPathScanPattern:
         self.am.iterpath = gen
         assert self.am._get_iterpath_size() == 3
 
+
 class TestIterPathScanPatternSignal2D:
     def setup_method(self, method):
-        s = Signal2D(zeros((3, 3, 3, 2, 1)))
+        s = Signal2D(np.zeros((3, 3, 3, 2, 1)))
         self.am = s.axes_manager
+        self.s = s
 
     def test_wrong_iterpath_signal2D(self):
         with pytest.raises(ValueError):
@@ -511,10 +513,26 @@ class TestIterPathScanPatternSignal2D:
                 assert self.am.indices == (2, 2, 1)
             break
 
+    def test_switch_iterpath(self):
+        s = self.s
+        s.axes_manager.iterpath = "serpentine"
+        with s.axes_manager.switch_iterpath('flyback'):
+            assert s.axes_manager.iterpath == 'flyback'
+            for i, _ in enumerate(s.axes_manager):
+                if i == 3:
+                    assert self.am.indices == (0, 1, 0)
+                # Hits a new layer on index 9
+                if i == 9:
+                    assert self.am.indices == (0, 0, 1)
+                break
+        assert s.axes_manager.iterpath == 'serpentine'
+
+
 def test_iterpath_function_flyback():
     for i, indices in enumerate(_flyback_iter((3,3,3))):
         if i == 3:
             assert indices == (0, 1, 0)
+
 
 def test_iterpath_function_serpentine():
     for i, indices in enumerate(_serpentine_iter((3,3,3))):

--- a/hyperspy/tests/signals/test_1D_tools.py
+++ b/hyperspy/tests/signals/test_1D_tools.py
@@ -113,6 +113,7 @@ def test_align1D():
     shifts = np.random.random(len(s.axes_manager[0].axis)) * 2
     shifts[0] = 0
     s.shift1D(-shifts, show_progressbar=False)
+    s.axes_manager.indices = (0, )
     shifts2 = s.estimate_shift1D(show_progressbar=False)
     np.testing.assert_allclose(shifts, shifts2, rtol=0.5)
 
@@ -257,7 +258,7 @@ class TestInterpolateInBetween:
         s.interpolate_in_between(8, 12, delta=0.31, kind='cubic')
         print(s.data[8:12])
         np.testing.assert_allclose(
-            s.data[8:12], np.array([46.595205, 109.802805, 
+            s.data[8:12], np.array([46.595205, 109.802805,
                                     164.512803, 178.615201]),
             atol=1,
         )

--- a/hyperspy/tests/signals/test_find_peaks2D.py
+++ b/hyperspy/tests/signals/test_find_peaks2D.py
@@ -178,6 +178,7 @@ class TestFindPeaks2D:
 
     def test_return_peaks(self):
         sig = self.sparse_nav2d_shifted
+        sig.axes_manager.indices = (0, 0)
         axes_dict = sig.axes_manager._get_axes_dicts(
             sig.axes_manager.navigation_axes)
         peaks = BaseSignal(np.empty(sig.axes_manager.navigation_shape),

--- a/upcoming_changes/2795.enhancements.rst
+++ b/upcoming_changes/2795.enhancements.rst
@@ -1,0 +1,1 @@
+Add :py:meth:`~.axes.AxesManager.switch_iterpath` context manager to switch iterpath


### PR DESCRIPTION
### Progress of the PR
- [x] Add context manager to set switch iterpath,
- [x] Remove `_iterate_signal` of lazy signal, its non-lazy counterpart works fine
- [x] simplify `_iterate_signal` and make it use `__call__` so that lazy signal would benefit from the speed improvement in #2568,
- [x] update docstring (if appropriate),
- [x] update user guide (if appropriate),
- [x] Fix warning when building user guide, 
- [x] add an changelog entry in the `upcoming_changes` folder (see [`upcoming_changes/README.rst`](https://github.com/hyperspy/hyperspy/blob/RELEASE_next_minor/upcoming_changes/README.rst)),
- [x] Check formatting changelog entry in the `readthedocs` doc build of this PR (link in github checks)
- [x] add tests,
- [x] ready for review.

### Minimal example of the bug fix or the new feature
```python
import hyperspy.api as hs
import numpy as np

s = hs.signals.Signal1D(np.arange(2*3*4).reshape([3, 2, 4]))

with s.axes_manager.switch_iterpath('serpentine'):
    for indices in s.axes_manager:
        print(indices)
```
