### PR TITLE
Bug fix in _map_iterate method on lazy data with function that changes axes

### DIFF
--- a/hyperspy/_signals/lazy.py
+++ b/hyperspy/_signals/lazy.py
@@ -637,7 +637,7 @@ class LazySignal(BaseSignal):
             axes_changed = True
             if len(output_signal_size) != len(old_sig.axes_manager.signal_shape):
                 drop_axis = old_sig.axes_manager.signal_indices_in_array
-                new_axis = tuple(range(len(output_signal_size)))
+                new_axis = tuple(range(len(nav_indexes), len(nav_indexes) + len(output_signal_size)))
             else:
                 drop_axis = [it for (o, i, it) in zip(output_signal_size,
                                                       old_sig.axes_manager.signal_shape,

--- a/hyperspy/tests/signals/test_map_method.py
+++ b/hyperspy/tests/signals/test_map_method.py
@@ -366,6 +366,7 @@ class TestLazyMap:
 
         s_out = self.s.map(function=f, inplace=False)
         assert s_out.data.shape[2:] == output_signal_size
+        assert s_out.axes_manager.signal_shape == output_signal_size[::-1]
 
 
 @pytest.mark.parametrize('ragged', [True, False, None])

--- a/hyperspy/tests/signals/test_map_method.py
+++ b/hyperspy/tests/signals/test_map_method.py
@@ -359,6 +359,14 @@ class TestLazyMap:
                                inplace=False)
         np.testing.assert_array_equal(s_out.mean(axis=(2, 3)).data, iter_array)
 
+    @pytest.mark.parametrize("output_signal_size", [(3,), (3, 4), (3, 4, 5)])
+    def test_map_output_signal_size(self, output_signal_size):
+        def f(data):
+            return np.ones(output_signal_size)
+
+        s_out = self.s.map(function=f, inplace=False)
+        assert s_out.data.shape[2:] == output_signal_size
+
 
 @pytest.mark.parametrize('ragged', [True, False, None])
 def test_singleton(ragged):

--- a/upcoming_changes/2837.bugfix.rst
+++ b/upcoming_changes/2837.bugfix.rst
@@ -1,0 +1,1 @@
+Fix :py:func:`hyperspy._signals.lazy.LazySignal._map_iterate` output incorrect signal size when input and output axes do not match


### PR DESCRIPTION
### Description of the change
Fixed bug in `_map_iterate` method that gives incorrect output signal size when output axes of the function are different from the input signal. Previous version would feed `map_blocks` function in dask.array with incorrect new axis index.

### Progress of the PR
- [x] Change implemented (can be split into several points),
- [N/A ] update docstring (if appropriate),
- [N/A] update user guide (if appropriate),
- [x] add an changelog entry in the `upcoming_changes` folder (see [`upcoming_changes/README.rst`](https://github.com/hyperspy/hyperspy/blob/RELEASE_next_minor/upcoming_changes/README.rst)),
- [x] Check formatting changelog entry in the `readthedocs` doc build of this PR (link in github checks)
- [x] add tests,
- [x] ready for review.

### Minimal example of the bug fix or the new feature
```python
import hyperspy.api as hs
import numpy as np
import dask.array as da
s = hs.signals.Signal2D(da.zeros((10,10,12,12))).as_lazy()
s.rechunk(nav_chunks=(5,5))
def test_axes(data):
    return np.zeros((5))
sl = s.map(test_axes,inplace=False)
```

Before the fix the output signal dimensions are (10, 10|10) instead of (10, 10|5).


