### PR TITLE
Suspend plotting during fit

### DIFF
--- a/doc/user_guide/eels.rst
+++ b/doc/user_guide/eels.rst
@@ -75,13 +75,13 @@ more information about the edges.
     +-------+-------------------+-----------+-----------------------------+
 
 The method :py:meth:`~._signals.eels.EELSSpectrum_mixin.edges_at_energy` allows
-inspecting different sections of the signal for interactive edge 
-identification (the default). A region can be selected by dragging the mouse 
-across the signal and after clicking the `Update` button, edges with onset 
-energies within the selected energy range will be displayed. By toggling the 
-edge buttons, it will put or remove the corresponding edges on the signal. When 
-the `Complementary edge` box is ticked, edges outside the selected range with 
-the same element of edges within the selected energy range will be shown as well 
+inspecting different sections of the signal for interactive edge
+identification (the default). A region can be selected by dragging the mouse
+across the signal and after clicking the `Update` button, edges with onset
+energies within the selected energy range will be displayed. By toggling the
+edge buttons, it will put or remove the corresponding edges on the signal. When
+the `Complementary edge` box is ticked, edges outside the selected range with
+the same element of edges within the selected energy range will be shown as well
 to aid identification of edges.
 
 .. code-block:: python
@@ -94,7 +94,7 @@ to aid identification of edges.
    :width:   500
 
    Labels of edges can be put or remove by toggling the edge buttons.
-    
+
 
 .. _eels_thickness-label:
 
@@ -259,8 +259,9 @@ We must enable them to accurately fit this spectrum.
     >>> m.enable_fine_structure()
 
 
-We use smart_fit instead of standard fit method because smart_fit is optimized
-to fit EELS core-loss spectra
+We use :py:meth:`~.models.eelsmodel.EELSModel.smart_fit` instead of standard
+fit method because :py:meth:`~.models.eelsmodel.EELSModel.smart_fit` is
+optimized to fit EELS core-loss spectra
 
 .. code-block:: python
 
@@ -276,12 +277,15 @@ image
 
 .. NOTE::
 
-    `m.smart_fit()` and `m.multifit(kind='smart')` are methods specific to the EELS model.
-    The fitting procedure acts in iterative manner along the energy-loss-axis.
-    First it fits only the background up to the first edge. It continues by deactivating all edges except the first one, then performs the fit.
-    Then it only activates the the first two, fits, and repeats this until all edges are fitted simultanously.
+    `m.smart_fit()` and `m.multifit(kind='smart')` are methods specific to the
+    EELS model. The fitting procedure acts in iterative manner along the
+    energy-loss-axis. First it fits only the background up to the first edge.
+    It continues by deactivating all edges except the first one, then performs
+    the fit. Then it only activates the the first two, fits, and repeats this
+    until all edges are fitted simultanously.
 
-    Other, non-EELSCLEdge components, are never deactivated, and fitted on every iteration.
+    Other, non-EELSCLEdge components, are never deactivated, and fitted on every
+    iteration.
 
 Print the result of the fit
 

--- a/hyperspy/models/eelsmodel.py
+++ b/hyperspy/models/eelsmodel.py
@@ -24,7 +24,9 @@ from hyperspy import components1d
 from hyperspy._signals.eels import EELSSpectrum
 from hyperspy.components1d import EELSCLEdge, PowerLaw
 from hyperspy.docstrings.model import FIT_PARAMETERS_ARG
+from hyperspy.misc.utils import dummy_context_manager
 from hyperspy.models.model1d import Model1D
+
 
 _logger = logging.getLogger(__name__)
 
@@ -350,12 +352,14 @@ class EELSModel(Model1D):
         * :py:meth:`~hyperspy.model.EELSModel.fit`
 
         """
-        # Fit background
-        self.fit_background(start_energy, **kwargs)
+        cm = self.suspend_update if self._plot_active else dummy_context_manager
+        with cm(update_on_resume=True):
+            # Fit background
+            self.fit_background(start_energy, **kwargs)
 
-        # Fit the edges
-        for i in range(0, len(self._active_edges)):
-            self._fit_edge(i, start_energy, **kwargs)
+            # Fit the edges
+            for i in range(0, len(self._active_edges)):
+                self._fit_edge(i, start_energy, **kwargs)
 
     smart_fit.__doc__ %= FIT_PARAMETERS_ARG
 

--- a/hyperspy/models/eelsmodel.py
+++ b/hyperspy/models/eelsmodel.py
@@ -738,11 +738,29 @@ class EELSModel(Model1D):
         self.resolve_fine_structure()
 
     def set_all_edges_intensities_positive(self):
+        """
+        Set all edges intensities positive by setting ``ext_force_positive``
+        and ``ext_bounded`` to ``True``.
+
+        Returns
+        -------
+        None.
+
+        """
         for edge in self._active_edges:
             edge.intensity.ext_force_positive = True
             edge.intensity.ext_bounded = True
 
     def unset_all_edges_intensities_positive(self):
+        """
+        Unset all edges intensities positive by setting ``ext_force_positive``
+        and ``ext_bounded`` to ``False``.
+
+        Returns
+        -------
+        None.
+
+        """
         for edge in self._active_edges:
             edge.intensity.ext_force_positive = False
             edge.intensity.ext_bounded = False

--- a/upcoming_changes/2796.bugfix.rst
+++ b/upcoming_changes/2796.bugfix.rst
@@ -1,1 +1,1 @@
-Suspend plotting during smart_fit call
+Suspend plotting during :py:meth:`~.models.eelsmodel.EELSModel.smart_fit` call

--- a/upcoming_changes/2796.bugfix.rst
+++ b/upcoming_changes/2796.bugfix.rst
@@ -1,0 +1,1 @@
+Suspend plotting during smart_fit call


### PR DESCRIPTION
### Progress of the PR
- [x] Suspend plotting when calling `smart_fit` to avoid error with event connections,
- [x] add an changelog entry in the `upcoming_changes` folder (see [`upcoming_changes/README.rst`](https://github.com/hyperspy/hyperspy/blob/RELEASE_next_minor/upcoming_changes/README.rst)),
- [x] Check formatting changelog entry in the `readthedocs` doc build of this PR (link in github checks)
- [x] ready for review.

### Minimal example of the bug fix or the new feature
```python
import hyperspy.api as hs

s = hs.datasets.eelsdb(title="Hexagonal Boron Nitride", spectrum_type="coreloss")[0]
ll = hs.datasets.eelsdb(title="Hexagonal Boron Nitride", spectrum_type="lowloss")[0]

s.set_microscope_parameters(beam_energy=300,
                            convergence_angle=0.2,
                            collection_angle=2.55)

s.add_elements(('B', 'N'))
m = s.create_model()
# m = s.create_model(ll=ll)
m.plot()
m.smart_fit()
m.enable_fine_structure()
m.smart_fit()
```
traceback:
```python
Traceback (most recent call last):

  File "/home/eric/Dev/hyperspy/hyperspy/model.py", line 582, in update_plot
    self._model_line.update(render_figure=render_figure,

  File "/home/eric/Dev/hyperspy/hyperspy/drawing/signal1d.py", line 473, in update
    ydata = self._get_data()

  File "/home/eric/Dev/hyperspy/hyperspy/drawing/signal1d.py", line 431, in _get_data
    ydata = self.data_function(axes_manager=self.axes_manager,

  File "/home/eric/Dev/hyperspy/hyperspy/models/model1d.py", line 683, in _model2plot
    s = self.__call__(non_convolved=False, onlyactive=True)

  File "/home/eric/Dev/hyperspy/hyperspy/models/model1d.py", line 413, in __call__
    sum_ += component.function(axis)

  File "/home/eric/Dev/hyperspy/hyperspy/_components/eels_cl_edge.py", line 315, in function
    cts[bfs] = splev(

  File "/opt/miniconda3/lib/python3.8/site-packages/scipy/interpolate/fitpack.py", line 374, in splev
    return _impl.splev(x, tck, der, ext)

  File "/opt/miniconda3/lib/python3.8/site-packages/scipy/interpolate/_fitpack_impl.py", line 598, in splev
    raise ValueError("Invalid input data")

ValueError: Invalid input data


During handling of the above exception, another exception occurred:

Traceback (most recent call last):

  File "/home/eric/Dev/hyperspy/untitled1.py", line 23, in <module>
    m.smart_fit()

  File "/home/eric/Dev/hyperspy/hyperspy/models/eelsmodel.py", line 358, in smart_fit
    self._fit_edge(i, start_energy, **kwargs)

  File "/home/eric/Dev/hyperspy/hyperspy/models/eelsmodel.py", line 528, in _fit_edge
    self.remove_fine_structure_data(to_activate_fs)

  File "/home/eric/Dev/hyperspy/hyperspy/models/eelsmodel.py", line 597, in remove_fine_structure_data
    self.remove_signal_range(start, stop)

  File "/home/eric/Dev/hyperspy/hyperspy/decorators.py", line 107, in wrapper
    cm(self, *args, **kwargs)

  File "/home/eric/Dev/hyperspy/hyperspy/models/model1d.py", line 505, in remove_signal_range
    self._remove_signal_range_in_pixels(*indices)

  File "/home/eric/Dev/hyperspy/hyperspy/models/model1d.py", line 493, in _remove_signal_range_in_pixels
    self.update_plot()

  File "/home/eric/Dev/hyperspy/hyperspy/model.py", line 589, in update_plot
    self._disconnect_parameters2update_plot(components=self)

  File "/home/eric/Dev/hyperspy/hyperspy/model.py", line 563, in _disconnect_parameters2update_plot
    component.events.active_changed.disconnect(

  File "/home/eric/Dev/hyperspy/hyperspy/events.py", line 392, in disconnect
    raise ValueError("The %s function is not connected to %s." %

ValueError: The <bound method Signal1DLine._auto_update_line of <hyperspy.drawing.signal1d.Signal1DLine object at 0x7f0a51cf7cd0>> function is not connected to <hyperspy.events.Event: Event that triggers when the `Component.active` changes.: set()>.
```

It is surprising that with convolution with the low loss, `smart_fit` works fine when the model is plotted and without convolution, it raise an error (only when the model is plotted)! I am not sure if the `ValueError("Invalid input data")` is a red herring or not.
In any case, the plot should be suspended during calling `smart_fit`, because it slows down the fit, as it does for `multifit`