### PR TITLE
Fix interactive `set_signal_range` model

### DIFF
--- a/hyperspy/models/model1d.py
+++ b/hyperspy/models/model1d.py
@@ -469,7 +469,7 @@ class Model1D(BaseModel):
         if i2 is not None:
             i2 += 1
         self.channel_switches[i1:i2] = True
-        self.update_plot()
+        self.update_plot(render_figure=True)
 
     def _parse_signal_range_values(self, x1=None, x2=None):
         """Parse signal range values to be used by the `set_signal_range`,

--- a/hyperspy/signal_tools.py
+++ b/hyperspy/signal_tools.py
@@ -203,14 +203,20 @@ class SpanSelectorInSignal1D(t.HasTraits):
 
     def __init__(self, signal):
         if signal.axes_manager.signal_dimension != 1:
-            raise SignalDimensionError(
-                signal.axes_manager.signal_dimension, 1)
+            raise SignalDimensionError(signal.axes_manager.signal_dimension, 1)
+
+        # Plot the signal (or model) if it is not already plotted
+        if signal._plot is None or not signal._plot.is_active:
+            signal.plot()
+        
+        from hyperspy.model import BaseModel
+        if isinstance(signal, BaseModel):
+            signal = signal.signal
 
         self.signal = signal
         self.axis = self.signal.axes_manager.signal_axes[0]
         self.span_selector = None
-        if signal._plot is None or not signal._plot.is_active:
-            signal.plot()
+
         self.span_selector_switch(on=True)
 
         self.signal._plot.signal_plot.events.closed.connect(

--- a/hyperspy/tests/drawing/test_plot_signal_tools.py
+++ b/hyperspy/tests/drawing/test_plot_signal_tools.py
@@ -19,6 +19,7 @@ import matplotlib.pyplot as plt
 import numpy as np
 import pytest
 
+from hyperspy.datasets.artificial_data import get_core_loss_eels_model
 from hyperspy import signals, components1d, datasets
 from hyperspy.signal_tools import (
     ImageContrastEditor,
@@ -269,6 +270,17 @@ def test_span_selector_in_signal1d():
     calibration_tool.span_selector_changed()
     calibration_tool.span_selector.extents = (10.1, 10.2)
     calibration_tool.span_selector_changed()
+
+
+def test_span_selector_in_signal1d_model():
+    m = get_core_loss_eels_model()
+    calibration_tool = SpanSelectorInSignal1D(m)
+    assert len(m.signal._plot.signal_plot.ax_lines) == 2
+    assert m.signal is calibration_tool.signal
+    calibration_tool.span_selector.extents = (420, 460)
+    calibration_tool.span_selector_changed()
+    calibration_tool.span_selector_switch(False)
+    assert calibration_tool.span_selector is None
 
 
 def test_signal1d_calibration():

--- a/upcoming_changes/2946.bugfix.rst
+++ b/upcoming_changes/2946.bugfix.rst
@@ -1,1 +1,1 @@
-Respect ``show_progressbar`` parameter in ``BaseSignal.map()``
+Respect ``show_progressbar`` parameter in :py:meth:`~.signal.BaseSignal.map`

--- a/upcoming_changes/2948.bugfix.rst
+++ b/upcoming_changes/2948.bugfix.rst
@@ -1,0 +1,1 @@
+Fix regression in :py:meth:`~.models.model1d.Model1D.set_signal_range` which was raising an error when used interactively


### PR DESCRIPTION
Fix #2935.

### Progress of the PR
- [x] Fix setting the signal attribute when the `SpanSelectorInSignal1D` is used with model,
- [n/a] update docstring (if appropriate),
- [n/a] update user guide (if appropriate),
- [x] add an changelog entry in the `upcoming_changes` folder (see [`upcoming_changes/README.rst`](https://github.com/hyperspy/hyperspy/blob/RELEASE_next_minor/upcoming_changes/README.rst)),
- [x] Check formatting changelog entry in the `readthedocs` doc build of this PR (link in github checks)
- [x] add tests,
- [x] ready for review.

