### PR TITLE
compatibility of io with format_alias defined in rsciio

### DIFF
--- a/hyperspy/io.py
+++ b/hyperspy/io.py
@@ -56,6 +56,8 @@ def _format_name_to_reader(format_name):
     for reader in IO_PLUGINS:
         if format_name.lower() == reader["format_name"].lower():
             return reader
+        elif reader.get("format_alias") and format_name.lower() == reader.get("format_alias").lower():
+            return reader
     raise ValueError("The format_name given does not match any format available.")
 
 
@@ -92,7 +94,7 @@ def _infer_file_reader(string):
             "Will attempt to load the file with the Python imaging library."
         )
 
-        reader, = [reader for reader in IO_PLUGINS if reader["format_name"] == "image"]
+        reader, = [reader for reader in IO_PLUGINS if reader["format_name"].lower() == "image"]
     elif len(rdrs) > 1:
         names = [rdr["format_name"] for rdr in rdrs]
         raise ValueError(

--- a/hyperspy/io.py
+++ b/hyperspy/io.py
@@ -54,13 +54,13 @@ f_error_fmt = (
 
 def _format_name_to_reader(format_name):
     for reader in IO_PLUGINS:
-        if format_name.lower() == reader["format_name"].lower():
+        if format_name.lower() == reader["name"].lower():
             return reader
-        elif reader.get("format_name_aliases"):
-            aliases = [s.lower() for s in reader["format_name_aliases"]]
+        elif reader.get("name_aliases"):
+            aliases = [s.lower() for s in reader["name_aliases"]]
             if format_name.lower() in aliases: 
                 return reader
-    raise ValueError("The format_name given does not match any format available.")
+    raise ValueError("The `format_name` given does not match any format available.")
 
 
 def _infer_file_reader(string):
@@ -96,9 +96,9 @@ def _infer_file_reader(string):
             "Will attempt to load the file with the Python imaging library."
         )
 
-        reader, = [reader for reader in IO_PLUGINS if reader["format_name"].lower() == "image"]
+        reader, = [reader for reader in IO_PLUGINS if reader["name"].lower() == "image"]
     elif len(rdrs) > 1:
-        names = [rdr["format_name"] for rdr in rdrs]
+        names = [rdr["name"] for rdr in rdrs]
         raise ValueError(
             f"There are multiple file readers that could read the file. "
             f"Please select one from the list below with the `reader` keyword. "
@@ -140,7 +140,7 @@ def _infer_file_writer(string):
             )
 
     elif len(writers) > 1:
-        names = [writer["format_name"] for writer in writers]
+        names = [writer["name"] for writer in writers]
         raise ValueError(
             f"There are multiple file formats matching the extension of your file. "
             f"Please select one from the list below with the `format` keyword. "
@@ -883,7 +883,7 @@ def save(filename, signal, overwrite=None, file_format=None, **kwds):
 
 
     if writer["writes"] is not True and [sd, nd] not in writer["writes"]:
-        compatible_writers = [plugin["format_name"] for plugin in IO_PLUGINS
+        compatible_writers = [plugin["name"] for plugin in IO_PLUGINS
                       if plugin["writes"] is True or
                       plugin["writes"] is not False and
                       [sd, nd] in plugin["writes"]]
@@ -894,7 +894,7 @@ def save(filename, signal, overwrite=None, file_format=None, **kwds):
         )
 
     if not writer["non_uniform_axis"] and not signal.axes_manager.all_uniform:
-        compatible_writers = [plugin["format_name"] for plugin in IO_PLUGINS
+        compatible_writers = [plugin["name"] for plugin in IO_PLUGINS
                       if plugin["non_uniform_axis"] is True]
         raise TypeError("Writing to this format is not supported for "
                       "non-uniform axes. Use one of the following "

--- a/hyperspy/io.py
+++ b/hyperspy/io.py
@@ -56,8 +56,10 @@ def _format_name_to_reader(format_name):
     for reader in IO_PLUGINS:
         if format_name.lower() == reader["format_name"].lower():
             return reader
-        elif reader.get("format_alias") and format_name.lower() == reader.get("format_alias").lower():
-            return reader
+        elif reader.get("format_name_aliases"):
+            aliases = [s.lower() for s in reader["format_name_aliases"]]
+            if format_name.lower() in aliases: 
+                return reader
     raise ValueError("The format_name given does not match any format available.")
 
 

--- a/hyperspy/tests/test_io.py
+++ b/hyperspy/tests/test_io.py
@@ -223,14 +223,27 @@ def test_file_reader_options(tmp_path):
     t = hs.load(Path(tmp_path, "temp.hspy"), reader="hspy")
     assert len(t) == 1
     np.testing.assert_allclose(t.data, np.arange(10))
+    
+    # Test string reader uppercase
+    t = hs.load(Path(tmp_path, "temp.hspy"), reader="HSpy")
+    assert len(t) == 1
+    np.testing.assert_allclose(t.data, np.arange(10))
 
-    # Test name reader
+    # Test string reader alias
+    t = hs.load(Path(tmp_path, "temp.hspy"), reader="hyperspy")
+    assert len(t) == 1
+    np.testing.assert_allclose(t.data, np.arange(10))
+
+    # Test string reader name
     t = hs.load(Path(tmp_path, "temp.emd"), reader="emd")
     assert len(t) == 1
     np.testing.assert_allclose(t.data, np.arange(10))
 
-    # Test alias reader
+    # Test string reader aliases
     t = hs.load(Path(tmp_path, "temp.emd"), reader="Electron Microscopy Data (EMD)")
+    assert len(t) == 1
+    np.testing.assert_allclose(t.data, np.arange(10))
+    t = hs.load(Path(tmp_path, "temp.emd"), reader="Electron Microscopy Data")
     assert len(t) == 1
     np.testing.assert_allclose(t.data, np.arange(10))
 

--- a/hyperspy/tests/test_io.py
+++ b/hyperspy/tests/test_io.py
@@ -216,10 +216,21 @@ def test_file_reader_warning(caplog, tmp_path):
 def test_file_reader_options(tmp_path):
     s = Signal1D(np.arange(10))
 
-    s.save(tmp_path / "temp.hspy")
+    s.save(Path(tmp_path, "temp.hspy"))
+    s.save(Path(tmp_path, "temp.emd"))
 
     # Test string reader
-    t = hs.load(tmp_path / "temp.hspy", reader="hspy")
+    t = hs.load(Path(tmp_path, "temp.hspy"), reader="hspy")
+    assert len(t) == 1
+    np.testing.assert_allclose(t.data, np.arange(10))
+
+    # Test name reader
+    t = hs.load(Path(tmp_path, "temp.emd"), reader="emd")
+    assert len(t) == 1
+    np.testing.assert_allclose(t.data, np.arange(10))
+
+    # Test alias reader
+    t = hs.load(Path(tmp_path, "temp.emd"), reader="Electron Microscopy Data (EMD)")
     assert len(t) == 1
     np.testing.assert_allclose(t.data, np.arange(10))
 

--- a/hyperspy/tests/test_io.py
+++ b/hyperspy/tests/test_io.py
@@ -111,7 +111,7 @@ class TestNonUniformAxisCheck:
     def test_nonuniform_writer_characteristic(self):
         for plugin in IO_PLUGINS:
             if not "non_uniform_axis" in plugin:
-                print(plugin.format_name + ' IO-plugin is missing the '
+                print(plugin.name + ' IO-plugin is missing the '
                       'characteristic `non_uniform_axis`')
 
     def test_nonuniform_error(self):

--- a/upcoming_changes/3009.api.rst
+++ b/upcoming_changes/3009.api.rst
@@ -1,0 +1,1 @@
+Extend the IO functions to accept alias names for ``format_name`` as defined in RosettaSciIO.

--- a/upcoming_changes/3009.api.rst
+++ b/upcoming_changes/3009.api.rst
@@ -1,1 +1,1 @@
-Extend the IO functions to accept alias names for ``format_name`` as defined in RosettaSciIO.
+Extend the IO functions to accept alias names for format ``name`` as defined in RosettaSciIO.


### PR DESCRIPTION
### Description of the change
https://github.com/hyperspy/rosettasciio/pull/35 introduces a `format_alias` field so that `format_name` fields can be renamed and backwards compatibility assured. This PR adapts HyperSpy to handle the `format_alias` equivalently when choosing the reader/writer.

### Progress of the PR
- [X] Change implemented (can be split into several points),
- [x] add an changelog entry in the `upcoming_changes` folder (see [`upcoming_changes/README.rst`](https://github.com/hyperspy/hyperspy/blob/RELEASE_next_minor/upcoming_changes/README.rst)),
- [x] Check formatting changelog entry in the `readthedocs` doc build of this PR (link in github checks)
- [X] add tests,
- [x] ready for review.