### PR TITLE
Deprecate setting `metadata` and `original_metadata` attributes

### DIFF
--- a/hyperspy/_signals/complex_signal.py
+++ b/hyperspy/_signals/complex_signal.py
@@ -333,8 +333,9 @@ class ComplexSignal(BaseSignal):
                 raise ValueError('display_range should be array_like, shape(2,2) or shape(2,).')
 
         argand_diagram, real_edges, imag_edges = np.histogram2d(re, im, bins=size, range=range)
-        argand_diagram = Signal2D(argand_diagram.T)
-        argand_diagram.metadata = self.metadata.deepcopy()
+        argand_diagram = Signal2D(argand_diagram.T,
+                                  metadata=self.metadata.as_dictionary(),
+                                  )
         argand_diagram.metadata.General.title = f'Argand diagram of {self.metadata.General.title}'
 
         if self.real.metadata.Signal.has_item('quantity'):

--- a/hyperspy/_signals/eds_sem.py
+++ b/hyperspy/_signals/eds_sem.py
@@ -106,7 +106,7 @@ class EDSSEMSpectrum(EDSSpectrum):
 
         """
 
-        self.original_metadata = ref.original_metadata.deepcopy()
+        self._original_metadata = ref.original_metadata.deepcopy()
         # Setup the axes_manager
         ax_m = self.axes_manager.signal_axes[0]
         ax_ref = ref.axes_manager.signal_axes[0]

--- a/hyperspy/_signals/eds_tem.py
+++ b/hyperspy/_signals/eds_tem.py
@@ -268,7 +268,7 @@ class EDSTEMSpectrum(EDSSpectrum):
 
         """
 
-        self.original_metadata = ref.original_metadata.deepcopy()
+        self._original_metadata = ref.original_metadata.deepcopy()
         # Setup the axes_manager
         ax_m = self.axes_manager.signal_axes[0]
         ax_ref = ref.axes_manager.signal_axes[0]

--- a/hyperspy/io.py
+++ b/hyperspy/io.py
@@ -553,7 +553,7 @@ def load_with_reader(
             if convert_units:
                 signal.axes_manager.convert_units()
             if not load_original_metadata:
-                signal.original_metadata = type(signal.original_metadata)()
+                signal._original_metadata = type(signal.original_metadata)()
             signal_list.append(signal)
         else:
             # it's a standalone model

--- a/hyperspy/io_plugins/nexus.py
+++ b/hyperspy/io_plugins/nexus.py
@@ -28,7 +28,6 @@ import pprint
 import traits.api as t
 
 from hyperspy.io_plugins.hspy import (get_signal_chunks, overwrite_dataset)
-from hyperspy.misc.utils import DictionaryTreeBrowser
 from hyperspy.exceptions import VisibleDeprecationWarning
 
 
@@ -1277,12 +1276,6 @@ def file_writer(filename,
         for i, sig in enumerate(signals):
             nxentry = f.create_group("entry%d" % (i + 1))
             nxentry.attrs["NX_class"] = _parse_to_file("NXentry")
-
-            if isinstance(sig.metadata, dict):
-                sig.metadata = DictionaryTreeBrowser(sig.metadata)
-            if isinstance(sig.original_metadata, dict):
-                sig.original_metadata = DictionaryTreeBrowser(
-                    sig.original_metadata)
 
             signal_name = sig.metadata.General.title \
                 if sig.metadata.General.title else 'unnamed__%d' % i

--- a/hyperspy/misc/date_time_tools.py
+++ b/hyperspy/misc/date_time_tools.py
@@ -89,30 +89,31 @@ def get_date_time_from_metadata(metadata, formatting='ISO'):
 
 
 def update_date_time_in_metadata(dt, metadata):
-    """ Update the date and time in a metadata tree.
+    """
+    Update the date and time in a metadata tree.
 
-        Parameters
-        ----------
-            dt : date and time information: it can be a ISO 8601 string,
-                a datetime.datetime or a numpy.datetime64 object
-            metadata : metadata object to update
+    Parameters
+    ----------
+        dt : date and time information: it can be a ISO 8601 string,
+            a datetime.datetime or a numpy.datetime64 object
+        metadata : metadata object to update
 
-        Return
-        ----------
-            metadata object
+    Return
+    ------
+        metadata object
 
-        Example
-        -------
-        >>> s = hs.load("example1.msa")
-        >>> dt = '2016-12-12T12:12:12-05:00'
-        >>> s.metadata = update_date_time_in_metadata(dt, s.metadata)
-        >>> s.metadata
-            ├── General
-            │   ├── date = 2016-12-12
-            │   ├── original_filename = example1.msa
-            │   ├── time = 12:12:12
-            │   ├── time_zone = 'EST'
-            │   └── title = NIO EELS OK SHELL
+    Example
+    -------
+    >>> s = hs.load("example1.msa")
+    >>> dt = '2016-12-12T12:12:12-05:00'
+    >>> s.metadata = update_date_time_in_metadata(dt, s.metadata)
+    >>> s.metadata
+        ├── General
+        │   ├── date = 2016-12-12
+        │   ├── original_filename = example1.msa
+        │   ├── time = 12:12:12
+        │   ├── time_zone = 'EST'
+        │   └── title = NIO EELS OK SHELL
     """
     time_zone = None
     if isinstance(dt, str):

--- a/hyperspy/misc/eels/eelsdb.py
+++ b/hyperspy/misc/eels/eelsdb.py
@@ -232,8 +232,9 @@ def eelsdb(spectrum_type=None, title=None, author=None, element=None, formula=No
         try:
             s = dict2signal(parse_msa_string(msa_string)[0])
             emsa = s.original_metadata
-            s.original_metadata = s.original_metadata.__class__(
-                {'json': json_spectrum})
+            s._original_metadata = type(s.original_metadata)(
+                {'json': json_spectrum}
+                )
             s.original_metadata.emsa = emsa
             spectra.append(s)
 

--- a/hyperspy/misc/utils.py
+++ b/hyperspy/misc/utils.py
@@ -1198,8 +1198,8 @@ def stack(
         signal.get_dimensions_from_data()
         # Set the metadata, if an stack_metadata is an integer, the metadata
         # will overwritten later
-        signal.metadata = first.metadata.deepcopy()
-        signal.metadata.General.title = f"Stack of {first.metadata.General.title}"
+        signal._metadata = first.metadata.deepcopy()
+        signal._metadata.General.title = f"Stack of {first.metadata.General.title}"
 
         # Stack metadata
         if isinstance(stack_metadata, bool):
@@ -1211,11 +1211,11 @@ def stack(
                     node.original_metadata = obj.original_metadata.deepcopy()
                     node.metadata = obj.metadata.deepcopy()
             else:
-                signal.original_metadata = DictionaryTreeBrowser({})
+                signal._original_metadata = DictionaryTreeBrowser({})
         elif isinstance(stack_metadata, int):
             obj = signal_list[stack_metadata]
-            signal.metadata = obj.metadata.deepcopy()
-            signal.original_metadata = obj.original_metadata.deepcopy()
+            signal._metadata = obj.metadata.deepcopy()
+            signal._original_metadata = obj.original_metadata.deepcopy()
         else:
             raise ValueError("`stack_metadata` must a boolean or an integer.")
 

--- a/hyperspy/samfire.py
+++ b/hyperspy/samfire.py
@@ -18,6 +18,7 @@
 
 import logging
 from multiprocessing import cpu_count
+import warnings
 
 import dill
 import numpy as np
@@ -27,8 +28,7 @@ from hyperspy.misc.utils import slugify
 from hyperspy.misc.math_tools import check_random_state
 from hyperspy.external.progressbar import progressbar
 from hyperspy.signal import BaseSignal
-from hyperspy.samfire_utils.strategy import (LocalStrategy,
-                                             GlobalStrategy)
+from hyperspy.samfire_utils.strategy import LocalStrategy, GlobalStrategy
 from hyperspy.samfire_utils.local_strategies import ReducedChiSquaredStrategy
 from hyperspy.samfire_utils.global_strategies import HistogramStrategy
 
@@ -137,7 +137,7 @@ class Samfire:
         if workers is None:
             workers = max(1, cpu_count() - 1)
         self.model = model
-        self.metadata = DictionaryTreeBrowser()
+        self._metadata = DictionaryTreeBrowser()
 
         self._scale = 1.0
         # -1 -> done pixel, use
@@ -167,6 +167,21 @@ class Samfire:
             self._setup(**kwargs)
         self.refresh_database()
         self.random_state = check_random_state(random_state)
+
+    @property
+    def metadata(self):
+        return self._metadata
+
+    @metadata.setter
+    def metadata(self, d):
+        warnings.warn(
+            "Setting `metadata` attribute is deprecated and will be removed "
+            "in HyperSpy 2.0. Use the `set_item` and `add_dictionary` methods "
+            "of `metadata` attribute instead."
+            )
+        if isinstance(d, dict):
+            d = DictionaryTreeBrowser(d)
+        self._metadata = d
 
     @property
     def active_strategy(self):

--- a/hyperspy/samfire.py
+++ b/hyperspy/samfire.py
@@ -175,9 +175,9 @@ class Samfire:
     @metadata.setter
     def metadata(self, d):
         warnings.warn(
-            "Setting `metadata` attribute is deprecated and will be removed "
+            "Setting the `metadata` attribute is deprecated and will be removed "
             "in HyperSpy 2.0. Use the `set_item` and `add_dictionary` methods "
-            "of `metadata` attribute instead."
+            "of the `metadata` attribute instead."
             )
         if isinstance(d, dict):
             d = DictionaryTreeBrowser(d)

--- a/hyperspy/signal.py
+++ b/hyperspy/signal.py
@@ -2423,9 +2423,9 @@ class BaseSignal(FancySlicing,
     @metadata.setter
     def metadata(self, d):
         warnings.warn(
-            "Setting `metadata` attribute is deprecated and will be removed "
+            "Setting the `metadata` attribute is deprecated and will be removed "
             "in HyperSpy 2.0. Use the `set_item` and `add_dictionary` methods "
-            "of `metadata` attribute instead."
+            "of the `metadata` attribute instead."
             )
         if isinstance(d, dict):
             d = DictionaryTreeBrowser(d)
@@ -2439,9 +2439,9 @@ class BaseSignal(FancySlicing,
     @original_metadata.setter
     def original_metadata(self, d):
         warnings.warn(
-            "Setting `original_metadata` attribute is deprecated and will be "
+            "Setting the `original_metadata` attribute is deprecated and will be removed "
             "removed in HyperSpy 2.0. Use the `set_item` and `add_dictionary` "
-            "methods of `original_metadata` attribute instead.")
+            "methods of the `original_metadata` attribute instead.")
         if isinstance(d, dict):
             d = DictionaryTreeBrowser(d)
         self._original_metadata = d

--- a/hyperspy/signal.py
+++ b/hyperspy/signal.py
@@ -2204,7 +2204,7 @@ class BaseSignal(FancySlicing,
             self._load_dictionary(kwds)
 
     def _create_metadata(self):
-        self.metadata = DictionaryTreeBrowser()
+        self._metadata = DictionaryTreeBrowser()
         mp = self.metadata
         mp.add_node("_HyperSpy")
         mp.add_node("General")
@@ -2215,7 +2215,7 @@ class BaseSignal(FancySlicing,
         folding.signal_unfolded = False
         folding.original_shape = None
         folding.original_axes_manager = None
-        self.original_metadata = DictionaryTreeBrowser()
+        self._original_metadata = DictionaryTreeBrowser()
         self.tmp_parameters = DictionaryTreeBrowser()
 
     def __repr__(self):
@@ -2413,6 +2413,38 @@ class BaseSignal(FancySlicing,
         if not isinstance(value, da.Array):
             value = np.asanyarray(value)
         self._data = np.atleast_1d(value)
+
+
+    @property
+    def metadata(self):
+        """The metadata of the signal."""
+        return self._metadata
+
+    @metadata.setter
+    def metadata(self, d):
+        warnings.warn(
+            "Setting `metadata` attribute is deprecated and will be removed "
+            "in HyperSpy 2.0. Use the `set_item` and `add_dictionary` methods "
+            "of `metadata` attribute instead."
+            )
+        if isinstance(d, dict):
+            d = DictionaryTreeBrowser(d)
+        self._metadata = d
+
+    @property
+    def original_metadata(self):
+        """The original metadata of the signal."""
+        return self._original_metadata
+
+    @original_metadata.setter
+    def original_metadata(self, d):
+        warnings.warn(
+            "Setting `original_metadata` attribute is deprecated and will be "
+            "removed in HyperSpy 2.0. Use the `set_item` and `add_dictionary` "
+            "methods of `original_metadata` attribute instead.")
+        if isinstance(d, dict):
+            d = DictionaryTreeBrowser(d)
+        self._original_metadata = d
 
     @property
     def ragged(self):
@@ -3372,10 +3404,10 @@ class BaseSignal(FancySlicing,
                 self.original_metadata, 'stack_elements'):
             for i, spectrum in enumerate(splitted):
                 se = self.original_metadata.stack_elements['element' + str(i)]
-                spectrum.metadata = copy.deepcopy(
-                    se['metadata'])
-                spectrum.original_metadata = copy.deepcopy(
-                    se['original_metadata'])
+                spectrum._metadata = copy.deepcopy(se['metadata'])
+                spectrum._original_metadata = copy.deepcopy(
+                    se['original_metadata']
+                    )
                 spectrum.metadata.General.title = se.metadata.General.title
 
         return splitted

--- a/hyperspy/tests/io/test_nexus_hdf.py
+++ b/hyperspy/tests/io/test_nexus_hdf.py
@@ -34,7 +34,9 @@ from hyperspy.io_plugins.nexus import (_byte_to_string, _fix_exclusion_keys,
                                        read_metadata_from_file, _getlink,
                                        _check_search_keys, _parse_from_file,
                                        _nexus_dataset_to_signal)
+from hyperspy.misc.utils import DictionaryTreeBrowser
 from hyperspy.signals import BaseSignal
+
 
 dirpath = os.path.dirname(__file__)
 
@@ -43,7 +45,6 @@ file2 = os.path.join(dirpath, 'nexus_files', 'saved_multi_signal.nxs')
 file3 = os.path.join(dirpath, 'nexus_files', 'nexus_dls_example.nxs')
 file4 = os.path.join(dirpath, 'nexus_files', 'nexus_dls_example_no_axes.nxs')
 file5 = os.path.join(dirpath, 'nexus_files', 'nexus_test_datakey.nxs')
-
 
 
 my_path = os.path.dirname(__file__)
@@ -337,8 +338,15 @@ class TestSavingMetadataContainers:
         s.original_metadata.set_item("testarray1", ["a", 2, "b", 4, 5])
         s.original_metadata.set_item("testarray2", (1, 2, 3, 4, 5))
         s.original_metadata.set_item("testarray3", np.array([1, 2, 3, 4, 5]))
-        s.original_metadata = s.original_metadata.as_dictionary()
-        s.metadata = s.metadata.as_dictionary()
+
+        with pytest.warns():
+            s.original_metadata = s.original_metadata.as_dictionary()
+        with pytest.warns():
+            s.metadata = s.metadata.as_dictionary()
+
+        assert isinstance(s.metadata, DictionaryTreeBrowser)
+        assert isinstance(s.original_metadata, DictionaryTreeBrowser)
+
         fname = tmp_path / 'test.nxs'
         s.save(fname)
         lin = load(fname, nxdata_only=True)

--- a/hyperspy/tests/io/test_tvips.py
+++ b/hyperspy/tests/io/test_tvips.py
@@ -205,7 +205,7 @@ def test_main_header_from_signal(unit, expected_scale_factor, version, fheb,
                                  sig, fake_signals, metadata, fake_metadatas):
     signal = fake_signals[sig]
     if metadata is not None:
-        signal.metadata = fake_metadatas[metadata]
+        signal._metadata = fake_metadatas[metadata]
     signal.axes_manager[-1].units = unit
     signal.axes_manager[-2].units = unit
     original_scale_x = signal.axes_manager[-2].scale

--- a/hyperspy/tests/misc/test_date_time_tools.py
+++ b/hyperspy/tests/misc/test_date_time_tools.py
@@ -109,13 +109,16 @@ def test_update_date_time_in_metadata():
     assert_deep_almost_equal(md13.General.date, md2.General.date)
     assert_deep_almost_equal(md13.General.time, md2.General.time)
     assert_deep_almost_equal(md13.General.time_zone, '-05:00')
-    assert_deep_almost_equal(dtt.update_date_time_in_metadata(dt2, md.deepcopy()).as_dictionary(),
-                             md2.as_dictionary())
+    assert_deep_almost_equal(
+        dtt.update_date_time_in_metadata(dt2, md.deepcopy()).as_dictionary(),
+        md2.as_dictionary())
 
-    assert_deep_almost_equal(dtt.update_date_time_in_metadata(iso3, md.deepcopy()).as_dictionary(),
-                             md3.as_dictionary())
-    assert_deep_almost_equal(dtt.update_date_time_in_metadata(dt3, md.deepcopy()).as_dictionary(),
-                             md3.as_dictionary())
+    assert_deep_almost_equal(
+        dtt.update_date_time_in_metadata(iso3, md.deepcopy()).as_dictionary(),
+        md3.as_dictionary())
+    assert_deep_almost_equal(
+        dtt.update_date_time_in_metadata(dt3, md.deepcopy()).as_dictionary(),
+        md3.as_dictionary())
 
 
 def test_serial_date_to_ISO_format():

--- a/hyperspy/tests/samfire/test_samfire.py
+++ b/hyperspy/tests/samfire/test_samfire.py
@@ -194,6 +194,15 @@ class TestSamfireEmpty:
         samf.stop()
         del samf
 
+    def test_samfire_set_metadata_deprecation(self):
+        m = self.model
+        samf = m.create_samfire(workers=N_WORKERS, setup=False)
+        with pytest.warns():
+            samf.metadata = samf.metadata.as_dictionary()
+        assert isinstance(samf.metadata, DictionaryTreeBrowser)
+        samf.stop()
+        del samf
+
     def test_samfire_init_strategy_list(self):
         from hyperspy.samfire import StrategyList
         m = self.model

--- a/hyperspy/tests/utils/test_stack.py
+++ b/hyperspy/tests/utils/test_stack.py
@@ -22,8 +22,6 @@ import pytest
 from hyperspy import utils
 from hyperspy.signal import BaseSignal
 from hyperspy.exceptions import VisibleDeprecationWarning
-from hyperspy.misc.utils import DictionaryTreeBrowser
-
 
 
 def test_stack_warning():
@@ -34,14 +32,15 @@ def test_stack_warning():
 class TestUtilsStack:
 
     def setup_method(self, method):
-        s = BaseSignal(np.random.random((3, 2, 5)))
+        s = BaseSignal(np.random.random((3, 2, 5)),
+                       original_metadata={'om': 'some metadata'}
+                       )
         s.axes_manager.set_signal_dimension(1)
         s.axes_manager[0].name = "x"
         s.axes_manager[1].name = "y"
         s.axes_manager[2].name = "E"
         s.axes_manager[2].scale = 0.5
         s.metadata.General.title = 'test'
-        s.original_metadata = DictionaryTreeBrowser({'om': 'some metadata'})
         self.signal = s
 
     @pytest.mark.parametrize('stack_metadata', [True, False, 0, 1])

--- a/upcoming_changes/2913.api.rst
+++ b/upcoming_changes/2913.api.rst
@@ -1,1 +1,4 @@
-Deprecate setting ``metadata`` and ``original_metadata`` attributes in favour of using :py:meth:`~.misc.utils.DictionaryTreeBrowser.set_item` and :py:meth:`~.misc.utils.DictionaryTreeBrowser.add_dictionary` methods or specifying metadata when creating signals
+Deprecate the ability to directly set ``metadata`` and ``original_metadata`` Signal 
+attributes in favor of using :py:meth:`~.misc.utils.DictionaryTreeBrowser.set_item` 
+and :py:meth:`~.misc.utils.DictionaryTreeBrowser.add_dictionary` methods or 
+specifying metadata when creating signals

--- a/upcoming_changes/2913.api.rst
+++ b/upcoming_changes/2913.api.rst
@@ -1,0 +1,1 @@
+Deprecate setting ``metadata`` and ``original_metadata`` attributes in favour of using :py:meth:`~.misc.utils.DictionaryTreeBrowser.set_item` and :py:meth:`~.misc.utils.DictionaryTreeBrowser.add_dictionary` methods or specifying metadata when creating signals


### PR DESCRIPTION
in favour of using `set_item` and `add_dictionary` methods or specifying metadata when creating signals - fix https://github.com/hyperspy/hyperspy/pull/2874#issuecomment-1079702636.

### Progress of the PR
- [x] Add deprecation warning when setting `metadata` and `original_metadata` attributes
- [n/a] update docstring (if appropriate),
- [n/a] update user guide (if appropriate),
- [x] add an changelog entry in the `upcoming_changes` folder (see [`upcoming_changes/README.rst`](https://github.com/hyperspy/hyperspy/blob/RELEASE_next_minor/upcoming_changes/README.rst)),
- [x] Check formatting changelog entry in the `readthedocs` doc build of this PR (link in github checks)
- [x] add tests,
- [x] ready for review.

### Minimal example of the bug fix or the new feature
```python
import hyperspy.api as hs
import numpy as np
s = hs.signals.Signal1D(np.arange(10))
s.original_metadata.add_dictionary({'a':'A', 'b':'B'})
print(s.original_metadata)
```