### PR TITLE
Fix run extension test suite kikuchipy

### DIFF
--- a/.github/workflows/tests_extension.yml
+++ b/.github/workflows/tests_extension.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   integration_test:
-    if: ${{ contains(github.event.pull_request.labels.*.name, 'run-extension-tests') }}
+    if: ${{ contains(github.event.pull_request.labels.*.name, 'run-extension-tests') || github.event_name == 'workflow_dispatch' }}
     name: Extension_${{ matrix.EXTENSION_VERSION }}
     runs-on: ubuntu-latest
     strategy:

--- a/.github/workflows/tests_extension.yml
+++ b/.github/workflows/tests_extension.yml
@@ -63,10 +63,17 @@ jobs:
           pip install https://github.com/pyxem/pyxem/archive/master.zip
           pip install https://gitlab.com/atomap/atomap/-/archive/master/atomap-master.zip
 
+      - name: Install xvfb
+        run: |
+          # required for running kikuchipy test suite
+          sudo apt-get install xvfb
+
       - name: Run Kikuchipy Test Suite
         if: ${{ always() }}
         run: |
-          python -m pytest --pyargs kikuchipy
+          # Virtual buffer (xvfb) required for tests using PyVista
+          sudo apt-get install xvfb
+          xvfb-run python -m pytest --pyargs kikuchipy
 
       - name: Run LumiSpy Test Suite
         if: ${{ always() }}

--- a/upcoming_changes/2982.maintenance.rst
+++ b/upcoming_changes/2982.maintenance.rst
@@ -1,0 +1,1 @@
+Fix extension test suite CI workflow. Enable workflow manual trigger


### PR DESCRIPTION
Wanted to run the extension test suite in #2981 but there the same issue as in https://github.com/hyperspy/hyperspy-extensions-list/pull/24.

### Progress of the PR
- [x] Fix running kikuchipy test suite,
- [x] Enable manual trigger for `tests_extension.yml`,
- [n/a] update user guide (if appropriate),
- [x] add an changelog entry in the `upcoming_changes` folder (see [`upcoming_changes/README.rst`](https://github.com/hyperspy/hyperspy/blob/RELEASE_next_minor/upcoming_changes/README.rst)),
- [x] Check formatting changelog entry in the `readthedocs` doc build of this PR (link in github checks)
- [x] add tests,
- [x] ready for review.


