### PR TITLE
Modify formula hydrogen k edge

### DIFF
--- a/hyperspy/misc/eels/hydrogenic_gos.py
+++ b/hyperspy/misc/eels/hydrogenic_gos.py
@@ -161,7 +161,7 @@ class HydrogenicGOS(GOSBase):
         if akh < 0.01:
             akh = 0.01
         if kh2 >= 0.0:
-            d = 1 - np.e ** (-2 * np.pi / kh2)
+            d = 1 - np.e ** (-2 * np.pi / akh)
             bp = np.arctan(2 * akh / (q - kh2 + 1))
             if bp < 0:
                 bp = bp + np.pi


### PR DESCRIPTION
### Description of the change
There was an error in the calculation for the gdos of the hydrogenic k edge.
In the code of Sigma3k (https://sites.google.com/site/temsemeels/) you can see that it 
should be parameter akh instead of kh2 for the expression: 1-np.e(-2 * np.pi/kh2)


