### PR TITLE
FIX-ENH update cutoff_at_kV behavior for bruker.py reader

### DIFF
--- a/doc/user_guide/io.rst
+++ b/doc/user_guide/io.rst
@@ -1047,8 +1047,16 @@ Extra loading arguments
   The underlying method of downsampling is unchangeable: sum. Differently than
   ``block_reduce`` from skimage.measure it is memory efficient (does not creates
   intermediate arrays, works inplace).
-- ``cutoff_at_kV`` : if set (can be int or float >= 0) can be used either to crop
-  or enlarge energy (or channels) range at max values (default None).
+- ``cutoff_at_kV`` : if set (can be None, int, float (kV), one of 'auto' or
+  'lowest_constraint') can be used either to crop or enlarge energy (or number of
+  channels) range at max values. It can be used to conserve memory or enlarge
+  the range if needed to mach the size of other file. Default value is None
+  (which does not influence size). Numerical values should be in kV.
+  "auto" truncates to the last non zero channel (should not be used for stacks,
+  as low beam current EDS can have different last non zero channel per slice).
+  "lowest_constraint" truncates channels to SEM/TEM acceleration voltage or 
+  energy at last channel, depending which is smaller
+  (should be used only if X-Rays were generated using electron beam).
 
 Example of loading reduced (downsampled, and with energy range cropped)
 "spectrum only" data from bcf (original shape: 80keV EDS range (4096 channels),

--- a/doc/user_guide/io.rst
+++ b/doc/user_guide/io.rst
@@ -1060,34 +1060,35 @@ Extra loading arguments
 
 Example of loading reduced (downsampled, and with energy range cropped)
 "spectrum only" data from bcf (original shape: 80keV EDS range (4096 channels),
-100x75 pixels):
+100x75 pixels; SEM acceleration voltage: 20kV):
 
 .. code-block:: python
 
     >>> hs.load("sample80kv.bcf", select_type='spectrum', downsample=2, cutoff_at_kV=10)
     <EDSSEMSpectrum, title: EDX, dimensions: (50, 38|595)>
 
-load the same file without extra arguments:
+load the same file to limiting array size to SEM acceleration voltage:
 
 .. code-block:: python
 
-    >>> hs.load("sample80kv.bcf")
+    >>> hs.load("sample80kv.bcf", cutoff_at_kV='lowest_constraint')
     [<Signal2D, title: BSE, dimensions: (|100, 75)>,
     <Signal2D, title: SE, dimensions: (|100, 75)>,
-    <EDSSEMSpectrum, title: EDX, dimensions: (100, 75|1095)>]
+    <EDSSEMSpectrum, title: EDX, dimensions: (100, 75|1024)>]
 
 The loaded array energy dimension can by forced to be larger than the data
 recorded by setting the 'cutoff_at_kV' kwarg to higher value:
 
 .. code-block:: python
 
-    >>> hs.load("sample80kv.bcf", cutoff_at_kV=80)
+    >>> hs.load("sample80kv.bcf", cutoff_at_kV=60)
     [<Signal2D, title: BSE, dimensions: (|100, 75)>,
     <Signal2D, title: SE, dimensions: (|100, 75)>,
-    <EDSSEMSpectrum, title: EDX, dimensions: (100, 75|4096)>]
+    <EDSSEMSpectrum, title: EDX, dimensions: (100, 75|3072)>]
 
-Note that setting downsample to >1 currently locks out using SEM imagery
-as navigator in the plotting.
+loading without setting cutoff_at_kV value would return data with all 4096
+channels. Note that setting downsample to >1 currently locks out using SEM
+images for navigation in the plotting.
 
 .. _spx-format:
 

--- a/doc/user_guide/io.rst
+++ b/doc/user_guide/io.rst
@@ -1047,16 +1047,17 @@ Extra loading arguments
   The underlying method of downsampling is unchangeable: sum. Differently than
   ``block_reduce`` from skimage.measure it is memory efficient (does not creates
   intermediate arrays, works inplace).
-- ``cutoff_at_kV`` : if set (can be None, int, float (kV), one of 'auto' or
-  'lowest_constraint') can be used either to crop or enlarge energy (or number of
+- ``cutoff_at_kV`` : if set (can be None, int, float (kV), one of 'zealous'
+  or 'auto') can be used either to crop or enlarge energy (or number of
   channels) range at max values. It can be used to conserve memory or enlarge
   the range if needed to mach the size of other file. Default value is None
   (which does not influence size). Numerical values should be in kV.
-  "auto" truncates to the last non zero channel (should not be used for stacks,
-  as low beam current EDS can have different last non zero channel per slice).
-  "lowest_constraint" truncates channels to SEM/TEM acceleration voltage or 
-  energy at last channel, depending which is smaller
-  (should be used only if X-Rays were generated using electron beam).
+  'zealous' truncates to the last non zero channel (this option
+  should not be used for stacks, as low beam current EDS can have different
+  last non zero channel per slice). 'auto' truncates channels to SEM/TEM
+  acceleration voltage or energy at last channel, depending which is smaller.
+  In case the hv info is not there or hv is off (0 kV) then it fallbacks to
+  full channel range.
 
 Example of loading reduced (downsampled, and with energy range cropped)
 "spectrum only" data from bcf (original shape: 80keV EDS range (4096 channels),
@@ -1067,11 +1068,11 @@ Example of loading reduced (downsampled, and with energy range cropped)
     >>> hs.load("sample80kv.bcf", select_type='spectrum', downsample=2, cutoff_at_kV=10)
     <EDSSEMSpectrum, title: EDX, dimensions: (50, 38|595)>
 
-load the same file to limiting array size to SEM acceleration voltage:
+load the same file with limiting array size to SEM acceleration voltage:
 
 .. code-block:: python
 
-    >>> hs.load("sample80kv.bcf", cutoff_at_kV='lowest_constraint')
+    >>> hs.load("sample80kv.bcf", cutoff_at_kV='auto')
     [<Signal2D, title: BSE, dimensions: (|100, 75)>,
     <Signal2D, title: SE, dimensions: (|100, 75)>,
     <EDSSEMSpectrum, title: EDX, dimensions: (100, 75|1024)>]

--- a/hyperspy/io.py
+++ b/hyperspy/io.py
@@ -236,10 +236,18 @@ def load(filenames=None,
         pixel. This allows to improve signal and conserve the memory with the
         cost of lower resolution.
     cutoff_at_kV : None, int, float, optional
-        For Bruker bcf files, if set to numerical (default is None),
-        bcf is parsed into array with depth cutoff at coresponding given energy.
+        For Bruker bcf files and Jeol, if set to numerical (default is None),
+        hypermap is parsed into array with depth cutoff at set energy value.
         This allows to conserve the memory by cutting-off unused spectral
         tails, or force enlargement of the spectra size.
+        Bruker bcf reader accepts additional values for semi-automatic cutoff.
+        "zealous" value truncates to the last non zero channel (this option
+        should not be used for stacks, as low beam current EDS can have different
+        last non zero channel per slice).
+        "auto" truncates channels to SEM/TEM acceleration voltage or
+        energy at last channel, depending which is smaller.
+        In case the hv info is not there or hv is off (0 kV) then it fallbacks to
+        full channel range.
     select_type : 'spectrum_image', 'image', 'single_spectrum', None, optional
         If None (default), all data are loaded.
         For Bruker bcf and Velox emd files: if one of 'spectrum_image', 'image'

--- a/hyperspy/io_plugins/bruker.py
+++ b/hyperspy/io_plugins/bruker.py
@@ -961,16 +961,16 @@ class BCF_reader(SFS_reader):
             index = self.def_index
         if type(cutoff_at_kV) in (int, float):
             eds = self.header.spectra_data[index]
-            max_chan = eds.energy_to_channel(cutoff_at_kV)
+            n_channels = eds.energy_to_channel(cutoff_at_kV)
         elif cutoff_at_kV == 'auto':
-            max_chan = self.header.spectra_data[index].last_non_zero_channel()
+            n_channels = self.header.spectra_data[index].last_non_zero_channel() - 1
         elif cutoff_at_kV == 'lowest_constraint':
-            max_chan = self.header.estimate_map_channels(index=index)
+            n_channels = self.header.estimate_map_channels(index=index)
         else:  # ==None
-            max_chan = self.header.spectra_data[index].data.size + 1
+            n_channels = self.header.spectra_data[index].data.size
         shape = (ceil(self.header.image.height / downsample),
                  ceil(self.header.image.width / downsample),
-                 max_chan)
+                 n_channels)
         sfs_file = SFS_reader(self.filename)
         vrt_file_hand = sfs_file.get_file(
             'EDSDatabase/SpectrumData' + str(index))

--- a/hyperspy/tests/io/test_bruker.py
+++ b/hyperspy/tests/io/test_bruker.py
@@ -57,6 +57,20 @@ def test_load_16bit_reduced():
     assert str(hype.data.dtype)[0] == 'u'
 
 
+def test_load_16bit_cutoff_zealous():
+    filename = os.path.join(my_path, 'bruker_data', test_files[0])
+    print('testing downsampled 16bit bcf with cutoff_at_kV=zealous...')
+    hype = load(filename, cutoff_at_kV="zealous", select_type="spectrum_image")
+    assert hype.data.shape == (30, 30, 2048)
+
+
+def test_load_16bit_cutoff_auto():
+    filename = os.path.join(my_path, 'bruker_data', test_files[0])
+    print('testing downsampled 16bit bcf with cutoff_at_kV=auto...')
+    hype = load(filename, cutoff_at_kV="auto", select_type="spectrum_image")
+    assert hype.data.shape == (30, 30, 2048)
+
+
 def test_load_8bit():
     for bcffile in test_files[1:3]:
         filename = os.path.join(my_path, 'bruker_data', bcffile)

--- a/upcoming_changes/2898.bugfix.rst
+++ b/upcoming_changes/2898.bugfix.rst
@@ -1,0 +1,1 @@
+When loading Bruker Bcf, cutoff_at_kV=None does no cutoff

--- a/upcoming_changes/2910.api.rst
+++ b/upcoming_changes/2910.api.rst
@@ -1,2 +1,2 @@
 * when loading Bruker bcf, cutoff_at_kV=None (default) applies no more automatic cutoff.
-* New acceptable values "auto" and "minimal_constraint" does that.
+* New acceptable values "zealous" and "auto" do automatic cutoff.

--- a/upcoming_changes/2910.api.rst
+++ b/upcoming_changes/2910.api.rst
@@ -1,0 +1,2 @@
+* when loading Bruker bcf, cutoff_at_kV=None (default) applies no more automatic cutoff.
+* New acceptable values "auto" and "minimal_constraint" does that.


### PR DESCRIPTION
### Description of the change
Changes how bruker.py reader reacts to cutoff_at_kV:
* `None` as value does no more any cutoff
* introduced possible value `"zealous"` which cuts at last nonzero value
* previous behavior with None can be activated with value `"auto"`, with updated fallback if hv=0

This partly fixes the #2898

### Progress of the PR
- [x] Change implemented (can be split into several points),
- [x] update docstring
- [x] update user guide,
- [x] add an changelog entry in the `upcoming_changes` folder (see [`upcoming_changes/README.rst`](https://github.com/hyperspy/hyperspy/blob/RELEASE_next_minor/upcoming_changes/README.rst)),
- [x] Check formatting changelog entry in the `readthedocs` doc build of this PR (link in github checks)
- [x] add/modify tests,
- [x] ready for review.
