### PR TITLE
Fix doc build CI

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -15,8 +15,7 @@ jobs:
 
       - uses: ericpre/sphinx-action@latest_sphinx
         with:
-          # once numba 0.55 is release, remove "--pre" option to "pip install"
-          pre-build-command: "apt-get update -y && apt-get install -y ${{ env.BUILD_DEPS }} ${{ env.LATEX_DEPS }} && pip install --pre .[all,build-doc]"
+          pre-build-command: "apt-get update -y && apt-get install -y ${{ env.BUILD_DEPS }} ${{ env.LATEX_DEPS }} && pip install .[all,build-doc]"
           build-command: make html
           docs-folder: doc/
 

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,26 @@
+name: Docs
+
+on: [push, pull_request]
+
+jobs:
+  build_doc:
+    name: Build doc
+    runs-on: ubuntu-latest
+    env:
+      BUILD_DEPS: python3-dev build-essential graphviz
+      LATEX_DEPS: dvipng latexmk texlive-latex-recommended texlive-latex-extra texlive-fonts-recommended
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - uses: ericpre/sphinx-action@latest_sphinx
+        with:
+          # once numba 0.55 is release, remove "--pre" option to "pip install"
+          pre-build-command: "apt-get update -y && apt-get install -y ${{ env.BUILD_DEPS }} ${{ env.LATEX_DEPS }} && pip install --pre .[all,build-doc]"
+          build-command: make html
+          docs-folder: doc/
+
+      - uses: actions/upload-artifact@v3
+        with:
+          path: ./doc/_build/html/
+          name: doc_build

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -4,7 +4,7 @@ on: [push, pull_request]
 
 jobs:
   build_doc:
-    name: Build doc
+    name: Docs (PR comments)
     runs-on: ubuntu-latest
     env:
       BUILD_DEPS: python3-dev build-essential graphviz
@@ -23,3 +23,30 @@ jobs:
         with:
           path: ./doc/_build/html/
           name: doc_build
+
+  check_links:
+    # This build is to check external links
+    name: Check external links
+    runs-on: ubuntu-latest
+    env:
+      DOCS_PATH: ./doc/_build/html/
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-python@v3
+        name: Install Python
+        with:
+          python-version: '3.10'
+
+      - name: Install build docs
+        shell: bash -l {0}
+        run: |
+          pip install .[build-doc]
+
+      - name: Check links
+        shell: bash -l {0}
+        run: |
+          cd doc
+          make linkcheck

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -84,26 +84,3 @@ jobs:
       - name: Upload coverage to Codecov
         if: ${{ always() }} && ${{ matrix.PYTEST_ARGS_COVERAGE }}
         uses: codecov/codecov-action@v2
-
-  build_doc:
-    name: Build doc
-    runs-on: ubuntu-latest
-    env:
-      BUILD_DEPS: python3-dev build-essential graphviz
-      LATEX_DEPS: dvipng latexmk texlive-latex-recommended texlive-latex-extra texlive-fonts-recommended
-
-    steps:
-      - uses: actions/checkout@v3
-
-      - uses: ericpre/sphinx-action@latest_sphinx
-        with:
-          # once numba 0.55 is release, remove "--pre" option to "pip install"
-          pre-build-command: "apt-get update -y && apt-get install -y ${{ env.BUILD_DEPS }} ${{ env.LATEX_DEPS }} && pip install --pre .[all,build-doc]"
-          build-command: make html
-          docs-folder: doc/
-
-      - uses: actions/upload-artifact@v3
-        with:
-          path: ./doc/_build/html/
-          name: doc_build
-

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -40,6 +40,16 @@ extensions = [
     'sphinxcontrib.towncrier',
 ]
 
+linkcheck_ignore = [
+    'https://www.jstor.org/stable/24307705',  # 403 Client Error: Forbidden for url
+    'https://anaconda.org',  # 403 Client Error: Forbidden for url
+]
+
+linkcheck_exclude_documents = [
+    'user_guide/io/*',
+    'api/hyperspy.io_plugins*',
+    ]
+
 try:
     import sphinxcontrib.spelling
     extensions.append('sphinxcontrib.spelling')

--- a/doc/user_guide/axes.rst
+++ b/doc/user_guide/axes.rst
@@ -501,7 +501,7 @@ can be set and retrieved as quantity.
          <undefined> |     10 |        |     2.5 | 2.5e+03 |     nm
 
 
-Internally, HyperSpy uses the `pint <http://pint.readthedocs.io>`_ library to
+Internally, HyperSpy uses the `pint <https://pint.readthedocs.io>`_ library to
 manage the scale and offset quantities. The ``scale_as_quantity`` and
 ``offset_as_quantity`` attributes return pint object:
 
@@ -685,4 +685,3 @@ and a manually specified length as inputs:
     >>> from hyperspy.axes import GeneratorLen
     >>> gen = GeneratorLen(reverse_flyback_generator(), 6)
     >>> s.axes_manager.iterpath = gen
-

--- a/doc/user_guide/bibliography.rst
+++ b/doc/user_guide/bibliography.rst
@@ -28,7 +28,7 @@ Bibliography
    of Atomic Form Factors, Photoelectric Absorption and Scattering Cross
    Section, and Mass Attenuation Coefficients for Z = 1-92 from E = 1-10 eV
    to E = 0.4-1.0 MeV" *NIST Standard Reference Data*
-   [`<http://physics.nist.gov/ffast>`_].
+   [`<https://physics.nist.gov/ffast>`_].
 
 .. _Egerton2011:
 
@@ -199,9 +199,9 @@ Bibliography
 .. _Lerotic2004:
 
 :ref:`[Lerotic2004] <Lerotic2004>`
-   M Lerotic, C Jacobsen, T Schafer, S Vogt 
+   M Lerotic, C Jacobsen, T Schafer, S Vogt
    "Cluster analysis of soft X-ray spectromicroscopy data".
-   Ultramicroscopy 100 (2004) 35–57 
+   Ultramicroscopy 100 (2004) 35–57
    [`<https://doi.org/10.1016/j.ultramic.2004.01.008>`_]
 
 .. _Iakoubovskii2008:

--- a/doc/user_guide/eds.rst
+++ b/doc/user_guide/eds.rst
@@ -519,7 +519,7 @@ EDS curve fitting
 
 The intensity of X-ray lines can be extracted using curve-fitting in HyperSpy.
 This example uses an EDS-SEM spectrum of a test material (EDS-TM001) provided
-by `BAM <http://www.webshop.bam.de>`_.
+by `BAM <https://www.webshop.bam.de>`_.
 
 First, we load the spectrum, define the chemical composition of the sample and
 set the beam energy:

--- a/doc/user_guide/getting_started.rst
+++ b/doc/user_guide/getting_started.rst
@@ -70,9 +70,9 @@ and the
 Possible warnings when importing HyperSpy?
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-HyperSpy supports different GUIs and 
-`matplotlib backends <https://matplotlib.org/tutorials/introductory/usage.html#backends>`_ 
-which in specific cases can lead to warnings when importing HyperSpy. Most of the time 
+HyperSpy supports different GUIs and
+`matplotlib backends <https://matplotlib.org/stable/users/explain/backends.html>`_
+which in specific cases can lead to warnings when importing HyperSpy. Most of the time
 there is nothing to worry about — the warnings simply inform you of several choices you have.
 There may be several causes for a warning, for example:
 
@@ -102,8 +102,8 @@ These warnings can be turned off using the
 
 
 .. versionchanged:: v1.3
-    HyperSpy works with all matplotlib backends, including the ``notebook`` 
-    (also called ``nbAgg``) backend that enables interactive plotting embedded 
+    HyperSpy works with all matplotlib backends, including the ``notebook``
+    (also called ``nbAgg``) backend that enables interactive plotting embedded
     in the jupyter notebook.
 
 
@@ -134,7 +134,7 @@ accessed by adding a question mark to the name of a function. e.g.:
 
 This syntax is a shortcut to the standard way one of displaying the help
 associated to a given functions (docstring in Python jargon) and it is one of
-the many features of `IPython <http://ipython.scipy.org/moin/>`_, which is the
+the many features of `IPython <https://ipython.readthedocs.io/>`_, which is the
 interactive python shell that HyperSpy uses under the hood.
 
 Please note that the documentation of the code is a work in progress, so not
@@ -147,13 +147,11 @@ Up-to-date documentation is always available in `the HyperSpy website.
 Autocompletion
 --------------
 
-Another useful `IPython <http://ipython.scipy.org/moin/>`_ feature is the
-autocompletion of commands and filenames using the tab and arrow keys. It is
-highly recommended to read the `Ipython documentation
-<http://ipython.scipy.org/moin/Documentation>`_ (specially their `Getting
-started <http://ipython.org/ipython-doc/stable/interactive/tutorial.html>`_
-section) for many more useful features that will boost your efficiency when
-working with HyperSpy/Python interactively.
+Another useful IPython feature is the
+`autocompletion <https://ipython.readthedocs.io/en/stable/interactive/tutorial.html#tab-completion>`_
+of commands and filenames using the tab and arrow keys. It is highly recommended
+to read the `Ipython introduction <https://ipython.readthedocs.io/en/stable/interactive/tutorial.html>`_ for many more useful features that will
+boost your efficiency when working with HyperSpy/Python interactively.
 
 
 Loading data
@@ -176,7 +174,7 @@ the use of a specific IO-plugin, you can provide the ``reader`` attribute:
 .. note::
 
    When the file contains several datasets, the :py:func:`~.io.load` function
-   will return a list of HyperSpy signals, instead of a single HyperSpy signal. 
+   will return a list of HyperSpy signals, instead of a single HyperSpy signal.
    Each signal can then be accessed using list indexation.
 
    .. code-block:: python
@@ -188,7 +186,7 @@ the use of a specific IO-plugin, you can provide the ``reader`` attribute:
        <Signal1D, title: ham, dimensions: (32,32|1024)>]
 
    Using indexation to access the first signal (index 0):
-   
+
    .. code-block:: python
 
       >>> s[0]

--- a/doc/user_guide/getting_started.rst
+++ b/doc/user_guide/getting_started.rst
@@ -22,7 +22,7 @@ Starting Python in Linux and MacOS
 You can start IPython by opening a system terminal and executing ``ipython``,
 (optionally followed by the "frontend": "qtconsole" for example). However, in
 most cases, **the most agreeable way** to work with HyperSpy interactively
-is using the `Jupyter Notebook <http://jupyter.org>`_ (previously known as
+is using the `Jupyter Notebook <https://jupyter.org>`_ (previously known as
 the IPython Notebook), which can be started as follows:
 
 .. code-block:: bash
@@ -38,7 +38,7 @@ Starting HyperSpy in the notebook (or terminal)
 -----------------------------------------------
 Typically you will need to `set up IPython for interactive plotting with
 matplotlib
-<http://ipython.readthedocs.org/en/stable/interactive/plotting.html>`_ using
+<https://ipython.readthedocs.org/en/stable/interactive/plotting.html>`_ using
 ``%matplotlib`` (which is known as a 'Jupyter magic')
 *before executing any plotting command*. So, typically, after starting
 IPython, you can import HyperSpy and set up interactive matplotlib plotting by
@@ -141,7 +141,7 @@ Please note that the documentation of the code is a work in progress, so not
 all the objects are documented yet.
 
 Up-to-date documentation is always available in `the HyperSpy website.
-<http://hyperspy.org/documentation.html>`_
+<https://hyperspy.org/documentation.html>`_
 
 
 Autocompletion
@@ -259,7 +259,7 @@ experimental data.
 .. _eelsdb-label:
 
 The :py:func:`~.misc.eels.eelsdb.eelsdb` function in `hs.datasets` can
-directly load spectra from `The EELS Database <http://eelsdb.eu>`_. For
+directly load spectra from `The EELS Database <https://eelsdb.eu>`_. For
 example, the following loads all the boron trioxide spectra currently
 available in the database:
 

--- a/doc/user_guide/install.rst
+++ b/doc/user_guide/install.rst
@@ -149,8 +149,8 @@ Installation using pip
 ----------------------
 
 HyperSpy is listed in the `Python Package Index
-<http://pypi.python.org/pypi>`_. Therefore, it can be automatically downloaded
-and installed  `pip <http://pypi.python.org/pypi/pip>`__. You may need to
+<https://pypi.python.org/pypi>`_. Therefore, it can be automatically downloaded
+and installed  `pip <https://pypi.python.org/pypi/pip>`__. You may need to
 install pip for the following commands to run.
 
 To install all of HyperSpy's functionalities, run:
@@ -170,9 +170,9 @@ See the following list of selectors to select the installation of optional
 dependencies required by specific functionalities:
 
 * ``learning`` for some machine learning features,
-* ``gui-jupyter`` to use the `Jupyter widgets <http://ipywidgets.readthedocs.io/en/stable/>`_
+* ``gui-jupyter`` to use the `Jupyter widgets <https://ipywidgets.readthedocs.io/en/stable/>`_
   GUI elements,
-* ``gui-traitsui`` to use the GUI elements based on `traitsui <http://docs.enthought.com/traitsui/>`_,
+* ``gui-traitsui`` to use the GUI elements based on `traitsui <https://docs.enthought.com/traitsui/>`_,
 * ``mrcz`` to read mrcz file,
 * ``speed`` to speed up some functionalities,
 * ``usid`` to read usid file,
@@ -271,7 +271,7 @@ Clone the hyperspy repository
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 To get the development version from our git repository you need to install `git
-<http://git-scm.com//>`_. Then just do:
+<https://git-scm.com//>`_. Then just do:
 
 .. code-block:: bash
 
@@ -287,8 +287,8 @@ To get the development version from our git repository you need to install `git
 
 Installation in a Anaconda/Miniconda distribution
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Optionally, create an environment to separate your hyperspy installation from 
-other anaconda environments (`read more about environments here 
+Optionally, create an environment to separate your hyperspy installation from
+other anaconda environments (`read more about environments here
 <https://conda.io/projects/conda/en/latest/user-guide/concepts/environments.html>`_):
 
 .. code-block:: bash
@@ -307,7 +307,7 @@ The package ``hyperspy-dev`` will install the development dependencies required
 for testing and building the documentation.
 
 From the root folder of your hyperspy repository (folder containing the
-``setup.py`` file) run `pip <http://www.pip-installer.org>`_ in development mode:
+``setup.py`` file) run `pip <https://pip.pypa.io/>`_ in development mode:
 
 .. code-block:: bash
 
@@ -317,7 +317,7 @@ Installation in other (non-system) Python distribution
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 From the root folder of your hyperspy repository (folder containing the
-``setup.py`` file) run `pip <http://www.pip-installer.org>`_ in development mode:
+``setup.py`` file) run `pip <https://pip.pypa.io/>`_ in development mode:
 
 .. code-block:: bash
 
@@ -341,7 +341,7 @@ When using a system Python distribution, it is recommended to install the
 dependencies using your system package manager.
 
 From the root folder of your hyperspy repository (folder containing the
-``setup.py`` file) run `pip <http://www.pip-installer.org>`_ in development mode.
+``setup.py`` file) run `pip <https://pip.pypa.io/>`_ in development mode.
 
 .. code-block:: bash
 
@@ -361,4 +361,3 @@ You can create binaries for Debian/Ubuntu from the source by running the
 
     For this to work, the following packages must be installed in your system
     python-stdeb, debhelper, dpkg-dev and python-argparser are required.
-

--- a/doc/user_guide/intro.rst
+++ b/doc/user_guide/intro.rst
@@ -61,5 +61,5 @@ that sets its character:
   and
   `hyperspy-gui-traitsui <https://github.com/hyperspy/hyperspy_gui_traitsui>`_
   packages for details. Not enough? If you
-  need a full, standalone GUI, `HyperSpyUI <http://hyperspy.org/hyperspyUI/>`_
+  need a full, standalone GUI, `HyperSpyUI <https://hyperspy.org/hyperspyUI/>`_
   is for you.

--- a/doc/user_guide/io.rst
+++ b/doc/user_guide/io.rst
@@ -134,7 +134,7 @@ functions, e.g.:
 
     >>> s = hs.load(["file1.hspy", "file2.hspy"])
 
-or by using `shell-style wildcards <http://docs.python.org/library/glob.html>`_:
+or by using `shell-style wildcards <https://docs.python.org/library/glob.html>`_:
 
 .. code-block:: python
 
@@ -1905,7 +1905,7 @@ Extra loading arguments
   acquired last frame, which typically occurs when the acquisition was
   interrupted. When loading incomplete data (``only_valid_data=False``),
   the missing data are filled with zeros. If ``sum_frames=True``, this argument
-  will be ignored to enforce consistent sum over the mapped area. 
+  will be ignored to enforce consistent sum over the mapped area.
 - ``read_em_image`` : bool, default False.
   for ``pts`` file only, If ``read_em_image=True``,
   read SEM/STEM image from pts file if available. In this case, both
@@ -1953,8 +1953,8 @@ TVIPS format
 
 The TVIPS format is the default format for image series collected by pixelated
 cameras from the TVIPS company. Typically individual images captured by these
-cameras are stored in the :ref:`TIFF format<tiff-format>` which can also be 
-loaded by Hyperspy. This format instead serves to store image streams from 
+cameras are stored in the :ref:`TIFF format<tiff-format>` which can also be
+loaded by Hyperspy. This format instead serves to store image streams from
 in-situ and 4D-STEM experiments. During collection, the maximum file size is
 typically capped meaning the dataset is typically split over multiple files
 ending in `_xyz.tvips`. The `_000.tvips` will contain the main header and
@@ -1969,7 +1969,7 @@ will not work if no such file is found.
    interoperability with the official software can neither be guaranteed.
 
 .. warning::
-    
+
    The TVIPS format currently stores very limited amount of metadata about
    scanning experiments. To reconstruct scan data, e.g. 4D-STEM datasets,
    parameters like the shape and scales of the scan dimensions should be
@@ -1982,7 +1982,7 @@ Extra loading arguments
   in the x direction. If this argument is not provided, the data will be loaded
   as a 1D stack of images. `auto` is also an option which aims to reconstruct
   the scan based on the `rotidx` indices in frame headers. Since this only
-  works for square scan grids and is prone to failure, this option is not 
+  works for square scan grids and is prone to failure, this option is not
   recommended.
 - ``scan_start_frame``: index of the first frame of the dataset to consider,
   mainly relevant for 4D-STEM datasets. If `scan_shape="auto"` this parameter
@@ -2002,11 +2002,11 @@ Extra loading arguments
   default setting of `auto` rechunking is performed such that the navigation axes
   are optimally chunked and the signal axes are not chunked. If set to anything else, the
   value will be passed to the `chunks` argument in `dask.array.rechunk`.
-  
+
 Extra saving arguments
 ^^^^^^^^^^^^^^^^^^^^^^
 
-- ``max_file_size``: approximate maximum size of individual files in bytes. 
+- ``max_file_size``: approximate maximum size of individual files in bytes.
   In this way a dataset can be split into multiple files. A file needs to be
   at least the size of the main header in the first file plus one frame and its
   frame header. By default there is no maximum and the entire dataset is saved

--- a/doc/user_guide/model.rst
+++ b/doc/user_guide/model.rst
@@ -162,7 +162,7 @@ Both symbolic and numerical substitutions are allowed:
     ... name="Electron wavelength with voltage")
 
 :py:class:`~._components.expression.Expression` uses `Sympy
-<http://www.sympy.org>`_ internally to turn the string into
+<https://www.sympy.org>`_ internally to turn the string into
 a function. By default it "translates" the expression using
 numpy, but often it is possible to boost performance by using
 `numexpr <https://github.com/pydata/numexpr>`_ instead.
@@ -722,7 +722,7 @@ whether the optimizers find a local or global optima.
 
 .. [2] **All** of the fitting algorithms available in :py:func:`scipy.optimize.minimize` are currently
        supported by HyperSpy; however, only some of them support bounds and/or gradients. For more information,
-       please see the `SciPy documentation <http://docs.scipy.org/doc/scipy/reference/optimize.html>`_.
+       please see the `SciPy documentation <https://docs.scipy.org/doc/scipy/reference/optimize.html>`_.
 
 .. [3] Requires ``scipy >= 1.2.0``.
 
@@ -1638,7 +1638,7 @@ as follows:
     >>> samf = m.create_samfire(workers=None, ipyparallel=False)
 
 By default SAMFire will look for an `ipyparallel
-<http://ipyparallel.readthedocs.io/en/latest/index.html>`_ cluster for the
+<https://ipyparallel.readthedocs.io/>`_ cluster for the
 workers for around 30 seconds. If none is available, it will use
 multiprocessing instead.  However, if you are not planning to use ipyparallel,
 it's recommended specify it explicitly via the ``ipyparallel=False`` argument,

--- a/doc/user_guide/mva.rst
+++ b/doc/user_guide/mva.rst
@@ -502,7 +502,7 @@ links to the appropriate documentation for more information on each one.
    Except :py:func:`~.learn.orthomax.orthomax`, all of the implemented BSS algorithms listed above
    rely on external packages being available on your system. ``sklearn_fastica``, requires
    `scikit-learn <https://scikit-learn.org/>`_ while ``FastICA, JADE, CuBICA, TDSEP``
-   require the `Modular toolkit for Data Processing (MDP) <http://mdp-toolkit.sourceforge.net/>`_.
+   require the `Modular toolkit for Data Processing (MDP) <https://mdp-toolkit.github.io/>`_.
 
 .. _mva.orthomax:
 

--- a/doc/user_guide/signal.rst
+++ b/doc/user_guide/signal.rst
@@ -814,7 +814,7 @@ augmented binary assignments (+=, -=, \*=, /=, //=, %=, \*\*=, <<=, >>=, &=,
 
 These operations are performed element-wise. When the dimensions of the signals
 are not equal `numpy broadcasting rules apply
-<http://docs.scipy.org/doc/numpy/user/basics.broadcasting.html>`_ independently
+<https://numpy.org/doc/stable/user/basics.broadcasting.html>`_ independently
 for the navigation and signal axes.
 
 .. WARNING::
@@ -919,7 +919,7 @@ the original data, a property that we can use to perform operations on the
 data.  For example, the following code rotates the image at each coordinate  by
 a given angle and uses the :py:func:`~.utils.stack` function in combination
 with `list comprehensions
-<http://docs.python.org/2/tutorial/datastructures.html#list-comprehensions>`_
+<https://docs.python.org/3/tutorial/datastructures.html#list-comprehensions>`_
 to make a horizontal "collage" of the image stack:
 
 .. code-block:: python

--- a/doc/user_guide/visualisation.rst
+++ b/doc/user_guide/visualisation.rst
@@ -121,10 +121,10 @@ To close all the figures run the following command:
 
 .. NOTE::
 
-    ``plt.close('all')`` is a `matplotlib <http://matplotlib.sourceforge.net/>`_ command.
+    ``plt.close('all')`` is a `matplotlib <https://matplotlib.org/>`_ command.
     Matplotlib is the library that HyperSpy uses to produce the plots. You can
     learn how to pan/zoom and more  `in the matplotlib documentation
-    <http://matplotlib.sourceforge.net/users/navigation_toolbar.html>`_
+    <https://matplotlib.org/stable/users/explain/interactive.html>`_
 
 
 .. NOTE::
@@ -435,7 +435,7 @@ Data files used in the following examples can be downloaded using
 .. code-block:: python
 
     >>> from urllib.request import urlretrieve
-    >>> url = 'http://cook.msm.cam.ac.uk//~hyperspy//EDS_tutorial//'
+    >>> url = 'http://cook.msm.cam.ac.uk/~hyperspy/EDS_tutorial/'
     >>> urlretrieve(url + 'Ni_La_intensity.hdf5', 'Ni_La_intensity.hdf5')
 
 .. NOTE::
@@ -734,8 +734,8 @@ __ plot.spectra_
     functionality is only enabled if a ``matplotlib`` backend that supports the
     ``button_press_event`` in the figure canvas is being used.
 
-It is also possible to plot multiple images overlayed on the same figure by 
-passing the argument ``overlay=True`` to the 
+It is also possible to plot multiple images overlayed on the same figure by
+passing the argument ``overlay=True`` to the
 :py:func:`~.drawing.utils.plot_images` function. This should only be done when
 images have the same scale (eg. for elemental maps from the same dataset).
 Using the same data as above, the Fe and Pt signals can be plotted using
@@ -746,7 +746,7 @@ hex values.
 
     >>> si_EDS = hs.load("core_shell.hdf5")
     >>> im = si_EDS.get_lines_intensity()
-    >>> hs.plot.plot_images(im,scalebar='all', overlay=True, suptitle=False, 
+    >>> hs.plot.plot_images(im,scalebar='all', overlay=True, suptitle=False,
     >>>                     axes_decor='off')
 
 .. figure::  images/plot_images_overlay.png
@@ -1370,6 +1370,3 @@ Marker properties
 
 The optional parameters (``**kwargs``, keyword arguments) can be used for extra parameters used in matplotlib.
 (The ``color`` property in rectangle marker is an alias of ``edgecolor`` for backward compatibility)
-
-
-

--- a/hyperspy/Release.py
+++ b/hyperspy/Release.py
@@ -33,10 +33,10 @@ license = 'GPL v3'
 authors = {
     'all': ('The HyperSpy developers',), }
 
-url = 'http://hyperspy.org'
+url = 'https://hyperspy.org'
 
-download_url = 'http://www.hyperspy.org'
-documentation_url = 'http://hyperspy.org/hyperspy-doc/current/index.html'
+download_url = 'https://www.hyperspy.org'
+documentation_url = 'https://hyperspy.org/hyperspy-doc/current/index.html'
 
 PROJECT_URLS = {
     'Bug Tracker': 'https://github.com/hyperspy/hyperspy/issues',
@@ -84,6 +84,6 @@ info = """
     H y p e r S p y
     Version %s
 
-    http://www.hyperspy.org
+    https://www.hyperspy.org
 
     """ % version.replace('_', ' ')

--- a/hyperspy/__init__.py
+++ b/hyperspy/__init__.py
@@ -28,7 +28,7 @@ HyperSpy: a multi-dimensional data analysis package for Python
 ==============================================================
 
 Documentation is available in the docstrings and online at
-http://hyperspy.org/hyperspy-doc/current/index.html.
+https://hyperspy.org/hyperspy-doc/current/index.html.
 
 All public packages, functions and classes are in :mod:`~hyperspy.api`. All
 other packages and modules are for internal consumption and should not be

--- a/hyperspy/_components/gaussian.py
+++ b/hyperspy/_components/gaussian.py
@@ -150,7 +150,7 @@ class Gaussian(Expression):
 
         Notes
         -----
-        Adapted from http://www.scipy.org/Cookbook/FittingData
+        Adapted from https://scipy-cookbook.readthedocs.io/items/FittingData.html
 
         Examples
         --------

--- a/hyperspy/_components/gaussianhf.py
+++ b/hyperspy/_components/gaussianhf.py
@@ -128,7 +128,7 @@ class GaussianHF(Expression):
 
         Notes
         -----
-        Adapted from http://www.scipy.org/Cookbook/FittingData
+        Adapted from https://scipy-cookbook.readthedocs.io/items/FittingData.html
 
         Examples
         --------

--- a/hyperspy/_components/pes_voigt.py
+++ b/hyperspy/_components/pes_voigt.py
@@ -278,7 +278,7 @@ class PESVoigt(Component):
 
         Notes
         -----
-        Adapted from http://www.scipy.org/Cookbook/FittingData
+        Adapted from https://scipy-cookbook.readthedocs.io/items/FittingData.html
 
         Examples
         --------

--- a/hyperspy/_components/split_voigt.py
+++ b/hyperspy/_components/split_voigt.py
@@ -175,7 +175,7 @@ class SplitVoigt(Component):
 
         Notes
         -----
-        Adapted from http://www.scipy.org/Cookbook/FittingData
+        Adapted from https://scipy-cookbook.readthedocs.io/items/FittingData.html
 
         Examples
         --------

--- a/hyperspy/_components/voigt.py
+++ b/hyperspy/_components/voigt.py
@@ -145,7 +145,7 @@ class Voigt(Expression):
 
         Notes
         -----
-        Adapted from http://www.scipy.org/Cookbook/FittingData
+        Adapted from https://scipy-cookbook.readthedocs.io/items/FittingData.html
 
         Examples
         --------

--- a/hyperspy/datasets/__init__.py
+++ b/hyperspy/datasets/__init__.py
@@ -5,7 +5,7 @@ datasets.
 Functions:
 
     eelsdb
-        Download spectra from the EELS data base http://eelsdb.eu
+        Download spectra from the EELS data base https://eelsdb.eu
 
 Submodules:
 

--- a/hyperspy/external/astropy/bayesian_blocks.py
+++ b/hyperspy/external/astropy/bayesian_blocks.py
@@ -1,6 +1,6 @@
 """
-Ported first from the astroML project: http://astroml.org/
-Ported again from the astropy project: http://astropy.org/
+Ported first from the astroML project: https://astroml.org/
+Ported again from the astropy project: https://astropy.org/
 
 Bayesian Blocks for Time Series Analysis
 ========================================
@@ -35,8 +35,8 @@ function.
 
 References
 ----------
-.. [1] http://adsabs.harvard.edu/abs/2012arXiv1207.5578S
-.. [2] http://astroml.org/ https://github.com//astroML/astroML/
+.. [1] https://adsabs.harvard.edu/abs/2012arXiv1207.5578S
+.. [2] https://astroml.org/ https://github.com//astroML/astroML/
 """
 import warnings
 
@@ -136,7 +136,7 @@ def bayesian_blocks(t, x=None, sigma=None, fitness="events", **kwargs):
     References
     ----------
     .. [1] Scargle, J et al. (2012)
-       http://adsabs.harvard.edu/abs/2012arXiv1207.5578S
+       https://adsabs.harvard.edu/abs/2012arXiv1207.5578S
 
     See Also
     --------
@@ -193,7 +193,7 @@ class FitnessFunc:
     References
     ----------
     .. [1] Scargle, J et al. (2012)
-       http://adsabs.harvard.edu/abs/2012arXiv1207.5578S
+       https://adsabs.harvard.edu/abs/2012arXiv1207.5578S
     """
 
     def __init__(self, p0=0.05, gamma=None, ncp_prior=None):

--- a/hyperspy/external/astropy/histogram.py
+++ b/hyperspy/external/astropy/histogram.py
@@ -1,6 +1,6 @@
 """
-Ported first from the astroML project: http://astroml.org/
-Ported again from the astropy project: http://astropy.org/
+Ported first from the astroML project: https://astroml.org/
+Ported again from the astropy project: https://astropy.org/
 
 Tools for working with distributions
 """

--- a/hyperspy/external/mpfit/mpfit.py
+++ b/hyperspy/external/mpfit/mpfit.py
@@ -11,20 +11,20 @@ Craig Markwardt converted the FORTRAN code to IDL.
     Craig B. Markwardt, NASA/GSFC Code 662, Greenbelt, MD 20770
     craigm@lheamail.gsfc.nasa.gov
     UPDATED VERSIONs can be found on my WEB PAGE:
-    http://cow.physics.wisc.edu/~craigm/idl/idl.html
+    https://cow.physics.wisc.edu/~craigm/idl/idl.html
 
 Mark Rivers created this Python version from Craig's IDL version.
     Mark Rivers, University of Chicago
     Building 434A, Argonne National Laboratory
     9700 South Cass Avenue, Argonne, IL 60439
     rivers@cars.uchicago.edu
-    Updated versions can be found at http://cars.uchicago.edu/software
+    Updated versions can be found at https://cars.uchicago.edu/software
 
 Sergey Koposov converted the Mark's Python version from Numeric to numpy
     Sergey Koposov, University of Cambridge, Institute of Astronomy,
     Madingley road, CB3 0HA, Cambridge, UK
     koposov@ast.cam.ac.uk
-    Updated versions can be found at http://code.google.com/p/astrolibpy/source/browse/trunk/
+    Updated versions can be found at https://code.google.com/p/astrolibpy/source/browse/trunk/
 
 
 MODIFICATION HISTORY

--- a/hyperspy/learn/rpca.py
+++ b/hyperspy/learn/rpca.py
@@ -224,7 +224,7 @@ class ORPCA:
         via Stochastic Optimization", Advances in Neural Information Processing
         Systems 26, (2013), pp. 404-412.
     .. [Ruder2016] Sebastian Ruder, "An overview of gradient descent optimization
-        algorithms", arXiv:1609.04747, (2016), http://arxiv.org/abs/1609.04747.
+        algorithms", arXiv:1609.04747, (2016), https://arxiv.org/abs/1609.04747.
 
     """
 

--- a/hyperspy/misc/eds/ffast_mac.py
+++ b/hyperspy/misc/eds/ffast_mac.py
@@ -1,5 +1,5 @@
 # Mass absoption coefficient Chantler2005
-# See http://physics.nist.gov/ffast
+# See https://physics.nist.gov/ffast
 # Chantler, C.T., Olsen, K., Dragoset, R.A., Kishore, A.R., Kotochigova,
 # S.A., and Zucker, D.S. (2005), X-Ray Form Factor, Attenuation and
 # Scattering Tables (version 2.1).

--- a/hyperspy/misc/eels/eelsdb.py
+++ b/hyperspy/misc/eels/eelsdb.py
@@ -227,7 +227,7 @@ def eelsdb(spectrum_type=None, title=None, author=None, element=None, formula=No
     if show_progressbar is None:
         show_progressbar = preferences.General.show_progressbar
 
-    request = requests.get('http://api.eelsdb.eu/spectra', params=params, verify=verify_certificate)
+    request = requests.get('https://api.eelsdb.eu/spectra', params=params, verify=verify_certificate)
     spectra = []
     jsons = request.json()
     if "message" in jsons:
@@ -236,13 +236,13 @@ def eelsdb(spectrum_type=None, title=None, author=None, element=None, formula=No
             "Please report the following error to the HyperSpy developers: "
             f"{jsons['message']}."
             )
-        
+
     for json_spectrum in progressbar(jsons, disable=not show_progressbar):
         download_link = json_spectrum['download_link']
         if download_link.split('.')[-1].lower() != 'msa':
             _logger.exception(
                 "The source file is not a msa file, please report this error "
-                "to http://eelsdb.eu/about with the following details:\n"
+                "to https://eelsdb.eu/about with the following details:\n"
                 f"Title: {json_spectrum['title']}\nid: {json_spectrum['id']}\n"
                 f"Download link: {download_link}\n"
                 f"Permalink: {json_spectrum['permalink']}"
@@ -264,7 +264,7 @@ def eelsdb(spectrum_type=None, title=None, author=None, element=None, formula=No
             _logger.exception(
                 "Failed to load the spectrum.\n"
                 "Title: %s id: %s.\n"
-                "Please report this error to http://eelsdb.eu/about \n" %
+                "Please report this error to https://eelsdb.eu/about \n" %
                 (json_spectrum["title"], json_spectrum["id"]))
 
     if not spectra:
@@ -294,7 +294,7 @@ def eelsdb(spectrum_type=None, title=None, author=None, element=None, formula=No
                             "element information:\n"
                             "Title: %s id: %s. Elements: %s.\n"
                             "Please report this error in "
-                            "http://eelsdb.eu/about \n" %
+                            "https://eelsdb.eu/about \n" %
                             (json_md.title, json_md.id, json_md.elements))
                 if "collection" in json_md and " mrad" in json_md.collection:
                     beta = float(json_md.collection.replace(" mrad", ""))

--- a/hyperspy/misc/material.py
+++ b/hyperspy/misc/material.py
@@ -218,7 +218,7 @@ def _density_of_mixture(weight_percent,
         [elements_db[element]['Physical_properties']['density (g/cm^3)']
             for element in elements])
     sum_densities = np.zeros_like(weight_percent, dtype='float')
-    try : 
+    try :
         if mean == 'harmonic':
             for i, weight in enumerate(weight_percent):
                 sum_densities[i] = weight / densities[i]
@@ -232,7 +232,7 @@ def _density_of_mixture(weight_percent,
             sum_weight = np.sum(weight_percent, axis=0)
             density = sum_densities / sum_weight
             return np.where(sum_weight == 0.0, 0.0, density)
-    except TypeError : 
+    except TypeError :
         raise ValueError(
             'The density of one of the elements is unknown (Probably At or Fr).')
 
@@ -312,7 +312,7 @@ def mass_absorption_coefficient(element, energies):
 
     Note
     ----
-    See http://physics.nist.gov/ffast
+    See https://physics.nist.gov/ffast
     Chantler, C.T., Olsen, K., Dragoset, R.A., Kishore, A.R., Kotochigova,
     S.A., and Zucker, D.S. (2005), X-Ray Form Factor, Attenuation and
     Scattering Tables (version 2.1).
@@ -371,7 +371,7 @@ def _mass_absorption_mixture(weight_percent,
 
     Note
     ----
-    See http://physics.nist.gov/ffast
+    See https://physics.nist.gov/ffast
     Chantler, C.T., Olsen, K., Dragoset, R.A., Kishore, A.R., Kotochigova,
     S.A., and Zucker, D.S. (2005), X-Ray Form Factor, Attenuation and
     Scattering Tables (version 2.1).
@@ -434,7 +434,7 @@ def mass_absorption_mixture(weight_percent,
 
     Note
     ----
-    See http://physics.nist.gov/ffast
+    See https://physics.nist.gov/ffast
     Chantler, C.T., Olsen, K., Dragoset, R.A., Kishore, A.R., Kotochigova,
     S.A., and Zucker, D.S. (2005), X-Ray Form Factor, Attenuation and
     Scattering Tables (version 2.1).

--- a/hyperspy/misc/tv_denoise.py
+++ b/hyperspy/misc/tv_denoise.py
@@ -149,7 +149,7 @@ def _tv_denoise_2d(im, weight=50, eps=2.e-4, keep_type=False, n_iter_max=200):
     Notes
     -----
     The principle of total variation denoising is explained in
-    http://en.wikipedia.org/wiki/Total_variation_denoising
+    https://en.wikipedia.org/wiki/Total_variation_denoising
 
     This code is an implementation of the algorithm of Rudin, Fatemi and Osher
     that was proposed by Chambolle in [*]_.
@@ -244,7 +244,7 @@ def _tv_denoise_1d(im, weight=50, eps=2.e-4, keep_type=False, n_iter_max=200):
     Notes
     -----
     The principle of total variation denoising is explained in
-    http://en.wikipedia.org/wiki/Total_variation_denoising
+    https://en.wikipedia.org/wiki/Total_variation_denoising
 
     This code is an implementation of the algorithm of Rudin, Fatemi and Osher
     that was proposed by Chambolle in [*]_.
@@ -335,7 +335,7 @@ def tv_denoise(im, weight=50, eps=2.e-4, keep_type=False, n_iter_max=200):
     Notes
     -----
     The principle of total variation denoising is explained in
-    http://en.wikipedia.org/wiki/Total_variation_denoising
+    https://en.wikipedia.org/wiki/Total_variation_denoising
 
     The principle of total variation denoising is to minimize the
     total variation of the image, which can be roughly described as

--- a/hyperspy/misc/utils.py
+++ b/hyperspy/misc/utils.py
@@ -988,7 +988,7 @@ def ordinal(value):
     Notes
     -----
     Author:  Serdar Tumgoren
-    http://code.activestate.com/recipes/576888-format-a-number-as-an-ordinal/
+    https://code.activestate.com/recipes/576888-format-a-number-as-an-ordinal/
     MIT license
     """
     try:
@@ -1583,7 +1583,7 @@ def to_numpy(array):
     Returns
     -------
     array : numpy.ndarray
-    
+
     Raises
     ------
     ValueError

--- a/hyperspy/signal.py
+++ b/hyperspy/signal.py
@@ -4268,7 +4268,7 @@ class BaseSignal(FancySlicing,
             (default is ``False``).
         apodization : bool or str
             Apply an
-            `apodization window <http://mathworld.wolfram.com/ApodizationFunction.html>`_
+            `apodization window <https://mathworld.wolfram.com/ApodizationFunction.html>`_
             before calculating the FFT in order to suppress streaks.
             Valid string values are {``'hann'`` or ``'hamming'`` or ``'tukey'``}
             If ``True`` or ``'hann'``, applies a Hann window.
@@ -6324,7 +6324,7 @@ class BaseSignal(FancySlicing,
                           hann_order=None, tukey_alpha=0.5, inplace=False):
         """
         Apply an `apodization window
-        <http://mathworld.wolfram.com/ApodizationFunction.html>`_ to a Signal.
+        <https://mathworld.wolfram.com/ApodizationFunction.html>`_ to a Signal.
 
         Parameters
         ----------

--- a/hyperspy/tests/datasets/test_eelsdb.py
+++ b/hyperspy/tests/datasets/test_eelsdb.py
@@ -41,10 +41,10 @@ def _eelsdb(**kwargs):
 
 def eelsdb_down():
     try:
-        _ = requests.get('http://api.eelsdb.eu', verify=True)
+        _ = requests.get('https://api.eelsdb.eu', verify=True)
         return False
     except SSLError:
-        _ = requests.get('http://api.eelsdb.eu', verify=False)
+        _ = requests.get('https://api.eelsdb.eu', verify=False)
         return False
     except requests.exceptions.ConnectionError:
         return True

--- a/hyperspy/tests/misc/test_signal_tools.py
+++ b/hyperspy/tests/misc/test_signal_tools.py
@@ -14,7 +14,7 @@
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with HyperSpy. If not, see <http://www.gnu.org/licenses/>.
+# along with HyperSpy. If not, see <https://www.gnu.org/licenses/>.
 
 import pytest
 

--- a/hyperspy/tests/signals/test_cuda.py
+++ b/hyperspy/tests/signals/test_cuda.py
@@ -14,7 +14,7 @@
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with  HyperSpy.  If not, see <http://www.gnu.org/licenses/>.
+# along with  HyperSpy.  If not, see <https://www.gnu.org/licenses/>.
 
 from packaging.version import Version
 

--- a/hyperspy/utils/peakfinders2D.py
+++ b/hyperspy/utils/peakfinders2D.py
@@ -111,7 +111,7 @@ def find_local_max(z, **kwargs):
     **kwargs : dict
         Keyword arguments to be passed to the ``peak_local_max`` method of
         the ``scikit-image`` library. See its documentation for details
-        http://scikit-image.org/docs/dev/api/skimage.feature.html#peak-local-max
+        https://scikit-image.org/docs/dev/api/skimage.feature.html#peak-local-max
 
     Returns
     -------
@@ -459,7 +459,7 @@ def find_peaks_dog(z, min_sigma=1., max_sigma=50., sigma_ratio=1.6,
     min_sigma, max_sigma, sigma_ratio, threshold, overlap, exclude_border :
         Additional parameters to be passed to the algorithm. See `blob_dog`
         documentation for details:
-        http://scikit-image.org/docs/dev/api/skimage.feature.html#blob-dog
+        https://scikit-image.org/docs/dev/api/skimage.feature.html#blob-dog
 
     Returns
     -------
@@ -504,7 +504,7 @@ def find_peaks_log(z, min_sigma=1., max_sigma=50., num_sigma=10,
     min_sigma, max_sigma, num_sigma, threshold, overlap, log_scale, exclude_border :
         Additional parameters to be passed to the ``blob_log`` method of the
         ``scikit-image`` library. See its documentation for details:
-        http://scikit-image.org/docs/dev/api/skimage.feature.html#blob-log
+        https://scikit-image.org/docs/dev/api/skimage.feature.html#blob-log
 
     Returns
     -------

--- a/upcoming_changes/3001.maintenance.rst
+++ b/upcoming_changes/3001.maintenance.rst
@@ -1,0 +1,1 @@
+Fix external links in the documentation and add CI build to check external links


### PR DESCRIPTION
The CI workflow, which makes the PR comment on the docs is broken - see https://github.com/sphinx-contrib/sphinxcontrib-towncrier/issues/60: `sphinxcontrib-towncrier` is not compatible with the coming `towncrier` 22.8.0 release.

### Progress of the PR
- [x] Move doc build to separate workflow and add check external links,
- [x] Remove `--pre` flags, which isn't necessary anymore and fix the failure to the CI failure,
- [x] Update external links 
- [n/a] update docstring (if appropriate),
- [n/a] update user guide (if appropriate),
- [x] add an changelog entry in the `upcoming_changes` folder (see [`upcoming_changes/README.rst`](https://github.com/hyperspy/hyperspy/blob/RELEASE_next_minor/upcoming_changes/README.rst)),
- [x] Check formatting changelog entry in the `readthedocs` doc build of this PR (link in github checks)
- [n/a] add tests,
- [x] ready for review.

