### PR TITLE
expose Stage metadata for sem images in bruker BCF

### DIFF
--- a/hyperspy/io_plugins/bruker.py
+++ b/hyperspy/io_plugins/bruker.py
@@ -872,7 +872,8 @@ class HyperHeader(object):
                  'Microscope': self.sem_metadata,
                  'DSP Configuration': self.dsp_metadata,
                  'Stage': self.stage_metadata
-        }
+        },
+             'mapping': get_mapping(self.mode)
         }
         return i
 

--- a/hyperspy/tests/io/test_bruker.py
+++ b/hyperspy/tests/io/test_bruker.py
@@ -38,6 +38,8 @@ def test_load_16bit():
     np.testing.assert_array_equal(hype.data[:, :, 222:224],
                                   np.load(np_filename))
     assert hype.data.shape == (30, 30, 2048)
+    assert bse.metadata.get_item('Stage.x', full_path=False) == 66940.81
+    assert hype.metadata.get_item('Stage.x', full_path=False) == 66940.81
 
 
 def test_load_16bit_reduced():

--- a/upcoming_changes/2911.enhancements.rst
+++ b/upcoming_changes/2911.enhancements.rst
@@ -1,0 +1,1 @@
+expose Stage coordinates and rotation angle in metada for sem images in bcf reader.


### PR DESCRIPTION
### expose stage coordinates to SEM images in metadata too
Hitherto in bcf only spectral images had correctly mapped stage coordinates exposed in metadata.
But it was missing for SEM images (BSE, SEI ...),
This PR adds such mapping to expose it the same in such image metadata.  It is convenience feature when bcf is used mostly for 16bit images (i.e. for mosaic)

### Progress of the PR
- [x] Change implemented
~~- [ ] update docstring (if appropriate),~~
~~- [ ] update user guide (if appropriate),~~
- [x] add an changelog entry in the `upcoming_changes` folder (see [`upcoming_changes/README.rst`](https://github.com/hyperspy/hyperspy/blob/RELEASE_next_minor/upcoming_changes/README.rst)),
- [x] Check formatting changelog entry in the `readthedocs` doc build of this PR (link in github checks)
- [x] add tests (thank you @ericpre )
- [x] ready for review.