### PR TITLE
Specify scikit-image version in oldest supported version CI build

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -23,7 +23,7 @@ jobs:
           - os: ubuntu
             PYTHON_VERSION: 3.6
             OLDEST_SUPPORTED_VERSION: true
-            DEPENDENCIES: matplotlib==3.1.0 numpy==1.17.1 scipy==1.1 imagecodecs==2019.12.3 dask==2.1.0
+            DEPENDENCIES: matplotlib==3.1.0 numpy==1.17.1 scipy==1.1 imagecodecs==2019.12.3 dask==2.1.0 scikit-image==0.15
             PIP_SELECTOR: '[all, tests]'
             LABEL: -oldest
           # test minimum requirement


### PR DESCRIPTION
Latest scikit-image requires scipy>=1.4.1:

from https://github.com/hyperspy/hyperspy/runs/4461372557?check_suite_focus=true
```
scikit-image 0.19.0 requires scipy>=1.4.1, but you have scipy 1.1.0 which is incompatible.
```

### Progress of the PR
- [x] Specify the oldest scikit-image version we support to fix the incompatibility,
- [n/a] update docstring (if appropriate),
- [n/a] update user guide (if appropriate),
- [n/a] add an changelog entry in the `upcoming_changes` folder (see [`upcoming_changes/README.rst`](https://github.com/hyperspy/hyperspy/blob/RELEASE_next_minor/upcoming_changes/README.rst)),
- [n/a] Check formatting changelog entry in the `readthedocs` doc build of this PR (link in github checks)
- [n/a] add tests,
- [x] ready for review.

