### PR TITLE
BugFix: Basic way to save ragged arrays with ndim>1

### DIFF
--- a/hyperspy/io_plugins/_hierarchical.py
+++ b/hyperspy/io_plugins/_hierarchical.py
@@ -638,7 +638,7 @@ class HierarchicalWriter:
             new_data = np.empty(shape=data.shape, dtype=object)
             shapes = np.empty(shape=data.shape, dtype=object)
             for i in np.ndindex(data.shape):
-                new_data[i] = np.ndarray.flatten(data[i])
+                new_data[i] = data[i].ravel()
                 shapes[i] = np.array(data[i].shape)
             shape_dset = cls._get_object_dset(group, shapes, "ragged_shapes", shapes.shape, **kwds)
             cls._store_data(shapes, shape_dset, group, 'ragged_shapes', chunks=shapes.shape)

--- a/hyperspy/io_plugins/_hierarchical.py
+++ b/hyperspy/io_plugins/_hierarchical.py
@@ -639,7 +639,7 @@ class HierarchicalWriter:
             shapes = np.empty(shape=data.shape, dtype=object)
             for i in np.ndindex(data.shape):
                 new_data[i] = np.ndarray.flatten(data[i])
-                shapes[i] = data[i].shape
+                shapes[i] = np.array(data[i].shape)
             shape_dset = cls._get_object_dset(group, shapes, "ragged_shapes", shapes.shape, **kwds)
             cls._store_data(shapes, shape_dset, group, 'ragged_shapes', chunks=shapes.shape)
             cls._store_data(new_data, dset, group, key, chunks)

--- a/hyperspy/io_plugins/hspy.py
+++ b/hyperspy/io_plugins/hspy.py
@@ -22,7 +22,6 @@ from pathlib import Path
 
 import dask.array as da
 import h5py
-import numpy as np
 
 from hyperspy.io_plugins._hierarchical import (
     # hyperspy.io_plugins.hspy.get_signal_chunks is in the hyperspy public API
@@ -139,12 +138,7 @@ class HyperspyWriter(HierarchicalWriter):
         elif data.flags.c_contiguous:
             dset.write_direct(data)
         else:
-            if data.dtype == object:
-                shapes = [d.shape for d in data]
-                flat_data = [np.ndarray.flatten(d) for d in data]
-                dset[:] = flat_data
-            else:
-                dset[:] = data
+            dset[:] = data
 
     @staticmethod
     def _get_object_dset(group, data, key, chunks, **kwds):

--- a/hyperspy/io_plugins/hspy.py
+++ b/hyperspy/io_plugins/hspy.py
@@ -22,6 +22,7 @@ from pathlib import Path
 
 import dask.array as da
 import h5py
+import numpy as np
 
 from hyperspy.io_plugins._hierarchical import (
     # hyperspy.io_plugins.hspy.get_signal_chunks is in the hyperspy public API
@@ -138,7 +139,12 @@ class HyperspyWriter(HierarchicalWriter):
         elif data.flags.c_contiguous:
             dset.write_direct(data)
         else:
-            dset[:] = data
+            if data.dtype == object:
+                shapes = [d.shape for d in data]
+                flat_data = [np.ndarray.flatten(d) for d in data]
+                dset[:] = flat_data
+            else:
+                dset[:] = data
 
     @staticmethod
     def _get_object_dset(group, data, key, chunks, **kwds):

--- a/hyperspy/tests/io/test_hdf5.py
+++ b/hyperspy/tests/io/test_hdf5.py
@@ -814,6 +814,22 @@ def test_save_ragged_array(tmp_path, file):
     assert s.__class__ == s1.__class__
 
 
+@zspy_marker
+def test_save_ragged_dim2(tmp_path, file):
+    x = np.empty(5, dtype=object)
+    for i in range(1, 6):
+        x[i - 1] = np.array([list(range(i)), list(range(i))])
+
+    s = BaseSignal(x, ragged=True)
+
+    filename = tmp_path / file
+    s.save(filename)
+    s2 = load(filename)
+
+    for i, j in zip(s.data,s2.data):
+        np.testing.assert_array_equal(i,j)
+
+
 def test_load_missing_extension(caplog):
     path = my_path / "hdf5_files" / "hspy_ext_missing.hspy"
     with pytest.warns(UserWarning):

--- a/upcoming_changes/2906.bugfix.rst
+++ b/upcoming_changes/2906.bugfix.rst
@@ -1,0 +1,1 @@
+Fix bug for not saving ragged arrays with dimensions larger than 2 in the ragged dimension.


### PR DESCRIPTION
### This is a pretty basic way to fix the saving of signals with a ragged dim greater than 2

The motivation for this is with saving vector signals after some analysis.  Previously these signals weren't saving properly (see #2904)

**_The general procedure:_**
- Unwrapped ragged arrays with signal dim greater than two
- Save the original shape of the signal dim as a separate dataset 
- Load the unwrapped data and original shape
- Reshape the data using the original shape.

### Progress of the PR
- [x]  Change implemented (can be split into several points),
- [ ] update docstring (if appropriate),
- [ ] update user guide (if appropriate),
- [ ] add an changelog entry in the `upcoming_changes` folder (see [`upcoming_changes/README.rst`](https://github.com/hyperspy/hyperspy/blob/RELEASE_next_minor/upcoming_changes/README.rst)),
- [ ] Check formatting changelog entry in the `readthedocs` doc build of this PR (link in github checks)
- [ ] add tests,
- [ ] ready for review.

### Minimal example of the bug fix or the new feature
```python
import hyperspy.api as hs
import numpy as np

x = np.empty(5,dtype=object)
for i in range(1,6):
    x[i-1]= np.array([list(range(i)),list(range(i))])

s = hs.signals.BaseSignal(x, ragged=True)

s.save("test.hspy")

s =hs.load("test.hspy")
```

@ericpre  Any suggestions you have here would be greatly appreciated.  Right now it works and is only a rather small change.  That being said it am not extremely happy with how I got it to work.