### PR TITLE
Run extension test suite from PR

### DIFF
--- a/.github/workflows/tests_extension.yml
+++ b/.github/workflows/tests_extension.yml
@@ -6,11 +6,11 @@ on:
   label:
     types: [created]
   pull_request_review:
-    types: [edited]
+    types: [submitted, edited]
 
 jobs:
   integration_test:
-    if: ${{ github.event.label.name == 'run-extension-tests' }}
+    if: ${{ github.event.review || github.event.label.name == 'run-extension-tests' }}
     name: Extension_${{ matrix.EXTENSION_VERSION }}
     runs-on: ubuntu-latest
     strategy:

--- a/.github/workflows/tests_extension.yml
+++ b/.github/workflows/tests_extension.yml
@@ -58,9 +58,10 @@ jobs:
       - name: Install Extension Dev
         if: contains(matrix.EXTENSION_VERSION, 'dev')
         run: |
-          pip install https://github.com/lumispy/lumispy/archive/main.zip --no-deps
-          pip install https://github.com/pyxem/kikuchipy/archive/main.zip --no-deps
-          pip install https://github.com/pyxem/pyxem/archive/master.zip --no-deps
+          pip install https://github.com/lumispy/lumispy/archive/main.zip
+          pip install https://github.com/pyxem/kikuchipy/archive/main.zip
+          pip install https://github.com/pyxem/pyxem/archive/master.zip
+          pip install https://https://gitlab.com/atomap/atomap/-/archive/master/atomap-master.zip
 
       - name: Run Kikuchipy Test Suite
         if: ${{ always() }}
@@ -76,3 +77,9 @@ jobs:
         if: ${{ always() }}
         run: |
           python -m pytest --pyargs pyxem
+
+      # atomap test suite doesn't run headless 
+      #- name: Run atomap Test Suite
+      #  if: ${{ always() }}
+      #  run: |
+      #    python -m pytest --pyargs atomap

--- a/.github/workflows/tests_extension.yml
+++ b/.github/workflows/tests_extension.yml
@@ -1,0 +1,78 @@
+name: Integration tests
+
+on:
+  workflow_dispatch:
+    workflow: "*"
+  label:
+    types: [created]
+  pull_request_review:
+    types: [edited]
+
+jobs:
+  integration_test:
+    if: ${{ github.event.label.name == 'run-extension-tests' }}
+    name: Extension_${{ matrix.EXTENSION_VERSION }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        EXTENSION_VERSION: ['release', 'dev']
+
+    env:
+      MPLBACKEND: agg
+      EXTENSION: kikuchipy lumispy pyxem atomap
+      TEST_DEPS: pytest pytest-xdist pytest-rerunfailures pytest-instafail
+    defaults:
+      run:
+        shell: bash -l {0}
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: conda-incubator/setup-miniconda@master
+        with:
+          miniforge-variant: Mambaforge
+          miniforge-version: latest
+          # use base environment, so that when using pip, this is from the
+          # mambaforge distribution
+          auto-activate-base: true
+          activate-environment: ""
+
+      - name: Conda info
+        run: |
+          conda info
+          conda list
+
+      - name: Install extensions and Test dependencies
+        run: |
+          mamba install hyperspy-base ${{ env.EXTENSION }} ${{ env.TEST_DEPS }}
+
+      - name: Conda list
+        run: |
+          conda list
+
+      - name: Install HyperSpy
+        run: |
+          pip install .
+
+      - name: Install Extension Dev
+        if: contains(matrix.EXTENSION_VERSION, 'dev')
+        run: |
+          pip install https://github.com/lumispy/lumispy/archive/main.zip --no-deps
+          pip install https://github.com/pyxem/kikuchipy/archive/main.zip --no-deps
+          pip install https://github.com/pyxem/pyxem/archive/master.zip --no-deps
+
+      - name: Run Kikuchipy Test Suite
+        if: ${{ always() }}
+        run: |
+          python -m pytest --pyargs kikuchipy
+
+      - name: Run LumiSpy Test Suite
+        if: ${{ always() }}
+        run: |
+          python -m pytest --pyargs lumispy
+
+      - name: Run Pyxem Test Suite
+        if: ${{ always() }}
+        run: |
+          python -m pytest --pyargs pyxem

--- a/.github/workflows/tests_extension.yml
+++ b/.github/workflows/tests_extension.yml
@@ -59,7 +59,7 @@ jobs:
         if: contains(matrix.EXTENSION_VERSION, 'dev')
         run: |
           pip install https://github.com/lumispy/lumispy/archive/main.zip
-          pip install https://github.com/pyxem/kikuchipy/archive/main.zip
+          pip install https://github.com/pyxem/kikuchipy/archive/develop.zip
           pip install https://github.com/pyxem/pyxem/archive/master.zip
           pip install https://https://gitlab.com/atomap/atomap/-/archive/master/atomap-master.zip
 

--- a/doc/dev_guide/testing.rst
+++ b/doc/dev_guide/testing.rst
@@ -179,6 +179,8 @@ The testing matrix is as follows:
   all dependencies are installed from `Anaconda Cloud <https://anaconda.org/>`_
   using the `"conda-forge" <https://anaconda.org/conda-forge>`_ channel.
   See ``azure-pipelines.yml`` in the HyperSpy repository for further details.
+- The testing of **HyperSpy extensions** is described in the 
+  :ref:`integration test suite <integration_test_suite-label>` section.
 
 This testing matrix has been designed to be simple and easy to maintain, whilst
 ensuring that packages from PyPI and Anaconda cloud are not mixed in order to

--- a/doc/dev_guide/testing.rst
+++ b/doc/dev_guide/testing.rst
@@ -222,7 +222,7 @@ tests. The reference images are located in the folder defined by the argument
 
 To run plot tests, you simply need to add the option ``--mpl``:
 
-:: code:: bash
+.. code:: bash
 
     $ pytest --mpl
 

--- a/doc/dev_guide/writing_extensions.rst
+++ b/doc/dev_guide/writing_extensions.rst
@@ -26,7 +26,7 @@ data.
 Models can also be provided by external packages, but don't need to
 be registered. Instead, they are returned by the ``create_model`` method of
 the relevant :py:class:`hyperspy.signal.BaseSignal` subclass, see for example,
-the :py:meth:`hyperspy._signals.eds_tem.EDSTEM_mixin.create_model` of the
+the :py:meth:`~._signals.eds_tem.EDSTEMSpectrum.create_model` of the
 :py:class:`~._signals.eds_tem.EDSTEMSpectrum`.
 
 It is good practice to add all packages that extend HyperSpy
@@ -420,4 +420,9 @@ repository, which provides ``scipy``, ``numpy``, ``scikit-learn`` and ``scikit-i
 at the time of writing.
 The pre-release packages are obtained from `pypi <https://pypi.org>`_ and these
 will be used for any dependency which provides a pre-release package on pypi.
+
+A similar `Integration test  <https://github.com/hyperspy/hyperspy/actions>`__
+workflow can run from pull requests (PR) to the
+`hyperspy <https://github.com/hyperspy/hyperspy>`_ when the label
+``run-extension-tests`` is added to a PR or when a PR review is edited.
 

--- a/doc/dev_guide/writing_extensions.rst
+++ b/doc/dev_guide/writing_extensions.rst
@@ -423,6 +423,6 @@ will be used for any dependency which provides a pre-release package on pypi.
 
 A similar `Integration test  <https://github.com/hyperspy/hyperspy/actions>`__
 workflow can run from pull requests (PR) to the
-`hyperspy <https://github.com/hyperspy/hyperspy>`_ when the label
+`hyperspy <https://github.com/hyperspy/hyperspy>`_ repository when the label
 ``run-extension-tests`` is added to a PR or when a PR review is edited.
 

--- a/doc/dev_guide/writing_extensions.rst
+++ b/doc/dev_guide/writing_extensions.rst
@@ -421,7 +421,7 @@ at the time of writing.
 The pre-release packages are obtained from `pypi <https://pypi.org>`_ and these
 will be used for any dependency which provides a pre-release package on pypi.
 
-A similar `Integration test  <https://github.com/hyperspy/hyperspy/actions>`__
+A similar `Integration test  <https://github.com/hyperspy/hyperspy/actions/workflows/tests_extension.yml>`__
 workflow can run from pull requests (PR) to the
 `hyperspy <https://github.com/hyperspy/hyperspy>`_ repository when the label
 ``run-extension-tests`` is added to a PR or when a PR review is edited.

--- a/upcoming_changes/2824.enhancements.rst
+++ b/upcoming_changes/2824.enhancements.rst
@@ -1,0 +1,1 @@
+Add Github workflow to run test suite of extension from a pull request.


### PR DESCRIPTION
A regression was introduced in https://github.com/hyperspy/hyperspy/pull/2773, which breaks the pyxem test suite - see https://github.com/hyperspy/hyperspy-extensions-list/actions/runs/1215531490. This PR add a github workflow to run extensions test suite from PRs.

### Progress of the PR
- [x] Add github workflow from PR, when:
        - the label `run-extension-tests` is added
        - a PR review is edited
- [x] Skip atomap test suite - see https://gitlab.com/atomap/atomap/-/merge_requests/73
- [N/A] update docstring (if appropriate),
- [x] update user guide (if appropriate),
- [x] add an changelog entry in the `upcoming_changes` folder (see [`upcoming_changes/README.rst`](https://github.com/hyperspy/hyperspy/blob/RELEASE_next_minor/upcoming_changes/README.rst)),
- [x] Check formatting changelog entry in the `readthedocs` doc build of this PR (link in github checks)
- [N/A] add tests,
- [x] ready for review.


