### PR TITLE
BugFix: Map Function With non array signals.

### DIFF
--- a/hyperspy/misc/utils.py
+++ b/hyperspy/misc/utils.py
@@ -1340,9 +1340,9 @@ def process_function_blockwise(data,
             islice = np.s_[index]
             iter_dict = {}
             for key, a in zip(arg_keys, args):
-                arg_i = a[islice].squeeze()
-                # Some functions does not handle 0-dimension NumPy arrys
-                if arg_i.shape == ():
+                arg_i = np.squeeze(a[islice])
+                # Some functions do not handle 0-dimension NumPy arrays
+                if hasattr(arg_i, "shape") and arg_i.shape == ():
                     arg_i = arg_i[()]
                 iter_dict[key] = arg_i
             output_array[islice] = function(data[islice], **iter_dict, **kwargs)

--- a/hyperspy/tests/signals/test_map_method.py
+++ b/hyperspy/tests/signals/test_map_method.py
@@ -642,6 +642,15 @@ class TestGetIteratingKwargsSignal2D:
             assert np.all(np.squeeze(arg.chunks[nav_dim:]) == arg.shape[nav_dim:])
             assert np.all(s_iter0.data == np.squeeze(arg.compute()))
 
+    def test_iterating_kwarg_non_array(self):
+        def apply_func(data, f):
+            return f(data, data)
+        s = self.s.inav[0:2, 0:2]
+        iter_add = hs.signals.BaseSignal([[np.add, np.add],
+                                          [np.add, np.add]]).T
+        out = s.map(apply_func, f=iter_add, inplace=False)
+        np.testing.assert_array_equal(out.data, s.data)
+
 
 class TestGetBlockPattern:
     @pytest.mark.parametrize(

--- a/upcoming_changes/2903.bugfix.rst
+++ b/upcoming_changes/2903.bugfix.rst
@@ -1,0 +1,1 @@
+Fix bug where the :py:func:`~.signal.BaseSignal.map` function wasn't operating properly when an iterating signal was not an array.


### PR DESCRIPTION
This fixes a failing test in pyxem related to the `map` function when the iterating signal is made up of arrays.

- [ ] add an changelog entry in the `upcoming_changes` folder (see [`upcoming_changes/README.rst`](https://github.com/hyperspy/hyperspy/blob/RELEASE_next_minor/upcoming_changes/README.rst)),
- [x] add tests,
- [x] ready for review.

### Minimal example of the bug fix or the new feature

This bit of code was failing.  Affects how affine transformation are applied in pyxem.
```python
import hyperspy.api as hs
import numpy as np
data = np.zeros((2, 2, 10,10))
s = hs.signals.Signal2D(data)

def apply_func(data, f):
    return f(data, data)
iter_func = hs.signals.BaseSignal([[np.add, np.subtract],
                                          [np.add, np.subtract]]).T # Add or subtract with self
out = s.map(apply_func, f=iter_add, inplace=False)
```


