### PR TITLE
Remove scipy deprecated namespaces

### DIFF
--- a/hyperspy/_signals/eds_tem.py
+++ b/hyperspy/_signals/eds_tem.py
@@ -596,7 +596,7 @@ class EDSTEM_mixin:
         mask: signal
             The mask of the region
         """
-        from scipy.ndimage.morphology import binary_dilation, binary_erosion
+        from scipy.ndimage import binary_dilation, binary_erosion
         mask = (self.max(-1) <= threshold)
         if closing:
             mask.data = binary_dilation(mask.data, border_value=0)

--- a/hyperspy/utils/peakfinders2D.py
+++ b/hyperspy/utils/peakfinders2D.py
@@ -142,9 +142,9 @@ def find_peaks_minmax(z, distance=5., threshold=10.):
         Peak pixel coordinates.
 
     """
-    data_max = ndi.filters.maximum_filter(z, distance)
+    data_max = ndi.maximum_filter(z, distance)
     maxima = (z == data_max)
-    data_min = ndi.filters.minimum_filter(z, distance)
+    data_min = ndi.minimum_filter(z, distance)
     diff = ((data_max - data_min) > threshold)
     maxima[diff == 0] = 0
     labeled, num_objects = ndi.label(maxima)


### PR DESCRIPTION
Both scipy.ndimage.morphology and scipy.ndimage.filters has been removed, and only scipy.ndimage should be used now.

Follow-up on https://github.com/hyperspy/hyperspy/pull/2883