### PR TITLE
Fix test_blockfile unit test, due to change in dask keyword naming

### DIFF
--- a/hyperspy/tests/io/test_blockfile.py
+++ b/hyperspy/tests/io/test_blockfile.py
@@ -406,7 +406,10 @@ def test_load_readonly():
     s = hs.load(FILE2, lazy=True)
     k = next(
         filter(
-            lambda x: isinstance(x, str) and x.startswith("array-original"),
+            # The or statement with both "array-original" and "original-array"
+            # is due to dask changing the name of this key. After dask-2022.1.1
+            # the key is "original-array", before it is "array-original"
+            lambda x: isinstance(x, str) and (x.startswith("original-array") or x.startswith("array-original")),
             s.data.dask.keys(),
         )
     )


### PR DESCRIPTION
Due to the changes in the `dask` keyword.

Related pull request: https://github.com/hyperspy/hyperspy/pull/2888
Seems to be caused by https://github.com/dask/dask/pull/7417