### PR TITLE
Fix SpanSelector for matplotlib 3.6

### DIFF
--- a/hyperspy/drawing/_widgets/range.py
+++ b/hyperspy/drawing/_widgets/range.py
@@ -18,13 +18,18 @@
 
 import inspect
 import logging
+from packaging.version import Version
 
+import matplotlib
 import numpy as np
 
 from hyperspy.drawing.widget import ResizableDraggableWidgetBase
 from hyperspy.defaults_parser import preferences
 
-from hyperspy.external.matplotlib.widgets import SpanSelector
+if Version(matplotlib.__version__) >= Version('3.6.0'):
+    from matplotlib.widgets import SpanSelector
+else:
+    from hyperspy.external.matplotlib.widgets import SpanSelector
 
 _logger = logging.getLogger(__name__)
 

--- a/upcoming_changes/3016.maintenance.rst
+++ b/upcoming_changes/3016.maintenance.rst
@@ -1,0 +1,1 @@
+Fix matplotlib ``SpanSelector`` import for matplotlib 3.6


### PR DESCRIPTION
We have caught before the release of matplotlib 3.6 (happened today) with the test suite of https://github.com/hyperspy/hyperspy-extensions-list but because other test suites were failing for a while, it wasn't noticeable.

The issue is that we are using a vendored version of `matplotlib.widgets.SpanSelector` only for matplotlib<3.6 but the import "dispatch" was incorrect.

### Progress of the PR
- [x] Fix matplotlib `SpanSelector` import,
- [n/a] update docstring (if appropriate),
- [n/a] update user guide (if appropriate),
- [x] add an changelog entry in the `upcoming_changes` folder (see [`upcoming_changes/README.rst`](https://github.com/hyperspy/hyperspy/blob/RELEASE_next_minor/upcoming_changes/README.rst)),
- [x] Check formatting changelog entry in the `readthedocs` doc build of this PR (link in github checks)
- [n/a] add tests,
- [x] ready for review.


