### PR TITLE
Fix removing horizontal and vertical line widget

### DIFF
--- a/hyperspy/drawing/_widgets/horizontal_line.py
+++ b/hyperspy/drawing/_widgets/horizontal_line.py
@@ -31,14 +31,19 @@ class HorizontalLineWidget(Widget1DBase):
             self.patch[0].set_ydata(self._pos[0])
             self.draw_patch()
 
+    def _add_patch_to(self, ax):
+        """Create and add the matplotlib patches to 'ax'"""
+        self.blit = hasattr(ax, 'hspy_fig') and ax.figure.canvas.supports_blit
+        self._set_patch()
+        for p in self.patch:
+            p.set_animated(self.blit)
+
     def _set_patch(self):
         ax = self.ax
         kwargs = picker_kwargs(preferences.Plot.pick_tolerance)
-        self._patch = [ax.axhline(
-            self._pos[0],
-            color=self.color,
-            alpha=self.alpha,
-            **kwargs)]
+        self._patch = [
+            ax.axhline(self._pos[0], color=self.color, alpha=self.alpha, **kwargs)
+            ]
 
     def _onmousemove(self, event):
         """on mouse motion draw the cursor if picked"""

--- a/hyperspy/drawing/_widgets/vertical_line.py
+++ b/hyperspy/drawing/_widgets/vertical_line.py
@@ -31,13 +31,19 @@ class VerticalLineWidget(Widget1DBase):
             self.patch[0].set_xdata(self._pos[0])
             self.draw_patch()
 
+    def _add_patch_to(self, ax):
+        """Create and add the matplotlib patches to 'ax'"""
+        self.blit = hasattr(ax, 'hspy_fig') and ax.figure.canvas.supports_blit
+        self._set_patch()
+        for p in self.patch:
+            p.set_animated(self.blit)
+
     def _set_patch(self):
         ax = self.ax
         kwargs = picker_kwargs(preferences.Plot.pick_tolerance)
-        self._patch = [ax.axvline(self._pos[0],
-                                  color=self.color,
-                                  alpha=self.alpha,
-                                  **kwargs)]
+        self._patch = [
+            ax.axvline(self._pos[0], color=self.color, alpha=self.alpha, **kwargs)
+            ]
 
     def _onmousemove(self, event):
         """on mouse motion draw the cursor if picked"""

--- a/hyperspy/drawing/widget.py
+++ b/hyperspy/drawing/widget.py
@@ -17,10 +17,7 @@
 # along with HyperSpy. If not, see <https://www.gnu.org/licenses/#GPL>.
 
 from __future__ import division
-from packaging.version import Version
 
-
-import matplotlib
 import matplotlib.pyplot as plt
 from matplotlib.backend_bases import MouseEvent
 import numpy as np
@@ -113,7 +110,8 @@ class WidgetBase(object):
         return self._is_on
 
     def set_on(self, value, render_figure=True):
-        """Change the on state of the widget. If turning off, all patches will
+        """
+        Change the on state of the widget. If turning off, all patches will
         be removed from the matplotlib axes and the widget will disconnect from
         all events. If turning on, the patch(es) will be added to the
         matplotlib axes, and the widget will connect to its default events.
@@ -125,17 +123,8 @@ class WidgetBase(object):
                 self._add_patch_to(self.ax)
                 self.connect(self.ax)
             elif value is False:
-                for container in [
-                        self.ax.patches,
-                        self.ax.lines,
-                        self.ax.artists,
-                        self.ax.texts]:
-                    for p in self.patch:
-                        if p in container:
-                            if Version(matplotlib.__version__) >= Version('3.5.0'):
-                                p.remove()
-                            else:  # pragma: no cover
-                                container.remove(p)
+                for p in self.patch:
+                    p.remove()
                 self.disconnect()
         if hasattr(super(WidgetBase, self), 'set_on'):
             super(WidgetBase, self).set_on(value)
@@ -901,14 +890,8 @@ class ResizersMixin(object):
                     ax.add_artist(r)
                     r.set_animated(self.blit)
             else:
-                for container in [
-                        ax.patches,
-                        ax.lines,
-                        ax.artists,
-                        ax.texts]:
-                    for r in self._resizer_handles:
-                        if r in container:
-                            r.remove()
+                for r in self._resizer_handles:
+                    r.remove()
             self._resizers_on = value
 
     def _get_resizer_size(self):

--- a/hyperspy/tests/drawing/test_widget.py
+++ b/hyperspy/tests/drawing/test_widget.py
@@ -17,7 +17,7 @@
 
 import numpy as np
 
-from hyperspy.drawing import widget
+from hyperspy.drawing import widget, widgets
 from hyperspy import signals
 
 
@@ -29,8 +29,8 @@ def test_get_step():
     axis.index = 3
     step = widget.ResizableDraggableWidgetBase._get_step(s,s.axes_manager.navigation_axes[0])
     assert(step == 1)
-    
-    
+
+
 def test_scalebar_remove():
     im = signals.Signal2D(-np.arange(10000).reshape([100, 100]))
     for ax in im.axes_manager.signal_axes:
@@ -39,3 +39,31 @@ def test_scalebar_remove():
     im.plot()
     assert im._plot.signal_plot.ax.scalebar is not None
     im._plot.signal_plot.ax.scalebar.remove()
+
+
+def test_remove_widget_line():
+    s = signals.Signal1D(np.arange(10*25).reshape(10, 25))
+    s.plot()
+
+    ax = s._plot.navigator_plot.ax
+    assert len(ax.get_lines()) == 2
+    assert isinstance(s._plot.pointer, widgets.HorizontalLineWidget)
+    assert len(s._plot.pointer.patch) == 1
+
+    # Remove pointer
+    s._plot.pointer.close(render_figure=True)
+    assert len(ax.lines) == 1
+    assert len(s._plot.pointer.patch) == 1
+
+    im = signals.Signal2D(np.arange(10*25*25).reshape(10, 25, 25))
+    im.plot()
+
+    ax = im._plot.navigator_plot.ax
+    assert len(ax.get_lines()) == 2
+    assert isinstance(im._plot.pointer, widgets.VerticalLineWidget)
+    assert len(im._plot.pointer.patch) == 1
+
+    # Remove pointer
+    im._plot.pointer.close(render_figure=True)
+    assert len(ax.lines) == 1
+    assert len(im._plot.pointer.patch) == 1

--- a/upcoming_changes/3008.bugfix.rst
+++ b/upcoming_changes/3008.bugfix.rst
@@ -1,0 +1,1 @@
+Fix removing horizontal or vertical line widget; regression introduced in hyperspy 1.7.0


### PR DESCRIPTION
Fix #2965.

### Progress of the PR
- [x] Fix removing line widgets from figure: the lines were added twice to the `matplotlib` lines containter (`ax.lines`)
- [n/a] update docstring (if appropriate),
- [n/a] update user guide (if appropriate),
- [x] add an changelog entry in the `upcoming_changes` folder (see [`upcoming_changes/README.rst`](https://github.com/hyperspy/hyperspy/blob/RELEASE_next_minor/upcoming_changes/README.rst)),
- [x] Check formatting changelog entry in the `readthedocs` doc build of this PR (link in github checks)
- [x] add tests,
- [x] ready for review.

### Minimal example of the bug fix or the new feature
```python
import hyperspy.api as hs
import numpy as np

s = hs.signals.Signal2D(np.arange(10*25*25).reshape(10, 25, 25))
s.plot()

# Remove pointer
s._plot.pointer.close(render_figure=True)
```

