### PR TITLE
Add type-hinting to commonly-used methods

### DIFF
--- a/hyperspy/__init__.py
+++ b/hyperspy/__init__.py
@@ -18,6 +18,7 @@
 
 import importlib
 import logging
+from typing import TYPE_CHECKING
 from hyperspy import docstrings
 
 _logger = logging.getLogger(__name__)
@@ -40,6 +41,9 @@ More details in the :mod:`~hyperspy.api` docstring.
 
 """ % docstrings.START_HSPY
 
+if TYPE_CHECKING:
+    from hyperspy import api
+    from hyperspy.Release import version as __version__
 
 __all__ = [
     "api",
@@ -59,7 +63,7 @@ _import_mapping = {
 def __getattr__(name):
     if name in __all__:
         if name in _import_mapping.keys():
-            import_path = 'hyperspy' + _import_mapping.get(name)
+            import_path = 'hyperspy' + _import_mapping[name]
             return getattr(importlib.import_module(import_path), name)
         else:  # pragma: no cover
             # We can't get this block covered in the test suite because it is

--- a/hyperspy/_signals/eds_sem.py
+++ b/hyperspy/_signals/eds_sem.py
@@ -22,6 +22,7 @@ import traits.api as t
 
 from hyperspy._signals.eds import (EDSSpectrum, LazyEDSSpectrum)
 from hyperspy.defaults_parser import preferences
+from hyperspy.models.edstemmodel import EDSTEMModel
 from hyperspy.ui_registry import add_gui_method, DISPLAY_DT, TOOLKIT_DT
 from hyperspy.signal import BaseSetMetadataItems
 
@@ -278,7 +279,7 @@ class EDSSEMSpectrum(EDSSpectrum):
             return False
 
     def create_model(self, auto_background=True, auto_add_lines=True,
-                     *args, **kwargs):
+                     *args, **kwargs) -> EDSTEMModel:
         """Create a model for the current SEM EDS data.
 
         Parameters

--- a/hyperspy/_signals/eds_tem.py
+++ b/hyperspy/_signals/eds_tem.py
@@ -24,6 +24,7 @@ import traits.api as t
 import numpy as np
 from scipy import constants
 import pint
+from hyperspy.models.edstemmodel import EDSTEMModel
 
 from hyperspy.signal import BaseSetMetadataItems, BaseSignal
 from hyperspy import utils
@@ -746,7 +747,7 @@ class EDSTEMSpectrum(EDSSpectrum):
             self.learning_results.loadings)
 
     def create_model(self, auto_background=True, auto_add_lines=True,
-                     *args, **kwargs):
+                     *args, **kwargs) -> EDSTEMModel:
         """Create a model for the current TEM EDS data.
 
         Parameters

--- a/hyperspy/_signals/eels.py
+++ b/hyperspy/_signals/eels.py
@@ -24,6 +24,7 @@ import dask.array as da
 import traits.api as t
 from scipy import constants
 from prettytable import PrettyTable
+from hyperspy.models.eelsmodel import EELSModel
 
 from hyperspy.signal import BaseSetMetadataItems, BaseSignal
 from hyperspy._signals.signal1d import (Signal1D, LazySignal1D)
@@ -1537,7 +1538,7 @@ class EELSSpectrum(Signal1D):
             return eps, output
 
     def create_model(self, ll=None, auto_background=True, auto_add_edges=True,
-                     GOS=None, dictionary=None):
+                     GOS=None, dictionary=None) -> EELSModel:
         """Create a model for the current EELS data.
 
         Parameters

--- a/hyperspy/_signals/eels.py
+++ b/hyperspy/_signals/eels.py
@@ -16,15 +16,20 @@
 # You should have received a copy of the GNU General Public License
 # along with HyperSpy. If not, see <https://www.gnu.org/licenses/#GPL>.
 
+from __future__ import annotations
+
 import numbers
 import logging
+from typing import TYPE_CHECKING
 
 import numpy as np
 import dask.array as da
 import traits.api as t
 from scipy import constants
 from prettytable import PrettyTable
-from hyperspy.models.eelsmodel import EELSModel
+
+if TYPE_CHECKING:
+    from hyperspy.models.eelsmodel import EELSModel
 
 from hyperspy.signal import BaseSetMetadataItems, BaseSignal
 from hyperspy._signals.signal1d import (Signal1D, LazySignal1D)

--- a/hyperspy/_signals/signal1d.py
+++ b/hyperspy/_signals/signal1d.py
@@ -357,7 +357,7 @@ class Signal1D(BaseSignal, CommonSignal1D):
     spikes_removal_tool.__doc__ = SPIKES_REMOVAL_TOOL_DOCSTRING % (
         SIGNAL_MASK_ARG, NAVIGATION_MASK_ARG, "", DISPLAY_DT, TOOLKIT_DT,)
 
-    def create_model(self, dictionary=None):
+    def create_model(self, dictionary=None) -> Model1D:
         """Create a model for the current data.
 
         Returns

--- a/hyperspy/_signals/signal1d.py
+++ b/hyperspy/_signals/signal1d.py
@@ -16,6 +16,8 @@
 # You should have received a copy of the GNU General Public License
 # along with HyperSpy. If not, see <https://www.gnu.org/licenses/#GPL>.
 
+from __future__ import annotations
+
 import os
 import logging
 import math
@@ -27,10 +29,12 @@ from scipy import interpolate
 from scipy.signal import savgol_filter, medfilt
 from scipy.ndimage import gaussian_filter1d
 
+
+
+from hyperspy.models.model1d import Model1D
 from hyperspy.signal import BaseSignal
 from hyperspy._signals.common_signal1d import CommonSignal1D
 from hyperspy.signal_tools import SpikesRemoval, SpikesRemovalInteractive
-from hyperspy.models.model1d import Model1D
 from hyperspy.misc.lowess_smooth import lowess
 from hyperspy.misc.utils import is_binned # remove in v2.0
 
@@ -1249,7 +1253,7 @@ class Signal1D(BaseSignal, CommonSignal1D):
 
         self._check_signal_dimension_equals_one()
         # Create model here, so that we can return it
-        from hyperspy.models.model1d import Model1D
+
         model = Model1D(self)
         if signal_range == 'interactive':
             br = BackgroundRemoval(self, background_type=background_type,

--- a/hyperspy/_signals/signal2d.py
+++ b/hyperspy/_signals/signal2d.py
@@ -16,16 +16,21 @@
 # You should have received a copy of the GNU General Public License
 # along with HyperSpy. If not, see <https://www.gnu.org/licenses/#GPL>.
 
+from __future__ import annotations
+
 import matplotlib.pyplot as plt
 import numpy as np
 import numpy.ma as ma
 import dask.array as da
 import logging
+from typing import TYPE_CHECKING
 import warnings
 
 from scipy import ndimage
 
-from hyperspy.models.model2d import Model2D
+if TYPE_CHECKING:
+    from hyperspy.models.model2d import Model2D
+
 try:
     # For scikit-image >= 0.17.0
     from skimage.registration._phase_cross_correlation import _upsampled_dft

--- a/hyperspy/_signals/signal2d.py
+++ b/hyperspy/_signals/signal2d.py
@@ -24,6 +24,8 @@ import logging
 import warnings
 
 from scipy import ndimage
+
+from hyperspy.models.model2d import Model2D
 try:
     # For scikit-image >= 0.17.0
     from skimage.registration._phase_cross_correlation import _upsampled_dft
@@ -378,7 +380,7 @@ class Signal2D(BaseSignal, CommonSignal2D):
     plot.__doc__ %= (BASE_PLOT_DOCSTRING, BASE_PLOT_DOCSTRING_PARAMETERS,
                      PLOT2D_DOCSTRING, PLOT2D_KWARGS_DOCSTRING)
 
-    def create_model(self, dictionary=None):
+    def create_model(self, dictionary=None) -> Model2D:
         """Create a model for the current signal
 
         Parameters

--- a/hyperspy/api.py
+++ b/hyperspy/api.py
@@ -41,7 +41,7 @@ def __dir__():
 def __getattr__(name):
     if name in __all__:
         if name in _import_mapping.keys():
-            import_path = 'hyperspy' + _import_mapping.get(name)
+            import_path = 'hyperspy' + _import_mapping[name]
             return getattr(importlib.import_module(import_path), name)
         else:
             return importlib.import_module("." + name, 'hyperspy')

--- a/hyperspy/api.py
+++ b/hyperspy/api.py
@@ -19,6 +19,7 @@
 
 import importlib
 import logging
+from typing import TYPE_CHECKING
 
 import hyperspy.api_nogui
 from hyperspy.api_nogui import __doc__, get_configuration_directory_path
@@ -29,8 +30,43 @@ from hyperspy.Release import version as __version__
 
 _logger = logging.getLogger(__name__)
 
+# Eager imports when type checking since VSCode pylance doesn't support lazy loading
+if TYPE_CHECKING:
+    from hyperspy import datasets, interactive, model, signals
+    from hyperspy.io import load
+    from hyperspy.misc.utils import stack, transpose
+    from hyperspy.utils import (
+        eds,
+        markers,
+        material,
+        plot,
+        print_known_signal_types,
+        roi,
+        samfire
+        )
 
-__all__ = hyperspy.api_nogui.__all__
+# We can't link __all__ to api_nogui.__all__ due to VSCode autocomplete not supporting it.
+# See https://github.com/microsoft/pyright/issues/3595
+__all__ = [
+    'datasets',
+    'eds',
+    'get_configuration_directory_path',
+    'interactive',
+    'load',
+    'markers',
+    'material',
+    'model',
+    'plot',
+    'preferences',
+    'print_known_signal_types',
+    'roi',
+    'samfire',
+    'set_log_level',
+    'signals',
+    'stack',
+    'transpose',
+    '__version__',
+    ]
 _import_mapping = hyperspy.api_nogui._import_mapping
 
 

--- a/hyperspy/api_nogui.py
+++ b/hyperspy/api_nogui.py
@@ -22,6 +22,7 @@
 import logging
 import importlib
 import sys
+from typing import TYPE_CHECKING
 
 _logger = logging.getLogger(__name__)
 from hyperspy.logger import set_log_level
@@ -104,6 +105,19 @@ def get_configuration_directory_path():
     import hyperspy.misc.config_dir
     return hyperspy.misc.config_dir.config_path
 
+if TYPE_CHECKING:
+    from hyperspy import datasets, interactive, model, signals
+    from hyperspy.io import load
+    from hyperspy.misc.utils import stack, transpose
+    from hyperspy.utils import (
+        eds,
+        markers,
+        material,
+        plot,
+        print_known_signal_types,
+        roi,
+        samfire
+        )
 
 __all__ = [
     'datasets',

--- a/hyperspy/api_nogui.py
+++ b/hyperspy/api_nogui.py
@@ -144,7 +144,7 @@ __all__ = [
 # mapping following the pattern: from value import key
 _import_mapping = {
     'eds':'.utils',
-    'interactive': '.utils',
+    'interactive':'.utils',
     'load': '.io',
     'markers': '.utils',
     'material': '.utils',
@@ -153,8 +153,8 @@ _import_mapping = {
     'print_known_signal_types': '.utils',
     'roi': '.utils',
     'samfire': '.utils',
-    'stack': '.utils',
-    'transpose': '.utils',
+    'stack': '.misc.utils',
+    'transpose': '.misc.utils',
     }
 
 

--- a/hyperspy/api_nogui.py
+++ b/hyperspy/api_nogui.py
@@ -165,7 +165,7 @@ def __dir__():
 def __getattr__(name):
     if name in __all__:
         if name in _import_mapping.keys():
-            import_path = 'hyperspy' + _import_mapping.get(name)
+            import_path = 'hyperspy' + _import_mapping[name]
             return getattr(importlib.import_module(import_path), name)
         else:
             return importlib.import_module("." + name, 'hyperspy')

--- a/hyperspy/api_nogui.py
+++ b/hyperspy/api_nogui.py
@@ -105,6 +105,8 @@ def get_configuration_directory_path():
     import hyperspy.misc.config_dir
     return hyperspy.misc.config_dir.config_path
 
+
+# Eager imports when type checking since VSCode pylance doesn't support lazy loading
 if TYPE_CHECKING:
     from hyperspy import datasets, interactive, model, signals
     from hyperspy.io import load

--- a/hyperspy/axes.py
+++ b/hyperspy/axes.py
@@ -16,10 +16,13 @@
 # You should have received a copy of the GNU General Public License
 # along with HyperSpy. If not, see <https://www.gnu.org/licenses/#GPL>.
 
+from __future__ import annotations
+
 from contextlib import contextmanager
 import copy
 import math
 import logging
+from collections.abc import Sequence
 
 import dask.array as da
 import numpy as np
@@ -266,19 +269,19 @@ class BaseDataAxis(t.HasTraits):
     is_binned : bool, optional
         True if data along the axis is binned. Default False.
     """
-    name = t.Str()
-    units = t.Str()
-    size = t.CInt()
-    low_value = t.Float()
-    high_value = t.Float()
+    name: str = t.Str()
+    units: str = t.Str()
+    size: int = t.CInt()
+    low_value: int|float = t.Float()
+    high_value: int|float = t.Float()
     value = t.Range('low_value', 'high_value')
-    low_index = t.Int(0)
-    high_index = t.Int()
+    low_index: int = t.Int(0)
+    high_index: int = t.Int()
     slice = t.Instance(slice)
-    navigate = t.Bool(False)
-    is_binned = t.Bool(t.Undefined)
-    index = t.Range('low_index', 'high_index')
-    axis = t.Array()
+    navigate: bool = t.Bool(False)
+    is_binned: bool = t.Bool(t.Undefined)
+    index: int = t.Range('low_index', 'high_index')
+    axis: np.ndarray = t.Array()
 
     def __init__(self,
                  index_in_array=None,
@@ -331,7 +334,7 @@ class BaseDataAxis(t.HasTraits):
         self.index = 0
         self.navigate = navigate
         self.is_binned = is_binned
-        self.axes_manager = None
+        self.axes_manager: AxesManager | None = None
         self._is_uniform = False
 
         # The slice must be updated even if the default value did not
@@ -507,7 +510,7 @@ class BaseDataAxis(t.HasTraits):
             self.low_value, self.high_value = (
                 self.axis.min(), self.axis.max())
 
-    def _update_slice(self, value):
+    def _update_slice(self, value: bool):
         if value is False:
             self.slice = slice(None)
         else:
@@ -683,7 +686,7 @@ class BaseDataAxis(t.HasTraits):
                 i2 = self.value2index(v2)
         return i1, i2
 
-    def update_from(self, axis, attributes):
+    def update_from(self, axis: BaseDataAxis, attributes: Sequence[str]):
         """Copy values of specified axes fields from the passed AxesManager.
 
         Parameters
@@ -1457,8 +1460,8 @@ class AxesManager(t.HasTraits):
     """
 
     _axes = t.List(BaseDataAxis)
-    signal_axes = t.Tuple()
-    navigation_axes = t.Tuple()
+    signal_axes: tuple[BaseDataAxis] = t.Tuple()
+    navigation_axes: tuple[BaseDataAxis] = t.Tuple()
     _step = t.Int(1)
 
     def __init__(self, axes_list):
@@ -1527,7 +1530,7 @@ class AxesManager(t.HasTraits):
                  [1, ])[::-1]
         return ndindex_nat(*shape)
 
-    def __getitem__(self, y):
+    def __getitem__(self, y) -> BaseDataAxis | tuple[BaseDataAxis]:
         """x.__getitem__(y) <==> x[y]
 
         """

--- a/hyperspy/axes.py
+++ b/hyperspy/axes.py
@@ -23,7 +23,6 @@ import copy
 import math
 import logging
 from collections.abc import Sequence
-from typing_extensions import Self
 
 import dask.array as da
 import numpy as np
@@ -2192,7 +2191,7 @@ class AxesManager(t.HasTraits):
     def copy(self):
         return copy.copy(self)
 
-    def deepcopy(self) -> Self:
+    def deepcopy(self) -> AxesManager:
         return copy.deepcopy(self)
 
     def __deepcopy__(self, *args):

--- a/hyperspy/axes.py
+++ b/hyperspy/axes.py
@@ -23,6 +23,7 @@ import copy
 import math
 import logging
 from collections.abc import Sequence
+from typing_extensions import Self
 
 import dask.array as da
 import numpy as np
@@ -1464,7 +1465,7 @@ class AxesManager(t.HasTraits):
     navigation_axes: tuple[BaseDataAxis] = t.Tuple()
     _step = t.Int(1)
 
-    def __init__(self, axes_list):
+    def __init__(self, axes_list: list[BaseDataAxis | dict]):
         super().__init__()
         self.events = Events()
         self.events.indices_changed = Event("""
@@ -2044,22 +2045,22 @@ class AxesManager(t.HasTraits):
         self._update_max_index()
 
     @property
-    def signal_axes(self):
+    def signal_axes(self) -> tuple[BaseDataAxis]:
         """The signal axes as a tuple."""
         return self._signal_axes
 
     @property
-    def navigation_axes(self):
+    def navigation_axes(self) -> tuple[BaseDataAxis]:
         """The navigation axes as a tuple."""
         return self._navigation_axes
 
     @property
-    def signal_shape(self):
+    def signal_shape(self) -> tuple[int]:
         """The shape of the signal space."""
         return tuple([axis.size for axis in self._signal_axes])
 
     @property
-    def navigation_shape(self):
+    def navigation_shape(self) -> tuple[int] | tuple[()]:
         """The shape of the navigation space."""
         if self.navigation_dimension != 0:
             return tuple([axis.size for axis in self._navigation_axes])
@@ -2067,22 +2068,22 @@ class AxesManager(t.HasTraits):
             return ()
 
     @property
-    def signal_size(self):
+    def signal_size(self) -> int:
         """The size of the signal space."""
         return self._signal_size
 
     @property
-    def navigation_size(self):
+    def navigation_size(self) -> int:
         """The size of the navigation space."""
         return self._navigation_size
 
     @property
-    def navigation_dimension(self):
+    def navigation_dimension(self) -> int:
         """The dimension of the navigation space."""
         return self._navigation_dimension
 
     @property
-    def signal_dimension(self):
+    def signal_dimension(self) -> int:
         """The dimension of the signal space."""
         return self._signal_dimension
 
@@ -2191,7 +2192,7 @@ class AxesManager(t.HasTraits):
     def copy(self):
         return copy.copy(self)
 
-    def deepcopy(self):
+    def deepcopy(self) -> Self:
         return copy.deepcopy(self)
 
     def __deepcopy__(self, *args):
@@ -2350,7 +2351,7 @@ class AxesManager(t.HasTraits):
             self.events.indices_changed.trigger(obj=self)
 
     @property
-    def indices(self):
+    def indices(self) -> tuple[int]:
         """
         Get and set the current indices, if the navigation dimension
         is not 0. If the navigation dimension is 0, it raises
@@ -2359,7 +2360,7 @@ class AxesManager(t.HasTraits):
         return tuple([axis.index for axis in self.navigation_axes])
 
     @indices.setter
-    def indices(self, indices):
+    def indices(self, indices: tuple[int]):
         # See class docstring
         if len(indices) != self.navigation_dimension:
             raise AttributeError(
@@ -2401,11 +2402,11 @@ class AxesManager(t.HasTraits):
             setattr(axis, attr, value)
 
     @property
-    def navigation_indices_in_array(self):
+    def navigation_indices_in_array(self) -> tuple[int]:
         return tuple([axis.index_in_array for axis in self.navigation_axes])
 
     @property
-    def signal_indices_in_array(self):
+    def signal_indices_in_array(self) -> tuple[int]:
         return tuple([axis.index_in_array for axis in self.signal_axes])
 
     @property

--- a/hyperspy/component.py
+++ b/hyperspy/component.py
@@ -16,6 +16,9 @@
 # You should have received a copy of the GNU General Public License
 # along with HyperSpy. If not, see <https://www.gnu.org/licenses/#GPL>.
 
+from __future__ import annotations
+from typing import TYPE_CHECKING
+
 import numpy as np
 from dask.array import Array as dArray
 import traits.api as t
@@ -26,14 +29,15 @@ from packaging.version import Version
 from pathlib import Path
 
 import hyperspy
-from hyperspy.axes import AxesManager
+if TYPE_CHECKING:
+    from hyperspy.axes import AxesManager
+    from hyperspy.model import BaseModel
 from hyperspy.misc.utils import slugify, is_binned
 from hyperspy.misc.io.tools import (incremental_filename,
                                     append2pathname,)
 from hyperspy.misc.export_dictionary import export_to_dictionary, \
     load_from_dictionary
 from hyperspy.events import Events, Event
-from hyperspy.model import BaseModel
 from hyperspy.ui_registry import add_gui_method
 from IPython.display import display_pretty, display
 from hyperspy.misc.model_tools import current_component_values

--- a/hyperspy/component.py
+++ b/hyperspy/component.py
@@ -26,12 +26,14 @@ from packaging.version import Version
 from pathlib import Path
 
 import hyperspy
+from hyperspy.axes import AxesManager
 from hyperspy.misc.utils import slugify, is_binned
 from hyperspy.misc.io.tools import (incremental_filename,
                                     append2pathname,)
 from hyperspy.misc.export_dictionary import export_to_dictionary, \
     load_from_dictionary
 from hyperspy.events import Events, Event
+from hyperspy.model import BaseModel
 from hyperspy.ui_registry import add_gui_method
 from IPython.display import display_pretty, display
 from hyperspy.misc.model_tools import current_component_values
@@ -115,7 +117,7 @@ class Parameter(t.HasTraits):
     _free = True
     _bounds = (None, None)
     __twin = None
-    _axes_manager = None
+    _axes_manager: AxesManager | None = None
     __ext_bounded = False
     __ext_force_positive = False
 
@@ -123,13 +125,13 @@ class Parameter(t.HasTraits):
     # (it bugs out, because both editor shares the object, and Array editors
     # don't like non-sequence objects). TextEditor() works well, so does
     # RangeEditor() as it works with bmin/bmax.
-    value = t.Property(t.Either([t.CFloat(0), Array()]))
+    value: float = t.Property(t.Either([t.CFloat(0), Array()]))
 
-    units = t.Str('')
-    free = t.Property(t.CBool(True))
+    units: str = t.Str('')
+    free: bool = t.Property(t.CBool(True))
 
-    bmin = t.Property(NoneFloat(), label="Lower bounds")
-    bmax = t.Property(NoneFloat(), label="Upper bounds")
+    bmin: float = t.Property(NoneFloat(), label="Lower bounds")
+    bmax: float = t.Property(NoneFloat(), label="Upper bounds")
     _twin_function_expr = ""
     _twin_inverse_function_expr = ""
     twin_function = None
@@ -155,11 +157,11 @@ class Parameter(t.HasTraits):
         self.std = None
         self.component = None
         self.grad = None
-        self.name = ''
-        self.units = ''
+        self.name: str = ''
+        self.units: str = ''
         self._linear = False
         self.map = None
-        self.model = None
+        self.model: BaseModel | None = None
         self._whitelist = {'_id_name': None,
                            'value': None,
                            'std': None,
@@ -214,7 +216,7 @@ class Parameter(t.HasTraits):
         text = '<' + text + '>'
         return text
 
-    def __len__(self):
+    def __len__(self) -> int:
         return self._number_of_elements
 
     @property
@@ -289,7 +291,7 @@ class Parameter(t.HasTraits):
     def twin_inverse_function(self, value):
         self._twin_inverse_function = value
 
-    def _get_value(self):
+    def _get_value(self) -> float:
         if self.twin is None:
             return self.__value
         else:
@@ -298,7 +300,7 @@ class Parameter(t.HasTraits):
             else:
                 return self.twin.value
 
-    def _set_value(self, value):
+    def _set_value(self, value: float):
         try:
             # Use try/except instead of hasattr("__len__") because a numpy
             # memmap has a __len__ wrapper even for numbers that raises a
@@ -732,7 +734,7 @@ class Parameter(t.HasTraits):
 
 @add_gui_method(toolkey="hyperspy.Component")
 class Component(t.HasTraits):
-    __axes_manager = None
+    __axes_manager: AxesManager | None = None
 
     active = t.Property(t.CBool(True))
     name = t.Property(t.Str(''))
@@ -1072,7 +1074,7 @@ class Component(t.HasTraits):
         return component_array
 
     def _component2plot(self, axes_manager, out_of_range2nans=True):
-        old_axes_manager = None
+        old_axes_manager: AxesManager | None = None
         if axes_manager is not self.model.axes_manager:
             old_axes_manager = self.model.axes_manager
             self.model.axes_manager = axes_manager

--- a/hyperspy/model.py
+++ b/hyperspy/model.py
@@ -389,24 +389,24 @@ class BaseModel(list):
     def insert(self, **kwargs):
         raise NotImplementedError
 
-    def append(self, thing: Component):
+    def append(self, component: Component):
         """Add component to Model.
 
         Parameters
         ----------
-        thing: `Component` instance.
+        component: `Component` instance.
         """
-        if not isinstance(thing, Component):
+        if not isinstance(component, Component):
             raise ValueError(
                 "Only `Component` instances can be added to a model")
         # Check if any of the other components in the model has the same name
-        if thing in self:
+        if component in self:
             raise ValueError("Component already in model")
         component_name_list = [component.name for component in self]
-        if thing.name:
-            name_string = thing.name
+        if component.name:
+            name_string = component.name
         else:
-            name_string = thing.__class__.__name__
+            name_string = component.__class__.__name__
 
         if name_string in component_name_list:
             temp_name_string = name_string
@@ -415,16 +415,16 @@ class BaseModel(list):
                 temp_name_string = name_string + "_" + str(index)
                 index += 1
             name_string = temp_name_string
-        thing.name = name_string
+        component.name = name_string
 
-        thing._axes_manager = self.axes_manager
-        thing._create_arrays()
-        list.append(self, thing)
-        thing.model = self
+        component._axes_manager = self.axes_manager
+        component._create_arrays()
+        list.append(self, component)
+        component.model = self
         setattr(self.components, slugify(name_string,
-                                         valid_variable_name=True), thing)
+                                         valid_variable_name=True), component)
         if self._plot_active:
-            self._connect_parameters2update_plot(components=[thing])
+            self._connect_parameters2update_plot(components=[component])
             self.signal._plot.signal_plot.update()
 
     def extend(self, iterable: list[Component]):

--- a/hyperspy/model.py
+++ b/hyperspy/model.py
@@ -16,6 +16,8 @@
 # You should have received a copy of the GNU General Public License
 # along with HyperSpy. If not, see <https://www.gnu.org/licenses/#GPL>.
 
+from __future__ import annotations
+
 import copy
 import importlib
 import logging
@@ -375,13 +377,13 @@ class BaseModel(list):
 
     def _get_component(self, component: Component) -> Component | list[Component]:
         if isinstance(component, int) or isinstance(component, str):
-            comp = self[component]
+            component = self[component]
         elif np.iterable(component):
-            comp: list[Component] = [self._get_component(entry) for entry in component]
-            return comp
+            component: list[Component] = [self._get_component(entry) for entry in component]
+            return component
         elif not isinstance(component, Component):
             raise ValueError("Not a component or component id.")
-        if comp in self:
+        if component in self:
             return component
         else:
             raise ValueError("The component is not in the model.")

--- a/hyperspy/model.py
+++ b/hyperspy/model.py
@@ -389,7 +389,7 @@ class BaseModel(list):
     def insert(self, **kwargs):
         raise NotImplementedError
 
-    def append(self, thing):
+    def append(self, thing: Component):
         """Add component to Model.
 
         Parameters
@@ -427,7 +427,7 @@ class BaseModel(list):
             self._connect_parameters2update_plot(components=[thing])
             self.signal._plot.signal_plot.update()
 
-    def extend(self, iterable):
+    def extend(self, iterable: list[Component]):
         """Append multiple components to the model.
 
         Parameters

--- a/hyperspy/model.py
+++ b/hyperspy/model.py
@@ -928,7 +928,7 @@ class BaseModel(list):
                     comp_p_std, onlyfree=True)
                 counter += component._nfree_param
 
-    def _model2plot(self, axes_manager, out_of_range2nans=True):
+    def _model2plot(self, axes_manager: AxesManager, out_of_range2nans=True):
         old_axes_manager: AxesManager | None = None
         if axes_manager is not self.axes_manager:
             old_axes_manager = self.axes_manager

--- a/hyperspy/model.py
+++ b/hyperspy/model.py
@@ -21,6 +21,7 @@ import importlib
 import logging
 import os
 import tempfile
+from typing import TYPE_CHECKING
 import warnings
 from contextlib import contextmanager
 from packaging.version import Version
@@ -42,7 +43,9 @@ from scipy.optimize import (
     minimize,
     OptimizeResult
 )
-from hyperspy.axes import AxesManager
+if TYPE_CHECKING:
+    from hyperspy.axes import AxesManager
+    
 from hyperspy.component import Component
 from hyperspy.components1d import Expression
 from hyperspy.defaults_parser import preferences

--- a/hyperspy/model.py
+++ b/hyperspy/model.py
@@ -42,6 +42,7 @@ from scipy.optimize import (
     minimize,
     OptimizeResult
 )
+from hyperspy.axes import AxesManager
 from hyperspy.component import Component
 from hyperspy.components1d import Expression
 from hyperspy.defaults_parser import preferences
@@ -923,7 +924,7 @@ class BaseModel(list):
                 counter += component._nfree_param
 
     def _model2plot(self, axes_manager, out_of_range2nans=True):
-        old_axes_manager = None
+        old_axes_manager: AxesManager | None = None
         if axes_manager is not self.axes_manager:
             old_axes_manager = self.axes_manager
             self.axes_manager = axes_manager

--- a/hyperspy/models/eelsmodel.py
+++ b/hyperspy/models/eelsmodel.py
@@ -22,6 +22,7 @@ import warnings
 
 from hyperspy import components1d
 from hyperspy._signals.eels import EELSSpectrum
+from hyperspy.component import Component
 from hyperspy.components1d import EELSCLEdge, PowerLaw
 from hyperspy.docstrings.model import FIT_PARAMETERS_ARG
 from hyperspy.misc.utils import dummy_context_manager
@@ -108,7 +109,7 @@ class EELSModel(Model1D):
                 "but an object of type %s was provided" %
                 str(type(value)))
 
-    def append(self, component):
+    def append(self, component: Component):
         """Append component to EELS model.
 
         Parameters
@@ -139,7 +140,7 @@ class EELSModel(Model1D):
 
     append.__doc__ = Model1D.append.__doc__
 
-    def remove(self, component):
+    def remove(self, component: Component):
         super().remove(component)
         self._classify_components()
 

--- a/hyperspy/models/model1d.py
+++ b/hyperspy/models/model1d.py
@@ -23,7 +23,7 @@ from scipy.special import huber
 import traits.api as t
 
 import hyperspy.drawing.signal1d
-from hyperspy.axes import generate_uniform_axis
+from hyperspy.axes import AxesManager, generate_uniform_axis
 from hyperspy.exceptions import WrongObjectError, SignalDimensionError
 from hyperspy.decorators import interactive_range_selector
 from hyperspy.drawing.widgets import LabelWidget, VerticalLineWidget
@@ -694,7 +694,7 @@ class Model1D(BaseModel):
             * np.clip(self._errfunc(param, y, weights), -huber_delta, huber_delta)
         ).sum(axis=1)
 
-    def _model2plot(self, axes_manager, out_of_range2nans=True):
+    def _model2plot(self, axes_manager: AxesManager, out_of_range2nans=True):
         old_axes_manager = None
         if axes_manager is not self.axes_manager:
             old_axes_manager = self.axes_manager

--- a/hyperspy/models/model2d.py
+++ b/hyperspy/models/model2d.py
@@ -19,6 +19,7 @@
 import numpy as np
 
 from hyperspy._signals.signal2d import Signal2D
+from hyperspy.axes import AxesManager
 from hyperspy.decorators import interactive_range_selector
 from hyperspy.exceptions import WrongObjectError
 from hyperspy.model import BaseModel, ModelComponents, ModelSpecialSlicers
@@ -249,7 +250,7 @@ class Model2D(BaseModel):
     def _gradient_huber(self, param, y, weights=None, huber_delta=None):
         raise NotImplementedError
 
-    def _model2plot(self, axes_manager, out_of_range2nans=True):
+    def _model2plot(self, axes_manager: AxesManager, out_of_range2nans=True):
         old_axes_manager = None
         if axes_manager is not self.axes_manager:
             old_axes_manager = self.axes_manager

--- a/hyperspy/signal.py
+++ b/hyperspy/signal.py
@@ -3624,7 +3624,7 @@ class BaseSignal(FancySlicing,
         # if the value was loaded from a file its type can be np.bool_
         if folding.unfolded is True:
             self.data = self.data.reshape(folding.original_shape)
-            self.axes_manager = folding.original_axes_manager
+            self.axes_manager: AxesManager = folding.original_axes_manager
             folding.original_shape = None
             folding.original_axes_manager = None
             folding.unfolded = False

--- a/hyperspy/signal.py
+++ b/hyperspy/signal.py
@@ -25,6 +25,7 @@ import inspect
 from itertools import product
 import logging
 import numbers
+from typing_extensions import Self
 from packaging.version import Version
 from pathlib import Path
 import warnings
@@ -3804,7 +3805,7 @@ class BaseSignal(FancySlicing,
             s._remove_axis([ax.index_in_axes_manager for ax in axes])
             return s
 
-    def sum(self, axis=None, out=None, rechunk=True):
+    def sum(self, axis=None, out=None, rechunk=True) -> Self:
         """Sum the data over the given axes.
 
         Parameters

--- a/hyperspy/signal.py
+++ b/hyperspy/signal.py
@@ -16,6 +16,8 @@
 # You should have received a copy of the GNU General Public License
 # along with HyperSpy. If not, see <https://www.gnu.org/licenses/#GPL>.
 
+from __future__ import annotations
+
 from collections.abc import MutableMapping
 from contextlib import contextmanager
 import copy
@@ -25,7 +27,6 @@ import inspect
 from itertools import product
 import logging
 import numbers
-from typing_extensions import Self
 from packaging.version import Version
 from pathlib import Path
 import warnings
@@ -2148,7 +2149,6 @@ class BaseSetMetadataItems(t.HasTraits):
             if getattr(self, value) != t.Undefined:
                 self.signal.metadata.set_item(key, getattr(self, value))
 
-
 class BaseSignal(FancySlicing,
                  MVA,
                  MVATools,):
@@ -3805,7 +3805,7 @@ class BaseSignal(FancySlicing,
             s._remove_axis([ax.index_in_axes_manager for ax in axes])
             return s
 
-    def sum(self, axis=None, out=None, rechunk=True) -> Self:
+    def sum(self, axis=None, out=None, rechunk=True) -> BaseSignal:
         """Sum the data over the given axes.
 
         Parameters

--- a/hyperspy/signal.py
+++ b/hyperspy/signal.py
@@ -3624,7 +3624,7 @@ class BaseSignal(FancySlicing,
         # if the value was loaded from a file its type can be np.bool_
         if folding.unfolded is True:
             self.data = self.data.reshape(folding.original_shape)
-            self.axes_manager: AxesManager = folding.original_axes_manager
+            self.axes_manager = folding.original_axes_manager
             folding.original_shape = None
             folding.original_axes_manager = None
             folding.unfolded = False

--- a/hyperspy/utils/__init__.py
+++ b/hyperspy/utils/__init__.py
@@ -109,7 +109,7 @@ _import_mapping = {
 def __getattr__(name):
     if name in __all__:
         if name in _import_mapping.keys():
-            import_path = 'hyperspy' + _import_mapping.get(name)
+            import_path = 'hyperspy' + _import_mapping[name]
             return getattr(importlib.import_module(import_path), name)
         else:
             return importlib.import_module(


### PR DESCRIPTION
### Description of the change
1. Added "eager" imports under the `TYPE_CHECKING` filter (which is only `True` during e.g. pylance/mypy type checking) so that autocomplete works for the lazy modules imported through `hyperspy.api` and `hyperspy.api_nogui`.
2. Added type-hints for several commonly-used methods. Particularly useful when coding in VSCode, since the pylance engine understands e.g.:

```python
from hyperspy._signals.eels import EELSSpectrum

s = EELSSpectrum([1, 2, 3])
ax = s.axes_manager[0]
# ax.high<TAB> autocompletes to high_value

m = s.create_model()
a = m[0]
# a.na<TAB> autocompletes to name
```
Using the VSCode pylance Type Checking Mode setting "basic" is very useful, as it provides in-editor messages showing mypy errors. It also shows a lot of possible improvements, for instance where we are referencing child-class methods in parent-classes. For instance MVATools referring to entries of `axes_manager` even though this isn't an attribute of the 
MVATools class.

### Progress of the PR
- [x] Change implemented (can be split into several points),
- [ ] add an changelog entry in the `upcoming_changes` folder (see [`upcoming_changes/README.rst`](https://github.com/hyperspy/hyperspy/blob/RELEASE_next_minor/upcoming_changes/README.rst)),
- [ ] Check formatting changelog entry in the `readthedocs` doc build of this PR (link in github checks)
- [ ] add tests,
- [ ] ready for review.
