### PR TITLE
Fix ragged array

### DIFF
--- a/doc/user_guide/signal.rst
+++ b/doc/user_guide/signal.rst
@@ -303,14 +303,14 @@ Note that the array shape is (2, ):
 Numpy ragged array must have python ``object`` type to allow the variable length of
 the nested sequences - here ``[1, 2, 3]`` and ``[1]``. As explained in
 `NEP-34 <https://numpy.org/neps/nep-0034-infer-dtype-is-object.html>`_,
-``dtype=object`` needs to be specify when creating the array to avoid ambiguity
+``dtype=object`` needs to be specified when creating the array to avoid ambiguity
 about the shape of the array.
 
 HyperSpy supports the use of ragged array with the following conditions:
 
 - The signal must be explicitely define as being ``ragged``, either when creating
-  the signal or by changing the ragged attribute of the signal.
-- The signal dimension the variable length dimension
+  the signal or by changing the ragged attribute of the signal
+- The signal dimension is the variable length dimension of the array
 - The ``isig`` syntax is not supported
 - Signal with ragged array can't be transposed
 - Signal with ragged array can't be plotted

--- a/doc/user_guide/signal.rst
+++ b/doc/user_guide/signal.rst
@@ -277,6 +277,107 @@ The following example shows how to transform between different subclasses.
        >>> s
        <ComplexSignal1D, title: , dimensions: (20, 10|100)>
 
+.. _signal.ragged:
+
+Ragged array
+------------
+
+A ragged array (also called jagged array) is an array created with
+sequences-of-sequences, where the nested sequences don't have the same length.
+For example, a numpy ragged array can be created as follow:
+
+   .. code-block:: python
+
+       >>> arr = np.array([[1, 2, 3], [1]], dtype=object)
+       >>> arr
+       array([list([1, 2, 3]), list([1])], dtype=object)
+       
+Note that the array shape is (2, ):
+
+   .. code-block:: python
+
+       >>> arr.shape
+       (2, )
+
+
+Numpy ragged array must have python ``object`` type to allow the variable length of
+the nested sequences - here ``[1, 2, 3]`` and ``[1]``. As explained in
+`NEP-34 <https://numpy.org/neps/nep-0034-infer-dtype-is-object.html>`_,
+``dtype=object`` needs to be specify when creating the array to avoid ambiguity
+about the shape of the array.
+
+HyperSpy supports the use of ragged array with the following conditions:
+
+- The signal must be explicitely define as being ``ragged``, either when creating
+  the signal or by changing the ragged attribute of the signal.
+- The signal dimension the variable length dimension
+- The ``isig`` syntax is not supported
+- Signal with ragged array can't be transposed
+- Signal with ragged array can't be plotted
+
+To create a hyperspy signal of a numpy ragged array:
+
+   .. code-block:: python
+
+       >>> s = hs.signals.BaseSignal(arr, ragged=True)
+       >>> s
+       <BaseSignal, title: , dimensions: (2|ragged)>
+
+       >>> s.ragged
+       True
+
+       >>> s.axes_manager
+       <Axes manager, axes: (2|ragged)>
+                   Name |   size |  index |  offset |   scale |  units 
+       ================ | ====== | ====== | ======= | ======= | ====== 
+            <undefined> |      2 |      0 |       0 |       1 | <undefined> 
+       ---------------- | ------ | ------ | ------- | ------- | ------ 
+            Ragged axis |               Variable length
+
+.. note::
+    When possible, numpy will cast sequences-of-sequences to "non-ragged" array:
+
+       .. code-block:: python
+
+           >>> arr = np.array([np.array([1, 2]), np.array([1, 2])], dtype=object)
+           >>> arr
+           array([[1, 2],
+                  [1, 2]], dtype=object)
+
+       
+    Unlike in the previous example, here the array is not ragged, because
+    the length of the nested sequences are equal (2) and numpy will create
+    an array of shape (2, 2) instead of (2, ) as in the previous example of
+    ragged array
+
+       .. code-block:: python
+
+           >>> arr.shape
+           (2, 2)
+
+In addition to the use of the keyword ``ragged`` when creating an hyperspy
+signal, the ``ragged`` attribute can also be set to specify whether the signal
+contains a ragged array or not.
+
+In the following example, an hyperspy signal is created without specifying that
+the array is ragged. In this case, the signal dimension is 2, which *can be*
+misleading, because each item contains a list of number. To provide a clear
+representation of the fact that the signal contains a ragged array, the
+``ragged`` attribute can be set to ``True``. By doing so, the signal space will
+be described as "ragged" and the navigation shape will become the same as the
+shape of the ragged array:
+
+   .. code-block:: python
+
+       >>> arr = np.array([[1, 2, 3], [1]], dtype=object)
+       >>> s = hs.signals.BaseSignal(arr)
+       >>> s
+       <BaseSignal, title: , dimensions: (|2)>
+       
+       >>> s.ragged = True
+       >>> s
+       <BaseSignal, title: , dimensions: (2|ragged)>       
+       
 
 .. _signal.binned:
 

--- a/doc/user_guide/signal.rst
+++ b/doc/user_guide/signal.rst
@@ -308,7 +308,7 @@ about the shape of the array.
 
 HyperSpy supports the use of ragged array with the following conditions:
 
-- The signal must be explicitely define as being ``ragged``, either when creating
+- The signal must be explicitly defined as being ``ragged``, either when creating
   the signal or by changing the ragged attribute of the signal
 - The signal dimension is the variable length dimension of the array
 - The ``isig`` syntax is not supported
@@ -361,7 +361,7 @@ contains a ragged array or not.
 
 In the following example, an hyperspy signal is created without specifying that
 the array is ragged. In this case, the signal dimension is 2, which *can be*
-misleading, because each item contains a list of number. To provide a clear
+misleading, because each item contains a list of numbers. To provide a unambiguous
 representation of the fact that the signal contains a ragged array, the
 ``ragged`` attribute can be set to ``True``. By doing so, the signal space will
 be described as "ragged" and the navigation shape will become the same as the

--- a/hyperspy/_signals/lazy.py
+++ b/hyperspy/_signals/lazy.py
@@ -679,12 +679,14 @@ class LazySignal(BaseSignal):
         else:
             sig = self._deepcopy_with_new_data(mapped)
             if ragged:
-                sig.axes_manager.remove(sig.axes_manager.signal_axes)
-                sig._lazy = True
+                axes_dicts = self.axes_manager._get_axes_dicts(
+                    self.axes_manager.navigation_axes
+                    )
+                sig.axes_manager.__init__(axes_dicts)
                 sig._assign_subclass()
-
                 return sig
-            # remove if too many axes
+
+        # remove if too many axes
         if axes_changed:
             sig.axes_manager.remove(sig.axes_manager.signal_axes[len(output_signal_size):])
             # add additional required axes

--- a/hyperspy/_signals/lazy.py
+++ b/hyperspy/_signals/lazy.py
@@ -1102,6 +1102,8 @@ class LazySignal(BaseSignal):
             print("\n".join([str(pr) for pr in to_print]))
 
     def plot(self, navigator='auto', **kwargs):
+        if self.axes_manager.ragged:
+            raise RuntimeError("Plotting ragged signal is not supported.")
         if isinstance(navigator, str):
             if navigator == 'spectrum':
                 # We don't support the 'spectrum' option to keep it simple

--- a/hyperspy/_signals/lazy.py
+++ b/hyperspy/_signals/lazy.py
@@ -683,6 +683,7 @@ class LazySignal(BaseSignal):
                     self.axes_manager.navigation_axes
                     )
                 sig.axes_manager.__init__(axes_dicts)
+                sig.axes_manager._ragged = True
                 sig._assign_subclass()
                 return sig
 

--- a/hyperspy/_signals/signal1d.py
+++ b/hyperspy/_signals/signal1d.py
@@ -265,6 +265,8 @@ class Signal1D(BaseSignal, CommonSignal1D):
     _signal_dimension = 1
 
     def __init__(self, *args, **kwargs):
+        if kwargs.get('ragged', False):
+            raise ValueError("Signal1D can't be ragged.")
         super().__init__(*args, **kwargs)
         if self.axes_manager.signal_dimension != 1:
             self.axes_manager.set_signal_dimension(1)

--- a/hyperspy/_signals/signal2d.py
+++ b/hyperspy/_signals/signal2d.py
@@ -315,8 +315,10 @@ class Signal2D(BaseSignal, CommonSignal2D):
     _signal_dimension = 2
     _lazy = False
 
-    def __init__(self, *args, **kw):
-        super().__init__(*args, **kw)
+    def __init__(self, *args, **kwargs):
+        if kwargs.get('ragged', False):
+            raise ValueError("Signal2D can't be ragged.")
+        super().__init__(*args, **kwargs)
         if self.axes_manager.signal_dimension != 2:
             self.axes_manager.set_signal_dimension(2)
 

--- a/hyperspy/axes.py
+++ b/hyperspy/axes.py
@@ -2056,6 +2056,9 @@ class AxesManager(t.HasTraits):
             If value if greater than the number of axes or is negative.
 
         """
+        if self.ragged and value > 0:
+            raise ValueError("Signal containing ragged array must have zero "
+                             "signal dimension.")
         if len(self._axes) == 0:
             return
         elif value > len(self._axes):

--- a/hyperspy/axes.py
+++ b/hyperspy/axes.py
@@ -1492,6 +1492,11 @@ class AxesManager(t.HasTraits):
         self._update_attributes()
         self._update_trait_handlers()
         self.iterpath = 'flyback'
+        self._ragged = False
+
+    @property
+    def ragged(self):
+        return self._ragged
 
     def _update_trait_handlers(self, remove=False):
         things = {self._on_index_changed: '_axes.index',
@@ -2169,6 +2174,8 @@ class AxesManager(t.HasTraits):
         for axis in self.signal_axes:
             string += str(axis.size) + ", "
         string = string.rstrip(", ")
+        if self.ragged:
+            string += 'ragged'
         string += ")"
         return string
 
@@ -2202,6 +2209,9 @@ class AxesManager(t.HasTraits):
         for ax in self.signal_axes:
             text += '\n'
             text += axis_repr(ax, ax_signature_uniform, ax_signature_non_uniform)
+        if self.ragged:
+            text += '\n'
+            text += "     Ragged axis |               Variable length"
 
         return text
 

--- a/hyperspy/axes.py
+++ b/hyperspy/axes.py
@@ -1458,7 +1458,7 @@ class AxesManager(t.HasTraits):
     _step = t.Int(1)
 
     def __init__(self, axes_list):
-        super(AxesManager, self).__init__()
+        super().__init__()
         self.events = Events()
         self.events.indices_changed = Event("""
             Event that triggers when the indices of the `AxesManager` changes
@@ -1481,6 +1481,10 @@ class AxesManager(t.HasTraits):
             ----------
             obj : The AxesManager that the event belongs to.
             """, arguments=['obj'])
+
+        # Remove all axis for cases, we reinitiliase the AxesManager
+        if self._axes:
+            self.remove(self._axes)
         self.create_axes(axes_list)
         # set_signal_dimension is called only if there is no current
         # view. It defaults to spectrum
@@ -1679,13 +1683,14 @@ class AxesManager(t.HasTraits):
         if len(indices) == len(axes_list):
             axes_list.sort(key=lambda x: x['index_in_array'])
         for axis_dict in axes_list:
-            if isinstance(axis_dict,dict):
+            if isinstance(axis_dict, dict):
                 self._append_axis(**axis_dict)
             else:
                 self._axes.append(axis_dict)
 
     def set_axis(self, axis, index_in_axes_manager):
         """Replace an axis of current signal with one given in argument.
+
         Parameters
         ----------
         axis: BaseDataAxis axis to replace the current axis with

--- a/hyperspy/drawing/utils.py
+++ b/hyperspy/drawing/utils.py
@@ -498,7 +498,7 @@ def plot_images(images,
     images : list of Signal2D or BaseSignal
         `images` should be a list of Signals to plot. For `BaseSignal` with
         navigation dimensions 2 and signal dimension 0, the signal will be
-        tranposed to form a `Signal2D`.
+        transposed to form a `Signal2D`.
         Multi-dimensional images will have each plane plotted as a separate
         image.
         If any of the signal shapes is not suitable, a ValueError will be
@@ -1302,7 +1302,7 @@ def plot_spectra(
         Ordered spectra list of signal to plot. If `style` is "cascade" or
         "mosaic", the spectra can have different size and axes. For `BaseSignal`
         with navigation dimensions 1 and signal dimension 0, the signal will be
-        tranposed to form a `Signal1D`.
+        transposed to form a `Signal1D`.
     style : 'overlap', 'cascade', 'mosaic', 'heatmap', optional
         The style of the plot: 'overlap' (default), 'cascade', 'mosaic', or
         'heatmap'.

--- a/hyperspy/misc/slicing.py
+++ b/hyperspy/misc/slicing.py
@@ -18,7 +18,7 @@
 
 from operator import attrgetter
 import numpy as np
-from dask.array import Array as dArray
+import dask.array as da
 
 from hyperspy.misc.utils import attrsetter
 from hyperspy.misc.export_dictionary import parse_flag_string
@@ -55,7 +55,7 @@ def _slice_target(target, dims, both_slices, slice_nav=None, issignal=False):
         sl = tuple(array_slices[:nav_dims])
         if isinstance(target, np.ndarray):
             return np.atleast_1d(target[sl])
-        if isinstance(target, dArray):
+        if isinstance(target, da.Array):
             return target[sl]
         raise ValueError(
             'tried to slice with navigation dimensions, but was neither a '
@@ -66,7 +66,7 @@ def _slice_target(target, dims, both_slices, slice_nav=None, issignal=False):
         sl = tuple(array_slices[-sig_dims:])
         if isinstance(target, np.ndarray):
             return np.atleast_1d(target[sl])
-        if isinstance(target, dArray):
+        if isinstance(target, da.Array):
             return target[sl]
         raise ValueError(
             'tried to slice with navigation dimensions, but was neither a '

--- a/hyperspy/misc/slicing.py
+++ b/hyperspy/misc/slicing.py
@@ -278,12 +278,13 @@ class FancySlicing(object):
 
         array_slices = self._get_array_slices(slices, isNavigation)
         new_data = self.data[array_slices]
-        if new_data.shape == (1, ) and new_data.dtype is np.dtype(object):
-            # See https://github.com/hyperspy/hyperspy/pull/1336
-            if isinstance(new_data[0], (np.ndarray, dArray)):
-                return self.__class__(new_data[0]).transpose(navigation_axes=0)
-            else:
-                return new_data[0]
+        if (self.ragged and new_data.dtype != np.dtype(object) and
+                isinstance(new_data, np.ndarray)):
+            # Numpy will convert the array to non-ragged, for consistency,
+            # we make a ragged array with only one item
+            data = new_data.copy()
+            new_data = np.empty((1, ), dtype=object)
+            new_data[0] = data
 
         if out is None:
             _obj = self._deepcopy_with_new_data(new_data, copy_variance=True)

--- a/hyperspy/misc/utils.py
+++ b/hyperspy/misc/utils.py
@@ -469,9 +469,9 @@ class DictionaryTreeBrowser:
         if key == 'binned':
             warnings.warn('Use of the `binned` attribute in metadata is '
                           'going to be deprecated in v2.0. Set the '
-                          '`axis.is_binned` attribute instead. ', 
+                          '`axis.is_binned` attribute instead. ',
                           VisibleDeprecationWarning)
-            
+
         if key.startswith('_sig_'):
             key = key[5:]
             from hyperspy.signal import BaseSignal
@@ -920,7 +920,7 @@ def stack(signal_list, axis=None, new_axis_name="stack_element", lazy=None,
           stack_metadata=True, show_progressbar=None, **kwargs):
     """Concatenate the signals in the list over a given axis or a new axis.
 
-    The title is set to that of the first signal in the list. 
+    The title is set to that of the first signal in the list.
 
     Parameters
     ----------
@@ -1315,8 +1315,8 @@ def map_result_construction(signal,
             sig.axes_manager._append_axis(size=sig_shape[-ind], navigate=False)
     if not ragged:
         sig.get_dimensions_from_data()
-    if not sig.axes_manager._axes:
-        add_scalar_axis(sig, lazy=lazy)
+        if not sig.axes_manager._axes:
+            add_scalar_axis(sig, lazy=lazy)
     return res
 
 
@@ -1437,4 +1437,3 @@ def is_binned(signal, axis=-1):
         return signal.metadata.Signal.binned
     else:
         return signal.axes_manager[axis].is_binned
-

--- a/hyperspy/signal.py
+++ b/hyperspy/signal.py
@@ -2165,6 +2165,10 @@ class BaseSignal(FancySlicing,
             that will to stores in the ``original_metadata`` attribute. It
             typically contains all the parameters that has been
             imported from the original data file.
+        ragged : bool or None, optional
+            Define whether the signal is ragged or not. Overwrite the
+            ``ragged`` value in the ``attributes`` dictionary. If None, it does
+            nothing. Default is None
 
         """
         # the 'full_initialisation' keyword is private API to be used by the
@@ -2402,11 +2406,6 @@ class BaseSignal(FancySlicing,
 
     @data.setter
     def data(self, value):
-        if hasattr(value, 'dtype') and value.dtype == object:
-            self.axes_manager._ragged = True
-            self.axes_manager.set_signal_dimension(0)
-        else:
-            self.axes_manager._ragged = False
         from dask.array import Array
         if isinstance(value, Array):
             if not value.ndim:
@@ -2414,6 +2413,56 @@ class BaseSignal(FancySlicing,
             self._data = value
         else:
             self._data = np.atleast_1d(np.asanyarray(value))
+
+    @property
+    def ragged(self):
+        return self.axes_manager._ragged
+
+    @ragged.setter
+    def ragged(self, value):
+        # nothing needs to be done!
+        if self.ragged == value:
+            return
+
+        if value:
+            if self.data.dtype != object:
+                raise ValueError("The array is not ragged.")
+            axes = [axis for axis in self.axes_manager.signal_axes
+                    if axis.index_in_array not in list(range(self.data.ndim))]
+            self.axes_manager.remove(axes)
+            self.axes_manager.set_signal_dimension(0)
+        else:
+            if self._lazy:
+                raise NotImplementedError(
+                    "Conversion of a lazy ragged signal to its non-ragged "
+                    "counterpar is not supported. Make the required non-ragged "
+                    "dask array manually and make a new lazy signal."
+                    )
+
+            error = "The signal can't be converted to a non-ragged signal."
+            try:
+                # Check that we can actually make a non-ragged array
+                with warnings.catch_warnings():
+                    warnings.simplefilter("ignore")
+                    # As of numpy 1.20, it raises a VisibleDeprecationWarning
+                    # and in the future, it will raise an error
+                    data = np.array(self.data.tolist())
+            except:
+                _logger.error(error)
+
+            if data.dtype == object:
+                raise ValueError(error)
+
+            self.data = data
+            # Add axes which were previously in the ragged dimension
+            axes = [idx for idx in range(self.data.ndim) if
+                    idx not in self.axes_manager.navigation_indices_in_array]
+            for index in axes:
+                axis = {'index_in_array':index, 'size':self.data.shape[index]}
+                self.axes_manager._append_axis(**axis)
+            self.axes_manager._update_attributes()
+
+        self.axes_manager._ragged = value
 
     def _load_dictionary(self, file_data_dict):
         """Load data from dictionary.
@@ -2438,28 +2487,35 @@ class BaseSignal(FancySlicing,
               that will to stores in the `original_metadata` attribute. It
               typically contains all the parameters that has been
               imported from the original data file.
+            * ragged: a bool, defining whether the signal is ragged or not.
+              Overwrite the attributes['ragged'] entry
 
         """
         self.data = file_data_dict['data']
         oldlazy = self._lazy
+        attributes = file_data_dict.get('attributes', {})
+        ragged = file_data_dict.get('ragged')
+        if ragged is not None:
+            attributes['ragged'] = ragged
+        if 'axes' not in file_data_dict:
+            file_data_dict['axes'] = self._get_undefined_axes_list(
+                attributes.get('ragged', False))
+        self.axes_manager = AxesManager(file_data_dict['axes'])
+        # Setting `ragged` attributes requires the `axes_manager`
+        for key, value in attributes.items():
+            if hasattr(self, key):
+                if isinstance(value, dict):
+                    for k, v in value.items():
+                        setattr(getattr(self, key), k, v)
+                else:
+                    setattr(self, key, value)
         if 'models' in file_data_dict:
             self.models._add_dictionary(file_data_dict['models'])
-        if 'axes' not in file_data_dict:
-            file_data_dict['axes'] = self._get_undefined_axes_list()
-        self.axes_manager = AxesManager(
-            file_data_dict['axes'])
         if 'metadata' not in file_data_dict:
             file_data_dict['metadata'] = {}
         if 'original_metadata' not in file_data_dict:
             file_data_dict['original_metadata'] = {}
-        if 'attributes' in file_data_dict:
-            for key, value in file_data_dict['attributes'].items():
-                if hasattr(self, key):
-                    if isinstance(value, dict):
-                        for k, v in value.items():
-                            setattr(getattr(self, key), k, v)
-                    else:
-                        setattr(self, key, value)
+
         self.original_metadata.add_dictionary(
             file_data_dict['original_metadata'])
         self.metadata.add_dictionary(
@@ -2567,7 +2623,8 @@ class BaseSignal(FancySlicing,
                'axes': self.axes_manager._get_axes_dicts(),
                'metadata': copy.deepcopy(self.metadata.as_dictionary()),
                'tmp_parameters': self.tmp_parameters.as_dictionary(),
-               'attributes': {'_lazy': self._lazy},
+               'attributes': {'_lazy': self._lazy,
+                              'ragged': self.axes_manager._ragged},
                }
         if add_original_metadata:
             dic['original_metadata'] = copy.deepcopy(
@@ -2580,11 +2637,16 @@ class BaseSignal(FancySlicing,
             dic['models'] = self.models._models.as_dictionary()
         return dic
 
-    def _get_undefined_axes_list(self):
+    def _get_undefined_axes_list(self, ragged=False):
         """Returns default list of axes construct from the data array shape."""
         axes = []
         for s in self.data.shape:
             axes.append({'size': int(s), })
+        # With ragged signal with navigation dimension 0 and signal dimension 0
+        # we return an empty list to avoid getting a navigation axis of size 1,
+        # which is incorrect, because it corresponds to the ragged dimension
+        if ragged and len(axes) == 1 and axes[0]['size'] == 1:
+            axes = []
         return axes
 
     def __call__(self, axes_manager=None, fft_shift=False):
@@ -2613,6 +2675,8 @@ class BaseSignal(FancySlicing,
         %s
         %s
         """
+        if self.axes_manager.ragged:
+            raise RuntimeError("Plotting ragged signal is not supported.")
         if self._plot is not None:
             self._plot.close()
         if 'power_spectrum' in kwargs:
@@ -3588,12 +3652,12 @@ class BaseSignal(FancySlicing,
         axes = am[axes]
         if not np.iterable(axes):
             axes = (axes,)
-        if am.navigation_dimension + am.signal_dimension > len(axes):
+        if am.navigation_dimension + am.signal_dimension >= len(axes):
             old_signal_dimension = am.signal_dimension
             am.remove(axes)
             if old_signal_dimension != am.signal_dimension:
                 self._assign_subclass()
-        else:
+        if not self.axes_manager._axes and not self.ragged:
             # Create a "Scalar" axis because the axis is the last one left and
             # HyperSpy does not # support 0 dimensions
             from hyperspy.misc.utils import add_scalar_axis

--- a/hyperspy/signal.py
+++ b/hyperspy/signal.py
@@ -2406,13 +2406,9 @@ class BaseSignal(FancySlicing,
 
     @data.setter
     def data(self, value):
-        from dask.array import Array
-        if isinstance(value, Array):
-            if not value.ndim:
-                value = value.reshape((1,))
-            self._data = value
-        else:
-            self._data = np.atleast_1d(np.asanyarray(value))
+        if not isinstance(value, da.Array):
+            value = np.asanyarray(value)
+        self._data = np.atleast_1d(value)
 
     @property
     def ragged(self):
@@ -6073,7 +6069,7 @@ class BaseSignal(FancySlicing,
 
         if self.axes_manager.ragged:
             raise RuntimeError("Signal with ragged dimension can't be "
-                               "tranposed.")
+                               "transposed.")
 
         am = self.axes_manager
         ax_list = am._axes

--- a/hyperspy/signal.py
+++ b/hyperspy/signal.py
@@ -2168,7 +2168,7 @@ class BaseSignal(FancySlicing,
         ragged : bool or None, optional
             Define whether the signal is ragged or not. Overwrite the
             ``ragged`` value in the ``attributes`` dictionary. If None, it does
-            nothing. Default is None
+            nothing. Default is None.
 
         """
         # the 'full_initialisation' keyword is private API to be used by the
@@ -2431,8 +2431,9 @@ class BaseSignal(FancySlicing,
             if self._lazy:
                 raise NotImplementedError(
                     "Conversion of a lazy ragged signal to its non-ragged "
-                    "counterpar is not supported. Make the required non-ragged "
-                    "dask array manually and make a new lazy signal."
+                    "counterpart is not supported. Make the required "
+                    "non-ragged dask array manually and make a new lazy "
+                    "signal."
                     )
 
             error = "The signal can't be converted to a non-ragged signal."

--- a/hyperspy/signal.py
+++ b/hyperspy/signal.py
@@ -2402,6 +2402,11 @@ class BaseSignal(FancySlicing,
 
     @data.setter
     def data(self, value):
+        if hasattr(value, 'dtype') and value.dtype == object:
+            self.axes_manager._ragged = True
+            self.axes_manager.set_signal_dimension(0)
+        else:
+            self.axes_manager._ragged = False
         from dask.array import Array
         if isinstance(value, Array):
             if not value.ndim:
@@ -2576,6 +2581,7 @@ class BaseSignal(FancySlicing,
         return dic
 
     def _get_undefined_axes_list(self):
+        """Returns default list of axes construct from the data array shape."""
         axes = []
         for s in self.data.shape:
             axes.append({'size': int(s), })
@@ -6000,6 +6006,10 @@ class BaseSignal(FancySlicing,
         <BaseSignal, title: , dimensions: (8, 7, 6, 5, 4, 1|9, 3, 2)>
 
         """
+
+        if self.axes_manager.ragged:
+            raise RuntimeError("Signal with ragged dimension can't be "
+                               "tranposed.")
 
         am = self.axes_manager
         ax_list = am._axes

--- a/hyperspy/tests/axes/test_axes_manager.py
+++ b/hyperspy/tests/axes/test_axes_manager.py
@@ -538,3 +538,39 @@ def test_iterpath_function_serpentine():
     for i, indices in enumerate(_serpentine_iter((3,3,3))):
         if i == 3:
             assert indices == (2, 1, 0)
+
+
+def TestAxesManagerRagged():
+
+    def setup_method(self, method):
+        axes_list = [
+            {
+                "name": "a",
+                "navigate": True,
+                "offset": 0.0,
+                "scale": 1.3,
+                "size": 2,
+                "units": "aa",
+            },
+
+        ]
+
+        self.am = AxesManager(axes_list)
+        self.am._ragged = True
+
+    def test_ragged_property(self):
+        assert self.am.ragged
+        with pytest.raises(AttributeError):
+            self.am.ragged = False
+        self.am._ragged = False
+        assert not self.am.ragged
+
+    def test_reprs(self):
+        expected_string = \
+        "<Axes manager, axes: (2|ragged)>\n"
+        "            Name |   size |  index |  offset |   scale |  units \n"
+        "================ | ====== | ====== | ======= | ======= | ====== \n"
+        "               a |      2 |      0 |       0 |     1.3 |     aa \n"
+        "---------------- | ------ | ------ | ------- | ------- | ------ \n"
+        "     Ragged axis |               Variable length"
+        assert self.am.__repr__() == expected_string

--- a/hyperspy/tests/drawing/test_plot_signal.py
+++ b/hyperspy/tests/drawing/test_plot_signal.py
@@ -331,3 +331,12 @@ def test_plot_signal_scalar():
     s = hs.signals.BaseSignal([1.0])
     s.plot()
     assert s._plot is None
+
+
+def test_plot_ragged_array():
+    data = np.empty((2, 5), dtype=object)
+    data.fill(np.array([10, 20]))
+
+    s = hs.signals.BaseSignal(data, ragged=True)
+    with pytest.raises(RuntimeError):
+        s.plot()

--- a/hyperspy/tests/drawing/test_plot_signal.py
+++ b/hyperspy/tests/drawing/test_plot_signal.py
@@ -333,10 +333,13 @@ def test_plot_signal_scalar():
     assert s._plot is None
 
 
-def test_plot_ragged_array():
+@pytest.mark.parametrize('lazy', [True, False])
+def test_plot_ragged_array(lazy):
     data = np.empty((2, 5), dtype=object)
     data.fill(np.array([10, 20]))
 
     s = hs.signals.BaseSignal(data, ragged=True)
+    if lazy:
+        s = s.as_lazy()
     with pytest.raises(RuntimeError):
         s.plot()

--- a/hyperspy/tests/io/test_hdf5.py
+++ b/hyperspy/tests/io/test_hdf5.py
@@ -412,7 +412,7 @@ def test_non_valid_hspy(tmp_path, caplog):
 def test_nonuniformaxis(tmp_path, file, lazy):
     fname = tmp_path / file
     data = np.arange(10)
-    axis = DataAxis(axis=1/np.arange(1, data.size+1), navigate=False)
+    axis = DataAxis(axis =1/np.arange(1, data.size+1), navigate=False)
     s = Signal1D(data, axes=(axis.get_axis_dictionary(), ))
     if lazy:
         s = s.as_lazy()

--- a/hyperspy/tests/signals/test_assign_subclass.py
+++ b/hyperspy/tests/signals/test_assign_subclass.py
@@ -199,23 +199,3 @@ class TestConvertComplexSignal1D:
         assert isinstance(self.s, hs.signals.DielectricFunction)
         self.s.set_signal_type("")
         assert isinstance(self.s, hs.signals.ComplexSignal1D)
-
-
-def test_create_ragged_array(self):
-    data = np.empty((2, 5), dtype=object)
-    data.fill(np.array([10, 20]))
-
-    s = hs.signals.BaseSignal(data)
-    assert s.axes_manager.ragged
-    assert s.__repr__() == "<BaseSignal, title: , dimensions: (5, 2|ragged)>"
-
-    with pytest.raises(RuntimeError):
-        s.T
-
-    assert s.inav[0].axes_manager.ragged
-    assert s.inav[0].axes_manager.signal_dimension == 0
-    assert not s.inav[0, 0].axes_manager.ragged
-
-    data = np.array([[0, 1], [2, 3, 4]], dtype=object)
-    s = hs.signals.BaseSignal(data)
-    assert s.axes_manager.ragged

--- a/hyperspy/tests/signals/test_assign_subclass.py
+++ b/hyperspy/tests/signals/test_assign_subclass.py
@@ -199,3 +199,23 @@ class TestConvertComplexSignal1D:
         assert isinstance(self.s, hs.signals.DielectricFunction)
         self.s.set_signal_type("")
         assert isinstance(self.s, hs.signals.ComplexSignal1D)
+
+
+def test_create_ragged_array(self):
+    data = np.empty((2, 5), dtype=object)
+    data.fill(np.array([10, 20]))
+
+    s = hs.signals.BaseSignal(data)
+    assert s.axes_manager.ragged
+    assert s.__repr__() == "<BaseSignal, title: , dimensions: (5, 2|ragged)>"
+
+    with pytest.raises(RuntimeError):
+        s.T
+
+    assert s.inav[0].axes_manager.ragged
+    assert s.inav[0].axes_manager.signal_dimension == 0
+    assert not s.inav[0, 0].axes_manager.ragged
+
+    data = np.array([[0, 1], [2, 3, 4]], dtype=object)
+    s = hs.signals.BaseSignal(data)
+    assert s.axes_manager.ragged

--- a/hyperspy/tests/signals/test_fancy_indexing.py
+++ b/hyperspy/tests/signals/test_fancy_indexing.py
@@ -20,9 +20,11 @@ import numpy as np
 import pytest
 from numpy.testing import assert_array_equal
 
+from hyperspy.decorators import lazifyTestClass
 from hyperspy import roi, signals
 
 
+@lazifyTestClass
 class Test1D:
 
     def setup_method(self, method):
@@ -142,6 +144,7 @@ class Test1D:
         assert_array_equal(s.isig['rel0.0':'rel1.0'].data, s.data[:-1])
 
 
+@lazifyTestClass
 class Test2D:
 
     def setup_method(self, method):
@@ -161,6 +164,7 @@ class Test2D:
         assert s.data.shape == (3,)
 
 
+@lazifyTestClass
 class Test3D_SignalDim0:
 
     def setup_method(self, method):
@@ -188,6 +192,21 @@ class Test3D_SignalDim0:
         np.testing.assert_array_equal(s.data, s.inav[:].data)
 
 
+@pytest.mark.parametrize('slice_', ((2, 1), (1,)))
+def test_ragged_slicing(slice_):
+    array_ragged = np.empty((2, 3), dtype=object)
+    for iy, ix in np.ndindex(array_ragged.shape):
+        array_ragged[iy, ix] = np.random.randint(
+            0, 20, size=np.random.randint(2, 10)
+            )
+
+    s = signals.BaseSignal(array_ragged, ragged=True)
+    s_lazy = s.as_lazy()
+    np.testing.assert_allclose(s.inav[slice_].data[0],
+                               s_lazy.inav[slice_].data[0])
+
+
+@lazifyTestClass
 class Test3D_Navigate_0_and_1:
 
     def setup_method(self, method):
@@ -253,6 +272,7 @@ class Test3D_Navigate_0_and_1:
         assert s.data.shape == self.data[:, 0:1, :].shape
 
 
+@lazifyTestClass
 class Test3D_Navigate_1:
 
     def setup_method(self, method):
@@ -285,6 +305,7 @@ class Test3D_Navigate_1:
         assert isinstance(im.isig[0], signals.Signal1D)
 
 
+@lazifyTestClass
 class TestFloatArguments:
 
     def setup_method(self, method):
@@ -335,6 +356,7 @@ class TestFloatArguments:
                 self.signal.axes_manager._axes[0].scale * -2)
 
 
+@lazifyTestClass
 class TestEllipsis:
 
     def setup_method(self, method):
@@ -358,6 +380,7 @@ class TestEllipsis:
         np.testing.assert_array_equal(s.data, self.data[:, :, 0, ...])
 
 
+@lazifyTestClass
 class TestROISlicing:
 
     def setup_method(self, method):

--- a/hyperspy/tests/signals/test_find_peaks2D.py
+++ b/hyperspy/tests/signals/test_find_peaks2D.py
@@ -147,16 +147,19 @@ class TestFindPeaks2D:
         peaks = self.sparse_nav2d_shifted.find_peaks(parallel=parallel,
                                                      interactive=False)
 
-        np.testing.assert_equal(peaks.inav[0, 0].data,
-                        np.array([[27,  1],
-                                  [10, 17],
-                                  [22, 23],
-                                  [33, 29]]))
-        np.testing.assert_equal(peaks.inav[0, 1].data,
-                        np.array([[35,  3],
-                                  [ 6, 13],
-                                  [18, 19],
-                                  [29, 25]]))
+        peaks0 = peaks.inav[0]
+        if peaks0._lazy:
+            peaks0.data.compute()
+        np.testing.assert_equal(peaks0.data[0],
+                                np.array([[27,  1],
+                                          [10, 17],
+                                          [22, 23],
+                                          [33, 29]]))
+        np.testing.assert_equal(peaks0.data[1],
+                                np.array([[35,  3],
+                                          [ 6, 13],
+                                          [18, 19],
+                                          [29, 25]]))
 
     @pytest.mark.parametrize('method', PEAK_METHODS)
     @pytest.mark.parametrize('parallel', [True, False])

--- a/hyperspy/tests/signals/test_fourier_transform.py
+++ b/hyperspy/tests/signals/test_fourier_transform.py
@@ -33,9 +33,9 @@ def test_null_signal():
     rng = np.random.RandomState(123)
     s = BaseSignal(rng.random_sample())
     with pytest.raises(AttributeError):
-        s.T.fft()
+        s.fft()
     with pytest.raises(AttributeError):
-        s.T.ifft()
+        s.ifft()
 
 
 @lazifyTestClass

--- a/hyperspy/tests/signals/test_map_method.py
+++ b/hyperspy/tests/signals/test_map_method.py
@@ -382,8 +382,11 @@ def test_singleton(ragged):
     sig.map(np.sum, inplace=True, ragged=ragged)
     sig_list = (sig, sig1, sig2)
     for _s in sig_list:
-        assert len(_s.axes_manager._axes) == 1
-        assert _s.axes_manager[0].name == 'Scalar'
+        assert len(_s.axes_manager._axes) == 0 if ragged else 1
+        if ragged:
+            assert _s.axes_manager.ragged
+        else:
+            assert _s.axes_manager[0].name == 'Scalar'
         assert isinstance(_s, hs.signals.BaseSignal)
         assert not isinstance(_s, hs.signals.Signal1D)
 

--- a/hyperspy/tests/signals/test_map_method.py
+++ b/hyperspy/tests/signals/test_map_method.py
@@ -115,14 +115,14 @@ class TestSignal2D:
                       ragged=True)
             s = s.map(rotate, angle=angles.T, reshape=True, inplace=False,
                   ragged=True)
+            s.compute()
         else:
             s.map(rotate, angle=angles.T, reshape=True, show_progressbar=None,
                   parallel=parallel, ragged=True)
         # the dtype
         assert s.data.dtype is np.dtype('O')
-        # the special slicing
-        if not s._lazy:
-            assert s.inav[0].data.base is s.data[0]
+        # Check slicing
+        assert s.inav[0].data[0] is s.data[0]
         # actual values
         np.testing.assert_allclose(s.data[0],
                                    np.arange(9.).reshape((3, 3)),
@@ -324,9 +324,8 @@ def test_new_axes(parallel):
     assert isinstance(sl, hs.signals.BaseSignal)
     ax_names = {ax.name for ax in sl.axes_manager._axes}
     assert len(ax_names) == 1
-    assert not 'a' in ax_names
     assert not 'b' in ax_names
-    assert 0 == sl.axes_manager.navigation_dimension
+    assert sl.axes_manager.navigation_dimension == 1
 
 
 class TestLazyMap:

--- a/hyperspy/tests/signals/test_ragged_signal.py
+++ b/hyperspy/tests/signals/test_ragged_signal.py
@@ -1,0 +1,101 @@
+# -*- coding: utf-8 -*-
+# Copyright 2007-2021 The HyperSpy developers
+#
+# This file is part of  HyperSpy.
+#
+#  HyperSpy is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+#  HyperSpy is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with  HyperSpy.  If not, see <http://www.gnu.org/licenses/>.
+
+import pytest
+import numpy as np
+
+import hyperspy.api as hs
+from hyperspy.decorators import lazifyTestClass
+
+
+def test_setting_ragged_array():
+    s = hs.signals.Signal1D(np.arange(2*3*4*5).reshape(2, 3, 4, 5))
+    assert not s.ragged
+    assert s.axes_manager.signal_shape == (5, )
+    assert s.axes_manager.navigation_shape == (4, 3, 2)
+    assert s.axes_manager.signal_indices_in_array == (3, )
+    assert s.axes_manager.navigation_indices_in_array  == (2, 1, 0)
+    with pytest.raises(ValueError):
+        s.ragged = True
+
+    data = np.empty((2, 3, 4), dtype=object)
+    data.fill(np.array([10, 20, 30, 40, 50]))
+    s = hs.signals.BaseSignal(data, ragged=True)
+    assert s.ragged
+    assert s.axes_manager.signal_shape == ()
+    assert s.axes_manager.navigation_shape == (4, 3, 2)
+    assert s.axes_manager.signal_indices_in_array == ()
+    assert s.axes_manager.navigation_indices_in_array  == (2, 1, 0)
+    s.ragged = False
+    assert not s.ragged
+    assert s.axes_manager.signal_shape == (5, )
+    assert s.axes_manager.navigation_shape == (4, 3, 2)
+    assert s.axes_manager.signal_indices_in_array == (3, )
+    assert s.axes_manager.navigation_indices_in_array  == (2, 1, 0)
+
+
+@lazifyTestClass
+class TestRaggedArray:
+
+    def setup_method(self, method):
+        data = np.empty((3, 4), dtype=object)
+        data.fill(np.array([10, 20]))
+        s = hs.signals.BaseSignal(data, ragged=True)
+        self.s = s
+
+    def test_axes_manager(self):
+        s = self.s
+        class_ = 'LazySignal' if s._lazy else 'BaseSignal'
+        assert s.__repr__() == \
+            f"<{class_}, title: , dimensions: (4, 3|ragged)>"
+
+    def test_transpose(self):
+        with pytest.raises(RuntimeError):
+            self.s.T
+
+    def test_slicing(self):
+        s = self.s
+        s2 = s.inav[0]
+        assert s2.ragged
+        assert s2.axes_manager.signal_dimension == 0
+        assert s2.axes_manager.signal_shape == ()
+        assert s2.axes_manager.navigation_shape == (3,)
+        s3 = s.inav[0, 0]
+        assert s3.ragged
+        assert s3.axes_manager.signal_dimension == 0
+        assert s3.axes_manager.signal_shape == ()
+        assert s3.axes_manager.navigation_shape == ()
+
+        with pytest.raises(RuntimeError):
+            s.isig[0]
+
+
+def test_create_ragged_array():
+    data = np.array([[0, 1], [2, 3, 4]], dtype=object)
+    s = hs.signals.BaseSignal(data, ragged=True)
+    assert s.axes_manager.ragged
+
+    with pytest.raises(ValueError):
+        s.ragged = False
+
+    data = np.empty((1,), dtype=object)
+    data.fill(np.array([[0, 0], [25, -25], [-25, 25]]))
+
+    s2 = hs.signals.BaseSignal(data, ragged=True)
+    assert s2.axes_manager.ragged
+    assert s2.__repr__() == "<BaseSignal, title: , dimensions: (|ragged)>"

--- a/hyperspy/tests/signals/test_ragged_signal.py
+++ b/hyperspy/tests/signals/test_ragged_signal.py
@@ -106,3 +106,20 @@ def test_create_ragged_array():
     s2 = hs.signals.BaseSignal(data, ragged=True)
     assert s2.axes_manager.ragged
     assert s2.__repr__() == "<BaseSignal, title: , dimensions: (|ragged)>"
+
+
+def test_Signal1D_Signal2D_ragged():
+    data = np.array((1, 2))
+    with pytest.raises(ValueError):
+        _ = hs.signals.Signal1D(data, ragged=True)
+
+    with pytest.raises(ValueError):
+        _ = hs.signals.Signal2D(data, ragged=True)
+
+
+def test_conversion_signal():
+    data = np.empty((2, 3, 4), dtype=object)
+    data.fill(np.array([10, 20, 30, 40, 50]))
+    s = hs.signals.BaseSignal(data, ragged=True)
+    with pytest.raises(ValueError):
+        s.axes_manager.set_signal_dimension(1)

--- a/hyperspy/tests/signals/test_transpose.py
+++ b/hyperspy/tests/signals/test_transpose.py
@@ -134,3 +134,17 @@ def test_lazy_transpose_rechunks():
     assert s1.data.chunks == (cks[2], cks[3], cks[0], cks[1])
     s2 = s.transpose(optimize=True)
     assert s2.data.chunks != s1.data.chunks
+
+
+def test_transpose_nav0_sig0():
+    s = BaseSignal([0.])
+    assert s.axes_manager.signal_dimension == 0
+    assert s.axes_manager.navigation_dimension == 0
+    assert s.axes_manager.signal_axes[0].size == 1
+    assert s.axes_manager.navigation_axes == ()
+
+    s2 = s.T
+    assert s2.axes_manager.signal_dimension == 0
+    # assert s2.axes_manager.navigation_dimension == 0
+    assert s2.axes_manager.signal_axes == ()
+    assert s2.axes_manager.navigation_axes[0].size == 1

--- a/hyperspy/tests/signals/test_transpose.py
+++ b/hyperspy/tests/signals/test_transpose.py
@@ -145,6 +145,6 @@ def test_transpose_nav0_sig0():
 
     s2 = s.T
     assert s2.axes_manager.signal_dimension == 0
-    # assert s2.axes_manager.navigation_dimension == 0
+    assert s2.axes_manager.navigation_dimension == 1
     assert s2.axes_manager.signal_axes == ()
     assert s2.axes_manager.navigation_axes[0].size == 1

--- a/hyperspy/tests/test_dictionary_tree_browser.py
+++ b/hyperspy/tests/test_dictionary_tree_browser.py
@@ -109,7 +109,8 @@ class TestDictionaryBrowser:
                         "leaf211": 211},
                 },
                 "_sig_Some name": {
-                    'attributes': {'_lazy': False},
+                    'attributes': {'_lazy': False,
+                                   'ragged': False},
                     'axes': [
                         {
                             '_type': 'UniformDataAxis',

--- a/upcoming_changes/2842.enhancements.rst
+++ b/upcoming_changes/2842.enhancements.rst
@@ -1,0 +1,1 @@
+Add :py:attr:`~.signal.BaseSignal.ragged` attribute to :py:class:`~.signal.BaseSignal` to clarify when a signal contains a ragged array. Fix inconsistency caused by ragged array and add a :ref:`ragged array<signal.ragged>` section to the user guide


### PR DESCRIPTION
The changes in #2773 break the pyxem test suite. In my opinion, using the use of ragged array is not clear enough and there is an inconsistency in slicing array. This has been been discussed and introduced in #1336, in particular starting from https://github.com/hyperspy/hyperspy/pull/1336#issuecomment-263876213.

Before this PR
```python
import hyperspy.api as hs
import numpy as np

data = np.empty((3, 4), dtype=object)
data.fill(np.array([10, 20]))
s = hs.signals.BaseSignal(data).T

print(s)
# <BaseSignal, title: , dimensions: (4, 3|)>

s2 = s.inav[0]
print(s2)
# <BaseSignal, title: , dimensions: (3|)>
assert s2.axes_manager.signal_dimension == 0
assert s2.axes_manager.signal_shape == ()
assert s2.axes_manager.navigation_shape == (3,)

s3 = s.inav[0, 0]
print(s3)
# <BaseSignal, title: , dimensions: (|1)>
assert s3.axes_manager.signal_dimension == 0
assert s3.axes_manager.signal_shape == (1,)
assert s3.axes_manager.navigation_shape == ()

np.testing.assert_allclose(s()[0], s2()[0])
np.testing.assert_allclose(s()[0], s3()[0]) # fail
```
With this PR
```python
data = np.empty((3, 4), dtype=object)
data.fill(np.array([10, 20]))
s = hs.signals.BaseSignal(data, ragged=True)

print(s)
# <BaseSignal, title: , dimensions: (4, 3|ragged)>

print(s.axes_manager)
# <Axes manager, axes: (4, 3|ragged)>
#             Name |   size |  index |  offset |   scale |  units 
# ================ | ====== | ====== | ======= | ======= | ====== 
#      <undefined> |      4 |      0 |       0 |       1 | <undefined> 
#      <undefined> |      3 |      0 |       0 |       1 | <undefined> 
# ---------------- | ------ | ------ | ------- | ------- | ------ 
#      Ragged axis |               Variable length

s2 = s.inav[0]
print(s2)
# <BaseSignal, title: , dimensions: (3|ragged)>
assert s2.axes_manager.signal_dimension == 0
assert s2.axes_manager.signal_shape == ()
assert s2.axes_manager.navigation_shape == (3,)

s3 = s.inav[0, 0]
print(s3)
# <BaseSignal, title: , dimensions: (|ragged)>
assert s3.axes_manager.signal_dimension == 0
assert s3.axes_manager.signal_shape == ()
assert s3.axes_manager.navigation_shape == ()

np.testing.assert_allclose(s()[0], s2()[0])
np.testing.assert_allclose(s()[0], s3()[0])
```

### Progress of the PR
- [x] Make AxesManager ragged aware and show corresponding axis, this should be more transparent to the users
- [x] Remove special slicing for ragged array containing a single array 
- [x] update docstring,
- [x] update user guide,
- [x] add an changelog entry in the `upcoming_changes` folder (see [`upcoming_changes/README.rst`](https://github.com/hyperspy/hyperspy/blob/RELEASE_next_minor/upcoming_changes/README.rst)),
- [x] Check formatting changelog entry in the `readthedocs` doc build of this PR (link in github checks)
- [x] add tests,
- [x] ready for review.


