### PR TITLE
Check if plot is not active in add marker() before plotting (bugfix)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,3 +53,4 @@ hyperspy/tests/io/edax_files.zip
 .vscode/
 tsconfig.json
 jsconfig.json
+*egg-info*

--- a/hyperspy/signal.py
+++ b/hyperspy/signal.py
@@ -5665,7 +5665,7 @@ class BaseSignal(FancySlicing,
                 raise ValueError("Markers can not be added to several signals")
             m._plot_on_signal = plot_on_signal
             if plot_marker:
-                if self._plot is None:
+                if self._plot is None or not self._plot.is_active:
                     self.plot()
                 if m._plot_on_signal:
                     self._plot.signal_plot.add_marker(m)

--- a/hyperspy/tests/drawing/test_plot_markers.py
+++ b/hyperspy/tests/drawing/test_plot_markers.py
@@ -178,6 +178,13 @@ class TestMarkers:
             marker_list.append(markers.point(4, 8))
         s.add_marker(marker_list)
 
+    def test_check_if_plot_is_not_active(self):
+        s = Signal1D(np.arange(100).reshape([10,10]))
+        m = markers.vertical_line(np.arange(10))
+        s.add_marker(m)
+        s._plot.close()
+        s.add_marker(m)
+
 
 class Test_permanent_markers:
 

--- a/upcoming_changes/2799.bugfix.rst
+++ b/upcoming_changes/2799.bugfix.rst
@@ -1,0 +1,1 @@
+make add_marker() also check if the plot is not active before plotting signal

--- a/upcoming_changes/2799.bugfix.rst
+++ b/upcoming_changes/2799.bugfix.rst
@@ -1,1 +1,1 @@
-make add_marker() also check if the plot is not active before plotting signal
+make :py:meth:`~.signal.BaseSignal.add_marker` also check if the plot is not active before plotting signal


### PR DESCRIPTION
### Description of the change
This PR aims to fix a bug where `signal.add_marker()` would not check correctly if a plot is active.

### Progress of the PR
- [x] modified `if` statement to also check if plot is not active and not just if `signal._plot is None`
- [x] added changelog entry in the `upcoming_changes` folder
- [x] Check formatting changelog entry in the `readthedocs` doc build of this PR (link in github checks)
- [x] add tests,
- [x] ready for review.

### Minimal example of the bug fix or the new feature
```python
import hyperspy.api as hs
import numpy as np

s = hs.signals.Signal1D(np.arange(100).reshape([10,10]))
m = markers.vertical_line(np.arange(10))
s.add_marker(m)
s._plot.close()
s.add_marker(m)
```
before the code above would give this error:
```python
---------------------------------------------------------------------------
AttributeError                            Traceback (most recent call last)
<ipython-input-36-7302ff075bd5> in <module>
      6 s.add_marker(m)
      7 s._plot.close()
----> 8 s.add_marker(m)

c:\users\geri\documents\dev\hyperspy\hyperspy\signal.py in add_marker(self, marker, plot_on_signal, plot_marker, permanent, plot_signal, render_figure)
   5791                     self.plot()
   5792                 if m._plot_on_signal:
-> 5793                     self._plot.signal_plot.add_marker(m)
   5794                 else:
   5795                     if self._plot.navigator_plot is None:

AttributeError: 'NoneType' object has no attribute 'add_marker'
```