### PR TITLE
Fix eelsdb

### DIFF
--- a/hyperspy/io_plugins/msa.py
+++ b/hyperspy/io_plugins/msa.py
@@ -247,8 +247,6 @@ def parse_msa_string(string, filename=None):
                 'Possible malformed TIME field in msa file. The time '
                 f'information could not be retrieved.: {e}'
                 )
-    else:
-        _logger.warning('TIME information missing.')
 
     malformed_date_error = 'Possibly malformed DATE in msa file. The date information could not be retrieved.'
     if "DATE" in parameters and parameters["DATE"]:

--- a/hyperspy/tests/datasets/test_eelsdb.py
+++ b/hyperspy/tests/datasets/test_eelsdb.py
@@ -25,6 +25,20 @@ from requests.exceptions import SSLError
 from hyperspy.misc.eels.eelsdb import eelsdb
 
 
+def _eelsdb(**kwargs):
+    try:
+        ss = eelsdb(**kwargs)
+    except SSLError:
+        warnings.warn(
+            "The https://eelsdb.eu certificate seems to be invalid. "
+            "Consider notifying the issue to the EELSdb webmaster.")
+        ss = eelsdb(verify_certificate=False, **kwargs)
+    except Exception as e:
+        # e.g. failures such as ConnectionError or MaxRetryError
+        pytest.skip(f"Skipping eelsdb test due to {e}")
+    return ss
+
+
 def eelsdb_down():
     try:
         _ = requests.get('http://api.eelsdb.eu', verify=True)
@@ -38,45 +52,22 @@ def eelsdb_down():
 
 @pytest.mark.skipif(eelsdb_down(), reason="Unable to connect to EELSdb")
 def test_eelsdb_eels():
-    try:
-        ss = eelsdb(
-            title="Boron Nitride Multiwall Nanotube",
-            formula="BN",
-            spectrum_type="coreloss",
-            edge="K",
-            min_energy=370,
-            max_energy=1000,
-            min_energy_compare="gt",
-            max_energy_compare="lt",
-            resolution="0.7 eV",
-            resolution_compare="lt",
-            max_n=2,
-            order="spectrumMin",
-            order_direction='DESC',
-            monochromated=False, )
-    except SSLError:
-        warnings.warn(
-            "The https://eelsdb.eu certificate seems to be invalid. "
-            "Consider notifying the issue to the EELSdb webmaster.")
-        ss = eelsdb(
-            title="Boron Nitride Multiwall Nanotube",
-            formula="BN",
-            spectrum_type="coreloss",
-            edge="K",
-            min_energy=370,
-            max_energy=1000,
-            min_energy_compare="gt",
-            max_energy_compare="lt",
-            resolution="0.7 eV",
-            resolution_compare="lt",
-            max_n=2,
-            order="spectrumMin",
-            order_direction='DESC',
-            monochromated=False,
-            verify_certificate=False)
-    except Exception as e:
-        # e.g. failures such as ConnectionError or MaxRetryError
-        pytest.skip(f"Skipping eelsdb test due to {e}")
+    ss = _eelsdb(
+        title="Boron Nitride Multiwall Nanotube",
+        formula="BN",
+        spectrum_type="coreloss",
+        edge="K",
+        min_energy=370,
+        max_energy=1000,
+        min_energy_compare="gt",
+        max_energy_compare="lt",
+        resolution="0.7 eV",
+        resolution_compare="lt",
+        max_n=2,
+        order="spectrumMin",
+        order_direction='DESC',
+        monochromated=False,
+        )
 
     assert len(ss) == 2
     md = ss[0].metadata
@@ -94,16 +85,18 @@ def test_eelsdb_eels():
 
 @pytest.mark.skipif(eelsdb_down(), reason="Unable to connect to EELSdb")
 def test_eelsdb_xas():
-    try:
-        ss = eelsdb(
-            spectrum_type="xrayabs", max_n=1,)
-    except SSLError:
-        ss = eelsdb(
-            spectrum_type="xrayabs", max_n=1, verify_certificate=False)
-    except Exception as e:
-        # e.g. failures such as ConnectionError or MaxRetryError
-        pytest.skip(f"Skipping eelsdb test due to {e}")
-
+    ss = _eelsdb(spectrum_type="xrayabs", max_n=1,)
     assert len(ss) == 1
     md = ss[0].metadata
     assert md.Signal.signal_type == "XAS"
+
+
+@pytest.mark.skipif(eelsdb_down(), reason="Unable to connect to EELSdb")
+def test_eelsdb_corrupted_file():
+    ss = _eelsdb(
+        spectrum_type='coreloss', element='Cu', edge='K', formula='Cu4O3'
+        )
+    assert len(ss) == 1
+    assert ss[0].metadata.General.title == 'O-K edge in Cu4O3'
+    
+

--- a/hyperspy/tests/datasets/test_eelsdb.py
+++ b/hyperspy/tests/datasets/test_eelsdb.py
@@ -98,5 +98,16 @@ def test_eelsdb_corrupted_file():
         )
     assert len(ss) == 1
     assert ss[0].metadata.General.title == 'O-K edge in Cu4O3'
-    
 
+
+@pytest.mark.skipif(eelsdb_down(), reason="Unable to connect to EELSdb")
+def test_eelsdb_elements_no():
+    title = "Zero-loss c-FEG Hitachi Disp 0.214 eV"
+    ss = _eelsdb(author='Luc Lajaunie', title=title)
+    assert len(ss) == 1
+    assert ss[0].metadata.General.title == title
+
+
+@pytest.mark.skipif(eelsdb_down(), reason="Unable to connect to EELSdb")
+def test_eelsdb_txt_file():
+    _ = _eelsdb(title="Porous cobalt coating with He-filled nanopores")

--- a/upcoming_changes/2916.bugfix.rst
+++ b/upcoming_changes/2916.bugfix.rst
@@ -1,0 +1,1 @@
+Fix bug with importing some spectra from eelsdb and add progress bar


### PR DESCRIPTION
This PR fix reading some spectra from EELS. For example, the following is broken:
```python
import hyperspy.api as hs

hs.datasets.eelsdb(spectrum_type='coreloss', element='Cu', edge='K', formula='Cu4O3')
hs.datasets.eelsdb(title="Porous cobalt coating with He-filled nanopores")
hs.datasets.eelsdb(title="Zero-loss c-FEG Hitachi Disp 0.214 eV")
```

### Progress of the PR
- [x] Add progress bar when downloading spectra from eelsdb,
- [x] add workaround for malformatted msa file from eelsdb,
- [x] don't warn when the time is missing in msa file,
- [x] don't try to download txt file from the eelsdb - I suggested to https://eelsdb.eu/about/ to convert these file to msa, as this would be the proper fix 
- [x] add an changelog entry in the `upcoming_changes` folder (see [`upcoming_changes/README.rst`](https://github.com/hyperspy/hyperspy/blob/RELEASE_next_minor/upcoming_changes/README.rst)),
- [x] Check formatting changelog entry in the `readthedocs` doc build of this PR (link in github checks)
- [x] add tests,
- [x] ready for review.

### Minimal example of the bug fix or the new feature

Now, all spectra (saved as msa file) can be downloaded without error
```python
import hyperspy.api as hs

# get all spectra from the eelsdb database
list_spectra = hs.datasets.eelsdb(show_progressbar=True)
```