### PR TITLE
Fix hanning window calculation

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,5 +1,5 @@
 ### Requirements
-* Read the [developer guide](https://hyperspy.org/hyperspy-doc/current/dev_guide/index.html).
+* Read the [developer guide](https://hyperspy.org/hyperspy-doc/current/dev_guide/intro.html).
 * Base your pull request on the [correct branch](https://hyperspy.org/hyperspy-doc/current/dev_guide/git.html#semantic-versioning-and-hyperspy-main-branches).
 * Filling out the template; it helps the review process and it is useful to summarise the PR.
 * This template can be updated during the progression of the PR to summarise its status. 

--- a/hyperspy/_signals/signal1d.py
+++ b/hyperspy/_signals/signal1d.py
@@ -1304,7 +1304,7 @@ class Signal1D(BaseSignal, CommonSignal1D):
         # TODO: generalize it
         self._check_signal_dimension_equals_one()
         if channels is None:
-            channels = int(round(len(self()) * 0.02))
+            channels = int(round(self.axes_manager.signal_axes[0].size * 0.02))
             if channels < 20:
                 channels = 20
         dc = self._data_aligned_with_axes


### PR DESCRIPTION
### Description of the change: BUGFIX
While I very well may be wrong, when taking a 3D array (EELS Spectrum Image) and applying a hanning window for fourier_ratio_deconvolution, the signals have a hanning window applied. This window should be applied to the signal axis, not the navigation axes, but the window size is is calculated using len(hs_object), which is just np.prod(nav_axes_size). This change should (hopefully) calculate the correct hanning window size for the signal axis, such that it matches the documentation. 

If I am wrong, please reject. I also did not know which branch to propose to, and I'm happy to change that if necessary.

### Progress of the PR
- [x ] Change implemented (can be split into several points),
- [n/a ] update docstring (if appropriate),
- [n/a ] update user guide (if appropriate),
- [n/a] add an changelog entry in the `upcoming_changes` folder (see [`upcoming_changes/README.rst`](https://github.com/hyperspy/hyperspy/blob/RELEASE_next_minor/upcoming_changes/README.rst)),
- [n/a] Check formatting changelog entry in the `readthedocs` doc build of this PR (link in github checks)
- [n/a ] add tests,
- [ x] ready for review.

### Minimal example of the bug fix or the new feature


