### PR TITLE
Fix trigger extension test suite workflow

### DIFF
--- a/.github/workflows/tests_extension.yml
+++ b/.github/workflows/tests_extension.yml
@@ -3,14 +3,14 @@ name: Integration tests
 on:
   workflow_dispatch:
     workflow: "*"
-  label:
-    types: [created]
   pull_request_review:
     types: [submitted, edited]
+  pull_request:
+    types: [labeled, ready_for_review, reopened]
 
 jobs:
   integration_test:
-    if: ${{ github.event.review || github.event.label.name == 'run-extension-tests' }}
+    if: ${{ contains(github.event.pull_request.labels.*.name, 'run-extension-tests') }}
     name: Extension_${{ matrix.EXTENSION_VERSION }}
     runs-on: ubuntu-latest
     strategy:


### PR DESCRIPTION
The `test_extension.yml` is not triggered when adding a label to a PR.

