### PR TITLE
LazySignal.compute will now pass kwargs to dask.array.Array.compute

### DIFF
--- a/hyperspy/_signals/lazy.py
+++ b/hyperspy/_signals/lazy.py
@@ -243,14 +243,45 @@ class LazySignal(BaseSignal):
         Parameters
         ----------
         close_file : bool, default False
-            If True, attemp to close the file associated with the dask
+            If True, attempt to close the file associated with the dask
             array data if any. Note that closing the file will make all other
             associated lazy signals inoperative.
         %s
+        **kwargs : dict
+            Any other keyword arguments for :py:func:`dask.array.Array.compute`.
+            For example `scheduler` or `num_workers`.
 
         Returns
         -------
         None
+
+        Notes
+        -----
+        For alternative ways to set the compute settings see
+        https://docs.dask.org/en/stable/scheduling.html#configuration
+
+        Examples
+        --------
+        >>> import dask.array as da
+        >>> data = da.zeros((100, 100, 100), chunks=(10, 20, 20))
+        >>> s = hs.signals.Signal2D(data).as_lazy()
+
+        With default parameters
+
+        >>> s1 = s.deepcopy()
+        >>> s1.compute()
+
+        Using 2 workers, which can reduce the memory usage (depending on
+        the data and your computer hardware). Note that `num_workers` only
+        work for the 'threads' and 'processes' `scheduler`.
+
+        >>> s2 = s.deepcopy()
+        >>> s2.compute(num_workers=2)
+
+        Using a single threaded scheduler, which is useful for debugging
+
+        >>> s3 = s.deepcopy()
+        >>> s3.compute(scheduler='single-threaded')
 
         """
         if show_progressbar is None:
@@ -260,7 +291,7 @@ class LazySignal(BaseSignal):
 
         with cm():
             da = self.data
-            data = da.compute()
+            data = da.compute(**kwargs)
             if close_file:
                 self.close_file()
             self.data = data

--- a/hyperspy/tests/signals/test_lazy.py
+++ b/hyperspy/tests/signals/test_lazy.py
@@ -417,3 +417,10 @@ def test_get_chunk_size(signal):
     sig = _signal()
     chunk_size = sig.get_chunk_size(axes=0)
     chunk_size == ((2, 1, 3), )
+
+
+def test_compute_kwargs():
+    s = hs.signals.Signal2D(da.zeros((4, 8, 8), chunks=(2, 4, 4))).as_lazy()
+    s1 = s.deepcopy()
+    s1.compute(show_progressbar=False)
+    s.compute(scheduler="processes", num_workers=2, show_progressbar=False)

--- a/upcoming_changes/2971.new.rst
+++ b/upcoming_changes/2971.new.rst
@@ -1,0 +1,1 @@
+:py:meth:`~._signals.lazy.LazySignal.compute` will now pass keyword arguments to the dask ``compute`` method. This enables the scheduler and the number of computational workers to be set.


### PR DESCRIPTION
Currently, `kwargs` are not passed from `s.compute` to the dask `compute` function which is done on the data.

There are several useful parameters like `scheduler='processes'` and `num_workers=4`, which is useful when working with large datasets.

So this pull request simply passes `kwargs` in `s.compute` to `s.data.compute()`. It also improves the docstring for `compute`, and adds a test.

### Progress of the PR
- [x] Change implemented
- [x] update docstring
- [x] add an changelog entry in the `upcoming_changes` folder (see [`upcoming_changes/README.rst`](https://github.com/hyperspy/hyperspy/blob/RELEASE_next_minor/upcoming_changes/README.rst)),
- [x] Check formatting changelog entry in the `readthedocs` doc build of this PR (link in github checks)
- [x] add test
- [x] ready for review.

### Minimal example of the bug fix or the new feature
```python
import dask.array as da
data = da.zeros((100, 100, 100), chunks=(10, 20, 20))
s = hs.signals.Signal2D(data).as_lazy()
s.compute(scheduler="processes", num_workers=2)
```