### PR TITLE
bugfix: broken axis name when signal_type==""

### DIFF
--- a/hyperspy/io_plugins/digital_micrograph.py
+++ b/hyperspy/io_plugins/digital_micrograph.py
@@ -537,15 +537,13 @@ class ImageObject(object):
         names = [t.Undefined] * len(self.shape)
         indices = list(range(len(self.shape)))
 
-        if self.signal_type == "":
-            pass
-        elif self.signal_type == "EELS":
+        if self.signal_type == "EELS":
             if "eV" in self.units:
                 names[indices.pop(self.units.index("eV"))] = "Energy loss"
         elif self.signal_type in ("EDS", "EDX"):
             if "keV" in self.units:
                 names[indices.pop(self.units.index("keV"))] = "Energy"
-        elif self.signal_type in ("CL"):
+        elif self.signal_type == "CL":
             if "nm" in self.units:
                 names[indices.pop(self.units.index("nm"))] = "Wavelength"
         for index, name in zip(indices[::-1], ("x", "y", "z")):

--- a/hyperspy/io_plugins/digital_micrograph.py
+++ b/hyperspy/io_plugins/digital_micrograph.py
@@ -536,7 +536,10 @@ class ImageObject(object):
     def names(self):
         names = [t.Undefined] * len(self.shape)
         indices = list(range(len(self.shape)))
-        if self.signal_type == "EELS":
+
+        if self.signal_type == "":
+            pass
+        elif self.signal_type == "EELS":
             if "eV" in self.units:
                 names[indices.pop(self.units.index("eV"))] = "Energy loss"
         elif self.signal_type in ("EDS", "EDX"):

--- a/hyperspy/tests/io/test_dm3.py
+++ b/hyperspy/tests/io/test_dm3.py
@@ -489,3 +489,8 @@ def test_data(pdict):
                                   err_msg='content %s type % i: '
                                   '\n%s not equal to \n%s' %
                                   (subfolder, key, str(s.data), str(dat)))
+
+def test_axes_bug_for_image():
+    fname = os.path.join(MY_PATH, "dm3_2D_data", "test_STEM_image.dm3")
+    s = load(fname)
+    assert s.axes_manager[1].name == 'y'


### PR DESCRIPTION
### Description of the change
When signal_type=="" and unit == "nm", the axis name become broken.
(hit to   signal_type in ("CL"))

### Progress of the PR
- [x] Change implemented (can be split into several points),
- [ ] update docstring (if appropriate),
- [ ] update user guide (if appropriate),
- [ ] add an changelog entry in the `upcoming_changes` folder (see [`upcoming_changes/README.rst`](https://github.com/hyperspy/hyperspy/blob/RELEASE_next_minor/upcoming_changes/README.rst)),
- [ ] Check formatting changelog entry in the `readthedocs` doc build of this PR (link in github checks)
- [x] add tests,
- [x] ready for review.

### Minimal example of the bug fix or the new feature
depends on dm4 file.
