### PR TITLE
bugfix: initializing metadata breaks its default blank dicts when loading DigitalMicrograph files.

### DIFF
--- a/hyperspy/io_plugins/digital_micrograph.py
+++ b/hyperspy/io_plugins/digital_micrograph.py
@@ -107,10 +107,12 @@ class DigitalMicrographReader(object):
         else:
             self.endian = 'big'
 
-    def parse_tags(self, ntags, group_name='root', group_dict={}):
+    def parse_tags(self, ntags, group_name='root', group_dict=None):
         """Parse the DM file into a dictionary.
 
         """
+        if group_dict is None:
+            group_dict = {}
         unnammed_data_tags = 0
         unnammed_group_tags = 0
         for tag in range(ntags):
@@ -729,7 +731,9 @@ class ImageObject(object):
                     zip(self.names, self.shape, self.scales, self.offsets,
                         self.units))]
 
-    def get_metadata(self, metadata={}):
+    def get_metadata(self, metadata=None):
+        if metadata is None:
+            metadata = {}
         if "General" not in metadata:
             metadata['General'] = {}
         if "Signal" not in metadata:

--- a/hyperspy/io_plugins/digital_micrograph.py
+++ b/hyperspy/io_plugins/digital_micrograph.py
@@ -111,8 +111,8 @@ class DigitalMicrographReader(object):
         """Parse the DM file into a dictionary.
 
         """
-        if group_dict is None:
-            group_dict = {}
+        if group_dict is None: #pragma: no cover
+            group_dict = {}    # currently this default value is not used in this script
         unnammed_data_tags = 0
         unnammed_group_tags = 0
         for tag in range(ntags):

--- a/hyperspy/io_plugins/tiff.py
+++ b/hyperspy/io_plugins/tiff.py
@@ -679,7 +679,9 @@ def _is_digital_micrograph(op) -> bool:
     return any(search_result)
 
 
-def _intensity_axis_digital_micrograph(op, intensity_axis = {}):
+def _intensity_axis_digital_micrograph(op, intensity_axis=None):
+    if intensity_axis is None:
+        intensity_axis = {}
     if '65022' in op:
         intensity_axis['units'] = op['65022']  # intensity units
     if '65024' in op:


### PR DESCRIPTION
### Description of the change
- Bugfix: When reading second file, the metadata is not correctly initialized. Everytime loading dm4 images, the initializer overwrites its default blank dictionary.

### Progress of the PR
- [x] Change implemented (can be split into several points),
- [ ] update docstring (if appropriate),
- [ ] update user guide (if appropriate),
- [ ] add an changelog entry in the `upcoming_changes` folder (see [`upcoming_changes/README.rst`](https://github.com/hyperspy/hyperspy/blob/RELEASE_next_minor/upcoming_changes/README.rst)),
- [ ] Check formatting changelog entry in the `readthedocs` doc build of this PR (link in github checks)
- [ ] add tests,
- [x] ready for review.

### Minimal example of the bug fix or the new feature
```python
a = hs.load(dm4 file with rectangle markers)
b = hs.load(dm4 file without rectangle markers)
then the rectangle marker on a is also shown on b

------------------------------------------
## pseudo code to explain how it works.
# current situation
def test0(m = {}):
    print("test0: Initial m =", m)
    m['abc'] = 10
    return m

# fixed situation
def test1(m = None):
    if m is None:
        m = {}
    print("Test1: Initial m =", m)
    m['abc'] = 10
    return m

a = test0()
a['def'] = 'x'
b = test0()
print(a, b, a==b)
# {} in the function argument is overwritten on first call 

c = test1()
c['def'] = 'x'
d = test1()
print(c, d, c==d)
```

