### PR TITLE
Drop python 3.6

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -21,7 +21,7 @@ jobs:
         include:
           # test oldest supported version of main dependencies on python 3.6
           - os: ubuntu
-            PYTHON_VERSION: 3.6
+            PYTHON_VERSION: 3.7
             OLDEST_SUPPORTED_VERSION: true
             DEPENDENCIES: matplotlib==3.1.0 numpy==1.17.1 scipy==1.1 imagecodecs==2019.12.3 dask==2.1.0
             PIP_SELECTOR: '[all, tests, coverage]'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -23,7 +23,7 @@ jobs:
           - os: ubuntu
             PYTHON_VERSION: 3.7
             OLDEST_SUPPORTED_VERSION: true
-            DEPENDENCIES: matplotlib==3.1.0 numpy==1.17.1 scipy==1.1 imagecodecs==2019.12.3 dask==2.1.0
+            DEPENDENCIES: matplotlib==3.1.0 numpy==1.17.1 scipy==1.1 imagecodecs==2020.1.31 tifffile==2020.2.16 dask==2.1.0
             PIP_SELECTOR: '[all, tests, coverage]'
             PYTEST_ARGS_COVERAGE: --cov=. --cov-report=xml
             LABEL: -oldest
@@ -68,7 +68,7 @@ jobs:
         if: ${{ matrix.OLDEST_SUPPORTED_VERSION }}
         run: |
           pip install ${{ matrix.DEPENDENCIES }}
-
+          
       - name: Run test suite
         run: |
           pytest ${{ env.PYTEST_ARGS }} ${{ matrix.PYTEST_ARGS_COVERAGE }}

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -25,6 +25,8 @@ resources:
 
 strategy:
   matrix:
+    # Needs to update matplotlib reference image to add python3.9 build
+    # matplotlib 3.1 doesn't have a python 3.9 build
     Linux_Python38:
       vmImage: 'ubuntu-latest'
       PYTHON_VERSION: '3.8'
@@ -32,10 +34,6 @@ strategy:
     Linux_Python37:
       vmImage: 'ubuntu-latest'
       PYTHON_VERSION: '3.7'
-      MAMBAFORGE_PATH: $(Agent.BuildDirectory)/mambaforge
-    Linux_Python36:
-      vmImage: 'ubuntu-latest'
-      PYTHON_VERSION: '3.6'
       MAMBAFORGE_PATH: $(Agent.BuildDirectory)/mambaforge
     MacOS_Python38:
       vmImage: 'macOS-latest'
@@ -49,9 +47,9 @@ strategy:
       vmImage: 'windows-latest'
       PYTHON_VERSION: '3.8'
       MAMBAFORGE_PATH: $(Agent.BuildDirectory)\mambaforge
-    Windows_Python36:
+    Windows_Python37:
       vmImage: 'windows-latest'
-      PYTHON_VERSION: '3.6'
+      PYTHON_VERSION: '3.7'
       MAMBAFORGE_PATH: $(Agent.BuildDirectory)\mambaforge
 
 pool:

--- a/setup.py
+++ b/setup.py
@@ -58,7 +58,7 @@ install_req = ['scipy>=1.1',
                'packaging',
                'python-dateutil>=2.5.0',
                'ipyparallel',
-               'dask[array]>2.1.0',
+               'dask[array]>=2.1.0',
                # fsspec is missing from dask dependencies for dask < 2021.3.1
                'fsspec',
                'scikit-image>=0.15',
@@ -70,7 +70,7 @@ install_req = ['scipy>=1.1',
                # prettytable and ptable are API compatible
                # prettytable is maintained and ptable is an unmaintained fork
                'prettytable',
-               'tifffile>=2019.12.3',
+               'tifffile>=2020.2.16',
                'numba',
                 # included in stdlib since v3.8, but this required version requires Python 3.10
                 # We can remove this requirement when the minimum supported version becomes Python 3.10
@@ -86,7 +86,7 @@ extras_require = {
     "gui-jupyter": ["hyperspy_gui_ipywidgets>=1.1.0"],
     "gui-traitsui": ["hyperspy_gui_traitsui>=1.1.0"],
     "mrcz": ["blosc>=1.5", 'mrcz>=0.3.6'],
-    "speed": ["cython", "imagecodecs"],
+    "speed": ["cython", "imagecodecs>=2020.1.31"],
     "usid": ["pyUSID>=0.0.7", "sidpy"],
     "scalebar": ["matplotlib-scalebar"],
     # bug in pip: matplotib is ignored here because it is already present in

--- a/setup.py
+++ b/setup.py
@@ -387,7 +387,6 @@ with update_version_when_dev() as version:
         },
         classifiers=[
             "Programming Language :: Python :: 3",
-            "Programming Language :: Python :: 3.6",
             "Programming Language :: Python :: 3.7",
             "Programming Language :: Python :: 3.8",
             "Programming Language :: Python :: 3.9",

--- a/upcoming_changes/2839.maintenance.rst
+++ b/upcoming_changes/2839.maintenance.rst
@@ -1,0 +1,1 @@
+Drop support for python 3.6


### PR DESCRIPTION
This is based on #2797 to show that the test failure works fine and also because it includes the fixes for the latest version of `h5py` (3.5).
Only the last two commits are relevant, once #2797 has been merged, I will rebase this branch if necessary and the changes will mcuh more simple.

### Progress of the PR
- [x] Drop support for python 3.6,
- [n/a] update docstring (if appropriate),
- [n/a] update user guide (if appropriate),
- [x] add an changelog entry in the `upcoming_changes` folder (see [`upcoming_changes/README.rst`](https://github.com/hyperspy/hyperspy/blob/RELEASE_next_minor/upcoming_changes/README.rst)),
- [x] Check formatting changelog entry in the `readthedocs` doc build of this PR (link in github checks)
- [x] add tests,
- [x] ready for review.


