### PR TITLE
Release 1.6.5

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -143,5 +143,5 @@ jobs:
           TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
         run: |
           twine upload dist/*-manylinux*.whl --verbose 
-          twine upload sdist/*.tar.gz --verbose 
+          twine upload dist/*.tar.gz --verbose 
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -54,14 +54,14 @@ jobs:
           python --version
           which python
 
-      - name: install pep517 and twine
+      - name: install build and twine
         run: |
           python -m pip install --upgrade pip
-          python -m pip install pep517 twine
+          python -m pip install build twine
 
       - name: Build wheels
         run: |
-          python -m pep517.build --binary --out-dir dist/ .
+          python -m build
 
       - name: Display content dist folder
         run: |
@@ -105,21 +105,20 @@ jobs:
         run: |
           python -m pip install twine
 
+      - name: Build source distribution
+        run: |
+          pip install build
+          python -m build --sdist
+
       - name: Build manylinux Python wheels
         uses: RalfG/python-wheels-manylinux-build@v0.3.3
         with:
           python-versions: 'cp36-cp36m cp37-cp37m cp38-cp38 cp39-cp39'
           build-requirements: 'cython'
 
-      - name: Build source distribution
-        run: |
-          pip install pep517
-          python -m pep517.build --source --out-dir sdist/ .
-
       - name: Display content dist folder
         run: |
           ls dist/
-          ls sdist/
 
       - name: Install and test distribution
         env:

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,8 +8,34 @@ https://hyperspy.readthedocs.io/en/latest/user_guide/changes.html
 
 .. towncrier release notes start
 
-Hyperspy 1.6.4 (2021-07-08)
-===========================
+v1.6.5 (2021-10-24)
+===================
+
+Bug Fixes
+---------
+
+- Suspend plotting during :py:meth:`~.models.eelsmodel.EELSModel.smart_fit` call (`#2796 <https://github.com/hyperspy/hyperspy/issues/2796>`_)
+- make :py:meth:`~.signal.BaseSignal.add_marker` also check if the plot is not active before plotting signal (`#2799 <https://github.com/hyperspy/hyperspy/issues/2799>`_)
+- Fix irresponsive ROI added to a signal plot with a right hand side axis (`#2809 <https://github.com/hyperspy/hyperspy/issues/2809>`_)
+- Fix :py:func:`~.drawing.utils.plot_histograms` drawstyle following matplotlib API change (`#2810 <https://github.com/hyperspy/hyperspy/issues/2810>`_)
+- Fix :py:func:`hyperspy._signals.lazy.LazySignal._map_iterate` output incorrect signal size when input and output axes do not match (`#2837 <https://github.com/hyperspy/hyperspy/issues/2837>`_)
+- Add support for latest h5py release (3.5) (`#2843 <https://github.com/hyperspy/hyperspy/issues/2843>`_)
+
+
+Deprecations
+------------
+
+- Rename ``line_style`` to ``linestyle`` in :py:func:`~.drawing.utils.plot_spectra` to match matplotlib argument name (`#2810 <https://github.com/hyperspy/hyperspy/issues/2810>`_)
+
+
+Enhancements
+------------
+
+- :py:meth:`~.roi.BaseInteractiveROI.add_widget` can now take a string or integer instead of tuple of string or integer (`#2809 <https://github.com/hyperspy/hyperspy/issues/2809>`_)
+
+
+v1.6.4 (2021-07-08)
+===================
 
 Bug Fixes
 ---------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,7 +8,7 @@ https://hyperspy.readthedocs.io/en/latest/user_guide/changes.html
 
 .. towncrier release notes start
 
-v1.6.5 (2021-10-24)
+v1.6.5 (2021-10-28)
 ===================
 
 Bug Fixes
@@ -18,7 +18,7 @@ Bug Fixes
 - make :py:meth:`~.signal.BaseSignal.add_marker` also check if the plot is not active before plotting signal (`#2799 <https://github.com/hyperspy/hyperspy/issues/2799>`_)
 - Fix irresponsive ROI added to a signal plot with a right hand side axis (`#2809 <https://github.com/hyperspy/hyperspy/issues/2809>`_)
 - Fix :py:func:`~.drawing.utils.plot_histograms` drawstyle following matplotlib API change (`#2810 <https://github.com/hyperspy/hyperspy/issues/2810>`_)
-- Fix :py:func:`hyperspy._signals.lazy.LazySignal._map_iterate` output incorrect signal size when input and output axes do not match (`#2837 <https://github.com/hyperspy/hyperspy/issues/2837>`_)
+- Fix incorrect :py:meth:`~.signal.BaseSignal.map` output size of lazy signal when input and output axes do not match (`#2837 <https://github.com/hyperspy/hyperspy/issues/2837>`_)
 - Add support for latest h5py release (3.5) (`#2843 <https://github.com/hyperspy/hyperspy/issues/2843>`_)
 
 

--- a/hyperspy/Release.py
+++ b/hyperspy/Release.py
@@ -25,7 +25,7 @@ name = 'hyperspy'
 # When running setup.py the ".dev" string will be replaced (if possible)
 # by the output of "git describe" if git is available or the git
 # hash if .git is present.
-version = "1.6.5.dev0"
+version = "1.6.5"
 description = "Multidimensional data analysis toolbox"
 license = 'GPL v3'
 

--- a/hyperspy/Release.py
+++ b/hyperspy/Release.py
@@ -25,7 +25,7 @@ name = 'hyperspy'
 # When running setup.py the ".dev" string will be replaced (if possible)
 # by the output of "git describe" if git is available or the git
 # hash if .git is present.
-version = "1.6.5"
+version = "1.6.6.dev0"
 description = "Multidimensional data analysis toolbox"
 license = 'GPL v3'
 

--- a/hyperspy/axes.py
+++ b/hyperspy/axes.py
@@ -1203,10 +1203,7 @@ class AxesManager(t.HasTraits):
         self.signal_axes = self.signal_axes[::-1]
         self.navigation_axes = self.navigation_axes[::-1]
         self._getitem_tuple = tuple(getitem_tuple)
-        if len(self.signal_axes) == 1 and self.signal_axes[0].size == 1:
-            self.signal_dimension = 0
-        else:
-            self.signal_dimension = len(self.signal_axes)
+        self.signal_dimension = len(self.signal_axes)
         self.navigation_dimension = len(self.navigation_axes)
         if self.navigation_dimension != 0:
             self.navigation_shape = tuple([
@@ -1214,7 +1211,11 @@ class AxesManager(t.HasTraits):
         else:
             self.navigation_shape = ()
 
-        self.signal_shape = tuple([axis.size for axis in self.signal_axes])
+        if self.signal_dimension != 0:
+            self.signal_shape = tuple([
+                axis.size for axis in self.signal_axes])
+        else:
+            self.signal_shape = ()
         self.navigation_size = (np.cumprod(self.navigation_shape)[-1]
                                 if self.navigation_shape else 0)
         self.signal_size = (np.cumprod(self.signal_shape)[-1]

--- a/hyperspy/misc/signal_tools.py
+++ b/hyperspy/misc/signal_tools.py
@@ -171,7 +171,7 @@ def broadcast_signals(*args, ignore_axis=None):
         for s in args:
             data = s._data_aligned_with_axes
             sam = s.axes_manager
-            sdim_diff = len(new_sig_axes) - len(sam.signal_axes)
+            sdim_diff = len(new_sig_axes) - sam.signal_dimension
             while sdim_diff > 0:
                 slices = (slice(None),) * sam.navigation_dimension
                 slices += (None, Ellipsis)

--- a/hyperspy/signal.py
+++ b/hyperspy/signal.py
@@ -2619,11 +2619,6 @@ class BaseSignal(FancySlicing,
             else:
                 navigator = "slider"
         if axes_manager.signal_dimension == 0:
-            if axes_manager.navigation_dimension == 0:
-                # 0d signal without navigation axis: don't make a figure
-                # and instead, we display the value
-                print(self.data)
-                return
             self._plot = mpl_he.MPL_HyperExplorer()
         elif axes_manager.signal_dimension == 1:
             # Hyperspectrum

--- a/hyperspy/tests/drawing/test_plot_signal.py
+++ b/hyperspy/tests/drawing/test_plot_signal.py
@@ -314,9 +314,3 @@ def test_plot_autoscale(sdim):
 
     s.change_dtype(bool)
     s.plot()
-
-
-def test_plot_signal_scalar():
-    s = hs.signals.BaseSignal([1.0])
-    s.plot()
-    assert s._plot is None

--- a/hyperspy/tests/model/test_model.py
+++ b/hyperspy/tests/model/test_model.py
@@ -763,7 +763,7 @@ class TestAsSignal:
 @lazifyTestClass
 class TestCreateModel:
     def setup_method(self, method):
-        self.s = hs.signals.Signal1D(np.asarray([0, 1]))
+        self.s = hs.signals.Signal1D(np.asarray([0]))
         self.im = hs.signals.Signal2D(np.ones([1, 1]))
 
     def test_create_model(self):

--- a/hyperspy/tests/signals/test_2D.py
+++ b/hyperspy/tests/signals/test_2D.py
@@ -23,16 +23,14 @@ import numpy as np
 import pytest
 
 from hyperspy.decorators import lazifyTestClass
-from hyperspy.signal import BaseSignal
 from hyperspy.signals import Signal1D, Signal2D
 
 
 def _verify_test_sum_x_E(self, s):
     np.testing.assert_array_equal(self.signal.data.sum(), s.data)
     assert s.data.ndim == 1
-    # Check that the signal dimension is now 0
-    assert s.axes_manager.signal_dimension == 0
-    assert isinstance(s, BaseSignal)
+    # Check that there is still one signal axis.
+    assert s.axes_manager.signal_dimension == 1
 
 
 @lazifyTestClass

--- a/hyperspy/tests/signals/test_3D.py
+++ b/hyperspy/tests/signals/test_3D.py
@@ -183,7 +183,7 @@ class Test3D:
         s = self.signal
         s = s.transpose(signal_axes=3)
         ns = s._get_navigation_signal()
-        assert ns.axes_manager.signal_dimension == 0
+        assert ns.axes_manager.signal_dimension == 1
         assert ns.axes_manager.signal_size == 1
         assert ns.axes_manager.navigation_dimension == 0
 
@@ -233,7 +233,7 @@ class Test3D:
         ns = s._get_signal_signal()
         assert ns.axes_manager.navigation_dimension == 0
         assert ns.axes_manager.navigation_size == 0
-        assert ns.axes_manager.signal_dimension == 0
+        assert ns.axes_manager.signal_dimension == 1
 
     def test_get_signal_signal_nav_dim1(self):
         s = self.signal

--- a/hyperspy/tests/signals/test_assign_subclass.py
+++ b/hyperspy/tests/signals/test_assign_subclass.py
@@ -24,7 +24,6 @@ import pytest
 
 import hyperspy.api as hs
 from hyperspy import _lazy_signals
-from hyperspy.decorators import lazifyTestClass
 from hyperspy.exceptions import VisibleDeprecationWarning
 from hyperspy.io import assign_signal_subclass
 
@@ -88,21 +87,6 @@ def test_id_set_signal_type():
     assert id_om == id(s.original_metadata)
 
 
-@lazifyTestClass
-class TestToBaseSignalScalar:
-
-    def setup_method(self, method):
-        self.s = hs.signals.Signal1D(np.array([0]))
-
-    def test_simple(self):
-        self.s._assign_subclass()
-        assert isinstance(self.s, hs.signals.BaseSignal)
-        assert self.s.axes_manager.signal_dimension == 0
-        assert self.s.axes_manager.signal_shape == (1, )
-        if self.s._lazy:
-            assert isinstance(self.s, _lazy_signals.LazySignal)
-
-
 class TestConvertBaseSignal:
 
     def setup_method(self, method):
@@ -138,7 +122,7 @@ class TestConvertBaseSignal:
 class TestConvertSignal1D:
 
     def setup_method(self, method):
-        self.s = hs.signals.Signal1D([0, 1])
+        self.s = hs.signals.Signal1D([0])
 
     def test_lazy_to_eels_and_back(self):
         self.s = self.s.as_lazy()
@@ -192,7 +176,7 @@ class TestConvertComplexSignal:
 class TestConvertComplexSignal1D:
 
     def setup_method(self, method):
-        self.s = hs.signals.ComplexSignal1D([0, 1])
+        self.s = hs.signals.ComplexSignal1D([0])
 
     def test_complex_to_dielectric_function(self):
         self.s.set_signal_type("DielectricFunction")

--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,7 @@ setup_path = os.path.dirname(__file__)
 
 
 install_req = ['scipy>=1.1',
-               'matplotlib>=3.1.0',
+               'matplotlib>=3.1.0,<3.5',
                'numpy>=1.17.1',
                'traits>=4.5.0',
                'natsort',

--- a/upcoming_changes/2773.bugfix.rst
+++ b/upcoming_changes/2773.bugfix.rst
@@ -1,1 +1,0 @@
-Signals with 1 value in the signal dimension will now be :py:class:`~.signal.BaseSignal`

--- a/upcoming_changes/2796.bugfix.rst
+++ b/upcoming_changes/2796.bugfix.rst
@@ -1,1 +1,0 @@
-Suspend plotting during :py:meth:`~.models.eelsmodel.EELSModel.smart_fit` call

--- a/upcoming_changes/2799.bugfix.rst
+++ b/upcoming_changes/2799.bugfix.rst
@@ -1,1 +1,0 @@
-make :py:meth:`~.signal.BaseSignal.add_marker` also check if the plot is not active before plotting signal

--- a/upcoming_changes/2809.bugfix.rst
+++ b/upcoming_changes/2809.bugfix.rst
@@ -1,1 +1,0 @@
-Fix irresponsive ROI added to a signal plot with a right hand side axis

--- a/upcoming_changes/2809.enhancements.rst
+++ b/upcoming_changes/2809.enhancements.rst
@@ -1,1 +1,0 @@
-:py:meth:`~.roi.BaseInteractiveROI.add_widget` can now take a string or integer instead of tuple of string or integer

--- a/upcoming_changes/2810.bugfix.rst
+++ b/upcoming_changes/2810.bugfix.rst
@@ -1,1 +1,0 @@
-Fix :py:func:`~.drawing.utils.plot_histograms` drawstyle following matplotlib API change

--- a/upcoming_changes/2810.deprecation.rst
+++ b/upcoming_changes/2810.deprecation.rst
@@ -1,1 +1,0 @@
-Rename ``line_style`` to ``linestyle`` in :py:func:`~.drawing.utils.plot_spectra` to match matplotlib argument name

--- a/upcoming_changes/2837.bugfix.rst
+++ b/upcoming_changes/2837.bugfix.rst
@@ -1,1 +1,0 @@
-Fix :py:func:`hyperspy._signals.lazy.LazySignal._map_iterate` output incorrect signal size when input and output axes do not match

--- a/upcoming_changes/2843.bugfix.rst
+++ b/upcoming_changes/2843.bugfix.rst
@@ -1,1 +1,0 @@
-Add support for latest h5py release (3.5)


### PR DESCRIPTION
The latest h5py release 3.5 breaks saving signals and the coming matplotlib release (also a 3.5!) is going to break the span selector.
Since the release process should be quick now, 

Following https://github.com/hyperspy/hyperspy/blob/RELEASE_next_minor/releasing_guide.md:

### Progress of the PR
- [x] Bump version,
- [x] pin matplotlib to <3.5 
- [x] update release workflow to use the [`build`](https://pypi.org/project/build) library instead of the deprecated [`pep517.build`](https://pypi.org/project/pep517/). More details at https://pypa-build.readthedocs.io.
- [x] revert #2773 in 3fdff60 for this patch release because it breaks pyxem and it needs to be fixed separately. These changes are still in the `RELEASE_next_minor` branch and this issue should be discussed and fixed in #2842 - along with #2830 and #2703. 
- [x] Update and check changelog in CHANGES.rst: run towncrier build
- [x] ready for review.

