### PR TITLE
Exclude ipython 8.0

### DIFF
--- a/conda_environment.yml
+++ b/conda_environment.yml
@@ -7,6 +7,7 @@ dependencies:
 - h5py
 - imageio
 - ipyparallel
+- ipython !=8.0
 - matplotlib-base
 - mrcz
 - natsort

--- a/setup.py
+++ b/setup.py
@@ -58,6 +58,8 @@ install_req = ['scipy>=1.1',
                'packaging',
                'python-dateutil>=2.5.0',
                'ipyparallel',
+               # https://github.com/ipython/ipython/pull/13466
+               'ipython!=8.0',
                'dask[array]>2.1.0',
                'scikit-image>=0.15',
                'pint>=0.10',


### PR DESCRIPTION
ipython has a bug with a missing import, which makes the test suite fail - see https://github.com/ipython/ipython/pull/13466.

### Progress of the PR
- [x] Exclude ipython 8.0 ,
- [n/a] update docstring (if appropriate),
- [n/a] update user guide (if appropriate),
- [n/a] add an changelog entry in the `upcoming_changes` folder (see [`upcoming_changes/README.rst`](https://github.com/hyperspy/hyperspy/blob/RELEASE_next_minor/upcoming_changes/README.rst)),
- [n/a] Check formatting changelog entry in the `readthedocs` doc build of this PR (link in github checks)
- [n/a] add tests,
- [x] ready for review.


