### PR TITLE
Respect `show_progressbar` parameter in `BaseSignal.map()`

### DIFF
--- a/hyperspy/signal.py
+++ b/hyperspy/signal.py
@@ -30,6 +30,7 @@ from pathlib import Path
 import warnings
 
 import dask.array as da
+from dask.diagnostics import ProgressBar
 from matplotlib import pyplot as plt
 import numpy as np
 from pint import UndefinedUnitError
@@ -5029,6 +5030,10 @@ class BaseSignal(FancySlicing,
 
         data_stored = False
 
+        if show_progressbar:
+            pbar = ProgressBar()
+            pbar.register()
+
         if inplace:
             if (
                 not self._lazy
@@ -5074,6 +5079,9 @@ class BaseSignal(FancySlicing,
 
         if not lazy_output and not data_stored:
             sig.data = sig.data.compute(num_workers=max_workers)
+
+        if show_progressbar:
+            pbar.unregister()
 
         return sig
 

--- a/hyperspy/signal.py
+++ b/hyperspy/signal.py
@@ -53,7 +53,7 @@ from hyperspy.misc.utils import (
     add_scalar_axis,
     DictionaryTreeBrowser,
     guess_output_signal_size,
-    is_binned, # remove in v2.0
+    is_binned,  # remove in v2.0
     is_cupy_array,
     isiterable,
     iterable_not_string,
@@ -67,9 +67,7 @@ from hyperspy.misc.hist_tools import histogram
 from hyperspy.drawing.utils import animate_legend
 from hyperspy.drawing.marker import markers_metadata_dict_to_markers
 from hyperspy.misc.slicing import SpecialSlicers, FancySlicing
-from hyperspy.misc.utils import (
-    _get_block_pattern
-    )
+from hyperspy.misc.utils import _get_block_pattern
 from hyperspy.docstrings.signal import (
     ONE_AXIS_PARAMETER, MANY_AXIS_PARAMETER, OUT_ARG, NAN_FUNC, OPTIMIZE_ARG,
     RECHUNK_ARG, SHOW_PROGRESSBAR_ARG, PARALLEL_ARG, MAX_WORKERS_ARG,
@@ -4899,6 +4897,9 @@ class BaseSignal(FancySlicing,
         else:
             kwargs["output_signal_size"] = output_signal_size
             kwargs["output_dtype"] = output_dtype
+            if show_progressbar is None:
+                from hyperspy.defaults_parser import preferences
+                show_progressbar = preferences.General.show_progressbar
             # Iteration over coordinates.
             result = self._map_iterate(
                 function,

--- a/upcoming_changes/2946.bugfix.rst
+++ b/upcoming_changes/2946.bugfix.rst
@@ -1,0 +1,1 @@
+Respect ``show_progressbar`` parameter in ``BaseSignal.map()``


### PR DESCRIPTION
### Requirements
Addresses #2946.

### Description of the change
`BaseSignal.map(show_progressbar=True)` doesn't show a progressbar. This PR adds it to `BaseSignal._map_iterate()`.

### Progress of the PR
- [x] Change implemented (can be split into several points),
- [n/a] update docstring (if appropriate),
- [n/a] update user guide (if appropriate),
- [x] add an changelog entry in the `upcoming_changes` folder (see [`upcoming_changes/README.rst`](https://github.com/hyperspy/hyperspy/blob/RELEASE_next_minor/upcoming_changes/README.rst)),
- [x] Check formatting changelog entry in the `readthedocs` doc build of this PR (link in github checks)
- [n/a] add tests,
- [x] ready for review.

### Minimal example of the bug fix or the new feature
Setup

```python
>>> import numpy as np
>>> import scipy.ndimage
>>> import hyperspy.api as hs
>>> s = hs.signals.Signal2D(np.random.random((10, 64, 64)))
```

Before this PR

```python
>>> s.map(scipy.ndimage.gaussian_filter, show_progressbar=True, inplace=True, sigma=2.5)
```

After

```python
>>> s.map(scipy.ndimage.gaussian_filter, show_progressbar=True, inplace=True, sigma=2.5)
[########################################] | 100% Completed |  0.1s
```