### PR TITLE
io_plugins/jeol.py : Get scale information from pts file itself.

### DIFF
--- a/hyperspy/io_plugins/jeol.py
+++ b/hyperspy/io_plugins/jeol.py
@@ -121,10 +121,10 @@ def read_img(filename, scale=None, **kwargs):
             yscale = scale[3] / height
             units = "µm"
         else:
-            scale = header_long["Instrument"]["ScanSize"] / header_long["Instrument"]["Mag"] * 1.0E6
+            scale = header_long["Instrument"]["ScanSize"] / header_long["Instrument"]["Mag"] * 1.0E3
             xscale = scale / width
             yscale = scale / height
-            units = "nm"
+            units = "µm"
 
         axes = [
             {
@@ -248,10 +248,10 @@ def read_pts(filename, scale=None, rebin_energy=1, sum_frames=True,
             yscale = scale[3] / height
             units = "µm"
         else:
-            scale = header["PTTD Param"]["Params"]["PARAMPAGE0_SEM"]["ScanSize"] / meas_data_header["MeasCond"]["Mag"] * 1.0E6
+            scale = header["PTTD Param"]["Params"]["PARAMPAGE0_SEM"]["ScanSize"] / meas_data_header["MeasCond"]["Mag"] * 1.0E3
             xscale = scale / width
             yscale = scale / height
-            units = "nm"
+            units = "µm"
 
         ch_mod = meas_data_header["Meas Cond"]["Tpl"]
         ch_res = meas_data_header["Doc"]["CoefA"]

--- a/hyperspy/io_plugins/jeol.py
+++ b/hyperspy/io_plugins/jeol.py
@@ -121,9 +121,10 @@ def read_img(filename, scale=None, **kwargs):
             yscale = scale[3] / height
             units = "µm"
         else:
-            xscale = 1
-            yscale = 1
-            units = "px"
+            scale = header_long["Instrument"]["ScanSize"] / header_long["Instrument"]["Mag"] * 1.0E6
+            xscale = scale / width
+            yscale = scale / height
+            units = "nm"
 
         axes = [
             {

--- a/hyperspy/io_plugins/jeol.py
+++ b/hyperspy/io_plugins/jeol.py
@@ -247,9 +247,10 @@ def read_pts(filename, scale=None, rebin_energy=1, sum_frames=True,
             yscale = scale[3] / height
             units = "µm"
         else:
-            xscale = 1
-            yscale = 1
-            units = "px"
+            scale = header["PTTD Param"]["Params"]["PARAMPAGE0_SEM"]["ScanSize"] / meas_data_header["MeasCond"]["Mag"] * 1.0E6
+            xscale = scale / width
+            yscale = scale / height
+            units = "nm"
 
         ch_mod = meas_data_header["Meas Cond"]["Tpl"]
         ch_res = meas_data_header["Doc"]["CoefA"]

--- a/hyperspy/tests/io/test_jeol.py
+++ b/hyperspy/tests/io/test_jeol.py
@@ -75,12 +75,12 @@ def test_load_project():
     # check scale (image)
     filename = TESTS_FILE_PATH / 'Sample' / '00_View000' / test_files[1]
     s1 = hs.load(filename)
-    np.testing.assert_allclose(s[0].axes_manager[0].scale,s1.axes_manager[0].scale)
+    np.testing.assert_allclose(s[0].axes_manager[0].scale, s1.axes_manager[0].scale)
     assert s[0].axes_manager[0].units == s1.axes_manager[0].units
     # check scale (pts)
     filename = TESTS_FILE_PATH / 'Sample' / '00_View000' / test_files[7]
     s2 = hs.load(filename)
-    np.testing.assert_allclose(s[6].axes_manager[0].scale,s2.axes_manager[0].scale)
+    np.testing.assert_allclose(s[6].axes_manager[0].scale, s2.axes_manager[0].scale)
     assert s[6].axes_manager[0].units == s2.axes_manager[0].units
     
 
@@ -92,11 +92,11 @@ def test_load_image():
     assert s.data.dtype == np.uint8
     assert s.data.shape == (512, 512)
     assert s.axes_manager.signal_dimension == 2
-#    assert s.axes_manager[0].units == 'px'
-#    assert s.axes_manager[0].scale == 1
+    assert s.axes_manager[0].units == 'µm'
+    np.testing.assert_allclose(s.axes_manager[0].scale, 0.00869140587747097)
     assert s.axes_manager[0].name == 'x'
-#    assert s.axes_manager[1].units == 'px'
-#    assert s.axes_manager[1].scale == 1
+    assert s.axes_manager[1].units == 'µm'
+    np.testing.assert_allclose(s.axes_manager[1].scale, 0.00869140587747097)
     assert s.axes_manager[1].name == 'y'
 
 
@@ -109,11 +109,11 @@ def test_load_datacube(SI_dtype):
     assert s.data.shape == (512, 512, 4096)
     assert s.axes_manager.signal_dimension == 1
     assert s.axes_manager.navigation_dimension == 2
-#    assert s.axes_manager[0].units == 'px'
-#    assert s.axes_manager[0].scale == 1
+    assert s.axes_manager[0].units == 'µm'
+    np.testing.assert_allclose(s.axes_manager[0].scale, 0.00869140587747097)
     assert s.axes_manager[0].name == 'x'
-#    assert s.axes_manager[1].units == 'px'
-#    assert s.axes_manager[1].scale == 1
+    assert s.axes_manager[1].units == 'µm'
+    np.testing.assert_allclose(s.axes_manager[1].scale, 0.00869140587747097)
     assert s.axes_manager[1].name == 'y'
     assert s.axes_manager[2].units == 'keV'
     np.testing.assert_allclose(s.axes_manager[2].offset, -0.000789965-0.00999866*96)

--- a/hyperspy/tests/io/test_jeol.py
+++ b/hyperspy/tests/io/test_jeol.py
@@ -72,6 +72,17 @@ def test_load_project():
     np.testing.assert_allclose(s[-1].axes_manager[2].scale, 0.00999866)
     assert s[-1].axes_manager[2].name == 'Energy'
 
+    # check scale (image)
+    filename = TESTS_FILE_PATH / 'Sample' / '00_View000' / test_files[1]
+    s1 = hs.load(filename)
+    np.testing.assert_allclose(s[0].axes_manager[0].scale,s1.axes_manager[0].scale)
+    assert s[0].axes_manager[0].units == s1.axes_manager[0].units
+    # check scale (pts)
+    filename = TESTS_FILE_PATH / 'Sample' / '00_View000' / test_files[7]
+    s2 = hs.load(filename)
+    np.testing.assert_allclose(s[6].axes_manager[0].scale,s2.axes_manager[0].scale)
+    assert s[6].axes_manager[0].units == s2.axes_manager[0].units
+    
 
 def test_load_image():
     # test load work area haadf image
@@ -81,11 +92,11 @@ def test_load_image():
     assert s.data.dtype == np.uint8
     assert s.data.shape == (512, 512)
     assert s.axes_manager.signal_dimension == 2
-    assert s.axes_manager[0].units == 'px'
-    assert s.axes_manager[0].scale == 1
+#    assert s.axes_manager[0].units == 'px'
+#    assert s.axes_manager[0].scale == 1
     assert s.axes_manager[0].name == 'x'
-    assert s.axes_manager[1].units == 'px'
-    assert s.axes_manager[1].scale == 1
+#    assert s.axes_manager[1].units == 'px'
+#    assert s.axes_manager[1].scale == 1
     assert s.axes_manager[1].name == 'y'
 
 
@@ -98,11 +109,11 @@ def test_load_datacube(SI_dtype):
     assert s.data.shape == (512, 512, 4096)
     assert s.axes_manager.signal_dimension == 1
     assert s.axes_manager.navigation_dimension == 2
-    assert s.axes_manager[0].units == 'px'
-    assert s.axes_manager[0].scale == 1
+#    assert s.axes_manager[0].units == 'px'
+#    assert s.axes_manager[0].scale == 1
     assert s.axes_manager[0].name == 'x'
-    assert s.axes_manager[1].units == 'px'
-    assert s.axes_manager[1].scale == 1
+#    assert s.axes_manager[1].units == 'px'
+#    assert s.axes_manager[1].scale == 1
     assert s.axes_manager[1].name == 'y'
     assert s.axes_manager[2].units == 'keV'
     np.testing.assert_allclose(s.axes_manager[2].offset, -0.000789965-0.00999866*96)


### PR DESCRIPTION
### Description of the change

- Read scale information from pts file it self.
- In case of pts file reading without asw file, scale is read from pts file header.
- Updating the test will be needed  

### Progress of the PR
- [x] Change implemented (can be split into several points),
- [ ] update docstring (if appropriate),
- [ ] update user guide (if appropriate),
- [ ] add an changelog entry in the `upcoming_changes` folder (see [`upcoming_changes/README.rst`](https://github.com/hyperspy/hyperspy/blob/RELEASE_next_minor/upcoming_changes/README.rst)),
- [ ] Check formatting changelog entry in the `readthedocs` doc build of this PR (link in github checks)
- [ ] add tests,
- [ ] ready for review.

### Minimal example of the bug fix or the new feature
```python
import hyperspy.api as hs
data = hs.load("file.pts")
print(data.axes_manager)
```

