### PR TITLE
Fix masked norm poisson

### DIFF
--- a/hyperspy/learn/mva.py
+++ b/hyperspy/learn/mva.py
@@ -1664,7 +1664,7 @@ class MVA:
             if signal_mask is None:
                 signal_mask = slice(None)
             else:
-                signal_mask = ~signal_mask
+                signal_mask = ~signal_mask.ravel()
 
             if dc[:, signal_mask][navigation_mask, :].size == 0:
                 raise ValueError("All the data are masked, change the mask.")

--- a/hyperspy/tests/learn/test_decomposition.py
+++ b/hyperspy/tests/learn/test_decomposition.py
@@ -126,6 +126,9 @@ class TestNdAxes:
         # Check that views of the data don't change. See #871
         np.testing.assert_array_equal(s1.inav[0, 0, 0].data, s1n000.data)
 
+    def test_consistency_poissonian_masked(self):
+        s1 = self.s1
+
 
 @lazifyTestClass
 class TestGetModel:

--- a/hyperspy/tests/learn/test_decomposition.py
+++ b/hyperspy/tests/learn/test_decomposition.py
@@ -126,9 +126,33 @@ class TestNdAxes:
         # Check that views of the data don't change. See #871
         np.testing.assert_array_equal(s1.inav[0, 0, 0].data, s1n000.data)
 
-    def test_consistency_poissonian_masked(self):
+    @pytest.mark.parametrize("poisson", [True, False])
+    def test_consistency_masked(self, poisson):
         s1 = self.s1
+        sig_mask = s1._get_signal_signal(dtype="bool")
+        nav_mask = s1._get_navigation_signal(dtype="bool").T
+        sig_mask.data[:1, :] = True
+        nav_mask.data[:1, :, :] = True
+        s1s = s1.isig[:, 1:]
+        s1n = s1.inav[:, :, 1:]
+        s1sn = s1n.isig[:, 1:]
+        s1.decomposition(poisson, signal_mask=sig_mask)
+        s1s.decomposition(poisson)
+        np.testing.assert_array_almost_equal(
+            s1s.learning_results.explained_variance,
+            s1.learning_results.explained_variance)
 
+        s1.decomposition(poisson, navigation_mask=nav_mask)
+        s1n.decomposition(poisson)
+        np.testing.assert_array_almost_equal(
+            s1n.learning_results.explained_variance,
+            s1.learning_results.explained_variance)
+
+        s1.decomposition(poisson, navigation_mask=nav_mask, signal_mask=sig_mask)
+        s1sn.decomposition(poisson)
+        np.testing.assert_array_almost_equal(
+            s1sn.learning_results.explained_variance,
+            s1.learning_results.explained_variance)
 
 @lazifyTestClass
 class TestGetModel:

--- a/upcoming_changes/2964.bugfix.rst
+++ b/upcoming_changes/2964.bugfix.rst
@@ -1,3 +1,3 @@
 Fix two bugs in :py:meth:`~.learn.mva.MVA.decomposition`:
-* The poisson noise normalization was not applied when giving a `signal_mask`
-* An error was raised when applying a `signal_mask` on a signal with signal dimension larger than 1.
+ * The poisson noise normalization was not applied when giving a `signal_mask`
+ * An error was raised when applying a ``signal_mask`` on a signal with signal dimension larger than 1.

--- a/upcoming_changes/2964.bugfix.rst
+++ b/upcoming_changes/2964.bugfix.rst
@@ -1,0 +1,3 @@
+Fix two bugs in :py:meth:`~.learn.mva.MVA.decomposition`:
+* The poisson noise normalization was not applied when giving a `signal_mask`
+* An error was raised when applying a `signal_mask` on a signal with signal dimension larger than 1.


### PR DESCRIPTION
### Description of the change

Fixes two `decomposition` bugs:

* When `normalize_poissonian_noise` is `True` and `signal_mask` is not `None`, the poisson noise normalization is actually not applied (!).
* For signals with signals dimensions higher than one, masking the signal dimension was raising an error.

### Progress of the PR
- [x] Change implemented (can be split into several points),
- [x] add an changelog entry in the `upcoming_changes` folder (see [`upcoming_changes/README.rst`](https://github.com/hyperspy/hyperspy/blob/RELEASE_next_minor/upcoming_changes/README.rst)),
- [ ] Check formatting changelog entry in the `readthedocs` doc build of this PR (link in github checks)
- [x] add tests,
- [x] ready for review.

### Minimal example of the bug fix or the new feature

One can verify that executing the code below with `True` -> `False` gives the same result with the unfixed code, but not with this fix.

```python
import hyperspy.api as hs
import numpy as np

s = hs.datasets.artificial_data.get_core_loss_eels_line_scan_signal()
mask = s._get_signal_signal(dtype="bool")
nav_mask = s._get_navigation_signal(dtype="bool")

mask.data[:1] = True
nav_mask.data[:1] = True

s.decomposition(True, navigation_mask=nav_mask.T, signal_mask=mask, )
```


