### PR TITLE
add new issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,26 @@
+---
+name: Bug report
+about: Create a report to help us improve
+title: ''
+labels: 'type: bug'
+
+---
+
+#### Describe the bug
+A clear and concise description of what the bug is.
+
+#### To Reproduce
+Steps to reproduce the behavior:
+```
+Minimum working example of code
+```
+
+#### Expected behavior
+A clear and concise description of what you expected to happen.
+
+#### Python environement:
+ - HyperSpy version: 1.x.x
+ - Python version: 3.x
+
+#### Additional context
+Add any other context about the problem here. If necessary, add screenshots to help explain your problem.

--- a/.github/ISSUE_TEMPLATE/custom.md
+++ b/.github/ISSUE_TEMPLATE/custom.md
@@ -1,0 +1,8 @@
+---
+name: Custom issue template
+about: Describe this issue template's purpose here.
+title: ''
+labels: ''
+---
+
+

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,17 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+title: ''
+labels: 'type: feature request'
+assignees: ''
+
+---
+
+#### Describe the functionality you would like to see.
+A clear and concise description of what you would like to do.
+
+#### Describe the context
+Do you want to extend existing functionalities, what types of signals should it apply to, etc.
+
+#### Additional information
+Add any other context or screenshots about the feature request here.


### PR DESCRIPTION
Add three types of issue templates:
- bug report
- feature request
- custom 

Adapted from [Lumispy](https://github.com/LumiSpy/lumispy/tree/main/.github/ISSUE_TEMPLATE)

Improves community standards adherence: https://github.com/hyperspy/hyperspy/community

### Progress of the PR
- [X] Change implemented (can be split into several points),
- [X] ready for review.