### PR TITLE
Lazy save improvement

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -246,6 +246,7 @@ towncrier_draft_working_directory = ".."
 
 # Add the hyperspy website to the intersphinx domains
 intersphinx_mapping = {'python': ('https://docs.python.org/3', None),
+                       'h5py': ('https://docs.h5py.org/en/stable', None),
                        'hyperspyweb': ('https://hyperspy.org/', None),
                        'matplotlib': ('https://matplotlib.org', None),
                        'numpy': ('https://docs.scipy.org/doc/numpy', None),

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -254,6 +254,7 @@ intersphinx_mapping = {'python': ('https://docs.python.org/3', None),
                        'astroML': ('https://www.astroml.org/', None),
                        'sklearn': ('https://scikit-learn.org/stable', None),
                        'skimage': ('https://scikit-image.org/docs/stable', None),
+                       'zarr': ('https://zarr.readthedocs.io/en/stable', None),
                        }
 
 graphviz_output_format = "svg"

--- a/doc/user_guide/io.rst
+++ b/doc/user_guide/io.rst
@@ -461,7 +461,7 @@ numbers as strings if any other strings are present:
 By default, a :py:class:`zarr.storage.NestedDirectoryStore` is used, but other
 zarr store can be used by providing a `zarr store <https://zarr.readthedocs.io/en/stable/api/storage.html>`_
 instead as argument to the :py:meth:`~.signal.BaseSignal.save` or the
-:py:func:`~.io.load` function. If a zspy file have been saved with a different
+:py:func:`~.io.load` function. If a zspy file has been saved with a different
 store, it would need to be loaded by passing a store of the same type:
 
 .. code-block:: python
@@ -471,7 +471,9 @@ store, it would need to be loaded by passing a store of the same type:
     >>> store = zarr.LMDBStore(filename)
     >>> signal.save(store) # saved to LMDB
 
-To load again this file
+To load this file again
+
+.. code-block:: python
 
     >>> import zarr
     >>> filename = 'test.zspy'
@@ -495,16 +497,16 @@ Extra saving arguments
 
         Lazy operations are often i-o bound, reading and writing the data creates a bottle neck in processes
         due to the slow read write speed of many hard disks. In these cases, compressing your data is often
-        beneficial to the speed of some operation. Compression speeds up the process as there is less to
+        beneficial to the speed of some operations. Compression speeds up the process as there is less to
         read/write with the trade off of slightly more computational work on the CPU.
 
 
-- ``chunks``: tuple of interger or None. Define the chunking used for saving
+- ``chunks``: tuple of integer or None. Define the chunking used for saving
   the dataset. If None, calculates chunks for the signal, with preferably at
   least one chunk per signal space.
 - ``close_file``: only relevant for zarr store (``ZipStore``, ``DBMStore``)
-  requiring store to flush data to disk. if ``False``, doesn't close the file
-  after writing. The file  should not be closed if the data need to be accessed
+  requiring store to flush data to disk. If ``False``, doesn't close the file
+  after writing. The file should not be closed if the data need to be accessed
   lazily after saving.
   Default is ``True``.
 - ``write_dataset``: if ``False``, doesn't write the dataset when writing the file.
@@ -1415,7 +1417,7 @@ Nexus metadata and data are stored in Hierarchical Data Format Files (HDF5) with
 a .nxs extension although standards HDF5 extensions are sometimes used.
 Files must use the ``.nxs`` file extension in order to use this io plugin.
 Using the ``.nxs`` extension will default to the Nexus loader. If your file has
-a HDF5 extension, you can also explicitly set the Nexus file reader:
+an HDF5 extension, you can also explicitly set the Nexus file reader:
 
 .. code-block:: python
 

--- a/doc/user_guide/io.rst
+++ b/doc/user_guide/io.rst
@@ -458,38 +458,59 @@ the inner-most structures are converted to numpy arrays when saved. This
 procedure homogenizes any types of the objects inside, most notably casting
 numbers as strings if any other strings are present:
 
+By default, a :py:class:`zarr.storage.NestedDirectoryStore` is used, but other
+zarr store can be used by providing a `zarr store <https://zarr.readthedocs.io/en/stable/api/storage.html>`_
+instead as argument to the :py:meth:`~.signal.BaseSignal.save` or the
+:py:func:`~.io.load` function. If a zspy file have been saved with a different
+store, it would need to be loaded by passing a store of the same type:
+
+.. code-block:: python
+
+    >>> import zarr
+    >>> filename = 'test.zspy'
+    >>> store = zarr.LMDBStore(filename)
+    >>> signal.save(store) # saved to LMDB
+
+To load again this file
+
+    >>> import zarr
+    >>> filename = 'test.zspy'
+    >>> store = zarr.LMDBStore(filename)
+    >>> s = hs.load(store) # load from LMDB
+
 Extra saving arguments
 ^^^^^^^^^^^^^^^^^^^^^^
 
-- ``compressor``: A `Numcodecs Codec <https://numcodecs.readthedocs.io/en/stable/index.html?>`_.
-   A compresssor can be passed to the save function to compress the data efficiently. The defualt
-   is to call a Blosc Compressor object.
+- ``compressor``: `Numcodecs codec <https://numcodecs.readthedocs.io/en/stable/index.html?>`_,
+  a compresssor can be passed to the save function to compress the data efficiently. The default
+  is to call a Blosc compressor object.
 
-.. code-block:: python
+    .. code-block:: python
 
-    >>> from numcodecs import Blosc
-    >>> compressor=Blosc(cname='zstd', clevel=1, shuffle=Blosc.SHUFFLE)
-    >>> s.save('test.zspy', compressor = compressor) # will save with Blosc compression
+        >>> from numcodecs import Blosc
+        >>> compressor=Blosc(cname='zstd', clevel=1, shuffle=Blosc.SHUFFLE) # Used by default
+        >>> s.save('test.zspy', compressor = compressor) # will save with Blosc compression
 
-.. note::
+    .. note::
 
-    Lazy operations are often i-o bound, reading and writing the data creates a bottle neck in processes
-    due to the slow read write speed of many hard disks. In these cases, compressing your data is often
-    beneficial to the speed of some operation. Compression speeds up the process as there is less to
-    read/write with the trade off of slightly more computational work on the CPU."
+        Lazy operations are often i-o bound, reading and writing the data creates a bottle neck in processes
+        due to the slow read write speed of many hard disks. In these cases, compressing your data is often
+        beneficial to the speed of some operation. Compression speeds up the process as there is less to
+        read/write with the trade off of slightly more computational work on the CPU.
 
-- ``write_to_storage``: The write to storage option allows you to pass the path to a directory (or database)
-   and write directly to the storage container.  This gives you access to the `different storage methods
-   <https://zarr.readthedocs.io/en/stable/api/storage.html>`_
-   available through zarr. Namely using a SQL, MongoDB or LMDB database.  Additional downloads may need
-   to be configured to use these features.
 
-.. code-block:: python
+- ``chunks``: tuple of interger or None. Define the chunking used for saving
+  the dataset. If None, calculates chunks for the signal, with preferably at
+  least one chunk per signal space.
+- ``close_file``: only relevant for zarr store (``ZipStore``, ``DBMStore``)
+  requiring store to flush data to disk. if ``False``, doesn't close the file
+  after writing. The file  should not be closed if the data need to be accessed
+  lazily after saving.
+  Default is ``True``.
+- ``write_dataset``: if ``False``, doesn't write the dataset when writing the file.
+  This can be useful to overwrite signal attributes only (for example ``axes_manager``)
+  without having to write the whole dataset, which can take time. Default is ``True``.
 
-    >>>  filename = 'test.zspy/'
-    >>>  os.mkdir('test.zspy')
-    >>>  store = zarr.LMDBStore(path=filename)
-    >>>  signal.save(store.path, write_to_storage=True) # saved to Lmdb
 
 .. _netcdf-format:
 

--- a/doc/user_guide/io.rst
+++ b/doc/user_guide/io.rst
@@ -425,7 +425,7 @@ Extra saving arguments
   the dataset. If None, calculates chunks for the signal, with preferably at
   least one chunk per signal space.
 - ``close_file``: if ``False``, doesn't close the file after writing. The file
-  should not be close if the data need to be accessed lazily after saving.
+  should not be closed if the data need to be accessed lazily after saving.
   Default is ``True``.
 - ``write_dataset``: if ``False``, doesn't write the dataset when writing the file.
   This can be useful to overwrite signal attributes only (for example ``axes_manager``)
@@ -676,7 +676,7 @@ Extra saving arguments
   scalebar. Useful to set formattiong, location, etc. of the scalebar. See the
   `matplotlib-scalebar <https://pypi.org/project/matplotlib-scalebar/>`_
   documentation for more information.
-- ``output_size`` : (int, tuple of length 2 or None, optional): the output size 
+- ``output_size`` : (int, tuple of length 2 or None, optional): the output size
   of the image in pixels:
 
   * if ``int``, defines the width of the image, the height is
@@ -1837,7 +1837,7 @@ Extra loading arguments
   acquired last frame, which typically occurs when the acquisition was
   interrupted. When loading incomplete data (``only_valid_data=False``),
   the missing data are filled with zeros. If ``sum_frames=True``, this argument
-  will be ignored to enforce consistent sum over the mapped area. 
+  will be ignored to enforce consistent sum over the mapped area.
   (default True).
 
 

--- a/doc/user_guide/io.rst
+++ b/doc/user_guide/io.rst
@@ -405,21 +405,31 @@ Extra saving arguments
 - ``compression``: One of ``None``, ``'gzip'``, ``'szip'``, ``'lzf'`` (default is ``'gzip'``).
   ``'szip'`` may be unavailable as it depends on the HDF5 installation including it.
 
-.. note::
+    .. note::
 
-    HyperSpy uses h5py for reading and writing HDF5 files and, therefore, it
-    supports all `compression filters supported by h5py <https://docs.h5py.org/en/stable/high/dataset.html#dataset-compression>`_.
-    The default is ``'gzip'``. It is possible to enable other compression filters
-    such as ``blosc`` by installing e.g. `hdf5plugin <https://github.com/silx-kit/hdf5plugin>`_.
-    However, be aware that loading those files will require installing the package
-    providing the compression filter. If not available an error will be raised.
+        HyperSpy uses h5py for reading and writing HDF5 files and, therefore, it
+        supports all `compression filters supported by h5py <https://docs.h5py.org/en/stable/high/dataset.html#dataset-compression>`_.
+        The default is ``'gzip'``. It is possible to enable other compression filters
+        such as ``blosc`` by installing e.g. `hdf5plugin <https://github.com/silx-kit/hdf5plugin>`_.
+        However, be aware that loading those files will require installing the package
+        providing the compression filter. If not available an error will be raised.
 
-    Compression can significantly increase the saving speed. If file size is not
-    an issue, it can be disabled by setting ``compression=None``. Notice that only
-    ``compression=None`` and ``compression='gzip'`` are available in all platforms,
-    see the `h5py documentation <https://docs.h5py.org/en/stable/faq.html#what-compression-processing-filters-are-supported>`_
-    for more details. Therefore, if you choose any other compression filter for
-    saving a file, be aware that it may not be possible to load it in some platforms.
+        Compression can significantly increase the saving speed. If file size is not
+        an issue, it can be disabled by setting ``compression=None``. Notice that only
+        ``compression=None`` and ``compression='gzip'`` are available in all platforms,
+        see the `h5py documentation <https://docs.h5py.org/en/stable/faq.html#what-compression-processing-filters-are-supported>`_
+        for more details. Therefore, if you choose any other compression filter for
+        saving a file, be aware that it may not be possible to load it in some platforms.
+
+- ``chunks``: tuple of interger or None. Define the chunking used for saving
+  the dataset. If None, calculates chunks for the signal, with preferably at
+  least one chunk per signal space.
+- ``close_file``: if ``False``, doesn't close the file after writing. The file
+  should not be close if the data need to be accessed lazily after saving.
+  Default is ``True``.
+- ``write_dataset``: if ``False``, doesn't write the data when writing the file.
+  This can be useful to overwrite signal attributes only (for example ``axes_manager``)
+  without having to write the whole dataset, which can take time. Default is ``True``.
 
 
 .. _zspy-format:

--- a/doc/user_guide/io.rst
+++ b/doc/user_guide/io.rst
@@ -427,7 +427,7 @@ Extra saving arguments
 - ``close_file``: if ``False``, doesn't close the file after writing. The file
   should not be close if the data need to be accessed lazily after saving.
   Default is ``True``.
-- ``write_dataset``: if ``False``, doesn't write the data when writing the file.
+- ``write_dataset``: if ``False``, doesn't write the dataset when writing the file.
   This can be useful to overwrite signal attributes only (for example ``axes_manager``)
   without having to write the whole dataset, which can take time. Default is ``True``.
 

--- a/doc/user_guide/io.rst
+++ b/doc/user_guide/io.rst
@@ -421,7 +421,7 @@ Extra saving arguments
         for more details. Therefore, if you choose any other compression filter for
         saving a file, be aware that it may not be possible to load it in some platforms.
 
-- ``chunks``: tuple of interger or None. Define the chunking used for saving
+- ``chunks``: tuple of integer or None. Define the chunking used for saving
   the dataset. If None, calculates chunks for the signal, with preferably at
   least one chunk per signal space.
 - ``close_file``: if ``False``, doesn't close the file after writing. The file
@@ -484,7 +484,7 @@ Extra saving arguments
 ^^^^^^^^^^^^^^^^^^^^^^
 
 - ``compressor``: `Numcodecs codec <https://numcodecs.readthedocs.io/en/stable/index.html?>`_,
-  a compresssor can be passed to the save function to compress the data efficiently. The default
+  a compressor can be passed to the save function to compress the data efficiently. The default
   is to call a Blosc compressor object.
 
     .. code-block:: python
@@ -504,7 +504,7 @@ Extra saving arguments
 - ``chunks``: tuple of integer or None. Define the chunking used for saving
   the dataset. If None, calculates chunks for the signal, with preferably at
   least one chunk per signal space.
-- ``close_file``: only relevant for zarr store (``ZipStore``, ``DBMStore``)
+- ``close_file``: only relevant for some zarr store (``ZipStore``, ``DBMStore``)
   requiring store to flush data to disk. If ``False``, doesn't close the file
   after writing. The file should not be closed if the data need to be accessed
   lazily after saving.

--- a/hyperspy/_signals/lazy.py
+++ b/hyperspy/_signals/lazy.py
@@ -177,7 +177,7 @@ class LazySignal(BaseSignal):
         try:
             self._get_file_handle().close()
         except AttributeError:
-            _logger.warning("Failed to close lazy Signal file")
+            _logger.warning("Failed to close lazy signal file")
 
     def _get_file_handle(self, warn=True):
         """Return file handle when possible; currently only hdf5 file are
@@ -195,7 +195,7 @@ class LazySignal(BaseSignal):
                 if warn:
                     _logger.warning("Failed to retrieve file handle, either "
                                     "the file is already closed or it is not "
-                                    "a hdf5 file.")
+                                    "an hdf5 file.")
 
     def _get_dask_chunks(self, axis=None, dtype=None):
         """Returns dask chunks.

--- a/hyperspy/_signals/lazy.py
+++ b/hyperspy/_signals/lazy.py
@@ -177,9 +177,9 @@ class LazySignal(BaseSignal):
         try:
             self._get_file_handle().close()
         except AttributeError:
-            _logger.exception("Failed to close lazy Signal file")
+            _logger.warning("Failed to close lazy Signal file")
 
-    def _get_file_handle(self):
+    def _get_file_handle(self, warn=True):
         """Return file handle when possible; currently only hdf5 file are
         supported.
         """
@@ -191,8 +191,11 @@ class LazySignal(BaseSignal):
         if arrkey:
             try:
                 return self.data.dask[arrkey].file
-            except AttributeError:
-                _logger.exception("Failed to close lazy Signal file")
+            except (AttributeError, ValueError):
+                if warn:
+                    _logger.warning("Failed to retrieve file handle, either "
+                                    "the file is already closed or it is not "
+                                    "a hdf5 file.")
 
     def _get_dask_chunks(self, axis=None, dtype=None):
         """Returns dask chunks.

--- a/hyperspy/_signals/lazy.py
+++ b/hyperspy/_signals/lazy.py
@@ -167,13 +167,21 @@ class LazySignal(BaseSignal):
                                                                   **kwargs)
                                                 )
 
-
     def close_file(self):
         """Closes the associated data file if any.
 
         Currently it only supports closing the file associated with a dask
         array created from an h5py DataSet (default HyperSpy hdf5 reader).
 
+        """
+        try:
+            self._get_file_handle().close()
+        except AttributeError:
+            _logger.exception("Failed to close lazy Signal file")
+
+    def _get_file_handle(self):
+        """Return file handle when possible; currently only hdf5 file are
+        supported.
         """
         arrkey = None
         for key in self.data.dask.keys():
@@ -182,7 +190,7 @@ class LazySignal(BaseSignal):
                 break
         if arrkey:
             try:
-                self.data.dask[arrkey].file.close()
+                return self.data.dask[arrkey].file
             except AttributeError:
                 _logger.exception("Failed to close lazy Signal file")
 

--- a/hyperspy/axes.py
+++ b/hyperspy/axes.py
@@ -289,9 +289,10 @@ class BaseDataAxis(t.HasTraits):
 
         self.events = Events()
         if '_type' in kwargs:
-            if kwargs.get('_type') != self.__class__.__name__:
-                raise ValueError('The passed `_type` of axis is inconsistent '
-                                'with the given attributes')
+            _type = kwargs.get('_type')
+            if _type != self.__class__.__name__:
+                raise ValueError(f'The passed `_type` ({_type}) of axis is '
+                                 'inconsistent with the given attributes.')
         _name = self.__class__.__name__
         self.events.index_changed = Event("""
             Event that triggers when the index of the `{}` changes

--- a/hyperspy/io.py
+++ b/hyperspy/io.py
@@ -285,7 +285,7 @@ def load(filenames=None,
         Only for hspy files. Close the file after writing, default is True.
     write_dataset : bool, optional
         Only for hspy files. If True, write the dataset, otherwise, don't
-        write. Useful to save attributes without having the write the whole
+        write it. Useful to save attributes without having to write the whole
         dataset. Default is True.
 
 

--- a/hyperspy/io.py
+++ b/hyperspy/io.py
@@ -277,6 +277,17 @@ def load(filenames=None,
         acquisition stopped before the end: if True, load only the acquired
         data. If False, fill empty data with zeros. Default is False and this
         default value will change to True in version 2.0.
+    chunks : tuple of integer or None
+        Only for hspy files. Define the chunking used for saving the dataset.
+        If None, calculates chunks for the signal, with preferably at least
+        one chunk per signal space.
+    close_file : bool, optional
+        Only for hspy files. Close the file after writing, default is True.
+    write_dataset : bool, optional
+        Only for hspy files. If True, overwrite the data, otherwise, don't
+        overwrite. Useful to save attributes without having the write the whole
+        dataset. Default is True.
+
 
     Returns
     -------

--- a/hyperspy/io.py
+++ b/hyperspy/io.py
@@ -284,8 +284,8 @@ def load(filenames=None,
     close_file : bool, optional
         Only for hspy files. Close the file after writing, default is True.
     write_dataset : bool, optional
-        Only for hspy files. If True, overwrite the data, otherwise, don't
-        overwrite. Useful to save attributes without having the write the whole
+        Only for hspy files. If True, write the dataset, otherwise, don't
+        write. Useful to save attributes without having the write the whole
         dataset. Default is True.
 
 

--- a/hyperspy/io.py
+++ b/hyperspy/io.py
@@ -516,6 +516,11 @@ def load_with_reader(
             signal.tmp_parameters.folder = folder
             signal.tmp_parameters.filename = filename
             signal.tmp_parameters.extension = extension.replace('.', '')
+            # original_filename and original_file are used to keep track of
+            # where is the file which has been open lazily
+            signal.tmp_parameters.original_folder = folder
+            signal.tmp_parameters.original_filename = filename
+            signal.tmp_parameters.original_extension = extension.replace('.', '')
             # test if binned attribute is still in metadata
             if signal.metadata.has_item('Signal.binned'):
                 for axis in signal.axes_manager.signal_axes:

--- a/hyperspy/io.py
+++ b/hyperspy/io.py
@@ -288,17 +288,6 @@ def load(filenames=None,
         acquisition stopped before the end: if True, load only the acquired
         data. If False, fill empty data with zeros. Default is False and this
         default value will change to True in version 2.0.
-    chunks : tuple of integer or None
-        Only for hspy files. Define the chunking used for saving the dataset.
-        If None, calculates chunks for the signal, with preferably at least
-        one chunk per signal space.
-    close_file : bool, optional
-        Only for hspy files. Close the file after writing, default is True.
-    write_dataset : bool, optional
-        Only for hspy files. If True, write the dataset, otherwise, don't
-        write it. Useful to save attributes without having to write the whole
-        dataset. Default is True.
-
 
     Returns
     -------

--- a/hyperspy/io.py
+++ b/hyperspy/io.py
@@ -26,7 +26,7 @@ import numpy as np
 from natsort import natsorted
 from inspect import isgenerator
 from pathlib import Path
-from collections import MutableMapping
+from collections.abc import MutableMapping
 
 from hyperspy.drawing.marker import markers_metadata_dict_to_markers
 from hyperspy.exceptions import VisibleDeprecationWarning

--- a/hyperspy/io_plugins/_hierarchical.py
+++ b/hyperspy/io_plugins/_hierarchical.py
@@ -31,7 +31,7 @@ def get_signal_chunks(shape, dtype, signal_axes=None, target_size=1e6):
     Parameters
     ----------
     shape : tuple
-        The shape of the dataset to be sorted / chunked.
+        The shape of the dataset to be stored / chunked.
     dtype : {dtype, string}
         The numpy dtype of the data.
     signal_axes: {None, iterable of ints}

--- a/hyperspy/io_plugins/_hierarchical.py
+++ b/hyperspy/io_plugins/_hierarchical.py
@@ -28,8 +28,8 @@ class HierarchicalReader:
                  file):
         """ Initalizes a general reader for hierarchical signals.
 
-        Parmeters
-        ---------
+        Parameters
+        ----------
         file: str
             A file to be read.
         """

--- a/hyperspy/io_plugins/_hierarchical.py
+++ b/hyperspy/io_plugins/_hierarchical.py
@@ -31,11 +31,11 @@ def get_signal_chunks(shape, dtype, signal_axes=None, target_size=1e6):
     Parameters
     ----------
     shape : tuple
-        the shape of the dataset to be sored / chunked
+        The shape of the dataset to be sorted / chunked.
     dtype : {dtype, string}
-        the numpy dtype of the data
+        The numpy dtype of the data.
     signal_axes: {None, iterable of ints}
-        the axes defining "signal space" of the dataset. If None, the default
+        The axes defining "signal space" of the dataset. If None, the default
         h5py chunking is performed.
     target_size: int
         The target number of bytes for one chunk
@@ -183,7 +183,7 @@ class HierarchicalReader:
 
     def group2signaldict(self, group, lazy=False):
         """
-        Read a h5py/zarr group and returns a signal dictionary
+        Reads a h5py/zarr group and returns a signal dictionary.
 
         Parameters
         ----------

--- a/hyperspy/io_plugins/_hierarchical.py
+++ b/hyperspy/io_plugins/_hierarchical.py
@@ -2,6 +2,7 @@ import ast
 import datetime
 import logging
 from packaging.version import Version
+import warnings
 
 import dask.array as da
 import h5py
@@ -82,11 +83,19 @@ class HierarchicalReader:
             A file to be read.
         """
         self.file = file
+        # Getting version also check that this is a hyperspy format
         self.version = self.get_format_version()
         self.Dataset = None
         self.Group = None
         self.unicode_kwds = None
         self.ragged_kwds = None
+
+        if self.version > Version(version):
+            warnings.warn(
+                "This file was written using a newer version of the "
+                f"HyperSpy {self._file_type} file format. I will attempt to "
+                "load it, but, if I fail, it is likely that I will be more "
+                "successful at this and other tasks if you upgrade me.")
 
     def get_format_version(self):
         """Return the format version."""
@@ -104,6 +113,7 @@ class HierarchicalReader:
             version = "2.0"
         else:
             raise IOError(not_valid_format)
+
         return Version(version)
 
     def read(self, lazy):
@@ -543,12 +553,12 @@ class HierarchicalWriter:
         self.kwds = kwds
 
     @staticmethod
-    def _get_object_dset(*args, **kwargs):
+    def _get_object_dset(*args, **kwargs):  # pragma: no cover
         raise NotImplementedError(
             "This method must be implemented by subclasses.")
 
     @staticmethod
-    def _store_data(*arg):
+    def _store_data(*arg):  # pragma: no cover
         raise NotImplementedError(
             "This method must be implemented by subclasses.")
 

--- a/hyperspy/io_plugins/_hierarchical.py
+++ b/hyperspy/io_plugins/_hierarchical.py
@@ -60,6 +60,7 @@ class HierarchicalReader:
     def read(self, lazy):
         models_with_signals = []
         standalone_models = []
+
         if 'Analysis/models' in self.file:
             try:
                 m_gr = self.file['Analysis/models']
@@ -78,8 +79,10 @@ class HierarchicalReader:
                                 m_gr[model_name], lazy=lazy)})
             except TypeError:
                 raise IOError(not_valid_format)
+
         experiments = []
         exp_dict_list = []
+
         if 'Experiments' in self.file:
             for ds in self.file['Experiments']:
                 if isinstance(self.file['Experiments'][ds], self.Group):
@@ -104,11 +107,10 @@ class HierarchicalReader:
             standalone_models.append(m)
 
         exp_dict_list.extend(standalone_models)
+
         if not len(exp_dict_list):
-            raise IOError('This is not a valid HyperSpy HDF5 file. '
-                          'You can still load the data using a hdf5 reader, '
-                          'e.g. h5py, and manually create a Signal. '
-                          'Please, refer to the User Guide for details')
+            raise IOError(f'This is not a valid {self._file_type} file.')
+
         return exp_dict_list
 
     def group2signaldict(self,

--- a/hyperspy/io_plugins/_hierarchical.py
+++ b/hyperspy/io_plugins/_hierarchical.py
@@ -549,9 +549,9 @@ class HierarchicalWriter:
         if np.issubdtype(data.dtype, np.dtype('U')):
             # Saving numpy unicode type is not supported in h5py
             data = data.astype(np.dtype('S'))
+
         if data.dtype == np.dtype('O'):
             dset = cls._get_object_dset(group, data, key, chunks, **kwds)
-
         else:
             got_data = False
             while not got_data:
@@ -571,12 +571,9 @@ class HierarchicalWriter:
                     # if the shape or dtype/etc do not match,
                     # we delete the old one and create new in the next loop run
                     del group[key]
-        if dset == data:
-            # just a reference to already created thing
-            pass
-        else:
-            _logger.info(f"Chunks used for saving: {chunks}")
-            cls._store_data(data, dset, group, key, chunks, **kwds)
+
+        _logger.info(f"Chunks used for saving: {chunks}")
+        cls._store_data(data, dset, group, key, chunks, **kwds)
 
     def write(self):
         self.write_signal(self.signal,

--- a/hyperspy/io_plugins/_hierarchical.py
+++ b/hyperspy/io_plugins/_hierarchical.py
@@ -629,7 +629,7 @@ class HierarchicalWriter:
         self.dict2group(signal.learning_results.__dict__,
                       learning_results, **kwds)
 
-        if hasattr(signal, 'peak_learning_results'):
+        if hasattr(signal, 'peak_learning_results'):  # pragma: no cover
             peak_learning_results = group.require_group(
                 'peak_learning_results')
             self.dict2group(signal.peak_learning_results.__dict__,

--- a/hyperspy/io_plugins/_hierarchical.py
+++ b/hyperspy/io_plugins/_hierarchical.py
@@ -35,10 +35,10 @@ def get_signal_chunks(shape, dtype, signal_axes=None, target_size=1e6):
         The shape of the dataset to be stored / chunked.
     dtype : {dtype, string}
         The numpy dtype of the data.
-    signal_axes: {None, iterable of ints}
+    signal_axes : {None, iterable of ints}
         The axes defining "signal space" of the dataset. If None, the default
         h5py chunking is performed.
-    target_size: int
+    target_size : int
         The target number of bytes for one chunk
     """
     typesize = np.dtype(dtype).itemsize
@@ -75,7 +75,7 @@ class HierarchicalReader:
 
     def __init__(self, file):
         """
-        Initalizes a general reader for hierarchical signals.
+        Initializes a general reader for hierarchical signals.
 
         Parameters
         ----------
@@ -524,8 +524,8 @@ class HierarchicalReader:
 
 class HierarchicalWriter:
     """
-    An object used to simplify and orgainize the process for writing a
-    Hierachical signal, such as hspy/zspy format.
+    An object used to simplify and organize the process for writing a
+    Hierarchical signal, such as hspy/zspy format.
     """
     target_size = 1e6
 

--- a/hyperspy/io_plugins/emd.py
+++ b/hyperspy/io_plugins/emd.py
@@ -43,9 +43,7 @@ import pint
 from hyperspy.exceptions import VisibleDeprecationWarning
 from hyperspy.misc.elements import atomic_number2name
 import hyperspy.misc.io.fei_stream_readers as stream_readers
-from hyperspy.io_plugins.hspy import HyperspyWriter
-
-get_signal_chunks = HyperspyWriter._get_signal_chunks
+from hyperspy.io_plugins.hspy import get_signal_chunks
 
 
 # Plugin characteristics

--- a/hyperspy/io_plugins/hspy.py
+++ b/hyperspy/io_plugins/hspy.py
@@ -117,7 +117,7 @@ class HyperspyReader(HierarchicalReader):
 
 class HyperspyWriter(HierarchicalWriter):
     """
-    An object used to simplify and orgainize the process for
+    An object used to simplify and organize the process for
     writing a hyperspy signal.  (.hspy format)
     """
     target_size = 1e6
@@ -154,10 +154,7 @@ class HyperspyWriter(HierarchicalWriter):
         return dset
 
 
-def file_reader(
-                filename,
-                lazy=False,
-                **kwds):
+def file_reader(filename, lazy=False, **kwds):
     """Read data from hdf5 files saved with the hyperspy hdf5 format specification
 
     Parameters

--- a/hyperspy/io_plugins/hspy.py
+++ b/hyperspy/io_plugins/hspy.py
@@ -190,10 +190,14 @@ def file_writer(filename, signal, close_file=True, *args, **kwds):
 
     Parameters
     ----------
-    filename: str
+    filename : str
         The name of the file used to save the signal.
-    signal: a BaseSignal instance
+    signal : a BaseSignal instance
         The signal to save.
+    chunks : tuple of integer or None
+        Define the chunking used for saving the dataset. If None, calculates
+        chunks for the signal, with preferably at least one chunk per signal
+        space.
     close_file : bool, optional
         Close the file after writing, default is True.
     write_dataset : bool, optional
@@ -211,9 +215,9 @@ def file_writer(filename, signal, close_file=True, *args, **kwds):
         # Use shuffle by default to improve compression
         kwds["shuffle"] = True
 
-    folder = signal.tmp_parameters.get_item('folder', '')
-    fname = signal.tmp_parameters.get_item('filename', '')
-    ext = signal.tmp_parameters.get_item('extension', '')
+    folder = signal.tmp_parameters.get_item('original_folder', '')
+    fname = signal.tmp_parameters.get_item('original_filename', '')
+    ext = signal.tmp_parameters.get_item('original_extension', '')
     original_path = Path(folder, f"{fname}.{ext}")
 
     f = None

--- a/hyperspy/io_plugins/hspy.py
+++ b/hyperspy/io_plugins/hspy.py
@@ -185,7 +185,7 @@ def file_reader(
     return exp_dict_list
 
 
-def file_writer(filename, signal, close_file=True, *args, **kwds):
+def file_writer(filename, signal, close_file=True, **kwds):
     """Writes data to hyperspy's hdf5 format
 
     Parameters
@@ -194,17 +194,16 @@ def file_writer(filename, signal, close_file=True, *args, **kwds):
         The name of the file used to save the signal.
     signal : a BaseSignal instance
         The signal to save.
-    chunks : tuple of integer or None
+    chunks : tuple of integer or None, default: None
         Define the chunking used for saving the dataset. If None, calculates
         chunks for the signal, with preferably at least one chunk per signal
         space.
-    close_file : bool, optional
-        Close the file after writing, default is True.
-    write_dataset : bool, optional
+    close_file : bool, default: True
+        Close the file after writing.
+    write_dataset : bool, default: True
         If True, overwrite the data, otherwise, don't overwrite. Useful to
         save attributes without having the write the whole dataset.
-        Default is True.
-    **kwds, optional
+    **kwds
         The keyword argument are passed to the
         :py:func:`h5py.Group.require_dataset` function.
     """
@@ -230,8 +229,12 @@ def file_writer(filename, signal, close_file=True, *args, **kwds):
                           "signal.")
 
     if f is None:
-        # TODO: what should be the default mode? 'w' or 'a'
-        f = h5py.File(filename, mode=kwds.get('mode', 'w'))
+        # we need mode='a' to be able to use "write_dataset=False"
+        mode = kwds.get('mode', 'a')
+        if mode != 'a' and not kwds.get('write_dataset', True):
+            raise ValueError("`mode='a'` is required to use "
+                             "`write_dataset=False`.")
+        f = h5py.File(filename, mode=mode)
 
     f.attrs['file_format'] = "HyperSpy"
     f.attrs['file_format_version'] = version

--- a/hyperspy/io_plugins/hspy.py
+++ b/hyperspy/io_plugins/hspy.py
@@ -202,8 +202,8 @@ def file_writer(filename, signal, close_file=True, **kwds):
     close_file : bool, default: True
         Close the file after writing.
     write_dataset : bool, default: True
-        If True, write the data, otherwise, don't write. Useful to
-        save attributes without having to the write the whole dataset.
+        If True, write the data, otherwise, don't write it. Useful to
+        save attributes without having to write the whole dataset.
     **kwds
         The keyword argument are passed to the
         :py:func:`h5py.Group.require_dataset` function.

--- a/hyperspy/io_plugins/hspy.py
+++ b/hyperspy/io_plugins/hspy.py
@@ -229,9 +229,11 @@ def file_writer(filename, signal, close_file=True, **kwds):
                           "signal.")
 
     if f is None:
-        # we need mode='a' to be able to use "write_dataset=False"
-        mode = kwds.get('mode', 'a')
-        if mode != 'a' and not kwds.get('write_dataset', True):
+        write_dataset = kwds.get('write_dataset', True)
+        # with "write_dataset=False", we need mode='a', otherwise the dataset
+        # will be flushed with using 'w' mode
+        mode = kwds.get('mode', 'w' if write_dataset else 'a')
+        if mode != 'a' and not write_dataset:
             raise ValueError("`mode='a'` is required to use "
                              "`write_dataset=False`.")
         f = h5py.File(filename, mode=mode)

--- a/hyperspy/io_plugins/hspy.py
+++ b/hyperspy/io_plugins/hspy.py
@@ -25,7 +25,8 @@ import dask.array as da
 import h5py
 
 from hyperspy.io_plugins._hierarchical import (
-    HierarchicalWriter, HierarchicalReader, version
+    # hyperspy.io_plugins.hspy.get_signal_chunks is in the hyperspy public API
+    HierarchicalWriter, HierarchicalReader, version, get_signal_chunks
     )
 
 
@@ -113,7 +114,8 @@ class HyperspyReader(HierarchicalReader):
 
 
 class HyperspyWriter(HierarchicalWriter):
-    """An object used to simplify and orgainize the process for
+    """
+    An object used to simplify and orgainize the process for
     writing a hyperspy signal.  (.hspy format)
     """
     target_size = 1e6
@@ -127,7 +129,7 @@ class HyperspyWriter(HierarchicalWriter):
 
 
     @staticmethod
-    def _store_data(data, dset, group, key, chunks, **kwds):
+    def _store_data(data, dset, group, key, chunks):
         if isinstance(data, da.Array):
             if data.chunks != dset.chunks:
                 data = data.rechunk(dset.chunks)
@@ -206,7 +208,7 @@ def file_writer(filename, signal, close_file=True, **kwds):
         save attributes without having to write the whole dataset.
     **kwds
         The keyword argument are passed to the
-        :py:func:`h5py.Group.require_dataset` function.
+        :py:meth:`h5py.Group.require_dataset` function.
     """
     if 'compression' not in kwds:
         kwds['compression'] = 'gzip'
@@ -267,3 +269,5 @@ def file_writer(filename, signal, close_file=True, **kwds):
 
     if close_file:
         f.close()
+
+overwrite_dataset = HyperspyWriter.overwrite_dataset

--- a/hyperspy/io_plugins/hspy.py
+++ b/hyperspy/io_plugins/hspy.py
@@ -156,7 +156,7 @@ def file_reader(
                 **kwds):
     """Read data from hdf5 files saved with the hyperspy hdf5 format specification
 
-     Parameters
+    Parameters
     ----------
     filename: str
     lazy: bool

--- a/hyperspy/io_plugins/hspy.py
+++ b/hyperspy/io_plugins/hspy.py
@@ -201,8 +201,8 @@ def file_writer(filename, signal, close_file=True, **kwds):
     close_file : bool, default: True
         Close the file after writing.
     write_dataset : bool, default: True
-        If True, overwrite the data, otherwise, don't overwrite. Useful to
-        save attributes without having the write the whole dataset.
+        If True, write the data, otherwise, don't write. Useful to
+        save attributes without having to the write the whole dataset.
     **kwds
         The keyword argument are passed to the
         :py:func:`h5py.Group.require_dataset` function.

--- a/hyperspy/io_plugins/hspy.py
+++ b/hyperspy/io_plugins/hspy.py
@@ -109,6 +109,7 @@ class HyperspyReader(HierarchicalReader):
         self.Dataset = h5py.Dataset
         self.Group = h5py.Group
         self.unicode_kwds = {"dtype": h5py.special_dtype(vlen=str)}
+        self._file_type = format_name.lower()
 
 
 class HyperspyWriter(HierarchicalWriter):

--- a/hyperspy/io_plugins/nexus.py
+++ b/hyperspy/io_plugins/nexus.py
@@ -27,7 +27,7 @@ import numpy as np
 import pprint
 import traits.api as t
 
-from hyperspy.io_plugins.hspy import HyperspyWriter
+from hyperspy.io_plugins.hspy import (get_signal_chunks, overwrite_dataset)
 from hyperspy.misc.utils import DictionaryTreeBrowser
 from hyperspy.exceptions import VisibleDeprecationWarning
 
@@ -50,8 +50,6 @@ non_uniform_axis = False
 # ----------------------
 
 
-overwrite_dataset = HyperspyWriter.overwrite_dataset
-get_signal_chunks = HyperspyWriter._get_signal_chunks
 
 def _byte_to_string(value):
     """Decode a byte string.

--- a/hyperspy/io_plugins/zspy.py
+++ b/hyperspy/io_plugins/zspy.py
@@ -116,7 +116,8 @@ class ZspyWriter(HierarchicalWriter):
         if isinstance(data, da.Array):
             if data.chunks != dset.chunks:
                 data = data.rechunk(dset.chunks)
-            da.store(data, dset)
+            # lock=False is necessary with the distributed scheduler
+            data.store(dset, lock=False)
         else:
             dset[:] = data
 

--- a/hyperspy/io_plugins/zspy.py
+++ b/hyperspy/io_plugins/zspy.py
@@ -212,7 +212,7 @@ def file_reader(filename, lazy=False, **kwds):
     except BaseException:
         _logger.error(
             "The file can't be read. It may be possible that the zspy file is "
-            "saved with a different store than a zarr Directory store. Try "
+            "saved with a different store than a zarr directory store. Try "
             "passing a different zarr store instead of the file name."
             )
         raise

--- a/hyperspy/io_plugins/zspy.py
+++ b/hyperspy/io_plugins/zspy.py
@@ -19,11 +19,10 @@
 import warnings
 import logging
 from packaging.version import Version
-from collections import MutableMapping
+from collections.abc import MutableMapping
 
 import dask.array as da
 import numcodecs
-import numpy as np
 import zarr
 
 from hyperspy.io_plugins._hierarchical import (
@@ -113,24 +112,12 @@ class ZspyWriter(HierarchicalWriter):
 
     @staticmethod
     def _store_data(data, dset, group, key, chunks, **kwds):
-        """Overrides the hyperspy store data function for using zarr format."""
+        """Write data to zarr format."""
         if isinstance(data, da.Array):
             if data.chunks != dset.chunks:
                 data = data.rechunk(dset.chunks)
-            path = group._store.dir_path() + "/" + dset.path
-            data.to_zarr(url=path,
-                         overwrite=True,
-                            **kwds)  # add in compression etc
-        elif data.dtype == np.dtype('O'):
-            group[key][:] = data[:]  # check lazy
+            da.store(data, dset)
         else:
-            path = group._store.dir_path() + "/" + dset.path
-            dset = zarr.open_array(path,
-                                   mode="w",
-                                   shape=data.shape,
-                                    dtype=data.dtype,
-                                    chunks=chunks,
-                                    **kwds)
             dset[:] = data
 
 

--- a/hyperspy/io_plugins/zspy.py
+++ b/hyperspy/io_plugins/zspy.py
@@ -110,7 +110,7 @@ class ZspyWriter(HierarchicalWriter):
         return dset
 
     @staticmethod
-    def _store_data(data, dset, group, key, chunks, **kwds):
+    def _store_data(data, dset, group, key, chunks):
         """Write data to zarr format."""
         if isinstance(data, da.Array):
             if data.chunks != dset.chunks:
@@ -143,7 +143,7 @@ def file_writer(filename, signal, close_file=True, **kwds):
         save attributes without having to write the whole dataset.
     **kwds
         The keyword argument are passed to the
-        :py:func:`zarr.Group.require_dataset` function.
+        :py:meth:`zarr.hierarchy.Group.require_dataset` function.
     """
     if "compressor" not in kwds:
         from numcodecs import Blosc

--- a/hyperspy/signal.py
+++ b/hyperspy/signal.py
@@ -16,24 +16,24 @@
 # You should have received a copy of the GNU General Public License
 # along with  HyperSpy.  If not, see <http://www.gnu.org/licenses/>.
 
+from collections.abc import MutableMapping
 import copy
-import warnings
-import inspect
 from contextlib import contextmanager
 from datetime import datetime
+import inspect
 from itertools import product
 import logging
-from pint import UnitRegistry, UndefinedUnitError
+import numbers
 from pathlib import Path
+import warnings
 
-import numpy as np
-from scipy import integrate
-from scipy import signal as sp_signal
 import dask.array as da
 from matplotlib import pyplot as plt
+import numpy as np
+from pint import UnitRegistry, UndefinedUnitError
+from scipy import integrate
+from scipy import signal as sp_signal
 import traits.api as t
-import numbers
-from collections import MutableMapping
 
 from hyperspy.axes import AxesManager
 from hyperspy import io

--- a/hyperspy/signal.py
+++ b/hyperspy/signal.py
@@ -2777,8 +2777,7 @@ class BaseSignal(FancySlicing,
     plot.__doc__ %= (BASE_PLOT_DOCSTRING, BASE_PLOT_DOCSTRING_PARAMETERS,
                      PLOT1D_DOCSTRING, PLOT2D_KWARGS_DOCSTRING)
 
-    def save(self, filename=None, overwrite=None, extension=None,
-             **kwds):
+    def save(self, filename=None, overwrite=None, extension=None, **kwds):
         """Saves the signal in the specified format.
 
         The function gets the format from the specified extension (see
@@ -2841,6 +2840,13 @@ class BaseSignal(FancySlicing,
             Nexus file only. Define the default dataset in the file.
             If set to True the signal or first signal in the list of signals
             will be defined as the default (following Nexus v3 data rules).
+        write_dataset : bool, optional
+            Only for hspy files. If True, write the dataset, otherwise, don't
+            write it. Useful to save attributes without having to write the
+            whole dataset. Default is True.
+        close_file : bool, optional
+            Only for hdf5-based files and some zarr store. Close the file after
+            writing. Default is True.
 
         """
         if filename is None:

--- a/hyperspy/tests/io/test_hdf5.py
+++ b/hyperspy/tests/io/test_hdf5.py
@@ -37,7 +37,7 @@ from hyperspy.misc.test_utils import assert_deep_almost_equal
 from hyperspy.misc.test_utils import sanitize_dict as san_dict
 from hyperspy.roi import Point2DROI
 from hyperspy.utils import markers
-from hyperspy.io_plugins._hierarchical import HierarchicalWriter
+from hyperspy.io_plugins.hspy import get_signal_chunks
 
 
 
@@ -906,8 +906,8 @@ def test_title_with_slash(tmp_path, file):
 
 @pytest.mark.parametrize("target_size", (1e6, 1e7))
 def test_get_signal_chunks(target_size):
-    chunks = HierarchicalWriter._get_signal_chunks(shape=[15, 15, 256, 256],
-                                                   dtype=np.int64,
-                                                   signal_axes=(2, 3),
-                                                   target_size=target_size)
+    chunks = get_signal_chunks(shape=[15, 15, 256, 256],
+                               dtype=np.int64,
+                               signal_axes=(2, 3),
+                               target_size=target_size)
     assert (np.prod(chunks)*8 < target_size)

--- a/hyperspy/tests/io/test_hdf5.py
+++ b/hyperspy/tests/io/test_hdf5.py
@@ -833,7 +833,7 @@ def test_chunking_saving_lazy(tmp_path, file):
     assert tuple([c[0] for c in s3.data.chunks]) == chunks
 
 
-def test_saving_hspy_close_file(tmp_path):
+def test_saving_close_file(tmp_path):
     # Setup that we will reopen
     s = Signal1D(da.zeros((10, 100))).as_lazy()
     fname = tmp_path / 'test.hspy'
@@ -857,7 +857,7 @@ def test_saving_hspy_close_file(tmp_path):
         s4.save(fname, overwrite=True)
 
 
-def test_saving_hspy_overwrite_data(tmp_path):
+def test_saving_overwrite_data(tmp_path):
     s = Signal1D(da.zeros((10, 100))).as_lazy()
     fname = tmp_path / 'test.hspy'
     s.save(fname, close_file=True)
@@ -868,6 +868,15 @@ def test_saving_hspy_overwrite_data(tmp_path):
 
     s3 = load(fname)
     assert s3.axes_manager[0].units == 'nm'
+
+    # try with opening non-lazily to check opening mode
+    s4 = load(fname)
+    with pytest.raises(ValueError):
+        s4.save(fname, overwrite=True, write_dataset=False, mode='w')
+
+    s4.save(fname, overwrite=True, write_dataset=False)
+    # make sure we can open it after, file haven't been corrupted
+    _ = load(fname)
 
 
 @pytest.mark.parametrize("target_size", (1e6, 1e7))

--- a/hyperspy/tests/io/test_hdf5.py
+++ b/hyperspy/tests/io/test_hdf5.py
@@ -879,6 +879,15 @@ def test_saving_overwrite_data(tmp_path):
     _ = load(fname)
 
 
+def test_title_with_slash(tmp_path):
+    s = Signal1D(da.zeros((10, 100))).as_lazy()
+    fname = tmp_path / 'test.hspy'
+    s.metadata.General.title = 'A / B'
+    s.save(fname)
+    s2 = load(fname)
+    assert s2.metadata.General.title == s.metadata.General.title
+
+
 @pytest.mark.parametrize("target_size", (1e6, 1e7))
 def test_get_signal_chunks(target_size):
     chunks = HierarchicalWriter._get_signal_chunks(shape=[15, 15, 256, 256],

--- a/hyperspy/tests/io/test_zspy.py
+++ b/hyperspy/tests/io/test_zspy.py
@@ -35,20 +35,6 @@ class TestZspy:
         s = Signal1D(data)
         return s
 
-    def test_save_N5_type(self, signal, tmp_path):
-        filename = tmp_path / 'testmodels.zspy'
-        store = zarr.N5Store(path=filename)
-        signal.save(store, write_to_storage=True)
-        signal2 = load(filename)
-        np.testing.assert_array_equal(signal2.data, signal.data)
-
-    def test_save_N5_type_path(self, signal, tmp_path):
-        filename = tmp_path / 'testmodels.zspy'
-        store = zarr.N5Store(path=filename)
-        signal.save(store.path, write_to_storage=True)
-        signal2 = load(filename)
-        np.testing.assert_array_equal(signal2.data, signal.data)
-
     @pytest.mark.parametrize("overwrite",[None, True, False])
     def test_overwrite(self,signal, overwrite, tmp_path):
         filename = tmp_path / 'testmodels.zspy'

--- a/hyperspy/tests/io/test_zspy.py
+++ b/hyperspy/tests/io/test_zspy.py
@@ -17,6 +17,7 @@
 # along with  HyperSpy.  If not, see <http://www.gnu.org/licenses/>.
 
 import numpy as np
+import os
 import pytest
 
 from hyperspy._signals.signal1d import Signal1D
@@ -34,6 +35,22 @@ class TestZspy:
         data = np.ones((10,10,10,10))
         s = Signal1D(data)
         return s
+
+    @pytest.mark.parametrize('store_class', [zarr.N5Store, zarr.ZipStore])
+    def test_save_store(self, signal, tmp_path, store_class):
+        filename = tmp_path / 'testmodels.zspy'
+        store = store_class(path=filename)
+        signal.save(store)
+
+        if store_class is zarr.ZipStore:
+            os.path.isfile(filename)
+        else:
+            os.path.isdir(filename)
+
+        store2 = store_class(path=filename)
+        signal2 = load(store2)
+
+        np.testing.assert_array_equal(signal2.data, signal.data)
 
     @pytest.mark.parametrize("overwrite",[None, True, False])
     def test_overwrite(self,signal, overwrite, tmp_path):

--- a/upcoming_changes/2797.enhancements.rst
+++ b/upcoming_changes/2797.enhancements.rst
@@ -1,0 +1,1 @@
+Add options not to close file (lazy signal only) and not to write dataset for hspy file format, see :ref:`hspy-format` for details


### PR DESCRIPTION
### Progress of the PR
- [x] Add option to close file when saving lazy signal to hspy format,
- [x] add option not to write dataset, which can useful when saving large signal (hspy/zspy format only),
- [x] fix issue with latest `h5py` version (3.5)
- [x] update docstring,
- [x] update user guide,
- [x] add an changelog entry in the `upcoming_changes` folder (see [`upcoming_changes/README.rst`](https://github.com/hyperspy/hyperspy/blob/RELEASE_next_minor/upcoming_changes/README.rst)),
- [x] Check formatting changelog entry in the `readthedocs` doc build of this PR (link in github checks)
- [x] add tests,
- [x] ready for review.

### Minimal example of the bug fix or the new feature
```python
import hyperspy.api as hs
import numpy as np

s = hs.signals.Signal1D(np.arange(1000).reshape(10, 100))

fname = 'test.hspy'
s.save(fname, overwrite=True)

s2 = hs.load(fname, lazy=True, mode='a')
s2.axes_manager[-1].scale = 0.1
# write everything, except the dataset itself
s2.save(fname, overwrite=True, write_dataset=False)

s3 = hs.load(fname)
print(s3.axes_manager[-1].scale)
```