### PR TITLE
Fix for dask 2022.7.1

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -69,6 +69,11 @@ steps:
     conda list
   displayName: Install package
 
+- bash: |
+    source activate $ENV_NAME
+    conda clean --all -y
+  displayName: Clean conda cache
+
 # Note we must use `-n 2` argument for pytest-xdist due to
 # https://github.com/pytest-dev/pytest-xdist/issues/9.
 - bash: |
@@ -88,4 +93,3 @@ steps:
 #     # Set the token generated with github from the developer settings/personal
 #     # access tokens menu in azure pipeline
 #     github_token_name: ''
-

--- a/hyperspy/_signals/hologram_image.py
+++ b/hyperspy/_signals/hologram_image.py
@@ -238,9 +238,6 @@ class HologramImage(Signal2D):
             max_workers=max_workers,
             ragged=False)
 
-        # Workaround to a map disfunctionality:
-        sb_position.set_signal_type('signal1d')
-
         return sb_position
 
     estimate_sideband_position.__doc__ %= (SHOW_PROGRESSBAR_ARG, PARALLEL_ARG, MAX_WORKERS_ARG)

--- a/hyperspy/signal.py
+++ b/hyperspy/signal.py
@@ -4994,7 +4994,9 @@ class BaseSignal(FancySlicing,
             testing_kwargs = {}
             for ikey, key in enumerate(arg_keys):
                 test_ind = (0,) * len(os_am.navigation_axes)
-                testing_kwargs[key] = np.squeeze(args[ikey][test_ind]).compute()
+                # For discussion on if squeeze is necessary, see
+                # https://github.com/hyperspy/hyperspy/pull/2981
+                testing_kwargs[key] = np.squeeze(args[ikey][test_ind].compute())[()]
             testing_kwargs = {**kwargs, **testing_kwargs}
             test_data = np.array(
                 old_sig.inav[(0,) * len(os_am.navigation_shape)].data.compute()

--- a/hyperspy/tests/signals/test_map_method.py
+++ b/hyperspy/tests/signals/test_map_method.py
@@ -466,6 +466,7 @@ class TestLazyResultInplace:
 
 
 class TestOutputDtype:
+
     @pytest.mark.parametrize("dtype", [np.uint16, np.uint32, np.uint64, np.int32, np.float32])
     def test_output_dtype_specified_not_inplace(self, dtype):
         def a_function_dtype(data):
@@ -496,8 +497,6 @@ class TestOutputDtype:
         s_out.compute()
         assert s_out.data.dtype == dtype
 
-
-class TestOutputDtype:
     @pytest.mark.parametrize("output_signal_size", [(10,), (10, 20), (10, 20, 30)])
     def test_output_signal_size(self, output_signal_size):
         def a_function_signal_size(data, output_signal_size_for_function):
@@ -671,7 +670,6 @@ class TestGetBlockPattern:
         chunks = (10,) * len(input_shape)
         dask_array = da.random.random(input_shape, chunks=chunks)
         s = hs.signals.Signal1D(dask_array).as_lazy()
-        output_signal_size = input_shape[-1:]
         arg_pairs, adjust_chunks, new_axis, output_pattern = _get_block_pattern((s.data,), input_shape)
         assert new_axis == {}
         assert adjust_chunks == {}
@@ -832,10 +830,9 @@ class TestMapIterate:
     def test_iterating_kwargs_none(self):
         s = self.s
         s_out = s._map_iterate(np.sum, iterating_kwargs=None)
-        s_out.compute()
         assert (s_out.data == self.dx * self.dy).all()
 
-    def test_iterating_kwargs_none(self):
+    def test_iterating_kwargs_dict(self):
         def add_sum(image, add):
             out = np.sum(image) + add
             return out

--- a/upcoming_changes/2981.bugfix.rst
+++ b/upcoming_changes/2981.bugfix.rst
@@ -1,0 +1,1 @@
+Fix error which occurs when guessing output size in the :py:meth:`~.signal.BaseSignal.map` function and using dask newer than 2022.7.1 


### PR DESCRIPTION
Dask 2022.7.1 fixes an inconsistency between dask and numpy in the behaviour of `squeeze` in https://github.com/dask/dask/pull/9250, but it has a side effect in the `map` code, which is caught in the test suite.
@CSSFrancis, can you please have a look at this PR, since you are the main contributor for the latest change to this part of the code?

### Progress of the PR
- [x] Fix function to guess output size when using `map`,
- [x] Fix typo in tests name, which means that some were not running, 
- [n/a] update docstring (if appropriate),
- [n/a] update user guide (if appropriate),
- [x] add an changelog entry in the `upcoming_changes` folder (see [`upcoming_changes/README.rst`](https://github.com/hyperspy/hyperspy/blob/RELEASE_next_minor/upcoming_changes/README.rst)),
- [x] Check formatting changelog entry in the `readthedocs` doc build of this PR (link in github checks)
- [n/a] add tests,
- [x] ready for review.

### Minimal example of the bug fix or the new feature
This was the failing test:

```python
import dask.array as da
import hyperspy.api as hs
import numpy as np


dask_array = da.zeros((10, 20, 100, 100), chunks=(5, 10, 50, 50))
s = hs.signals.Signal2D(dask_array).as_lazy()


def apply_func(data, f):
    return f(data, data)

s = s.inav[0:2, 0:2]
iter_add = hs.signals.BaseSignal([[np.add, np.add],
                                  [np.add, np.add]]).T
out = s.map(apply_func, f=iter_add, inplace=False)
np.testing.assert_array_equal(out.data, s.data)
```

