### PR TITLE
Fix errors due to deprecation of scipy.ndimage.filters namespace

### DIFF
--- a/hyperspy/_signals/signal1d.py
+++ b/hyperspy/_signals/signal1d.py
@@ -26,7 +26,7 @@ import dask.array as da
 import scipy.interpolate
 import scipy as sp
 from scipy.signal import savgol_filter
-from scipy.ndimage.filters import gaussian_filter1d
+from scipy.ndimage import gaussian_filter1d
 
 from hyperspy.signal import BaseSignal
 from hyperspy._signals.common_signal1d import CommonSignal1D


### PR DESCRIPTION
Currently there are a lot of errors being caused by the `scipy.ndimage.filters` namespace being deprecated: https://github.com/hyperspy/hyperspy/runs/5103855252?check_suite_focus=true#step:8:3954

This pull request fixes this.

-------------------------------
I checked this with the minimum version of `scipy` in `setup.py`: `1.1`, and it worked nicely! So no need to bump the scipy version requirement.

