### PR TITLE
Test suite fixes

### DIFF
--- a/hyperspy/tests/io/test_jeol.py
+++ b/hyperspy/tests/io/test_jeol.py
@@ -161,21 +161,19 @@ def test_load_datacube(SI_dtype):
 
 def test_load_datacube_rebin_energy():
     filename = TESTS_FILE_PATH / 'Sample' / '00_View000' / test_files[7]
-    s = hs.load(filename, cutoff_at_kV=1)
+    s = hs.load(filename, cutoff_at_kV=0.1)
     s_sum = s.sum()
 
     ref_data = hs.signals.Signal1D(
-        np.array([1032, 1229, 1409, 1336, 1239, 1169, 969, 850, 759, 782, 773,
-                  779, 853, 810, 825, 927, 1110, 1271, 1656, 1948])
+        np.array([   3,   23,   77,  200,  487,  984, 1599, 2391])
         )
-    np.testing.assert_allclose(s_sum.isig[0.5:0.7].data, ref_data.data)
+    np.testing.assert_allclose(s_sum.data[88:96], ref_data.data)
 
-    rebin_energy = 2
+    rebin_energy = 8
     s2 = hs.load(filename, rebin_energy=rebin_energy)
     s2_sum = s2.sum()
 
-    ref_data2 = ref_data.rebin(scale=(rebin_energy,))
-    np.testing.assert_allclose(s2_sum.isig[0.5:0.7].data, ref_data2.data)
+    np.testing.assert_allclose(s2_sum.data[11:12], ref_data.data.sum())
 
     with pytest.raises(ValueError, match='must be a multiple'):
         _ = hs.load(filename, rebin_energy=10)

--- a/hyperspy/tests/model/test_linear_model.py
+++ b/hyperspy/tests/model/test_linear_model.py
@@ -297,7 +297,7 @@ class TestLinearEELSFitting:
         lm = m.as_signal()
         std_lm = m.p_std
         diff = linear - lm
-        np.testing.assert_allclose(diff.data.sum(), 0.0, atol=3E-7)
+        np.testing.assert_allclose(diff.data.sum(), 0.0, atol=1E-6)
         np.testing.assert_allclose(std_linear, std_lm)
 
     def test_nonconvolved(self):

--- a/hyperspy/tests/samfire/test_samfire.py
+++ b/hyperspy/tests/samfire/test_samfire.py
@@ -197,7 +197,7 @@ class TestSamfireEmpty:
     def test_samfire_set_metadata_deprecation(self):
         m = self.model
         samf = m.create_samfire(workers=N_WORKERS, setup=False)
-        with pytest.warns():
+        with pytest.warns(UserWarning):
             samf.metadata = samf.metadata.as_dictionary()
         assert isinstance(samf.metadata, DictionaryTreeBrowser)
         samf.stop()

--- a/setup.py
+++ b/setup.py
@@ -367,6 +367,7 @@ with update_version_when_dev() as version:
                 'tests/io/tiff_files/*.tif',
                 'tests/io/tiff_files/*.tif.gz',
                 'tests/io/tiff_files/*.dm3',
+                'tests/io/tvips_files/*.tvips'
                 'tests/io/npz_files/*.npz',
                 'tests/io/unf_files/*.unf',
                 'tests/io/bruker_data/*.bcf',

--- a/upcoming_changes/2933.maintenance.rst
+++ b/upcoming_changes/2933.maintenance.rst
@@ -1,0 +1,1 @@
+Fix packaging of test suite and tweak tests to pass on different platform of blas implementation


### PR DESCRIPTION
Fixes for https://github.com/hyperspy/hyperspy-bundle/blob/2eb21074943ba840b78f34538967204a7f22a872/.github/workflows/release.yml#L217

### Progress of the PR
- [x] Increase tolerance so that it pass on different platform/blas implementation,
- [x] Fix tvips test files packaging
- [x] Reduce memory usage of jeol test
- [x] Specify warning in `pytest.warns` call as required by older versions of pytest 
- [x] add an changelog entry in the `upcoming_changes` folder (see [`upcoming_changes/README.rst`](https://github.com/hyperspy/hyperspy/blob/RELEASE_next_minor/upcoming_changes/README.rst)),
- [x] Check formatting changelog entry in the `readthedocs` doc build of this PR (link in github checks)
- [n/a] add tests,
- [x] ready for review.

