### PR TITLE
Fix for h5py 3.5

### DIFF
--- a/hyperspy/io_plugins/hspy.py
+++ b/hyperspy/io_plugins/hspy.py
@@ -595,9 +595,6 @@ def overwrite_dataset(group, data, key, signal_axes=None, chunks=None, **kwds):
             # if the shape or dtype/etc do not match,
             # we delete the old one and create new in the next loop run
             del group[key]
-    if dset == data:
-        # just a reference to already created thing
-        pass
     else:
         _logger.info(f"Chunks used for saving: {dset.chunks}")
         if isinstance(data, da.Array):

--- a/hyperspy/io_plugins/hspy.py
+++ b/hyperspy/io_plugins/hspy.py
@@ -595,16 +595,16 @@ def overwrite_dataset(group, data, key, signal_axes=None, chunks=None, **kwds):
             # if the shape or dtype/etc do not match,
             # we delete the old one and create new in the next loop run
             del group[key]
+
+    _logger.info(f"Chunks used for saving: {dset.chunks}")
+    if isinstance(data, da.Array):
+        if data.chunks != dset.chunks:
+            data = data.rechunk(dset.chunks)
+        da.store(data, dset)
+    elif data.flags.c_contiguous:
+        dset.write_direct(data)
     else:
-        _logger.info(f"Chunks used for saving: {dset.chunks}")
-        if isinstance(data, da.Array):
-            if data.chunks != dset.chunks:
-                data = data.rechunk(dset.chunks)
-            da.store(data, dset)
-        elif data.flags.c_contiguous:
-            dset.write_direct(data)
-        else:
-            dset[:] = data
+        dset[:] = data
 
 
 def hdfgroup2dict(group, dictionary=None, lazy=False):

--- a/upcoming_changes/2843.bugfix.rst
+++ b/upcoming_changes/2843.bugfix.rst
@@ -1,0 +1,1 @@
+Add support for latest h5py release (3.5)


### PR DESCRIPTION
h5py 3.5 breaks saving file because of a `h5py.dataset` and `numpy.ndarray` comparison which is actually never used!
See for example, this build https://github.com/hyperspy/hyperspy/actions/runs/1373766813 on github CI - azure pipeline is using conda-forge packages and h5py 3.5 is not yet available.

### Progress of the PR
- [x] Remove unused code, which breaks with h5py 3.5
- [n/a] update docstring (if appropriate),
- [n/a] update user guide (if appropriate),
- [x] add an changelog entry in the `upcoming_changes` folder (see [`upcoming_changes/README.rst`](https://github.com/hyperspy/hyperspy/blob/RELEASE_next_minor/upcoming_changes/README.rst)),
- [x] Check formatting changelog entry in the `readthedocs` doc build of this PR (link in github checks)
- [n/a] add tests,
- [x] ready for review.


