### PR TITLE
Tweak display x-rays line when using log norm and the line intensity is 0

### DIFF
--- a/hyperspy/tests/drawing/test_plot_markers.py
+++ b/hyperspy/tests/drawing/test_plot_markers.py
@@ -519,6 +519,16 @@ def test_plot_eds_lines():
     return s._plot.signal_plot.figure
 
 
+@pytest.mark.parametrize("norm", [None, "log", "auto", "linear"])
+def test_plot_eds_lines_norm(norm):
+    a = EDS_TEM_Spectrum()
+    s = stack([a, a * 5])
+    # When norm is None, don't specify (use default)
+    # otherwise use specify value
+    kwargs = {"norm":norm} if norm else {}
+    s.plot(True, **kwargs)
+
+
 @pytest.mark.mpl_image_compare(
     baseline_dir=baseline_dir, tolerance=default_tol, style=style_pytest_mpl,
     filename='test_plot_eds_lines.png')

--- a/hyperspy/tests/signals/test_eds_tem.py
+++ b/hyperspy/tests/signals/test_eds_tem.py
@@ -207,7 +207,7 @@ class Test_quantification:
         method = 'CL'
         kfactors = [1, 2.0009344042484134]
         intensities = s.get_lines_intensity()[:1]
-        assert len(intensities) == 1    
+        assert len(intensities) == 1
         with pytest.raises(ValueError):
             _ = s.quantification(intensities, method, kfactors)
 
@@ -294,7 +294,7 @@ class Test_quantification:
                                    atol=1e-3)
         np.testing.assert_allclose(res3[0][0].data, np.ones((2, 2)) * 31.816908,
                                    atol=1e-3)
-        np.testing.assert_allclose(res[0].data, res4[0][0].data, atol=1e-5)     
+        np.testing.assert_allclose(res[0].data, res4[0][0].data, atol=1e-5)
 
     def test_quant_zeta(self):
         s = self.signal
@@ -585,6 +585,7 @@ class Test_eds_markers:
 
     def test_manual_add_line(self):
         s = self.signal
+        s.plot()
         s.add_xray_lines_markers(['Zn_La'])
         assert (
             list(s._xray_markers.keys()) ==
@@ -593,8 +594,14 @@ class Test_eds_markers:
         # Check that the line has both a vertical line marker and text marker:
         assert len(s._xray_markers['Zn_La']) == 2
 
+    def test_manual_add_line_error(self):
+        s = self.signal
+        with pytest.raises(RuntimeError):
+            s.add_xray_lines_markers(['Zn_La'])
+
     def test_manual_remove_element(self):
         s = self.signal
+        s.plot()
         s.add_xray_lines_markers(['Zn_Ka', 'Zn_Kb', 'Zn_La'])
         s.remove_xray_lines_markers(['Zn_Kb'])
         assert sorted(s._xray_markers.keys()) == ['Zn_Ka', 'Zn_La']

--- a/upcoming_changes/2995.bugfix.rst
+++ b/upcoming_changes/2995.bugfix.rst
@@ -1,0 +1,1 @@
+Fix display of x-ray lines when using log norm and the intensity at the line is 0


### PR DESCRIPTION
### Description of the change
Fix for #2991. As described in #2991, there are cases (`log` norm and intensity at line is 0), where the line and label is displayed far away from where it should be because of the log transform.


### Progress of the PR
- [x] Use calculated minimum value when necessary,
- [n/a] update docstring (if appropriate),
- [n/a] update user guide (if appropriate),
- [x] add an changelog entry in the `upcoming_changes` folder (see [`upcoming_changes/README.rst`](https://github.com/hyperspy/hyperspy/blob/RELEASE_next_minor/upcoming_changes/README.rst)),
- [x] Check formatting changelog entry in the `readthedocs` doc build of this PR (link in github checks)
- [x] add tests,
- [x] ready for review.

### Minimal example of the bug fix or the new feature

See example in #2991.

