### PR TITLE
Fixed ragged map with zero dim and Larger Iterating signal

### DIFF
--- a/hyperspy/tests/signals/test_ragged_signal.py
+++ b/hyperspy/tests/signals/test_ragged_signal.py
@@ -105,7 +105,7 @@ def test_create_ragged_array():
 
     s2 = hs.signals.BaseSignal(data, ragged=True)
     assert s2.axes_manager.ragged
-    assert s2.__repr__() == "<BaseSignal, title: , dimensions: (|ragged)>"
+    assert s2.__repr__() == "<BaseSignal, title: , dimensions: (1|ragged)>"
 
 
 def test_Signal1D_Signal2D_ragged():


### PR DESCRIPTION
### Description of the change
This is kind of a small change to fix some bugs that I have come across with the map function

- Ragged signals always have a navigation dimension.  I think this makes sense as a numpy object array has to have some size rather than be some scalar.  
- Mapping now works when the iterating signal dimension is larger than the base signal

### Progress of the PR
- [ x] Change implemented (can be split into several points),
- [ ] add an changelog entry in the `upcoming_changes` folder (see [`upcoming_changes/README.rst`](https://github.com/hyperspy/hyperspy/blob/RELEASE_next_minor/upcoming_changes/README.rst)),
- [ x] add tests,
- [x ] ready for review.


