### PR TITLE
Add hs.datasets.example_signals back in to init

### DIFF
--- a/doc/user_guide/model.rst
+++ b/doc/user_guide/model.rst
@@ -200,7 +200,7 @@ following template to suit your needs:
 
             # Optionally we can set the initial values
             self.parameter_1.value = parameter_1
-            self.parameter_1.value = parameter_1
+            self.parameter_2.value = parameter_2
 
             # The units (optional)
             self.parameter_1.units = 'Tesla'

--- a/hyperspy/datasets/__init__.py
+++ b/hyperspy/datasets/__init__.py
@@ -18,4 +18,4 @@ The :mod:`~hyperspy.api.datasets` module contains the following submodules:
 """
 
 from hyperspy.misc.eels.eelsdb import eelsdb
-from hyperspy.datasets import artificial_data
+from hyperspy.datasets import artificial_data, example_signals


### PR DESCRIPTION
### Description of the change
commit a737190 somehow got stopped added `datasets` into being added in hs.example_signals.
I don't think that was intentional, and this fixes that.

 
### Progress of the PR
- [x] Change implemented (can be split into several points),
- [x] ready for review.
