### PR TITLE
Improve documentation `hs.load` returns list

### DIFF
--- a/doc/user_guide/getting_started.rst
+++ b/doc/user_guide/getting_started.rst
@@ -164,7 +164,14 @@ Once HyperSpy is running, to load from a supported file format (see
 
 .. code-block:: python
 
-    >>> s = hs.load("filename")
+    >>> s = hs.load("filename.ext")
+
+The used IO-plugin will be inferred from the file extension. If you want to force
+the use of a specific IO-plugin, you can provide the ``reader`` attribute:
+
+.. code-block:: python
+
+    >>> s = hs.load("spam.ham", reader="hspy")
 
 .. note::
 

--- a/doc/user_guide/getting_started.rst
+++ b/doc/user_guide/getting_started.rst
@@ -168,8 +168,8 @@ Once HyperSpy is running, to load from a supported file format (see
 
 .. note::
 
-   When the file contains several datasets, the :py:func:`~.io.load`  function
-   will return a list of hyperspy signal, instead of a single hyperspy signal. 
+   When the file contains several datasets, the :py:func:`~.io.load` function
+   will return a list of HyperSpy signals, instead of a single HyperSpy signal. 
    Each signal can then be accessed using list indexation.
 
    .. code-block:: python
@@ -180,7 +180,7 @@ Once HyperSpy is running, to load from a supported file format (see
        <Signal1D, title: eggs, dimensions: (32,32|1024)>,
        <Signal1D, title: ham, dimensions: (32,32|1024)>]
 
-   Using indexation to assess the first signal (index 0):
+   Using indexation to access the first signal (index 0):
    
    .. code-block:: python
 

--- a/doc/user_guide/getting_started.rst
+++ b/doc/user_guide/getting_started.rst
@@ -166,6 +166,28 @@ Once HyperSpy is running, to load from a supported file format (see
 
     >>> s = hs.load("filename")
 
+.. note::
+
+   When the file contains several datasets, the :py:func:`~.io.load`  function
+   will return a list of hyperspy signal, instead of a single hyperspy signal. 
+   Each signal can then be accessed using list indexation.
+
+   .. code-block:: python
+
+      >>> s = hs.load("spameggsandham.hspy")
+      >>> s
+      [<Signal1D, title: spam, dimensions: (32,32|1024)>,
+       <Signal1D, title: eggs, dimensions: (32,32|1024)>,
+       <Signal1D, title: ham, dimensions: (32,32|1024)>]
+
+   Using indexation to assess the first signal (index 0):
+   
+   .. code-block:: python
+
+      >>> s[0]
+      <Signal1D, title: spam, dimensions: (32,32|1024)>
+
+
 .. HINT::
 
    The load function returns an object that contains data read from the file.
@@ -182,7 +204,7 @@ allows to select a single file through your OS file manager, e.g.:
     >>> s = hs.load()
 
 It is also possible to load multiple files at once or even stack multiple
-files. For more details read :ref:`loading_files`
+files. For more details read :ref:`loading_files`.
 
 "Loading" data from a numpy array
 ---------------------------------

--- a/hyperspy/io.py
+++ b/hyperspy/io.py
@@ -334,6 +334,18 @@ def load(filenames=None,
 
     >>> s = hs.load('a_nexus_file.h5', reader='nxs')
 
+    Loading a file containing several datasets:
+
+    >>> s = hs.load("spameggsandham.nxs")
+    >>> s
+    [<Signal1D, title: spam, dimensions: (32,32|1024)>,
+     <Signal1D, title: eggs, dimensions: (32,32|1024)>,
+     <Signal1D, title: ham, dimensions: (32,32|1024)>]
+    >>> # Use list indexation to access single signal
+    >>> s[0]
+    <Signal1D, title: spam, dimensions: (32,32|1024)>
+
+
     """
     deprecated = ['mmap_dir', 'load_to_memory']
     warn_str = "'{}' argument is deprecated, please use 'lazy' instead"

--- a/upcoming_changes/2975.doc.rst
+++ b/upcoming_changes/2975.doc.rst
@@ -1,1 +1,1 @@
-Add a note in the user guide to explain that when a file contains several dataset, :py:func:`~.io.load` returns a list of signals instead of a single signal and that list indexation can be used to access single signal.
+Add a note in the user guide to explain that when a file contains several datasets, :py:func:`~.io.load` returns a list of signals instead of a single signal and that list indexation can be used to access a single signal.

--- a/upcoming_changes/2975.doc.rst
+++ b/upcoming_changes/2975.doc.rst
@@ -1,0 +1,1 @@
+Add a note in the user guide to explain that when a file contains several dataset, :py:func:`~.io.load` returns a list of signals instead of a single signal and that list indexation can be used to access single signal.


### PR DESCRIPTION
Add a note in the user guide to explain that when a file contains several dataset, `hs.load` will return a list of signals instead of a single signal and therefore that the list indexation needs to be used.
https://github.com/hyperspy/hyperspy/issues/2970

### Progress of the PR
- [x] improve user guide,
- [x] update docstring (if appropriate),
- [x] update user guide (if appropriate),
- [x] add an changelog entry in the `upcoming_changes` folder (see [`upcoming_changes/README.rst`](https://github.com/hyperspy/hyperspy/blob/RELEASE_next_minor/upcoming_changes/README.rst)),
- [x] Check formatting changelog entry in the `readthedocs` doc build of this PR (link in github checks)
- [x] add tests,
- [x] ready for review.


