### PR TITLE
Fix failing test due to changes in dask.keys keyword

### DIFF
--- a/hyperspy/_signals/lazy.py
+++ b/hyperspy/_signals/lazy.py
@@ -177,7 +177,10 @@ class LazySignal(BaseSignal):
         """
         arrkey = None
         for key in self.data.dask.keys():
-            if "array-original" in key:
+            # The if statement with both "array-original" and "original-array"
+            # is due to dask changing the name of this key. After dask-2022.1.1
+            # the key is "original-array", before it is "array-original"
+            if ("array-original" in key) or ("original-array" in key):
                 arrkey = key
                 break
         if arrkey:


### PR DESCRIPTION
Currently a test in RELEASE_next_minor is failing: `FAILED hyperspy/tests/io/test_hdf5.py::test_saving_close_file`.

This is due to this code:

```python
for key in self.data.dask.keys():
    if "array-original" in key:
        arrkey = key
        break
```

Since `dask-2022.1.1` this key starts with `original-array`, while in `dask-2022.1.0` (and earlier), `array-original`.

There has been some changes in `RELEASE_next_minor`, compared to `RELEASE_next_patch`. In `RNp`, this functionality is in `close_file` (https://github.com/hyperspy/hyperspy/blob/RELEASE_next_patch/hyperspy/_signals/lazy.py#L171)

In `RNm`, this is in `_get_file_handle` (https://github.com/hyperspy/hyperspy/blob/RELEASE_next_minor/hyperspy/_signals/lazy.py#L323)

-------

Thus, this pull request fixes the issue in RNp, which should be easy to "move" to RNm.