### PR TITLE
Update docstrings concerning area parameters

### DIFF
--- a/hyperspy/_components/gaussian.py
+++ b/hyperspy/_components/gaussian.py
@@ -70,7 +70,7 @@ class Gaussian(Expression):
     ============== ===========
     Variable        Parameter
     ============== ===========
-    :math:`A`       area
+    :math:`A`       A
     :math:`\sigma`  sigma
     :math:`x_0`     centre
     ============== ===========

--- a/hyperspy/_components/gaussian.py
+++ b/hyperspy/_components/gaussian.py
@@ -70,7 +70,7 @@ class Gaussian(Expression):
     ============== ===========
     Variable        Parameter
     ============== ===========
-    :math:`A`       A
+    :math:`A`       area
     :math:`\sigma`  sigma
     :math:`x_0`     centre
     ============== ===========
@@ -79,8 +79,8 @@ class Gaussian(Expression):
     Parameters
     -----------
     A : float
-        Height scaled by :math:`\sigma\sqrt{(2\pi)}`. ``GaussianHF``
-        implements the Gaussian function with a height parameter
+        Area, equals height scaled by :math:`\sigma\sqrt{(2\pi)}`.
+        ``GaussianHF`` implements the Gaussian function with a height parameter
         corresponding to the peak height.
     sigma : float
         Scale parameter of the Gaussian distribution.

--- a/hyperspy/_components/gaussian2d.py
+++ b/hyperspy/_components/gaussian2d.py
@@ -36,7 +36,7 @@ class Gaussian2D(Expression):
     =============== =============
     Variable         Parameter
     =============== =============
-    :math:`A`        A
+    :math:`A`        area
     :math:`s_x,s_y`  sigma_x/y
     :math:`x_0,y_0`  centre_x/y
     =============== =============
@@ -45,7 +45,7 @@ class Gaussian2D(Expression):
     Parameters
     ----------
     A : float
-        Amplitude (height of the peak scaled by :math:`2 \pi s_x s_y`).
+        Area (height of the peak scaled by :math:`2 \pi s_x s_y`).
     sigma_x : float
         Width (scale parameter) of the Gaussian distribution in `x` direction.
     sigma_y : float

--- a/hyperspy/_components/gaussian2d.py
+++ b/hyperspy/_components/gaussian2d.py
@@ -46,7 +46,7 @@ class Gaussian2D(Expression):
     ----------
     A : float
         Volume (height of the peak scaled by :math:`2 \pi s_x s_y`) --
-        eqivalent to the Area in a 1D Gaussian.
+        eqivalent to the area in a 1D Gaussian.
     sigma_x : float
         Width (scale parameter) of the Gaussian distribution in `x` direction.
     sigma_y : float

--- a/hyperspy/_components/gaussian2d.py
+++ b/hyperspy/_components/gaussian2d.py
@@ -45,7 +45,8 @@ class Gaussian2D(Expression):
     Parameters
     ----------
     A : float
-        Area (height of the peak scaled by :math:`2 \pi s_x s_y`).
+        Volume (height of the peak scaled by :math:`2 \pi s_x s_y`) --
+        eqivalent to the Area in a 1D Gaussian.
     sigma_x : float
         Width (scale parameter) of the Gaussian distribution in `x` direction.
     sigma_y : float

--- a/hyperspy/_components/gaussian2d.py
+++ b/hyperspy/_components/gaussian2d.py
@@ -36,7 +36,7 @@ class Gaussian2D(Expression):
     =============== =============
     Variable         Parameter
     =============== =============
-    :math:`A`        area
+    :math:`A`        A
     :math:`s_x,s_y`  sigma_x/y
     :math:`x_0,y_0`  centre_x/y
     =============== =============

--- a/hyperspy/_components/gaussianhf.py
+++ b/hyperspy/_components/gaussianhf.py
@@ -28,8 +28,8 @@ sigma2fwhm = 2 * math.sqrt(2 * math.log(2))
 class GaussianHF(Expression):
 
     r"""Normalized gaussian function component, with a `fwhm` parameter instead
-    of the sigma parameter, and a `height` parameter instead of the `A`
-    parameter (scaling difference of :math:`\sigma \sqrt{\left(2\pi\right)}`).
+    of the sigma parameter, and a `height` parameter instead of the area
+    parameter `A` (scaling difference of :math:`\sigma \sqrt{\left(2\pi\right)}`).
     This makes the parameter vs. peak maximum independent of :math:`\sigma`,
     and thereby makes locking of the parameter more viable. As long as there
     is no binning, the `height` parameter corresponds directly to the peak
@@ -65,8 +65,8 @@ class GaussianHF(Expression):
         Extra keyword arguments are passed to the ``Expression`` component.
 
 
-    The helper properties `sigma` and `A` are also defined for compatibility
-    with `Gaussian` component.
+    The helper properties `sigma` and `A` (Area) are also defined for
+    compatibility with the `Gaussian` component.
 
     See also
     --------

--- a/hyperspy/_components/gaussianhf.py
+++ b/hyperspy/_components/gaussianhf.py
@@ -65,7 +65,7 @@ class GaussianHF(Expression):
         Extra keyword arguments are passed to the ``Expression`` component.
 
 
-    The helper properties `sigma` and `A` (Area) are also defined for
+    The helper properties `sigma` and `A` (area) are also defined for
     compatibility with the `Gaussian` component.
 
     See also

--- a/hyperspy/_components/lorentzian.py
+++ b/hyperspy/_components/lorentzian.py
@@ -68,7 +68,7 @@ class Lorentzian(Expression):
     ============== =============
     Variable        Parameter
     ============== =============
-    :math:`A`       area
+    :math:`A`       A
     :math:`\gamma`  gamma
     :math:`x_0`     centre
     ============== =============

--- a/hyperspy/_components/lorentzian.py
+++ b/hyperspy/_components/lorentzian.py
@@ -68,7 +68,7 @@ class Lorentzian(Expression):
     ============== =============
     Variable        Parameter
     ============== =============
-    :math:`A`       A
+    :math:`A`       area
     :math:`\gamma`  gamma
     :math:`x_0`     centre
     ============== =============
@@ -77,7 +77,7 @@ class Lorentzian(Expression):
     Parameters
     -----------
     A : float
-        Height parameter, where :math:`A/(\gamma\pi)` is the maximum of the
+        Area parameter, where :math:`A/(\gamma\pi)` is the maximum (height) of
         peak.
     gamma : float
         Scale parameter corresponding to the half-width-at-half-maximum of the


### PR DESCRIPTION
### Description of the change
Clarified in the docstrings of `Gaussian`, `Lorentzian` and `GaussianHF` that `A` parameter is the area, in `Gaussian2D` the equivalent would be a volume.

### Progress of the PR
- [x] Change implemented (can be split into several points),
- [x] update docstring (if appropriate),
- [x] ready for review.
