### PR TITLE
Fix axes.CodeConversion initializer: offset was initialized by units

### DIFF
--- a/hyperspy/axes.py
+++ b/hyperspy/axes.py
@@ -81,7 +81,7 @@ class UnitConversion:
     def __init__(self, units=t.Undefined, scale=1.0, offset=0.0):
         self.units = units
         self.scale = scale
-        self.offset = units
+        self.offset = offset
 
     def _ignore_conversion(self, units):
         if units == t.Undefined:

--- a/hyperspy/tests/axes/test_conversion_units.py
+++ b/hyperspy/tests/axes/test_conversion_units.py
@@ -439,3 +439,7 @@ class TestAxesManager:
                                   same_units=same_units)
         assert_deep_almost_equal(self.am._get_axes_dicts(),
                                  self.axes_list)
+
+    def test_initialize_UnitConversion_bug(self):
+        uc = UnitConversion(units="m", scale=1.0, offset=0)
+        assert uc.offset == 0

--- a/upcoming_changes/2864.bugfix.rst
+++ b/upcoming_changes/2864.bugfix.rst
@@ -1,0 +1,1 @@
+Fix bug for axes.CodeConversion the offset value was initialized by units.


### PR DESCRIPTION
A few sentences and/or a bulleted list to describe and motivate the change:
- hyperspy.axes.Unitconversion.__init__
     replace self.offset = units by self.offset = offset

### Progress of the PR
- [x] Change implemented (can be split into several points),
- [ ] update docstring (if appropriate),
- [ ] update user guide (if appropriate),
- [x] add an changelog entry in the `upcoming_changes` folder (see [`upcoming_changes/README.rst`](https://github.com/hyperspy/hyperspy/blob/RELEASE_next_minor/upcoming_changes/README.rst)),
- [ ] Check formatting changelog entry in the `readthedocs` doc build of this PR (link in github checks)
- [x] add tests,
- [x] ready for review.

### Minimal example of the bug fix or the new feature
```python
from hyperspy.axes import UnitConversion
uc = UnitConversion(units="m", scale=1.0, offset=0.0)
print(uc._convert_units("mm",inplace=False)[0])

```
