### PR TITLE
Fix dm4/tiff reader, initializing metadata overwrites its default val…

### DIFF
--- a/rosettasciio/rsciio/digital_micrograph/api.py
+++ b/rosettasciio/rsciio/digital_micrograph/api.py
@@ -94,10 +94,12 @@ class DigitalMicrographReader(object):
         else:
             self.endian = 'big'
 
-    def parse_tags(self, ntags, group_name='root', group_dict={}):
+    def parse_tags(self, ntags, group_name='root', group_dict=None):
         """Parse the DM file into a dictionary.
 
         """
+        if group_dict is None:  #pragma no cover
+            group_dict = {}     # This default value is currently not used in this script
         unnammed_data_tags = 0
         unnammed_group_tags = 0
         for tag in range(ntags):
@@ -716,7 +718,9 @@ class ImageObject(object):
                     zip(self.names, self.shape, self.scales, self.offsets,
                         self.units))]
 
-    def get_metadata(self, metadata={}):
+    def get_metadata(self, metadata=None):
+        if metadata is None:
+            metadata = {}
         if "General" not in metadata:
             metadata['General'] = {}
         if "Signal" not in metadata:

--- a/rosettasciio/rsciio/tiff/api.py
+++ b/rosettasciio/rsciio/tiff/api.py
@@ -672,7 +672,9 @@ def _is_digital_micrograph(op) -> bool:
     return any(search_result)
 
 
-def _intensity_axis_digital_micrograph(op, intensity_axis = {}):
+def _intensity_axis_digital_micrograph(op, intensity_axis=None):
+    if intensity_axis is None:
+        intensity_axis = {}
     if '65022' in op:
         intensity_axis['units'] = op['65022']  # intensity units
     if '65024' in op:


### PR DESCRIPTION
### Description of the change
- This is the same as PR: #2992 but for RELEASE_next_major branch
- fixed: Initial metadata of dm3/dm4 files is overwritten when calling dm loader.
  
### Progress of the PR
- [x] Change implemented (can be split into several points),
- [ ] update docstring (if appropriate),
- [ ] update user guide (if appropriate),
- [ ] add an changelog entry in the `upcoming_changes` folder (see [`upcoming_changes/README.rst`](https://github.com/hyperspy/hyperspy/blob/RELEASE_next_minor/upcoming_changes/README.rst)),
- [ ] Check formatting changelog entry in the `readthedocs` doc build of this PR (link in github checks)
- [ ] add tests,
- [ ] ready for review.

### Minimal example of the bug fix or the new feature
\## pseudo code to explain how it works.
\# current situation
def test0(m = {}):
    print("test0: Initial m =", m)
    m['abc'] = 10
    return m

\# fixed situation
def test1(m = None):
    if m is None:
        m = {}
    print("Test1: Initial m =", m)
    m['abc'] = 10
    return m

a = test0()
a['def'] = 'x'
b = test0()
print(a, b, a==b)
\# {} in the function argument is overwritten on first call 

c = test1()
c['def'] = 'x'
d = test1()
print(c, d, c==d)
