### PR TITLE
Fix drone CI

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -13,6 +13,8 @@ steps:
     - lscpu
     - mamba install hyperspy-base --only-deps
     - mamba install scikit-learn pytest pytest-xdist
+    # Need rosettasciio
+    - pip install https://github.com/hyperspy/rosettasciio/archive/refs/heads/main.zip
     - pip install -e .
     - pytest -n 4
 


### PR DESCRIPTION
I disabled drone CI because there was an issue with an dependencies, which is gone now, so now we can re-enable it again but we need to update the build to install RosettaSciIO.

Needs the fix in https://github.com/hyperspy/rosettasciio/pull/42.

### Progress of the PR
- [x] Install rosettasciio on drone CI,
- [n/a] update docstring (if appropriate),
- [n/a] update user guide (if appropriate),
- [n/a] add an changelog entry in the `upcoming_changes` folder (see [`upcoming_changes/README.rst`](https://github.com/hyperspy/hyperspy/blob/RELEASE_next_minor/upcoming_changes/README.rst)),
- [n/a] Check formatting changelog entry in the `readthedocs` doc build of this PR (link in github checks)
- [n/a] add tests,
- [x] ready for review.


