### PR TITLE
Bugfix around partly swept frame

### DIFF
--- a/doc/user_guide/io.rst
+++ b/doc/user_guide/io.rst
@@ -1762,6 +1762,9 @@ Extra loading arguments
   dataset, it can be integer or a tuple of length 2 to define ``x`` and ``y``
   separetely and it must be a mutiple of the size of the navigation dimension.
   (default 1).
+- ``only_valid_data`` : ignore incomplete (partly aquiered, interrupted) frame when reading pts file.
+  (default True).
+
 
 Example of loading data downsampled, and with energy range cropped with the
 original navigation dimension 512 x 512 and the EDS range 40 keV over 4096

--- a/doc/user_guide/io.rst
+++ b/doc/user_guide/io.rst
@@ -1762,7 +1762,11 @@ Extra loading arguments
   dataset, it can be integer or a tuple of length 2 to define ``x`` and ``y``
   separetely and it must be a mutiple of the size of the navigation dimension.
   (default 1).
-- ``only_valid_data`` : ignore incomplete (partly aquiered, interrupted) frame when reading pts file.
+- ``only_valid_data`` : for ``pts`` file only, ignore incomplete and partly
+  acquired last frame, which typically occurs when the acquisition was
+  interrupted. When loading incomplete data (``only_valid_data=False``),
+  the missing data are filled with zeros. If ``sum_frames=True``, this argument
+  will be ignored to enforce consistent sum over the mapped area. 
   (default True).
 
 

--- a/hyperspy/io_plugins/jeol.py
+++ b/hyperspy/io_plugins/jeol.py
@@ -309,13 +309,13 @@ def read_pts(filename, scale=None, rebin_energy=1, sum_frames=True,
         data, swept = datacube_reader(rawdata, data, sweep,
                                       rebin_energy, channel_number,
                                width_norm, height_norm, np.iinfo(SI_dtype).max)
-        if sum_frames and sweep == swept:
+        if not sum_frames and sweep == swept:
             data = data[:sweep]  # dispose additional frame
         if sweep < swept:
             if sum_frames:
-                _logger.warning("Broken frame %d was ignored" % (swept))
+                _logger.info("Broken frame %d was ignored" % (swept))
             else:
-                _logger.warning("Broken frame %d was read, but not counted" % (swept))
+                _logger.info("Broken frame %d was read, but not counted" % (swept))
 
                 
         hv = meas_data_header["MeasCond"]["AccKV"]

--- a/hyperspy/io_plugins/jeol.py
+++ b/hyperspy/io_plugins/jeol.py
@@ -309,6 +309,8 @@ def read_pts(filename, scale=None, rebin_energy=1, sum_frames=True,
         data, swept = datacube_reader(rawdata, data, sweep,
                                       rebin_energy, channel_number,
                                width_norm, height_norm, np.iinfo(SI_dtype).max)
+        if sum_frames and sweep == swept:
+            data = data[:sweep]  # dispose additional frame
         if sweep < swept:
             if sum_frames:
                 _logger.warning("Broken frame %d was ignored" % (swept))

--- a/hyperspy/io_plugins/jeol.py
+++ b/hyperspy/io_plugins/jeol.py
@@ -463,7 +463,7 @@ def readcube(rawdata, hypermap, sweep, only_valid_data, rebin_energy,
             y = int((value - 36864) / height_norm)
             if y < previous_y:
                 frame_idx += 1
-                if only_valid_data and frame_idx >= sweep:
+                if frame_idx >= sweep:
                     # skip incomplete_frame
                     break 
             previous_y = y


### PR DESCRIPTION
### Description of the change
- Bug fix for JEOL-EDS (io_plugins/jeol.py) pts file reader
-  [Bug] When the final frame was partly recorded (measurement was manually interrupted), the readcube function summing up upper swept area of the final (broken) frame and the counts in upper and lower-frame become unbalanced.
-  [Bug] When the final frame was partly recorded, the readcube_frames function hangs-up (overrun hyperdata array)
- Count the frame index to detect the partly swept frame
- function readcube: ignore final broken frame
- function readcube_frames: extend array for 1 more frame. the axes value keeps the number of completely swept frame

### Progress of the PR
- [x] Change implemented (can be split into several points),
- [ ] update docstring (if appropriate),
- [ ] update user guide (if appropriate),
- [ ] add an changelog entry in the `upcoming_changes` folder (see [`upcoming_changes/README.rst`](https://github.com/hyperspy/hyperspy/blob/RELEASE_next_minor/upcoming_changes/README.rst)),
- [ ] Check formatting changelog entry in the `readthedocs` doc build of this PR (link in github checks)
- [ ] add tests,
- [ ] ready for review.

### Minimal example of the bug fix or the new feature
```python
import hyperspy.api as hs
s = hs.load("broken.pts")
```
