### PR TITLE
Bugfix for cliff-lorimer quantification

### DIFF
--- a/hyperspy/_signals/eds_tem.py
+++ b/hyperspy/_signals/eds_tem.py
@@ -559,7 +559,7 @@ class EDSTEMSpectrum(EDSSpectrum):
             utils.plot.plot_signals(composition, **kwargs)
 
         if absorption_correction:
-            _logger.info(f'Conversion found after {it} interations.')
+            _logger.info(f'Convergence reach after {it} interations.')
 
         if method == 'zeta':
             mass_thickness.metadata.General.title = 'Mass thickness'

--- a/hyperspy/_signals/eds_tem.py
+++ b/hyperspy/_signals/eds_tem.py
@@ -25,7 +25,7 @@ import numpy as np
 from scipy import constants
 import pint
 
-from hyperspy.signal import BaseSetMetadataItems
+from hyperspy.signal import BaseSetMetadataItems, BaseSignal
 from hyperspy import utils
 from hyperspy._signals.eds import (EDSSpectrum, LazyEDSSpectrum)
 from hyperspy.defaults_parser import preferences
@@ -399,13 +399,22 @@ class EDSTEMSpectrum(EDSSpectrum):
         --------
         vacuum_mask
         """
+        if (not isinstance(intensities, (list, tuple)) or
+                not isinstance(intensities[0], BaseSignal)):
+            raise ValueError(
+                "The parameter `intensities` must be a list of signals."
+                )
+        elif len(intensities) <= 1:
+            raise ValueError("Several X-ray line intensities are required.")
+        
         if isinstance(navigation_mask, float):
             if self.axes_manager.navigation_dimension > 0:
                 navigation_mask = self.vacuum_mask(navigation_mask, closing)
             else:
                 navigation_mask = None
 
-        xray_lines = [intensity.metadata.Sample.xray_lines[0] for intensity in intensities]
+        xray_lines = [intensity.metadata.Sample.xray_lines[0]
+                      for intensity in intensities]
         it = 0
         if absorption_correction:
             if show_progressbar is None:  # pragma: no cover
@@ -559,7 +568,7 @@ class EDSTEMSpectrum(EDSSpectrum):
             utils.plot.plot_signals(composition, **kwargs)
 
         if absorption_correction:
-            _logger.info(f'Convergence reach after {it} interations.')
+            _logger.info(f'Convergence reached after {it} interations.')
 
         if method == 'zeta':
             mass_thickness.metadata.General.title = 'Mass thickness'

--- a/hyperspy/misc/eds/utils.py
+++ b/hyperspy/misc/eds/utils.py
@@ -442,11 +442,9 @@ def quantification_cliff_lorimer(intensities,
         return intens
     else:
         index = np.where(intensities > min_intensity)[0]
-        if absorption_correction is not None:
-            absorption_correction = absorption_correction
-        else:
+        if absorption_correction is None:
             # default to ones
-            absorption_correction = np.ones_like(intens, dtype='float')
+            absorption_correction = np.ones_like(intensities, dtype='float')
         if len(index) > 1:
             ref_index, ref_index2 = index[:2]
             intens = _quantification_cliff_lorimer(
@@ -543,9 +541,7 @@ def quantification_zeta_factor(intensities,
     A numpy.array containing the weight fraction with the same
     shape as intensities and mass thickness in kg/m^2.
     """
-    if absorption_correction is not None:
-        absorption_correction = absorption_correction
-    else:
+    if absorption_correction is None:
         # default to ones
         absorption_correction = np.ones_like(intensities, dtype='float')
 
@@ -616,9 +612,7 @@ def quantification_cross_section(intensities,
     """
 
 
-    if absorption_correction is not None:
-        absorption_correction = absorption_correction
-    else:
+    if absorption_correction is None:
         # default to ones
         absorption_correction = np.ones_like(intensities, dtype='float')
 

--- a/hyperspy/tests/signals/test_eds_tem.py
+++ b/hyperspy/tests/signals/test_eds_tem.py
@@ -283,6 +283,20 @@ class Test_quantification:
                                    atol=1e-3)
         np.testing.assert_allclose(res[0].data, res4[0][0].data, atol=1e-5)
 
+    def test_quant_lorimer_ac_single_spectrum(self):
+        s = self.signal.inav[0]
+        method = 'CL'
+        kfactors = [1, 2.0009344042484134]
+        composition_units = 'weight'
+        intensities = s.get_lines_intensity()
+        res = s.quantification(intensities, method, kfactors,
+                               composition_units)
+        np.testing.assert_allclose(res[0].data, 22.70779, atol=1e-3)
+        res2 = s.quantification(intensities, method, kfactors,
+                                composition_units,
+                                absorption_correction=True,
+                                thickness=1.)
+        np.testing.assert_allclose(res2[0].data, 22.743013, atol=1e-3)        
 
     def test_quant_zeta(self):
         s = self.signal

--- a/hyperspy/tests/signals/test_eds_tem.py
+++ b/hyperspy/tests/signals/test_eds_tem.py
@@ -202,6 +202,19 @@ class Test_quantification:
             TEM_md.probe_area, 1.2)
         np.testing.assert_approx_equal(TEM_md.Detector.EDS.real_time, 3.1)
 
+    def test_quant_one_intensity_error(self):
+        s = self.signal
+        method = 'CL'
+        kfactors = [1, 2.0009344042484134]
+        intensities = s.get_lines_intensity()[:1]
+        assert len(intensities) == 1    
+        with pytest.raises(ValueError):
+            _ = s.quantification(intensities, method, kfactors)
+
+        intensities = s.get_lines_intensity()[0]
+        with pytest.raises(ValueError):
+            _ = s.quantification(intensities, method, kfactors)
+
     def test_quant_lorimer(self):
         s = self.signal
         method = 'CL'
@@ -281,22 +294,7 @@ class Test_quantification:
                                    atol=1e-3)
         np.testing.assert_allclose(res3[0][0].data, np.ones((2, 2)) * 31.816908,
                                    atol=1e-3)
-        np.testing.assert_allclose(res[0].data, res4[0][0].data, atol=1e-5)
-
-    def test_quant_lorimer_ac_single_spectrum(self):
-        s = self.signal.inav[0]
-        method = 'CL'
-        kfactors = [1, 2.0009344042484134]
-        composition_units = 'weight'
-        intensities = s.get_lines_intensity()
-        res = s.quantification(intensities, method, kfactors,
-                               composition_units)
-        np.testing.assert_allclose(res[0].data, 22.70779, atol=1e-3)
-        res2 = s.quantification(intensities, method, kfactors,
-                                composition_units,
-                                absorption_correction=True,
-                                thickness=1.)
-        np.testing.assert_allclose(res2[0].data, 22.743013, atol=1e-3)        
+        np.testing.assert_allclose(res[0].data, res4[0][0].data, atol=1e-5)     
 
     def test_quant_zeta(self):
         s = self.signal

--- a/upcoming_changes/2822.bugfix.rst
+++ b/upcoming_changes/2822.bugfix.rst
@@ -1,0 +1,1 @@
+Improve error message when performing Cliff-Lorimer quantification with a single line intensity


### PR DESCRIPTION
### Description of the change
- There would be an an error on quantifying a single array of intensities due to a typo
- Several `if absorption_correction is not None` led to `absorption_correction = absorption_correction`, which was unnecessary.
I'm afraid that I don't have time to add tests.
 
### Progress of the PR
- [x] Change implemented (can be split into several points),
- [x] ready for review.
