### PR TITLE
Fix estimate_shift2d and align2d  docstrings

### DIFF
--- a/doc/user_guide/interactive_operations_ROIs.rst
+++ b/doc/user_guide/interactive_operations_ROIs.rst
@@ -258,7 +258,7 @@ ROIs can be used in place of slices when indexing. For example:
 
 In addition the following all ROIs have a py:meth:`__getitem__` method that enables
 using them in place of tuples.
-For example, the method :py:meth:`~._signals.signal2d.align2D` takes a ``roi``
+For example, the method :py:meth:`~._signals.Signal2D.align2D` takes a ``roi``
 argument with the left, right, top, bottom coordinates of the ROI.
 Handily, we can pass a :py:class:`~.roi.RectangularROI` ROI instead.
 

--- a/hyperspy/_signals/signal2d.py
+++ b/hyperspy/_signals/signal2d.py
@@ -625,8 +625,10 @@ class Signal2D(BaseSignal, CommonSignal2D):
         fill_value : int, float, nan
             The areas with missing data are filled with the given value.
             Default is nan.
-        shifts : None or list of tuples
-            If None the shifts are estimated using
+        shifts : None or array.
+            The array of shifts must be in pixel units. The shape must be
+            the navigation shape using numpy order convention. If `None`
+            the shifts are estimated using 
             :py:meth:`~._signals.signal2D.estimate_shift2D`.
         expand : bool
             If True, the data will be expanded to fit all data after alignment.

--- a/hyperspy/_signals/signal2d.py
+++ b/hyperspy/_signals/signal2d.py
@@ -463,8 +463,8 @@ class Signal2D(BaseSignal, CommonSignal2D):
 
         Returns
         -------
-        shifts : list of array
-            List of estimated shifts
+        shifts : array
+            Estimated shifts in pixels. 
 
         Notes
         -----

--- a/hyperspy/_signals/signal2d.py
+++ b/hyperspy/_signals/signal2d.py
@@ -181,7 +181,7 @@ def estimate_image_shift(ref, image, roi=None, sobel=True,
     Returns
     -------
     shifts: np.array
-        containing the estimate shifts
+        containing the estimate shifts in pixels
     max_value : float
         The maximum value of the correlation
 

--- a/upcoming_changes/2961.doc.rst
+++ b/upcoming_changes/2961.doc.rst
@@ -1,1 +1,1 @@
-Fix and complete docstrings of :py:meth:`~._signals.signal2d.align2D` and :py:meth:`~._signals.signal2d.Signal2D.estimate_shift2D`.
+Fix and complete docstrings of :py:meth:`~._signals.signal2d.Signal2D.align2D` and :py:meth:`~._signals.signal2d.Signal2D.estimate_shift2D`.

--- a/upcoming_changes/2961.doc.rst
+++ b/upcoming_changes/2961.doc.rst
@@ -1,0 +1,1 @@
+Fix and complete docstrings of :py:meth:`~._signals.signal2d.align2D` and :py:meth:`~._signals.signal2d.Signal2D.estimate_shift2D`.


### PR DESCRIPTION
### Description of the change

Following @Nordicus comment in gitter (@Nordicus  :point_up: [June 15, 2022 11:34 AM](https://gitter.im/hyperspy/hyperspy?at=62a9a799c9382316a6567429)), this fixes the docstrings of ``estimate_shift2D`` and ``align2D``.

