### PR TITLE
Update docs on installing hyperspy dev version

### DIFF
--- a/doc/user_guide/install.rst
+++ b/doc/user_guide/install.rst
@@ -291,9 +291,11 @@ Installation in a Anaconda/Miniconda distribution
 Install the runtime and development dependencies requirements using conda:
 
 .. code-block:: bash
-
-    $ conda install hyperspy-base -c conda-forge --only-deps
-    $ conda install hyperspy-dev -c conda-forge
+ 
+    $ conda create -n hspy_dev python # create an empty environment with latest python
+    $ conda activate hspy_dev # activate environment
+    $ conda install hyperspy-base -c conda-forge --only-deps # install hyperspy dependencies
+    $ conda install hyperspy-dev -c conda-forge # install developer dependencies
 
 The package ``hyperspy-dev`` will install the development dependencies required
 for testing and building the documentation.
@@ -303,7 +305,7 @@ From the root folder of your hyperspy repository (folder containing the
 
 .. code-block:: bash
 
-    $ pip install -e . --no-deps
+    $ pip install -e . --no-deps # install the currently checkout-out branch of hyperspy
 
 Installation in other (non-system) Python distribution
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/doc/user_guide/install.rst
+++ b/doc/user_guide/install.rst
@@ -288,7 +288,8 @@ To get the development version from our git repository you need to install `git
 Installation in a Anaconda/Miniconda distribution
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Optionally, create an environment to separate your hyperspy installation from 
-other anaconda environments:
+other anaconda environments (`read more about environments here 
+<https://conda.io/projects/conda/en/latest/user-guide/concepts/environments.html>`_):
 
 .. code-block:: bash
 

--- a/doc/user_guide/install.rst
+++ b/doc/user_guide/install.rst
@@ -287,13 +287,18 @@ To get the development version from our git repository you need to install `git
 
 Installation in a Anaconda/Miniconda distribution
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Optionally, create an environment to separate your hyperspy installation from 
+other anaconda environments:
+
+.. code-block:: bash
+
+    $ conda create -n hspy_dev python # create an empty environment with latest python
+    $ conda activate hspy_dev # activate environment
 
 Install the runtime and development dependencies requirements using conda:
 
 .. code-block:: bash
- 
-    $ conda create -n hspy_dev python # create an empty environment with latest python
-    $ conda activate hspy_dev # activate environment
+
     $ conda install hyperspy-base -c conda-forge --only-deps # install hyperspy dependencies
     $ conda install hyperspy-dev -c conda-forge # install developer dependencies
 
@@ -305,7 +310,7 @@ From the root folder of your hyperspy repository (folder containing the
 
 .. code-block:: bash
 
-    $ pip install -e . --no-deps # install the currently checkout-out branch of hyperspy
+    $ pip install -e . --no-deps # install the currently checked-out branch of hyperspy
 
 Installation in other (non-system) Python distribution
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
### Description of the change
To make for an easier debugging experience, developers should (first) install the hyperspy dev install in a fresh environment.
I suggest specifying `python` on environment creation, since I've had trouble with creating totally empty environments in the past.

### Progress of the PR
- [x] Change implemented (can be split into several points),
- [x] ready for review.