### PR TITLE
Fix errors due to deprecation of scipy.ndimage.filters namespace

### DIFF
--- a/hyperspy/_signals/signal1d.py
+++ b/hyperspy/_signals/signal1d.py
@@ -25,7 +25,7 @@ import numpy as np
 import dask.array as da
 from scipy import interpolate
 from scipy.signal import savgol_filter, medfilt
-from scipy.ndimage.filters import gaussian_filter1d
+from scipy.ndimage import gaussian_filter1d
 
 from hyperspy.signal import BaseSignal
 from hyperspy._signals.common_signal1d import CommonSignal1D


### PR DESCRIPTION
Currently there are a lot of errors being caused by the `scipy.ndimage.filters` namespace being deprecated: https://github.com/hyperspy/hyperspy/runs/5103855252?check_suite_focus=true#step:8:3954

This was pull request fixes this.

-----------------------------

Note that this _might_ require an increase in the `scipy` version. Will see if the "minimum dependency" test run fails or not.

Currently the minimum `scipy` version is set to `1.1`. I tested this with `1.3`, which works fine.

-----------------------------

For some reason, the errors did not appear when I ran this locally for `RELEASE_next_patch`.