### PR TITLE
Add file reading metadata to Signals

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,6 +46,7 @@ hyperspy/misc/etc/test_compilers.obj
 *nbc
 *nbi
 hyperspy/tests/io/edax_files.zip
+.python-version
 
 ### Code ###
 # Visual Studio Code - https://code.visualstudio.com/

--- a/doc/user_guide/metadata_structure.rst
+++ b/doc/user_guide/metadata_structure.rst
@@ -78,10 +78,18 @@ in the following sections of this chapter.
     │           ├── y (mm)
     │           └── z (mm)
     ├── General
-    |   |── FileReader
-    |   |   ├── hyperspy_version
-    |   |   ├── io_plugin
-    |   │   └── load_timestamp
+    |   |── FileIO
+    |   |   ├── 0
+    |   |   |   ├── operation
+    |   |   |   ├── hyperspy_version
+    |   |   |   ├── io_plugin
+    |   │   |   └── timestamp
+    |   |   ├── 1
+    |   |   |   ├── operation
+    |   |   |   ├── hyperspy_version
+    |   |   |   ├── io_plugin
+    |   │   |   └── timestamp
+    |   |   └── ...
     │   ├── authors
     │   ├── date
     │   ├── doi
@@ -161,33 +169,42 @@ notes
 
 .. _general-file-metadata:
 
-FileReader
-----------
+FileIO
+------
 
-Contains information about the software packages and versions used when the
-Signal was first created by reading the original data format (added in HyperSpy
-v1.7). In the event the signal is saved to HyperSpy's native format (``.hspy``)
-and reloaded, the metadata within the ``FileReader`` node will be persisted as
-a record of the software configuration when the conversion was made from
-the proprietary/original format to HyperSpy's format.
+Contains information about the software packages and versions used any time the
+Signal was created by reading the original data format (added in HyperSpy
+v1.7) or saved by one of HyperSpy's IO tools. If the signal is saved
+to HyperSpy's native format (``.hspy``), the metadata within the ``FileIO``
+node will be represent a history of the software configurations used when the
+conversion was made from the proprietary/original format to HyperSpy's
+format, as well as any time the signal was subsequently loaded from and saved
+to disk. Under the ``FileIO`` node will be one or more nodes named ``0``,
+``1``, ``2``, etc., each with the following structure:
+
+operation
+   type: Str
+
+   This value will be either ``"load"`` or ``"save"`` to indicate whether
+   this node represents a load from, or save to disk operation, respectively.
 
 hyperspy_version
     type: Str
 
     The version number of the HyperSpy software used to extract a Signal from
-    this data file.
+    this data file or save this Signal to disk
 
 io_plugin
     type: Str
 
     The specific input/output plugin used to originally extract this data file
-    into a HyperSpy Signal -- will be of the form
+    into a HyperSpy Signal or save it to disk -- will be of the form
     ``hyperspy.io_plugins.<plugin_name>``.
 
-load_timestamp
+timestamp
     type: Str
 
-    The timestamp of the computer running the data loading process (in a
+    The timestamp of the computer running the data loading/saving process (in a
     timezone-aware format). The timestamp will be in ISO 8601 format, as
     produced by the ``isoformat()`` method of the ``datetime`` class.
 

--- a/doc/user_guide/metadata_structure.rst
+++ b/doc/user_guide/metadata_structure.rst
@@ -78,6 +78,10 @@ in the following sections of this chapter.
     │           ├── y (mm)
     │           └── z (mm)
     ├── General
+    |   |── File
+    |   |   ├── hyperspy_version
+    |   |   ├── io_plugin
+    |   │   └── load_timestamp
     │   ├── authors
     │   ├── date
     │   ├── doi
@@ -154,6 +158,32 @@ notes
     type: Str
 
     Notes about the data.
+
+File
+----
+
+Contains information about the software packages and versions used when the
+Signal was created by reading the original data format (added in HyperSpy v1.7)
+
+hyperspy_version
+    type: Str
+
+    The version number of the HyperSpy software used to extract a Signal from
+    this data file.
+
+io_plugin
+    type: Str
+
+    The specific input/output plugin used to originally extract this data file
+    into a HyperSpy Signal -- will be of the form
+    ``hyperspy.io_plugins.<plugin_name>``.
+
+load_timestamp
+    type: Str
+
+    The timestamp of the computer running the data loading process (in a
+    timezone-aware format). The timestamp will be in ISO 8601 format, as
+    produced by the ``isoformat()`` method of the ``datetime`` class.
 
 Acquisition_instrument
 ======================

--- a/doc/user_guide/metadata_structure.rst
+++ b/doc/user_guide/metadata_structure.rst
@@ -174,8 +174,8 @@ FileIO
 
 Contains information about the software packages and versions used any time the
 Signal was created by reading the original data format (added in HyperSpy
-v1.7) or saved by one of HyperSpy's IO tools. If the signal is saved
-to HyperSpy's native format (``.hspy``), the metadata within the ``FileIO``
+v1.7) or saved by one of HyperSpy's IO tools. If the signal is saved to one
+of the ``hspy``, ``zspy`` or ``nxs`` formats, the metadata within the ``FileIO``
 node will represent a history of the software configurations used when the 
 conversion was made from the proprietary/original format to HyperSpy's
 format, as well as any time the signal was subsequently loaded from and saved

--- a/doc/user_guide/metadata_structure.rst
+++ b/doc/user_guide/metadata_structure.rst
@@ -78,7 +78,7 @@ in the following sections of this chapter.
     │           ├── y (mm)
     │           └── z (mm)
     ├── General
-    |   |── File
+    |   |── FileReader
     |   |   ├── hyperspy_version
     |   |   ├── io_plugin
     |   │   └── load_timestamp

--- a/doc/user_guide/metadata_structure.rst
+++ b/doc/user_guide/metadata_structure.rst
@@ -159,6 +159,8 @@ notes
 
     Notes about the data.
 
+.. _general-file-metadata:
+
 File
 ----
 

--- a/doc/user_guide/metadata_structure.rst
+++ b/doc/user_guide/metadata_structure.rst
@@ -176,7 +176,7 @@ Contains information about the software packages and versions used any time the
 Signal was created by reading the original data format (added in HyperSpy
 v1.7) or saved by one of HyperSpy's IO tools. If the signal is saved
 to HyperSpy's native format (``.hspy``), the metadata within the ``FileIO``
-node will be represent a history of the software configurations used when the
+node will represent a history of the software configurations used when the 
 conversion was made from the proprietary/original format to HyperSpy's
 format, as well as any time the signal was subsequently loaded from and saved
 to disk. Under the ``FileIO`` node will be one or more nodes named ``0``,

--- a/doc/user_guide/metadata_structure.rst
+++ b/doc/user_guide/metadata_structure.rst
@@ -161,11 +161,15 @@ notes
 
 .. _general-file-metadata:
 
-File
-----
+FileReader
+----------
 
 Contains information about the software packages and versions used when the
-Signal was created by reading the original data format (added in HyperSpy v1.7)
+Signal was first created by reading the original data format (added in HyperSpy
+v1.7). In the event the signal is saved to HyperSpy's native format (``.hspy``)
+and reloaded, the metadata within the ``FileReader`` node will be persisted as
+a record of the software configuration when the conversion was made from
+the proprietary/original format to HyperSpy's format.
 
 hyperspy_version
     type: Str

--- a/hyperspy/io.py
+++ b/hyperspy/io.py
@@ -869,9 +869,6 @@ def _add_file_load_save_metadata(operation, signal, io_plugin):
         'hyperspy_version': hs_version,
         'timestamp': datetime.now().astimezone().isoformat()
     }
-    if isinstance(signal.metadata, dict):
-        return _add_file_load_save_metadata_dict(operation, signal,
-                                                 io_plugin, mdata_dict)
 
     # get the largest integer key present under General.FileIO, returning 0
     # as default if none are present
@@ -880,31 +877,5 @@ def _add_file_load_save_metadata(operation, signal, io_plugin):
          for i in signal.metadata.get_item('General.FileIO', {}).keys()] + [0])
 
     signal.metadata.set_item(f"General.FileIO.{largest_index}", mdata_dict)
-
-    return signal
-
-
-def _add_file_load_save_metadata_dict(operation, signal, io_plugin, mdata_dict):
-    """
-    A version of :py:func:`_add_file_load_save_metadata` that processes
-    when the metadata is stored as a dict rather than the usual
-    DictionaryTreeBrowser
-    """
-    try:
-        f_io = signal.metadata['General']['FileIO']
-        largest_index = max([int(i) + 1 for i in f_io.keys()] + [0])
-    except KeyError:
-        largest_index = 0
-
-    if 'General' not in signal.metadata:
-        signal.metadata['General'] = {
-            'FileIO': {f'{largest_index}': mdata_dict}
-        }
-    elif 'FileIO' not in signal.metadata['General']:
-        signal.metadata['General']['FileIO'] = \
-            {f'{largest_index}': mdata_dict}
-    else:
-        signal.metadata['General'][
-            'FileIO'][f'{largest_index}'] = mdata_dict
 
     return signal

--- a/hyperspy/io.py
+++ b/hyperspy/io.py
@@ -27,7 +27,9 @@ from natsort import natsorted
 from inspect import isgenerator
 from pathlib import Path
 from collections.abc import MutableMapping
+from datetime import datetime
 
+from hyperspy import __version__ as hs_version
 from hyperspy.drawing.marker import markers_metadata_dict_to_markers
 from hyperspy.exceptions import VisibleDeprecationWarning
 from hyperspy.misc.io.tools import ensure_directory
@@ -537,6 +539,11 @@ def load_with_reader(
                 signal_dict["metadata"]["Signal"] = {}
             if signal_type is not None:
                 signal_dict['metadata']["Signal"]['signal_type'] = signal_type
+            signal_dict['metadata']['General']['File'] = {
+                'io_plugin': reader.__loader__.name,
+                'hyperspy_version': hs_version,
+                'load_timestamp': datetime.now().astimezone().isoformat()
+            }
             signal = dict2signal(signal_dict, lazy=lazy)
             path = _parse_path(filename)
             folder, filename = os.path.split(os.path.abspath(path))

--- a/hyperspy/io.py
+++ b/hyperspy/io.py
@@ -539,11 +539,13 @@ def load_with_reader(
                 signal_dict["metadata"]["Signal"] = {}
             if signal_type is not None:
                 signal_dict['metadata']["Signal"]['signal_type'] = signal_type
-            signal_dict['metadata']['General']['File'] = {
-                'io_plugin': reader.__loader__.name,
-                'hyperspy_version': hs_version,
-                'load_timestamp': datetime.now().astimezone().isoformat()
-            }
+            # do not replace existing FileReader metadata if it already exists
+            if not 'FileReader' in signal_dict['metadata']['General']:
+                signal_dict['metadata']['General']['FileReader'] = {
+                    'io_plugin': reader.__loader__.name,
+                    'hyperspy_version': hs_version,
+                    'load_timestamp': datetime.now().astimezone().isoformat()
+                }
             signal = dict2signal(signal_dict, lazy=lazy)
             path = _parse_path(filename)
             folder, filename = os.path.split(os.path.abspath(path))

--- a/hyperspy/io.py
+++ b/hyperspy/io.py
@@ -869,10 +869,6 @@ def add_file_load_metadata(signal_dict, reader):
         'hyperspy_version': hs_version,
         'timestamp': datetime.now().astimezone().isoformat()
     }
-    if 'General' not in signal_dict['metadata']:
-        # if we don't even have basic metadata, just return as-is (shouldn't
-        # happen, but this came up in certain tests)
-        return signal_dict
     if 'FileIO' not in signal_dict['metadata']['General']:
         signal_dict['metadata']['General']['FileIO'] = {
             '0': mdata_dict

--- a/hyperspy/io.py
+++ b/hyperspy/io.py
@@ -539,13 +539,7 @@ def load_with_reader(
                 signal_dict["metadata"]["Signal"] = {}
             if signal_type is not None:
                 signal_dict['metadata']["Signal"]['signal_type'] = signal_type
-            # do not replace existing FileReader metadata if it already exists
-            if not 'FileReader' in signal_dict['metadata']['General']:
-                signal_dict['metadata']['General']['FileReader'] = {
-                    'io_plugin': reader.__loader__.name,
-                    'hyperspy_version': hs_version,
-                    'load_timestamp': datetime.now().astimezone().isoformat()
-                }
+            signal_dict = add_file_load_metadata(signal_dict, reader)
             signal = dict2signal(signal_dict, lazy=lazy)
             path = _parse_path(filename)
             folder, filename = os.path.split(os.path.abspath(path))
@@ -852,6 +846,7 @@ def save(filename, signal, overwrite=None, **kwds):
     if write:
         # Pass as a string for now, pathlib.Path not
         # properly supported in io_plugins
+        signal = add_file_save_metadata(signal, writer)
         if not isinstance(filename, MutableMapping):
             writer.file_writer(str(filename), signal, **kwds)
             _logger.info(f'{filename} was created')
@@ -865,3 +860,55 @@ def save(filename, signal, overwrite=None, **kwds):
                 signal.tmp_parameters.set_item('folder', file.parent)
                 signal.tmp_parameters.set_item('filename', file.stem)
                 signal.tmp_parameters.set_item('extension', extension)
+
+
+def add_file_load_metadata(signal_dict, reader):
+    mdata_dict = {
+        'operation': 'load',
+        'io_plugin': reader.__loader__.name,
+        'hyperspy_version': hs_version,
+        'timestamp': datetime.now().astimezone().isoformat()
+    }
+    if 'General' not in signal_dict['metadata']:
+        # if we don't even have basic metadata, just return as-is (shouldn't
+        # happen, but this came up in certain tests)
+        return signal_dict
+    if 'FileIO' not in signal_dict['metadata']['General']:
+        signal_dict['metadata']['General']['FileIO'] = {
+            '0': mdata_dict
+        }
+    else:
+        largest_index = max([
+            int(i.replace('Number_', '')) for i in
+            signal_dict['metadata']['General']['FileIO'].keys()])
+        signal_dict['metadata'][
+            'General']['FileIO'][str(largest_index + 1)] = mdata_dict
+
+    return signal_dict
+
+
+def add_file_save_metadata(signal, writer):
+    mdata_dict = {
+        'operation': 'save',
+        'io_plugin': writer.__loader__.name,
+        'hyperspy_version': hs_version,
+        'timestamp': datetime.now().astimezone().isoformat()
+    }
+    if 'General' not in signal.metadata or isinstance(signal.metadata, dict):
+        # if we don't even have basic metadata as a DictionaryTreeBrowser,
+        # just return as-is (shouldn't happen, but this came up in tests of
+        # test_nexus_hdf.test_save_metadata_as_dict())
+        return signal
+    if 'FileIO' not in signal.metadata.General:
+        signal.metadata.General.add_dictionary = {
+            '0': mdata_dict
+        }
+    else:
+        largest_index = \
+            max([int(i.replace('Number_', '')) for i in
+                 signal.metadata.General.FileIO.keys()])
+        signal.metadata.General.FileIO.add_dictionary({
+            f'{largest_index + 1}': mdata_dict
+        })
+
+    return signal

--- a/hyperspy/tests/io/test_blockfile.py
+++ b/hyperspy/tests/io/test_blockfile.py
@@ -289,8 +289,8 @@ def test_save_load_cycle(save_path, convert_units):
         signal.metadata.General.original_filename
     )
     # change file timestamp to make the metadata of both signals equal
-    sig_reload.metadata.General.File.load_timestamp = (
-        signal.metadata.General.File.load_timestamp
+    sig_reload.metadata.General.FileReader.load_timestamp = (
+        signal.metadata.General.FileReader.load_timestamp
     )
     assert_deep_almost_equal(
         signal.metadata.as_dictionary(), sig_reload.metadata.as_dictionary()

--- a/hyperspy/tests/io/test_blockfile.py
+++ b/hyperspy/tests/io/test_blockfile.py
@@ -288,10 +288,18 @@ def test_save_load_cycle(save_path, convert_units):
     sig_reload.metadata.General.original_filename = (
         signal.metadata.General.original_filename
     )
-    # change file timestamp to make the metadata of both signals equal
-    sig_reload.metadata.General.FileReader.load_timestamp = (
-        signal.metadata.General.FileReader.load_timestamp
-    )
+    # assert file reading tests here, then delete so we can compare
+    # entire metadata structure at once:
+    plugin = 'hyperspy.io_plugins.blockfile'
+    assert signal.metadata.General.FileIO.Number_0.operation == 'load'
+    assert signal.metadata.General.FileIO.Number_0.io_plugin == plugin
+    assert signal.metadata.General.FileIO.Number_1.operation == 'save'
+    assert signal.metadata.General.FileIO.Number_1.io_plugin == plugin
+    assert sig_reload.metadata.General.FileIO.Number_0.operation == 'load'
+    assert sig_reload.metadata.General.FileIO.Number_0.io_plugin == plugin
+    del signal.metadata.General.FileIO
+    del sig_reload.metadata.General.FileIO
+
     assert_deep_almost_equal(
         signal.metadata.as_dictionary(), sig_reload.metadata.as_dictionary()
     )

--- a/hyperspy/tests/io/test_blockfile.py
+++ b/hyperspy/tests/io/test_blockfile.py
@@ -288,6 +288,10 @@ def test_save_load_cycle(save_path, convert_units):
     sig_reload.metadata.General.original_filename = (
         signal.metadata.General.original_filename
     )
+    # change file timestamp to make the metadata of both signals equal
+    sig_reload.metadata.General.File.load_timestamp = (
+        signal.metadata.General.File.load_timestamp
+    )
     assert_deep_almost_equal(
         signal.metadata.as_dictionary(), sig_reload.metadata.as_dictionary()
     )

--- a/hyperspy/tests/io/test_bruker.py
+++ b/hyperspy/tests/io/test_bruker.py
@@ -4,6 +4,7 @@ import os
 import numpy as np
 import pytest
 
+from hyperspy import __version__ as hs_version
 from hyperspy import signals
 from hyperspy.io import load
 from hyperspy.misc.test_utils import assert_deep_almost_equal
@@ -129,7 +130,11 @@ def test_hyperspy_wrap():
                 '30x30_instructively_packed_16bit_compressed.bcf',
             'title': 'EDX',
             'date': '2018-10-04',
-            'time': '13:02:07'},
+            'time': '13:02:07',
+            'File': {
+                'hyperspy_version': hs_version,
+                'io_plugin': 'hyperspy.io_plugins.bruker',
+            }},
         'Sample': {
             'name': 'chevkinite',
             'elements': ['Al', 'C', 'Ca', 'Ce', 'Fe', 'Gd', 'K', 'Mg', 'Na',
@@ -153,6 +158,8 @@ def test_hyperspy_wrap():
     with open(filename_omd) as fn:
         # original_metadata:
         omd_ref = json.load(fn)
+    # delete timestamp since it's runtime dependent
+    del hype.metadata.General.File.load_timestamp
     assert_deep_almost_equal(hype.metadata.as_dictionary(), md_ref)
     assert_deep_almost_equal(hype.original_metadata.as_dictionary(), omd_ref)
     assert hype.metadata.General.date == "2018-10-04"

--- a/hyperspy/tests/io/test_bruker.py
+++ b/hyperspy/tests/io/test_bruker.py
@@ -131,7 +131,7 @@ def test_hyperspy_wrap():
             'title': 'EDX',
             'date': '2018-10-04',
             'time': '13:02:07',
-            'File': {
+            'FileReader': {
                 'hyperspy_version': hs_version,
                 'io_plugin': 'hyperspy.io_plugins.bruker',
             }},
@@ -159,7 +159,7 @@ def test_hyperspy_wrap():
         # original_metadata:
         omd_ref = json.load(fn)
     # delete timestamp since it's runtime dependent
-    del hype.metadata.General.File.load_timestamp
+    del hype.metadata.General.FileReader.load_timestamp
     assert_deep_almost_equal(hype.metadata.as_dictionary(), md_ref)
     assert_deep_almost_equal(hype.original_metadata.as_dictionary(), omd_ref)
     assert hype.metadata.General.date == "2018-10-04"

--- a/hyperspy/tests/io/test_bruker.py
+++ b/hyperspy/tests/io/test_bruker.py
@@ -131,9 +131,12 @@ def test_hyperspy_wrap():
             'title': 'EDX',
             'date': '2018-10-04',
             'time': '13:02:07',
-            'FileReader': {
-                'hyperspy_version': hs_version,
-                'io_plugin': 'hyperspy.io_plugins.bruker',
+            'FileIO': {
+                '0': {
+                    'operation': 'load',
+                    'hyperspy_version': hs_version,
+                    'io_plugin': 'hyperspy.io_plugins.bruker',
+                }
             }},
         'Sample': {
             'name': 'chevkinite',
@@ -158,8 +161,8 @@ def test_hyperspy_wrap():
     with open(filename_omd) as fn:
         # original_metadata:
         omd_ref = json.load(fn)
-    # delete timestamp since it's runtime dependent
-    del hype.metadata.General.FileReader.load_timestamp
+    # delete FileIO timestamp since it's runtime dependent
+    del hype.metadata.General.FileIO.Number_0.timestamp
     assert_deep_almost_equal(hype.metadata.as_dictionary(), md_ref)
     assert_deep_almost_equal(hype.original_metadata.as_dictionary(), omd_ref)
     assert hype.metadata.General.date == "2018-10-04"

--- a/hyperspy/tests/io/test_dm3.py
+++ b/hyperspy/tests/io/test_dm3.py
@@ -487,7 +487,7 @@ def test_multi_signal():
                     'date': '2019-12-10',
                     'time': '15:32:41',
                     'authors': 'JohnDoe',
-                    'File': {
+                    'FileReader': {
                         'hyperspy_version': hs_version,
                         'io_plugin': 'hyperspy.io_plugins.digital_micrograph'
                     }
@@ -526,7 +526,7 @@ def test_multi_signal():
         'General': {
             'title': 'Plot',
             'original_filename': 'multi_signal.dm3',
-            'File': {
+            'FileReader': {
                 'hyperspy_version': hs_version,
                 'io_plugin': 'hyperspy.io_plugins.digital_micrograph'
             }},
@@ -539,8 +539,8 @@ def test_multi_signal():
                     'gain_offset': 0.0}}}
     }
     # remove timestamps from metadata since these are runtime dependent
-    del s1.metadata.General.File.load_timestamp
-    del s2.metadata.General.File.load_timestamp
+    del s1.metadata.General.FileReader.load_timestamp
+    del s2.metadata.General.FileReader.load_timestamp
 
     # make sure the metadata dictionaries are as we expect
     assert s1.metadata.as_dictionary() == s1_md_truth

--- a/hyperspy/tests/io/test_dm3.py
+++ b/hyperspy/tests/io/test_dm3.py
@@ -23,6 +23,7 @@ import os
 import numpy as np
 import pytest
 
+from hyperspy import __version__ as hs_version
 from hyperspy.io import load
 from hyperspy.io_plugins.digital_micrograph import (DigitalMicrographReader,
                                                     ImageObject)
@@ -485,7 +486,12 @@ def test_multi_signal():
                     'original_filename': 'multi_signal.dm3',
                     'date': '2019-12-10',
                     'time': '15:32:41',
-                    'authors': 'JohnDoe'},
+                    'authors': 'JohnDoe',
+                    'File': {
+                        'hyperspy_version': hs_version,
+                        'io_plugin': 'hyperspy.io_plugins.digital_micrograph'
+                    }
+        },
         'Signal': {'signal_type': '',
                    'quantity': 'Intensity',
                    'Noise_properties': {
@@ -519,7 +525,11 @@ def test_multi_signal():
                 'original_axes_manager': None}},
         'General': {
             'title': 'Plot',
-            'original_filename': 'multi_signal.dm3'},
+            'original_filename': 'multi_signal.dm3',
+            'File': {
+                'hyperspy_version': hs_version,
+                'io_plugin': 'hyperspy.io_plugins.digital_micrograph'
+            }},
         'Signal': {
             'signal_type': '',
             'quantity': 'Intensity',
@@ -528,6 +538,9 @@ def test_multi_signal():
                     'gain_factor': 1.0,
                     'gain_offset': 0.0}}}
     }
+    # remove timestamps from metadata since these are runtime dependent
+    del s1.metadata.General.File.load_timestamp
+    del s2.metadata.General.File.load_timestamp
 
     # make sure the metadata dictionaries are as we expect
     assert s1.metadata.as_dictionary() == s1_md_truth

--- a/hyperspy/tests/io/test_dm3.py
+++ b/hyperspy/tests/io/test_dm3.py
@@ -487,9 +487,13 @@ def test_multi_signal():
                     'date': '2019-12-10',
                     'time': '15:32:41',
                     'authors': 'JohnDoe',
-                    'FileReader': {
-                        'hyperspy_version': hs_version,
-                        'io_plugin': 'hyperspy.io_plugins.digital_micrograph'
+                    'FileIO': {
+                        '0': {
+                            'operation': 'load',
+                            'hyperspy_version': hs_version,
+                            'io_plugin':
+                                'hyperspy.io_plugins.digital_micrograph'
+                        }
                     }
         },
         'Signal': {'signal_type': '',
@@ -526,9 +530,12 @@ def test_multi_signal():
         'General': {
             'title': 'Plot',
             'original_filename': 'multi_signal.dm3',
-            'FileReader': {
-                'hyperspy_version': hs_version,
-                'io_plugin': 'hyperspy.io_plugins.digital_micrograph'
+            'FileIO': {
+                '0': {
+                    'operation': 'load',
+                    'hyperspy_version': hs_version,
+                    'io_plugin': 'hyperspy.io_plugins.digital_micrograph'
+                }
             }},
         'Signal': {
             'signal_type': '',
@@ -539,8 +546,8 @@ def test_multi_signal():
                     'gain_offset': 0.0}}}
     }
     # remove timestamps from metadata since these are runtime dependent
-    del s1.metadata.General.FileReader.load_timestamp
-    del s2.metadata.General.FileReader.load_timestamp
+    del s1.metadata.General.FileIO.Number_0.timestamp
+    del s2.metadata.General.FileIO.Number_0.timestamp
 
     # make sure the metadata dictionaries are as we expect
     assert s1.metadata.as_dictionary() == s1_md_truth

--- a/hyperspy/tests/io/test_emd.py
+++ b/hyperspy/tests/io/test_emd.py
@@ -343,7 +343,7 @@ class TestFeiEMD():
                           'time': '09:56:41',
                           'time_zone': 'BST',
                           'title': 'HAADF',
-                          'File': {
+                          'FileReader': {
                               'hyperspy_version': hs_version,
                               'io_plugin':
                                   'hyperspy.io_plugins.emd'
@@ -366,7 +366,7 @@ class TestFeiEMD():
         signal = load(os.path.join(self.fei_files_path, 'fei_emd_image.emd'),
                       lazy=lazy)
         # delete timestamp from metadata since it's runtime dependent
-        del signal.metadata.General.File.load_timestamp
+        del signal.metadata.General.FileReader.load_timestamp
         if lazy:
             assert signal._lazy
             signal.compute(close_file=True)

--- a/hyperspy/tests/io/test_emd.py
+++ b/hyperspy/tests/io/test_emd.py
@@ -343,10 +343,12 @@ class TestFeiEMD():
                           'time': '09:56:41',
                           'time_zone': 'BST',
                           'title': 'HAADF',
-                          'FileReader': {
-                              'hyperspy_version': hs_version,
-                              'io_plugin':
-                                  'hyperspy.io_plugins.emd'
+                          'FileIO': {
+                              '0': {
+                                  'operation': 'load',
+                                  'hyperspy_version': hs_version,
+                                  'io_plugin': 'hyperspy.io_plugins.emd'
+                              }
                           }
               },
               'Signal': {'signal_type': ''},
@@ -366,7 +368,7 @@ class TestFeiEMD():
         signal = load(os.path.join(self.fei_files_path, 'fei_emd_image.emd'),
                       lazy=lazy)
         # delete timestamp from metadata since it's runtime dependent
-        del signal.metadata.General.FileReader.load_timestamp
+        del signal.metadata.General.FileIO.Number_0.timestamp
         if lazy:
             assert signal._lazy
             signal.compute(close_file=True)

--- a/hyperspy/tests/io/test_emd.py
+++ b/hyperspy/tests/io/test_emd.py
@@ -32,6 +32,7 @@ import pytest
 import tempfile
 import shutil
 
+from hyperspy import __version__ as hs_version
 from hyperspy.io import load
 from hyperspy.misc.test_utils import assert_deep_almost_equal
 from hyperspy.signals import (BaseSignal, EDSTEMSpectrum, Signal1D, Signal2D,
@@ -341,7 +342,13 @@ class TestFeiEMD():
                           'date': '2017-03-06',
                           'time': '09:56:41',
                           'time_zone': 'BST',
-                          'title': 'HAADF'},
+                          'title': 'HAADF',
+                          'File': {
+                              'hyperspy_version': hs_version,
+                              'io_plugin':
+                                  'hyperspy.io_plugins.emd'
+                          }
+              },
               'Signal': {'signal_type': ''},
               '_HyperSpy': {'Folding': {'original_axes_manager': None,
                                         'original_shape': None,
@@ -358,6 +365,8 @@ class TestFeiEMD():
 
         signal = load(os.path.join(self.fei_files_path, 'fei_emd_image.emd'),
                       lazy=lazy)
+        # delete timestamp from metadata since it's runtime dependent
+        del signal.metadata.General.File.load_timestamp
         if lazy:
             assert signal._lazy
             signal.compute(close_file=True)

--- a/hyperspy/tests/io/test_hdf5.py
+++ b/hyperspy/tests/io/test_hdf5.py
@@ -372,10 +372,12 @@ class TestSavingMetadataContainers:
                           'original_filename': 'test_diffraction_pattern.dm3',
                           'time': '18:56:37',
                           'title': 'test_diffraction_pattern',
-                          'FileReader': {
-                              'hyperspy_version': hs_version,
-                              'io_plugin':
-                                  'hyperspy.io_plugins.hspy'
+                          'FileIO': {
+                              '0': {
+                                  'operation': 'load',
+                                  'hyperspy_version': hs_version,
+                                  'io_plugin': 'hyperspy.io_plugins.hspy'
+                              }
                           }
               },
               'Signal': {'Noise_properties': {'Variance_linear_model': {'gain_factor': 1.0,
@@ -388,7 +390,7 @@ class TestSavingMetadataContainers:
                                         'unfolded': False}}}
         s = load(my_path / "hdf5_files" / 'example2_v3.1.hspy')
         # delete timestamp from metadata since it's runtime dependent
-        del s.metadata.General.FileReader.load_timestamp
+        del s.metadata.General.FileIO.Number_0.timestamp
         assert_deep_almost_equal(s.metadata.as_dictionary(), md)
 
 

--- a/hyperspy/tests/io/test_hdf5.py
+++ b/hyperspy/tests/io/test_hdf5.py
@@ -26,6 +26,7 @@ import h5py
 import numpy as np
 import pytest
 
+from hyperspy import __version__ as hs_version
 from hyperspy.io import load
 from hyperspy.axes import DataAxis, UniformDataAxis, FunctionalDataAxis, AxesManager
 from hyperspy.signal import BaseSignal
@@ -370,7 +371,13 @@ class TestSavingMetadataContainers:
               'General': {'date': '2014-07-09',
                           'original_filename': 'test_diffraction_pattern.dm3',
                           'time': '18:56:37',
-                          'title': 'test_diffraction_pattern'},
+                          'title': 'test_diffraction_pattern',
+                          'File': {
+                              'hyperspy_version': hs_version,
+                              'io_plugin':
+                                  'hyperspy.io_plugins.hspy'
+                          }
+              },
               'Signal': {'Noise_properties': {'Variance_linear_model': {'gain_factor': 1.0,
                                                                         'gain_offset': 0.0}},
                          'quantity': 'Intensity',
@@ -380,6 +387,8 @@ class TestSavingMetadataContainers:
                                         'signal_unfolded': False,
                                         'unfolded': False}}}
         s = load(my_path / "hdf5_files" / 'example2_v3.1.hspy')
+        # delete timestamp from metadata since it's runtime dependent
+        del s.metadata.General.File.load_timestamp
         assert_deep_almost_equal(s.metadata.as_dictionary(), md)
 
 

--- a/hyperspy/tests/io/test_hdf5.py
+++ b/hyperspy/tests/io/test_hdf5.py
@@ -372,7 +372,7 @@ class TestSavingMetadataContainers:
                           'original_filename': 'test_diffraction_pattern.dm3',
                           'time': '18:56:37',
                           'title': 'test_diffraction_pattern',
-                          'File': {
+                          'FileReader': {
                               'hyperspy_version': hs_version,
                               'io_plugin':
                                   'hyperspy.io_plugins.hspy'
@@ -388,7 +388,7 @@ class TestSavingMetadataContainers:
                                         'unfolded': False}}}
         s = load(my_path / "hdf5_files" / 'example2_v3.1.hspy')
         # delete timestamp from metadata since it's runtime dependent
-        del s.metadata.General.File.load_timestamp
+        del s.metadata.General.FileReader.load_timestamp
         assert_deep_almost_equal(s.metadata.as_dictionary(), md)
 
 

--- a/hyperspy/tests/io/test_io.py
+++ b/hyperspy/tests/io/test_io.py
@@ -30,6 +30,8 @@ import hyperspy.api as hs
 from hyperspy.signals import Signal1D
 from hyperspy.axes import DataAxis
 from hyperspy.io_plugins import io_plugins
+from hyperspy import __version__ as hs_version
+from hyperspy.misc.test_utils import assert_deep_almost_equal
 
 
 FULLFILENAME = Path(__file__).resolve().parent.joinpath("test_io_overwriting.hspy")
@@ -260,3 +262,19 @@ def test_load_original_metadata():
 
         t = hs.load(Path(dirpath, "temp.hspy"), load_original_metadata=False)
         assert t.original_metadata.as_dictionary() == {}
+
+
+def test_load_save_filereader_metadata():
+    # tests that original FileReader metadata is persisted through a save and
+    # load cycle
+
+    my_path = os.path.dirname(__file__)
+    s = hs.load(os.path.join(my_path, "msa_files", "example1.msa"))
+    assert s.metadata.General.FileReader.io_plugin == 'hyperspy.io_plugins.msa'
+    assert s.metadata.General.FileReader.hyperspy_version == hs_version
+    with tempfile.TemporaryDirectory() as dirpath:
+        f = os.path.join(dirpath, "temp")
+        s.save(f)
+        t = hs.load(Path(dirpath, "temp.hspy"))
+        assert_deep_almost_equal(s.metadata.General.FileReader.as_dictionary(),
+                                 t.metadata.General.FileReader.as_dictionary())

--- a/hyperspy/tests/io/test_jeol.py
+++ b/hyperspy/tests/io/test_jeol.py
@@ -259,18 +259,21 @@ def test_load_eds_file(filename_as_string):
     assert axis.scale == 0.0100004
 
     # delete timestamp from metadata since it's runtime dependent
-    del s.metadata.General.FileReader.load_timestamp
+    del s.metadata.General.FileIO.Number_0.timestamp
 
     md_dict = s.metadata.as_dictionary()
     assert md_dict['General'] == {'original_filename': 'met03.EDS',
                                   'time': '14:14:51',
                                   'date': '2018-06-25',
                                   'title': 'EDX',
-                                  'FileReader': {
-                                      'hyperspy_version': hs_version,
-                                      'io_plugin':
-                                          'hyperspy.io_plugins.jeol'
-                                      }
+                                  'FileIO': {
+                                    '0': {
+                                        'operation': 'load',
+                                        'hyperspy_version': hs_version,
+                                        'io_plugin':
+                                            'hyperspy.io_plugins.jeol'
+                                    }
+                                  }
                                   }
     TEM_dict = md_dict['Acquisition_instrument']['TEM']
     assert TEM_dict == {'beam_energy': 200.0,

--- a/hyperspy/tests/io/test_jeol.py
+++ b/hyperspy/tests/io/test_jeol.py
@@ -259,14 +259,14 @@ def test_load_eds_file(filename_as_string):
     assert axis.scale == 0.0100004
 
     # delete timestamp from metadata since it's runtime dependent
-    del s.metadata.General.File.load_timestamp
+    del s.metadata.General.FileReader.load_timestamp
 
     md_dict = s.metadata.as_dictionary()
     assert md_dict['General'] == {'original_filename': 'met03.EDS',
                                   'time': '14:14:51',
                                   'date': '2018-06-25',
                                   'title': 'EDX',
-                                  'File': {
+                                  'FileReader': {
                                       'hyperspy_version': hs_version,
                                       'io_plugin':
                                           'hyperspy.io_plugins.jeol'

--- a/hyperspy/tests/io/test_jeol.py
+++ b/hyperspy/tests/io/test_jeol.py
@@ -23,6 +23,7 @@ import pytest
 import numpy as np
 
 import hyperspy.api as hs
+from hyperspy import __version__ as hs_version
 
 
 def teardown_module(module):
@@ -257,11 +258,20 @@ def test_load_eds_file(filename_as_string):
     assert axis.offset == -0.00176612
     assert axis.scale == 0.0100004
 
+    # delete timestamp from metadata since it's runtime dependent
+    del s.metadata.General.File.load_timestamp
+
     md_dict = s.metadata.as_dictionary()
     assert md_dict['General'] == {'original_filename': 'met03.EDS',
                                   'time': '14:14:51',
-                                  'date':'2018-06-25',
-                                  'title': 'EDX'}
+                                  'date': '2018-06-25',
+                                  'title': 'EDX',
+                                  'File': {
+                                      'hyperspy_version': hs_version,
+                                      'io_plugin':
+                                          'hyperspy.io_plugins.jeol'
+                                      }
+                                  }
     TEM_dict = md_dict['Acquisition_instrument']['TEM']
     assert TEM_dict == {'beam_energy': 200.0,
                         'Detector': {'EDS': {'azimuth_angle': 90.0,

--- a/hyperspy/tests/io/test_mrcz.py
+++ b/hyperspy/tests/io/test_mrcz.py
@@ -81,7 +81,7 @@ class TestPythonMrcz:
 
         # Add "File" metadata to testSignal
         testSignal.metadata.General.add_dictionary({
-            'File': {
+            'FileReader': {
                 'hyperspy_version': hs_version,
                 'io_plugin': 'hyperspy.io_plugins.mrcz',
                 'load_timestamp': datetime.now().astimezone().isoformat()
@@ -134,8 +134,8 @@ class TestPythonMrcz:
             print("Warning: file {} left on disk".format(mrcName))
 
         # change file timestamp to make the metadata of both signals equal
-        testSignal.metadata.General.File.load_timestamp = (
-            reSignal.metadata.General.File.load_timestamp
+        testSignal.metadata.General.FileReader.load_timestamp = (
+            reSignal.metadata.General.FileReader.load_timestamp
         )
 
         npt.assert_array_almost_equal(

--- a/hyperspy/tests/io/test_mrcz.py
+++ b/hyperspy/tests/io/test_mrcz.py
@@ -81,10 +81,13 @@ class TestPythonMrcz:
 
         # Add "File" metadata to testSignal
         testSignal.metadata.General.add_dictionary({
-            'FileReader': {
-                'hyperspy_version': hs_version,
-                'io_plugin': 'hyperspy.io_plugins.mrcz',
-                'load_timestamp': datetime.now().astimezone().isoformat()
+            'FileIO': {
+                '0': {
+                    'operation': 'load',
+                    'hyperspy_version': hs_version,
+                    'io_plugin': 'hyperspy.io_plugins.mrcz',
+                    'timestamp': datetime.now().astimezone().isoformat()
+                }
             }
         })
 
@@ -134,8 +137,8 @@ class TestPythonMrcz:
             print("Warning: file {} left on disk".format(mrcName))
 
         # change file timestamp to make the metadata of both signals equal
-        testSignal.metadata.General.FileReader.load_timestamp = (
-            reSignal.metadata.General.FileReader.load_timestamp
+        testSignal.metadata.General.FileIO.Number_0.timestamp = (
+            reSignal.metadata.General.FileIO.Number_0.timestamp
         )
 
         npt.assert_array_almost_equal(
@@ -161,6 +164,9 @@ class TestPythonMrcz:
             assert isinstance(reSignal, signals.ComplexSignal2D)
         else:
             assert isinstance(reSignal, signals.Signal2D)
+
+        # delete last load operation from reSignal metadata so we can compare
+        del reSignal.metadata.General.FileIO.Number_2
         assert_deep_almost_equal(testSignal.axes_manager.as_dictionary(),
                                  reSignal.axes_manager.as_dictionary())
         assert_deep_almost_equal(testSignal.metadata.as_dictionary(),

--- a/hyperspy/tests/io/test_msa.py
+++ b/hyperspy/tests/io/test_msa.py
@@ -24,10 +24,10 @@ example1_metadata = {'Acquisition_instrument': {'TEM': example1_TEM},
                                  'title': "NIO EELS OK SHELL",
                                  'date': "1991-10-01",
                                  'time': "12:00:00",
-                                 'FileReader': {
+                                 'FileIO': {'0': {
+                                     'operation': 'load',
                                      'hyperspy_version': hs_version,
-                                     'io_plugin': 'hyperspy.io_plugins.msa'
-                                    }
+                                     'io_plugin': 'hyperspy.io_plugins.msa'}}
                                  },
                      'Sample': {'thickness': 50.0,
                                 'thickness_units': "nm"},
@@ -107,10 +107,10 @@ example2_metadata = {'Acquisition_instrument': {'TEM': example2_TEM},
                                  'title': "NIO Windowless Spectra OK NiL",
                                  'date': "1991-10-01",
                                  'time': "12:00:00",
-                                 'FileReader': {
+                                 'FileIO': {'0': {
+                                     'operation': 'load',
                                      'hyperspy_version': hs_version,
-                                     'io_plugin': 'hyperspy.io_plugins.msa'
-                                    }
+                                     'io_plugin': 'hyperspy.io_plugins.msa'}}
                                  },
                      'Sample': {'thickness': 50.0,
                                 'thickness_units': "nm"},
@@ -174,7 +174,7 @@ class TestExample1:
             "msa_files",
             "example1.msa"))
         # delete timestamp from metadata since it's runtime dependent
-        del self.s.metadata.General.FileReader.load_timestamp
+        del self.s.metadata.General.FileIO.Number_0.timestamp
 
     def test_data(self):
         assert (
@@ -215,7 +215,10 @@ class TestExample1:
             self.s.save(fname2)
             s2 = load(fname2)
             # delete timestamp from metadata since it's runtime dependent
-            del s2.metadata.General.FileReader.load_timestamp
+            del s2.metadata.General.FileIO.Number_0.timestamp
+            del self.s.metadata.General.FileIO.Number_1
+            if 'timestamp' in self.s.metadata.General.FileIO.Number_0:
+                del self.s.metadata.General.FileIO.Number_0.timestamp
             assert (s2.metadata.General.original_filename ==
                     "example1-export.msa")
             s2.metadata.General.original_filename = "example1.msa"
@@ -230,7 +233,7 @@ class TestExample1WrongDate:
             "msa_files",
             "example1_wrong_date.msa"))
         # delete timestamp from metadata since it's runtime dependent
-        del self.s.metadata.General.FileReader.load_timestamp
+        del self.s.metadata.General.FileIO.Number_0.timestamp
 
     def test_metadata(self):
         md = copy.copy(example1_metadata)
@@ -251,7 +254,7 @@ class TestExample2:
             "msa_files",
             "example2.msa"))
         # delete timestamp from metadata since it's runtime dependent
-        del self.s.metadata.General.FileReader.load_timestamp
+        del self.s.metadata.General.FileIO.Number_0.timestamp
 
     def test_data(self):
         assert (
@@ -354,7 +357,8 @@ class TestExample2:
                     "example2-export.msa")
             s2.metadata.General.original_filename = "example2.msa"
             # delete timestamp from metadata since it's runtime dependent
-            del s2.metadata.General.FileReader.load_timestamp
+            del s2.metadata.General.FileIO.Number_0.timestamp
+            del self.s.metadata.General.FileIO.Number_1
             assert_deep_almost_equal(self.s.metadata.as_dictionary(),
                                      s2.metadata.as_dictionary())
 

--- a/hyperspy/tests/io/test_msa.py
+++ b/hyperspy/tests/io/test_msa.py
@@ -24,7 +24,7 @@ example1_metadata = {'Acquisition_instrument': {'TEM': example1_TEM},
                                  'title': "NIO EELS OK SHELL",
                                  'date': "1991-10-01",
                                  'time': "12:00:00",
-                                 'File': {
+                                 'FileReader': {
                                      'hyperspy_version': hs_version,
                                      'io_plugin': 'hyperspy.io_plugins.msa'
                                     }
@@ -107,7 +107,7 @@ example2_metadata = {'Acquisition_instrument': {'TEM': example2_TEM},
                                  'title': "NIO Windowless Spectra OK NiL",
                                  'date': "1991-10-01",
                                  'time': "12:00:00",
-                                 'File': {
+                                 'FileReader': {
                                      'hyperspy_version': hs_version,
                                      'io_plugin': 'hyperspy.io_plugins.msa'
                                     }
@@ -174,7 +174,7 @@ class TestExample1:
             "msa_files",
             "example1.msa"))
         # delete timestamp from metadata since it's runtime dependent
-        del self.s.metadata.General.File.load_timestamp
+        del self.s.metadata.General.FileReader.load_timestamp
 
     def test_data(self):
         assert (
@@ -215,7 +215,7 @@ class TestExample1:
             self.s.save(fname2)
             s2 = load(fname2)
             # delete timestamp from metadata since it's runtime dependent
-            del s2.metadata.General.File.load_timestamp
+            del s2.metadata.General.FileReader.load_timestamp
             assert (s2.metadata.General.original_filename ==
                     "example1-export.msa")
             s2.metadata.General.original_filename = "example1.msa"
@@ -230,7 +230,7 @@ class TestExample1WrongDate:
             "msa_files",
             "example1_wrong_date.msa"))
         # delete timestamp from metadata since it's runtime dependent
-        del self.s.metadata.General.File.load_timestamp
+        del self.s.metadata.General.FileReader.load_timestamp
 
     def test_metadata(self):
         md = copy.copy(example1_metadata)
@@ -251,7 +251,7 @@ class TestExample2:
             "msa_files",
             "example2.msa"))
         # delete timestamp from metadata since it's runtime dependent
-        del self.s.metadata.General.File.load_timestamp
+        del self.s.metadata.General.FileReader.load_timestamp
 
     def test_data(self):
         assert (
@@ -354,7 +354,7 @@ class TestExample2:
                     "example2-export.msa")
             s2.metadata.General.original_filename = "example2.msa"
             # delete timestamp from metadata since it's runtime dependent
-            del s2.metadata.General.File.load_timestamp
+            del s2.metadata.General.FileReader.load_timestamp
             assert_deep_almost_equal(self.s.metadata.as_dictionary(),
                                      s2.metadata.as_dictionary())
 

--- a/hyperspy/tests/io/test_msa.py
+++ b/hyperspy/tests/io/test_msa.py
@@ -4,6 +4,7 @@ import tempfile
 
 from hyperspy.io import load
 from hyperspy.misc.test_utils import assert_deep_almost_equal
+from hyperspy import __version__ as hs_version
 
 my_path = os.path.dirname(__file__)
 
@@ -22,7 +23,12 @@ example1_metadata = {'Acquisition_instrument': {'TEM': example1_TEM},
                      'General': {'original_filename': "example1.msa",
                                  'title': "NIO EELS OK SHELL",
                                  'date': "1991-10-01",
-                                 'time': "12:00:00"},
+                                 'time': "12:00:00",
+                                 'File': {
+                                     'hyperspy_version': hs_version,
+                                     'io_plugin': 'hyperspy.io_plugins.msa'
+                                    }
+                                 },
                      'Sample': {'thickness': 50.0,
                                 'thickness_units': "nm"},
                      'Signal': {# bit silly...
@@ -100,7 +106,12 @@ example2_metadata = {'Acquisition_instrument': {'TEM': example2_TEM},
                      'General': {'original_filename': "example2.msa",
                                  'title': "NIO Windowless Spectra OK NiL",
                                  'date': "1991-10-01",
-                                 'time': "12:00:00"},
+                                 'time': "12:00:00",
+                                 'File': {
+                                     'hyperspy_version': hs_version,
+                                     'io_plugin': 'hyperspy.io_plugins.msa'
+                                    }
+                                 },
                      'Sample': {'thickness': 50.0,
                                 'thickness_units': "nm"},
                      'Signal': {'quantity': "X-RAY INTENSITY (Intensity)",
@@ -162,6 +173,8 @@ class TestExample1:
             my_path,
             "msa_files",
             "example1.msa"))
+        # delete timestamp from metadata since it's runtime dependent
+        del self.s.metadata.General.File.load_timestamp
 
     def test_data(self):
         assert (
@@ -201,6 +214,8 @@ class TestExample1:
             fname2 = os.path.join(tmpdir, "example1-export.msa")
             self.s.save(fname2)
             s2 = load(fname2)
+            # delete timestamp from metadata since it's runtime dependent
+            del s2.metadata.General.File.load_timestamp
             assert (s2.metadata.General.original_filename ==
                     "example1-export.msa")
             s2.metadata.General.original_filename = "example1.msa"
@@ -214,6 +229,8 @@ class TestExample1WrongDate:
             my_path,
             "msa_files",
             "example1_wrong_date.msa"))
+        # delete timestamp from metadata since it's runtime dependent
+        del self.s.metadata.General.File.load_timestamp
 
     def test_metadata(self):
         md = copy.copy(example1_metadata)
@@ -233,6 +250,8 @@ class TestExample2:
             my_path,
             "msa_files",
             "example2.msa"))
+        # delete timestamp from metadata since it's runtime dependent
+        del self.s.metadata.General.File.load_timestamp
 
     def test_data(self):
         assert (
@@ -334,6 +353,8 @@ class TestExample2:
             assert (s2.metadata.General.original_filename ==
                     "example2-export.msa")
             s2.metadata.General.original_filename = "example2.msa"
+            # delete timestamp from metadata since it's runtime dependent
+            del s2.metadata.General.File.load_timestamp
             assert_deep_almost_equal(self.s.metadata.as_dictionary(),
                                      s2.metadata.as_dictionary())
 

--- a/hyperspy/tests/io/test_nexus_hdf.py
+++ b/hyperspy/tests/io/test_nexus_hdf.py
@@ -339,9 +339,11 @@ class TestSavingMetadataContainers:
         s.original_metadata.set_item("testarray2", (1, 2, 3, 4, 5))
         s.original_metadata.set_item("testarray3", np.array([1, 2, 3, 4, 5]))
 
-        with pytest.warns():
+        with pytest.warns(UserWarning,
+                          match="Setting the `original_metadata` attribute"):
             s.original_metadata = s.original_metadata.as_dictionary()
-        with pytest.warns():
+        with pytest.warns(UserWarning,
+                          match="Setting the `metadata` attribute"):
             s.metadata = s.metadata.as_dictionary()
 
         assert isinstance(s.metadata, DictionaryTreeBrowser)

--- a/hyperspy/tests/io/test_tiff.py
+++ b/hyperspy/tests/io/test_tiff.py
@@ -389,7 +389,7 @@ FEI_Helios_metadata = {'Acquisition_instrument': {'SEM': {'Stage': {'rotation': 
                                    'authors': 'supervisor',
                                    'date': '2016-06-13',
                                    'time': '17:06:40',
-                                   'File': {
+                                   'FileReader': {
                                        'hyperspy_version': hs_version,
                                        'io_plugin':
                                            'hyperspy.io_plugins.tiff'
@@ -411,7 +411,7 @@ def test_read_FEI_SEM_scale_metadata_8bits():
     np.testing.assert_allclose(s.axes_manager[1].scale, 3.3724, rtol=1E-5)
     assert s.data.dtype == 'uint8'
     # delete timestamp from metadata since it's runtime dependent
-    del s.metadata.General.File.load_timestamp
+    del s.metadata.General.FileReader.load_timestamp
     FEI_Helios_metadata['General'][
         'original_filename'] = 'FEI-Helios-Ebeam-8bits.tif'
     assert_deep_almost_equal(s.metadata.as_dictionary(), FEI_Helios_metadata)
@@ -426,7 +426,7 @@ def test_read_FEI_SEM_scale_metadata_16bits():
     np.testing.assert_allclose(s.axes_manager[1].scale, 3.3724, rtol=1E-5)
     assert s.data.dtype == 'uint16'
     # delete timestamp from metadata since it's runtime dependent
-    del s.metadata.General.File.load_timestamp
+    del s.metadata.General.FileReader.load_timestamp
     FEI_Helios_metadata['General'][
         'original_filename'] = 'FEI-Helios-Ebeam-16bits.tif'
     assert_deep_almost_equal(s.metadata.as_dictionary(), FEI_Helios_metadata)
@@ -451,7 +451,7 @@ def test_read_Zeiss_SEM_scale_metadata_1k_image():
                       'original_filename': 'test_tiff_Zeiss_SEM_1k.tif',
                       'time': '09:40:32',
                       'title': '',
-                      'File': {
+                      'FileReader': {
                           'hyperspy_version': hs_version,
                           'io_plugin': 'hyperspy.io_plugins.tiff'
                           }
@@ -470,7 +470,7 @@ def test_read_Zeiss_SEM_scale_metadata_1k_image():
     np.testing.assert_allclose(s.axes_manager[1].scale, 2.614514, rtol=1E-6)
     assert s.data.dtype == 'uint8'
     # delete timestamp from metadata since it's runtime dependent
-    del s.metadata.General.File.load_timestamp
+    del s.metadata.General.FileReader.load_timestamp
     assert_deep_almost_equal(s.metadata.as_dictionary(), md)
 
 
@@ -489,7 +489,7 @@ def test_read_Zeiss_SEM_scale_metadata_512_image():
                       'original_filename': 'test_tiff_Zeiss_SEM_512pix.tif',
                       'time': '08:20:42',
                       'title': '',
-                      'File': {
+                      'FileReader': {
                           'hyperspy_version': hs_version,
                           'io_plugin': 'hyperspy.io_plugins.tiff'
                           }
@@ -508,7 +508,7 @@ def test_read_Zeiss_SEM_scale_metadata_512_image():
     np.testing.assert_allclose(s.axes_manager[1].scale, 0.011649976, rtol=1E-6)
     assert s.data.dtype == 'uint8'
     # delete timestamp from metadata since it's runtime dependent
-    del s.metadata.General.File.load_timestamp
+    del s.metadata.General.FileReader.load_timestamp
     assert_deep_almost_equal(s.metadata.as_dictionary(), md)
 
 
@@ -524,8 +524,8 @@ def test_read_RGB_Zeiss_optical_scale_metadata():
     np.testing.assert_allclose(s.axes_manager[1].scale, 1.0, rtol=1E-5)
     assert s.metadata.General.date == '2016-06-13'
     assert s.metadata.General.time == '15:59:52'
-    assert s.metadata.General.File.hyperspy_version == hs_version
-    assert s.metadata.General.File.io_plugin == 'hyperspy.io_plugins.tiff'
+    assert s.metadata.General.FileReader.hyperspy_version == hs_version
+    assert s.metadata.General.FileReader.io_plugin == 'hyperspy.io_plugins.tiff'
 
 
 def test_read_BW_Zeiss_optical_scale_metadata():
@@ -591,7 +591,7 @@ def test_read_TVIPS_metadata():
           'General': {'original_filename': 'TVIPS_bin4.tif',
                       'time': '9:01:17',
                       'title': '',
-                      'File': {
+                      'FileReader': {
                           'hyperspy_version': hs_version,
                           'io_plugin': 'hyperspy.io_plugins.tiff'
                           }
@@ -610,7 +610,7 @@ def test_read_TVIPS_metadata():
     np.testing.assert_allclose(s.axes_manager[0].scale, 1.42080, rtol=1E-5)
     np.testing.assert_allclose(s.axes_manager[1].scale, 1.42080, rtol=1E-5)
     # delete timestamp from metadata since it's runtime dependent
-    del s.metadata.General.File.load_timestamp
+    del s.metadata.General.FileReader.load_timestamp
     assert_deep_almost_equal(s.metadata.as_dictionary(), md)
 
 

--- a/hyperspy/tests/io/test_tiff.py
+++ b/hyperspy/tests/io/test_tiff.py
@@ -10,6 +10,7 @@ import tifffile
 
 import hyperspy.api as hs
 from hyperspy.misc.test_utils import assert_deep_almost_equal
+from hyperspy import __version__ as hs_version
 
 MY_PATH = os.path.dirname(__file__)
 MY_PATH2 = os.path.join(MY_PATH, "tiff_files")
@@ -387,7 +388,13 @@ FEI_Helios_metadata = {'Acquisition_instrument': {'SEM': {'Stage': {'rotation': 
                                    'title': '',
                                    'authors': 'supervisor',
                                    'date': '2016-06-13',
-                                   'time': '17:06:40'},
+                                   'time': '17:06:40',
+                                   'File': {
+                                       'hyperspy_version': hs_version,
+                                       'io_plugin':
+                                           'hyperspy.io_plugins.tiff'
+                                       }
+                                   },
                        'Signal': {'signal_type': ''},
                        '_HyperSpy': {'Folding': {'original_axes_manager': None,
                                                  'original_shape': None,
@@ -403,6 +410,8 @@ def test_read_FEI_SEM_scale_metadata_8bits():
     np.testing.assert_allclose(s.axes_manager[0].scale, 3.3724, rtol=1E-5)
     np.testing.assert_allclose(s.axes_manager[1].scale, 3.3724, rtol=1E-5)
     assert s.data.dtype == 'uint8'
+    # delete timestamp from metadata since it's runtime dependent
+    del s.metadata.General.File.load_timestamp
     FEI_Helios_metadata['General'][
         'original_filename'] = 'FEI-Helios-Ebeam-8bits.tif'
     assert_deep_almost_equal(s.metadata.as_dictionary(), FEI_Helios_metadata)
@@ -416,6 +425,8 @@ def test_read_FEI_SEM_scale_metadata_16bits():
     np.testing.assert_allclose(s.axes_manager[0].scale, 3.3724, rtol=1E-5)
     np.testing.assert_allclose(s.axes_manager[1].scale, 3.3724, rtol=1E-5)
     assert s.data.dtype == 'uint16'
+    # delete timestamp from metadata since it's runtime dependent
+    del s.metadata.General.File.load_timestamp
     FEI_Helios_metadata['General'][
         'original_filename'] = 'FEI-Helios-Ebeam-16bits.tif'
     assert_deep_almost_equal(s.metadata.as_dictionary(), FEI_Helios_metadata)
@@ -439,7 +450,12 @@ def test_read_Zeiss_SEM_scale_metadata_1k_image():
                       'date': '2015-12-23',
                       'original_filename': 'test_tiff_Zeiss_SEM_1k.tif',
                       'time': '09:40:32',
-                      'title': ''},
+                      'title': '',
+                      'File': {
+                          'hyperspy_version': hs_version,
+                          'io_plugin': 'hyperspy.io_plugins.tiff'
+                          }
+                      },
           'Signal': {'signal_type': ''},
           '_HyperSpy': {'Folding': {'original_axes_manager': None,
                                     'original_shape': None,
@@ -453,6 +469,8 @@ def test_read_Zeiss_SEM_scale_metadata_1k_image():
     np.testing.assert_allclose(s.axes_manager[0].scale, 2.614514, rtol=1E-6)
     np.testing.assert_allclose(s.axes_manager[1].scale, 2.614514, rtol=1E-6)
     assert s.data.dtype == 'uint8'
+    # delete timestamp from metadata since it's runtime dependent
+    del s.metadata.General.File.load_timestamp
     assert_deep_almost_equal(s.metadata.as_dictionary(), md)
 
 
@@ -470,7 +488,12 @@ def test_read_Zeiss_SEM_scale_metadata_512_image():
                       'date': '2018-09-25',
                       'original_filename': 'test_tiff_Zeiss_SEM_512pix.tif',
                       'time': '08:20:42',
-                      'title': ''},
+                      'title': '',
+                      'File': {
+                          'hyperspy_version': hs_version,
+                          'io_plugin': 'hyperspy.io_plugins.tiff'
+                          }
+                      },
           'Signal': {'signal_type': ''},
           '_HyperSpy': {'Folding': {'original_axes_manager': None,
                                     'original_shape': None,
@@ -484,6 +507,8 @@ def test_read_Zeiss_SEM_scale_metadata_512_image():
     np.testing.assert_allclose(s.axes_manager[0].scale, 0.011649976, rtol=1E-6)
     np.testing.assert_allclose(s.axes_manager[1].scale, 0.011649976, rtol=1E-6)
     assert s.data.dtype == 'uint8'
+    # delete timestamp from metadata since it's runtime dependent
+    del s.metadata.General.File.load_timestamp
     assert_deep_almost_equal(s.metadata.as_dictionary(), md)
 
 
@@ -499,6 +524,8 @@ def test_read_RGB_Zeiss_optical_scale_metadata():
     np.testing.assert_allclose(s.axes_manager[1].scale, 1.0, rtol=1E-5)
     assert s.metadata.General.date == '2016-06-13'
     assert s.metadata.General.time == '15:59:52'
+    assert s.metadata.General.File.hyperspy_version == hs_version
+    assert s.metadata.General.File.io_plugin == 'hyperspy.io_plugins.tiff'
 
 
 def test_read_BW_Zeiss_optical_scale_metadata():
@@ -563,7 +590,12 @@ def test_read_TVIPS_metadata():
                                              'magnification': 32000.0}},
           'General': {'original_filename': 'TVIPS_bin4.tif',
                       'time': '9:01:17',
-                      'title': ''},
+                      'title': '',
+                      'File': {
+                          'hyperspy_version': hs_version,
+                          'io_plugin': 'hyperspy.io_plugins.tiff'
+                          }
+                      },
           'Signal': {'signal_type': ''},
           '_HyperSpy': {'Folding': {'original_axes_manager': None,
                                     'original_shape': None,
@@ -577,6 +609,8 @@ def test_read_TVIPS_metadata():
     assert s.axes_manager[1].units == 'nm'
     np.testing.assert_allclose(s.axes_manager[0].scale, 1.42080, rtol=1E-5)
     np.testing.assert_allclose(s.axes_manager[1].scale, 1.42080, rtol=1E-5)
+    # delete timestamp from metadata since it's runtime dependent
+    del s.metadata.General.File.load_timestamp
     assert_deep_almost_equal(s.metadata.as_dictionary(), md)
 
 

--- a/hyperspy/tests/io/test_tiff.py
+++ b/hyperspy/tests/io/test_tiff.py
@@ -389,11 +389,11 @@ FEI_Helios_metadata = {'Acquisition_instrument': {'SEM': {'Stage': {'rotation': 
                                    'authors': 'supervisor',
                                    'date': '2016-06-13',
                                    'time': '17:06:40',
-                                   'FileReader': {
+                                   'FileIO': {'0': {
+                                       'operation': 'load',
                                        'hyperspy_version': hs_version,
-                                       'io_plugin':
-                                           'hyperspy.io_plugins.tiff'
-                                       }
+                                       'io_plugin': 'hyperspy.io_plugins.tiff'
+                                   }}
                                    },
                        'Signal': {'signal_type': ''},
                        '_HyperSpy': {'Folding': {'original_axes_manager': None,
@@ -411,7 +411,7 @@ def test_read_FEI_SEM_scale_metadata_8bits():
     np.testing.assert_allclose(s.axes_manager[1].scale, 3.3724, rtol=1E-5)
     assert s.data.dtype == 'uint8'
     # delete timestamp from metadata since it's runtime dependent
-    del s.metadata.General.FileReader.load_timestamp
+    del s.metadata.General.FileIO.Number_0.timestamp
     FEI_Helios_metadata['General'][
         'original_filename'] = 'FEI-Helios-Ebeam-8bits.tif'
     assert_deep_almost_equal(s.metadata.as_dictionary(), FEI_Helios_metadata)
@@ -426,7 +426,7 @@ def test_read_FEI_SEM_scale_metadata_16bits():
     np.testing.assert_allclose(s.axes_manager[1].scale, 3.3724, rtol=1E-5)
     assert s.data.dtype == 'uint16'
     # delete timestamp from metadata since it's runtime dependent
-    del s.metadata.General.FileReader.load_timestamp
+    del s.metadata.General.FileIO.Number_0.timestamp
     FEI_Helios_metadata['General'][
         'original_filename'] = 'FEI-Helios-Ebeam-16bits.tif'
     assert_deep_almost_equal(s.metadata.as_dictionary(), FEI_Helios_metadata)
@@ -451,10 +451,11 @@ def test_read_Zeiss_SEM_scale_metadata_1k_image():
                       'original_filename': 'test_tiff_Zeiss_SEM_1k.tif',
                       'time': '09:40:32',
                       'title': '',
-                      'FileReader': {
+                      'FileIO': {'0': {
+                          'operation': 'load',
                           'hyperspy_version': hs_version,
                           'io_plugin': 'hyperspy.io_plugins.tiff'
-                          }
+                      }}
                       },
           'Signal': {'signal_type': ''},
           '_HyperSpy': {'Folding': {'original_axes_manager': None,
@@ -470,7 +471,7 @@ def test_read_Zeiss_SEM_scale_metadata_1k_image():
     np.testing.assert_allclose(s.axes_manager[1].scale, 2.614514, rtol=1E-6)
     assert s.data.dtype == 'uint8'
     # delete timestamp from metadata since it's runtime dependent
-    del s.metadata.General.FileReader.load_timestamp
+    del s.metadata.General.FileIO.Number_0.timestamp
     assert_deep_almost_equal(s.metadata.as_dictionary(), md)
 
 
@@ -489,10 +490,11 @@ def test_read_Zeiss_SEM_scale_metadata_512_image():
                       'original_filename': 'test_tiff_Zeiss_SEM_512pix.tif',
                       'time': '08:20:42',
                       'title': '',
-                      'FileReader': {
+                      'FileIO': {'0': {
+                          'operation': 'load',
                           'hyperspy_version': hs_version,
                           'io_plugin': 'hyperspy.io_plugins.tiff'
-                          }
+                      }}
                       },
           'Signal': {'signal_type': ''},
           '_HyperSpy': {'Folding': {'original_axes_manager': None,
@@ -508,7 +510,7 @@ def test_read_Zeiss_SEM_scale_metadata_512_image():
     np.testing.assert_allclose(s.axes_manager[1].scale, 0.011649976, rtol=1E-6)
     assert s.data.dtype == 'uint8'
     # delete timestamp from metadata since it's runtime dependent
-    del s.metadata.General.FileReader.load_timestamp
+    del s.metadata.General.FileIO.Number_0.timestamp
     assert_deep_almost_equal(s.metadata.as_dictionary(), md)
 
 
@@ -524,8 +526,8 @@ def test_read_RGB_Zeiss_optical_scale_metadata():
     np.testing.assert_allclose(s.axes_manager[1].scale, 1.0, rtol=1E-5)
     assert s.metadata.General.date == '2016-06-13'
     assert s.metadata.General.time == '15:59:52'
-    assert s.metadata.General.FileReader.hyperspy_version == hs_version
-    assert s.metadata.General.FileReader.io_plugin == 'hyperspy.io_plugins.tiff'
+    assert s.metadata.General.FileIO.Number_0.hyperspy_version == hs_version
+    assert s.metadata.General.FileIO.Number_0.io_plugin == 'hyperspy.io_plugins.tiff'
 
 
 def test_read_BW_Zeiss_optical_scale_metadata():
@@ -591,10 +593,11 @@ def test_read_TVIPS_metadata():
           'General': {'original_filename': 'TVIPS_bin4.tif',
                       'time': '9:01:17',
                       'title': '',
-                      'FileReader': {
+                      'FileIO': {'0': {
+                          'operation': 'load',
                           'hyperspy_version': hs_version,
                           'io_plugin': 'hyperspy.io_plugins.tiff'
-                          }
+                      }}
                       },
           'Signal': {'signal_type': ''},
           '_HyperSpy': {'Folding': {'original_axes_manager': None,
@@ -610,7 +613,7 @@ def test_read_TVIPS_metadata():
     np.testing.assert_allclose(s.axes_manager[0].scale, 1.42080, rtol=1E-5)
     np.testing.assert_allclose(s.axes_manager[1].scale, 1.42080, rtol=1E-5)
     # delete timestamp from metadata since it's runtime dependent
-    del s.metadata.General.FileReader.load_timestamp
+    del s.metadata.General.FileIO.Number_0.timestamp
     assert_deep_almost_equal(s.metadata.as_dictionary(), md)
 
 

--- a/upcoming_changes/2873.enhancements.rst
+++ b/upcoming_changes/2873.enhancements.rst
@@ -1,0 +1,3 @@
+Add metadata about the file-reading operation to the Signals produced by
+``hs.load()`` (see the :ref:`metadata structure <general-file-metadata>`
+section of the user guide)

--- a/upcoming_changes/2873.enhancements.rst
+++ b/upcoming_changes/2873.enhancements.rst
@@ -1,3 +1,3 @@
-Add metadata about the file-reading operation to the Signals produced by
-``hs.load()`` (see the :ref:`metadata structure <general-file-metadata>`
-section of the user guide)
+Add metadata about the file-reading and saving operations to the Signals
+produced by ``hs.load()`` and ``s.save()`` (see the :ref:`metadata structure
+<general-file-metadata>` section of the user guide)

--- a/upcoming_changes/2873.enhancements.rst
+++ b/upcoming_changes/2873.enhancements.rst
@@ -1,3 +1,3 @@
 Add metadata about the file-reading and saving operations to the Signals
-produced by ``hs.load()`` and ``s.save()`` (see the :ref:`metadata structure
-<general-file-metadata>` section of the user guide)
+produced by :py:func:`~hyperspy.io.load` and :py:meth:`~.signal.BaseSignal.save`
+(see the :ref:`metadata structure <general-file-metadata>` section of the user guide)


### PR DESCRIPTION
### Description of the change
This PR adds three new metadata parameters under `signal.metadata.General.File` to document information about the system/software used to load data from one of the proprietary/native formats into HyperSpy. This is desirable for future reproducibility, as it will indicate exactly when, which HyperSpy version, and which import module was used to read the data.

Resolves #2873 

### Progress of the PR
- [x] Change implemented (can be split into several points),
- [x] update docstring (if appropriate),
- [x] update user guide (if appropriate),
- [x] add an changelog entry in the `upcoming_changes` folder (see [`upcoming_changes/README.rst`](https://github.com/hyperspy/hyperspy/blob/RELEASE_next_minor/upcoming_changes/README.rst)),
- [x] Check formatting changelog entry in the `readthedocs` doc build of this PR (link in github checks)
- [x] add tests,
- [x] ready for review.

### Minimal example of the bug fix or the new feature
```python
>>> import hyperspy.api as hs
>>> s = hs.load('hyperspy/tests/io/msa_files/example1.msa')
>>> s.metadata
├── Acquisition_instrument
│   └── TEM
│       ├── Detector
│       │   └── EELS
│       │       ├── collection_angle = 3.4
│       │       ├── collection_angle_units = mR
│       │       ├── dwell_time = 100.0
│       │       └── dwell_time_units = ms
│       ├── beam_current = 12.345
│       ├── beam_current_units = nA
│       ├── beam_energy = 120.0
│       ├── beam_energy_units = kV
│       ├── convergence_angle = 1.5
│       └── convergence_angle_units = mR
├── General
│   ├── File
│   │   ├── hyperspy_version = 1.7.0.dev0
│   │   ├── io_plugin = hyperspy.io_plugins.msa
│   │   └── load_timestamp = 2022-01-19T12:57:21.222973-07:00
│   ├── date = 1991-10-01
│   ├── original_filename = example1.msa
│   ├── time = 12:00:00
│   └── title = NIO EELS OK SHELL
├── Sample
│   ├── thickness = 50.0
│   └── thickness_units = nm
└── Signal
    ├── quantity = Counts (Intensity)
    └── signal_type = EELS
```
Note that this example can be useful to update the user guide.

