### PR TITLE
Handling Axis attributes with @property decorator

### DIFF
--- a/hyperspy/_signals/lazy.py
+++ b/hyperspy/_signals/lazy.py
@@ -333,7 +333,13 @@ class LazySignal(BaseSignal):
         dcshape = dc.shape
         for _axis in self.axes_manager._axes:
             if _axis.index_in_array < len(dcshape):
-                _axis.size = int(dcshape[_axis.index_in_array])
+                if _axis.size != int(dcshape[_axis.index_in_array]):
+                    if _axis.is_uniform:
+                        _axis.size = int(dcshape[_axis.index_in_array])
+                    else:
+                        _logger.warning(f"Axis {_axis} converted to a UniformDataAxis")
+                        _axis.convert_to_uniform_axis()
+                        _axis.size = int(dcshape[_axis.index_in_array])
 
         if axis is not None:
             need_axes = self.axes_manager[axis]

--- a/hyperspy/axes.py
+++ b/hyperspy/axes.py
@@ -887,7 +887,6 @@ class DataAxis(BaseDataAxis):
 
         slice_ = self._get_array_slices(slice(start, end))
         self.axis = self.axis[slice_]
-        self.size = len(self.axis)
 
     def convert_to_uniform_axis(self):
         """Convert to an uniform axis."""
@@ -1188,7 +1187,7 @@ class UniformDataAxis(DataAxis, UnitConversion):
             )
         self.scale = scale
         self.offset = offset
-        self._size = size
+        self.size = size
         self._is_uniform = True
 
     @t.cached_property

--- a/hyperspy/axes.py
+++ b/hyperspy/axes.py
@@ -539,24 +539,8 @@ class DataAxis(BaseDataAxis):
         """
         my_slice = self._get_array_slices(slice_)
         self.axis = self.axis[my_slice]
-        self.update_axis()
         return my_slice
 
-    def update_axis(self):
-        """Set the value of an axis. The axis values need to be ordered.
-
-        Raises
-        ------
-        ValueError
-            If the axis values are not ordered.
-
-        """
-        if len(self.axis) > 1:
-            if isinstance(self.axis, list):
-                self.axis = np.asarray(self.axis)
-            if self._is_increasing_order is None:
-                raise ValueError("The non-uniform axis needs to be ordered.")
-        self.size = len(self.axis)
 
     def get_axis_dictionary(self):
         d = super().get_axis_dictionary()
@@ -1246,7 +1230,7 @@ class UniformDataAxis(DataAxis, UnitConversion):
         return my_slice
 
     def get_axis_dictionary(self):
-        d = super(DataAxis).get_axis_dictionary()
+        d = super(DataAxis, self).get_axis_dictionary()
         d.update({'size': self.size,
                   'scale': self.scale,
                   'offset': self.offset})
@@ -2139,11 +2123,8 @@ class AxesManager(t.HasTraits):
     def _on_index_changed(self):
         self.events.indices_changed.trigger(obj=self)
 
-    def _on_index_changed(self):
-        self.events.indices_changed.trigger(obj=self)
-
-    def _on_index_changed(self):
-        self.events.indices_changed.trigger(obj=self)
+    def _on_axes_changed(self):
+        self.events.any_axis_changed.trigger(obj=self)
 
     @property
     def signal_axes(self):

--- a/hyperspy/axes.py
+++ b/hyperspy/axes.py
@@ -1045,7 +1045,7 @@ class FunctionalDataAxis(DataAxis):
 
         """
         if attributes is None:
-            attributes = self.parameters_list + ["_expression", "x"]
+            attributes = ["parameters", ]
         return super().update_from(axis, attributes)
 
     def calibrate(self, *args, **kwargs):
@@ -1590,7 +1590,7 @@ class AxesManager(t.HasTraits):
         else:
             axes = [self._axes_getter(ax) for ax in y]
             indices = [self.axes.index(ax) for ax in axes]
-            for ind, v in zip(axes, indices):
+            for ind, v in zip(indices, value):
                 self.axes[ind] = v
 
     @property

--- a/hyperspy/axes.py
+++ b/hyperspy/axes.py
@@ -30,6 +30,8 @@ import pint
 import traits.api as t
 from sympy.utilities.lambdify import lambdify
 from traits.trait_errors import TraitError
+from traits.api import observe
+from traits.observation.api import trait
 
 from hyperspy._components.expression import _parse_substitutions
 from hyperspy.api_nogui import _ureg
@@ -239,13 +241,20 @@ class UnitConversion:
     @units.setter
     def units(self, s):
         if s == "":
-            self._units = t.Undefined
+            s = t.Undefined
         self._units = s
 
 
 @add_gui_method(toolkey="hyperspy.DataAxis")
 class BaseDataAxis(t.HasTraits):
     """Parent class defining common attributes for all DataAxis classes.
+
+    The Base Data class has name and units attributes. Both of these can be freely set/ mutated
+     as long as the values are strings.
+     This axis cannot be plotted as it has no `.axis` attribute or size.
+     The axes_manager property should only be set by an `AxesManager` class to avoid
+     confusion. This value is automatically set when any Axis is appended or added to
+     an `AxesManager.axes` list attribute.
 
     Parameters
     ----------
@@ -261,27 +270,15 @@ class BaseDataAxis(t.HasTraits):
 
     name = t.Str()
     units = t.Str()
-    size = t.CInt()
-    low_value = t.Float()
-    high_value = t.Float()
-    value = t.Range("low_value", "high_value")
-    low_index = t.Int(0)
-    high_index = t.Int()
-    slice = t.Instance(slice)
     navigate = t.Bool(False)
     is_binned = t.Bool(False)
-    index = t.Range("low_index", "high_index")
-    axis = t.Array()
 
-    def __init__(
-        self,
-        index_in_array=None,
-        name=None,
-        units=None,
-        navigate=False,
-        is_binned=False,
-        **kwargs,
-    ):
+    def __init__(self,
+                 name=None,
+                 units=None,
+                 navigate=False,
+                 is_binned=False,
+                 **kwargs):
         super().__init__()
         if name is None:
             name = t.Undefined
@@ -326,54 +323,23 @@ class BaseDataAxis(t.HasTraits):
             arguments=["obj", "value"],
         )
 
-        self._suppress_value_changed_trigger = False
-        self._suppress_update_value = False
         self.name = name
         self.units = units
-        self.low_index = 0
-        self.on_trait_change(self._update_slice, "navigate")
-        self.on_trait_change(self.update_index_bounds, "size")
-        self.on_trait_change(self._update_bounds, "axis")
-
-        self.index = 0
         self.navigate = navigate
         self.is_binned = is_binned
         self.axes_manager = None
         self._is_uniform = False
 
-        # The slice must be updated even if the default value did not
-        # change to correctly set its value.
-        self._update_slice(self.navigate)
-
     @property
     def is_uniform(self):
         return self._is_uniform
 
-    def _index_changed(self, name, old, new):
-        self.events.index_changed.trigger(obj=self, index=self.index)
-        if not self._suppress_update_value:
-            new_value = self.axis[self.index]
-            if new_value != self.value:
-                self.value = new_value
-
-    def _value_changed(self, name, old, new):
-        old_index = self.index
-        new_index = self.value2index(new)
-        if old_index != new_index:
-            self.index = new_index
-            if new == self.axis[self.index]:
-                self.events.value_changed.trigger(obj=self, value=new)
+    @property
+    def slice(self):
+        if self.navigate:
+            return None
         else:
-            new_value = self.index2value(new_index)
-            if new_value == old:
-                self._suppress_value_changed_trigger = True
-                try:
-                    self.value = new_value
-                finally:
-                    self._suppress_value_changed_trigger = False
-
-            elif new_value == new and not self._suppress_value_changed_trigger:
-                self.events.value_changed.trigger(obj=self, value=new)
+            return slice(None)
 
     @property
     def index_in_array(self):
@@ -411,78 +377,6 @@ class BaseDataAxis(t.HasTraits):
         else:
             return value
 
-    def _get_array_slices(self, slice_):
-        """Returns a slice to slice the corresponding data axis.
-
-        Parameters
-        ----------
-        slice_ : {float, int, slice}
-
-        Returns
-        -------
-        my_slice : slice
-
-        """
-        if isinstance(slice_, slice):
-            if not self.is_uniform and isfloat(slice_.step):
-                raise ValueError("Float steps are only supported for uniform axes.")
-
-        v2i = self.value2index
-
-        if isinstance(slice_, slice):
-            start = slice_.start
-            stop = slice_.stop
-            step = slice_.step
-        else:
-            if isfloat(slice_):
-                start = v2i(slice_)
-            else:
-                start = self._get_positive_index(slice_)
-            stop = start + 1
-            step = None
-
-        start = self._parse_value(start)
-        stop = self._parse_value(stop)
-        step = self._parse_value(step)
-
-        if isfloat(step):
-            step = int(round(step / self.scale))
-
-        if isfloat(start):
-            try:
-                start = v2i(start)
-            except ValueError:
-                if start > self.high_value:
-                    # The start value is above the axis limit
-                    raise IndexError(
-                        "Start value above axis high bound for  axis %s."
-                        "value: %f high_bound: %f"
-                        % (repr(self), start, self.high_value)
-                    )
-                else:
-                    # The start value is below the axis limit,
-                    # we slice from the start.
-                    start = None
-        if isfloat(stop):
-            try:
-                stop = v2i(stop)
-            except ValueError:
-                if stop < self.low_value:
-                    # The stop value is below the axis limits
-                    raise IndexError(
-                        "Stop value below axis low bound for  axis %s."
-                        "value: %f low_bound: %f" % (repr(self), stop, self.low_value)
-                    )
-                else:
-                    # The stop value is below the axis limit,
-                    # we slice until the end.
-                    stop = None
-
-        if step == 0:
-            raise ValueError("slice step cannot be zero")
-
-        return slice(start, stop, step)
-
     def _slice_me(self, slice_):
         raise NotImplementedError("This method must be implemented by subclasses")
 
@@ -497,30 +391,18 @@ class BaseDataAxis(t.HasTraits):
         return name
 
     def __repr__(self):
-        text = "<%s axis, size: %i" % (
-            self._get_name(),
-            self.size,
-        )
-        if self.navigate is True:
+        if hasattr(self, "size"):
+            text = '<%s axis, size: %i' % (self._get_name(),
+                                           self.size,)
+        else:
+            text = '<%s axis, size: None' % (self._get_name(),)
+        if self.navigate is True and hasattr(self, "index"):
             text += ", index: %i" % self.index
         text += ">"
         return text
 
     def __str__(self):
         return self._get_name() + " axis"
-
-    def update_index_bounds(self):
-        self.high_index = self.size - 1
-
-    def _update_bounds(self):
-        if len(self.axis) != 0:
-            self.low_value, self.high_value = (self.axis.min(), self.axis.max())
-
-    def _update_slice(self, value):
-        if value is False:
-            self.slice = slice(None)
-        else:
-            self.slice = None
 
     def get_axis_dictionary(self):
         return {
@@ -540,164 +422,6 @@ class BaseDataAxis(t.HasTraits):
     def __deepcopy__(self, memo):
         cp = self.copy()
         return cp
-
-    def _parse_value_from_string(self, value):
-        """Return calibrated value from a suitable string"""
-        if len(value) == 0:
-            raise ValueError("Cannot index with an empty string")
-        # Starting with 'rel', it must be relative slicing
-        elif value.startswith("rel"):
-            try:
-                relative_value = float(value[3:])
-            except ValueError:
-                raise ValueError("`rel` must be followed by a number in range [0, 1].")
-            if relative_value < 0 or relative_value > 1:
-                raise ValueError("Relative value must be in range [0, 1]")
-            value = self.low_value + relative_value * (self.high_value - self.low_value)
-        # if first character is a digit, try unit conversion
-        # otherwise we don't support it
-        elif value[0].isdigit():
-            if self.is_uniform:
-                value = self._get_value_from_value_with_units(value)
-            else:
-                raise ValueError(
-                    "Unit conversion is only supported for " "uniform axis."
-                )
-        else:
-            raise ValueError(f"`{value}` is not a suitable string for slicing.")
-
-        return value
-
-    def _parse_value(self, value):
-        """Convert the input to calibrated value if string, otherwise,
-        return the same value."""
-        if isinstance(value, str):
-            value = self._parse_value_from_string(value)
-        elif isinstance(value, (list, tuple, np.ndarray, da.Array)):
-            value = np.asarray(value)
-            if value.dtype.type is np.str_:
-                value = np.array([self._parse_value_from_string(v) for v in value])
-        return value
-
-    def value2index(self, value, rounding=round):
-        """Return the closest index/indices to the given value(s) if between the axis limits.
-
-        Parameters
-        ----------
-        value : float or numpy.ndarray
-        rounding : callable
-            Handling of values between two axis points:
-
-            - If ``rounding=round``, use round-half-away-from-zero strategy to find closest value.
-            - If ``rounding=math.floor``, round to the next lower value.
-            - If ``rounding=math.ceil``, round to the next higher value.
-
-        Returns
-        -------
-        int or numpy array
-
-        Raises
-        ------
-        ValueError
-            If value is out of bounds or contains out of bounds values (array).
-            If value is NaN or contains NaN values (array).
-        """
-        if value is None:
-            return None
-        else:
-            value = np.asarray(value)
-
-        # Should evaluate on both arrays and scalars. Raises error if there are
-        # nan values in array
-        if np.all((value >= self.low_value) * (value <= self.high_value)):
-            # Only if all values will evaluate correctly do we implement rounding
-            # function. Rounding functions will strictly operate on numpy arrays
-            # and only evaluate self.axis - v input, v a scalar within value.
-            if rounding is round:
-                # Use argmin(abs) which will return the closest value
-                # rounding_index = lambda x: np.abs(x).argmin()
-                index = numba_closest_index_round(self.axis, value).astype(int)
-            elif rounding is math.ceil:
-                # Ceiling means finding index of the closest xi with xi - v >= 0
-                # we look for argmin of strictly non-negative part of self.axis-v.
-                # The trick is to replace strictly negative values with +np.inf
-                index = numba_closest_index_ceil(self.axis, value).astype(int)
-            elif rounding is math.floor:
-                # flooring means finding index of the closest xi with xi - v <= 0
-                # we look for armgax of strictly non-positive part of self.axis-v.
-                # The trick is to replace strictly positive values with -np.inf
-                index = numba_closest_index_floor(self.axis, value).astype(int)
-            else:
-                raise ValueError(
-                    "Non-supported rounding function. Use "
-                    "`round`, `math.ceil` or `math.floor`."
-                )
-            # initialise the index same dimension as input, force type to int
-            # index = np.empty_like(value,dtype=int)
-            # assign on flat, iterate on flat.
-            # for i,v in enumerate(value):
-            # index.flat[i] = rounding_index(self.axis - v)
-            # Squeezing to get a scalar out if scalar in. See squeeze doc
-            return np.squeeze(index)[()]
-        else:
-            raise ValueError(
-                f"The value {value} is out of the limits "
-                f"[{self.low_value:.3g}-{self.high_value:.3g}] of the "
-                f'"{self._get_name()}" axis.'
-            )
-
-    def index2value(self, index):
-        if isinstance(index, da.Array):
-            index = index.compute()
-        if isinstance(index, np.ndarray):
-            return self.axis[index.ravel()].reshape(index.shape)
-        else:
-            return self.axis[index]
-
-    def value_range_to_indices(self, v1, v2):
-        """Convert the given range to index range.
-
-        When a value is out of the axis limits, the endpoint is used instead.
-        `v1` must be preceding `v2` in the axis values
-
-          - if the axis scale is positive, it means v1 < v2
-          - if the axis scale is negative, it means v1 > v2
-
-        Parameters
-        ----------
-        v1, v2 : float
-            The end points of the interval in the axis units.
-
-        Returns
-        -------
-        i2, i2 : float
-            The indices corresponding to the interval [v1, v2]
-        """
-        i1, i2 = 0, self.size - 1
-        error_message = "Wrong order of the values: for axis with"
-        if self._is_increasing_order:
-            if v1 is not None and v2 is not None and v1 > v2:
-                raise ValueError(
-                    f"{error_message} increasing order, v2 ({v2}) "
-                    f"must be greater than v1 ({v1})."
-                )
-
-            if v1 is not None and self.low_value < v1 <= self.high_value:
-                i1 = self.value2index(v1)
-            if v2 is not None and self.high_value > v2 >= self.low_value:
-                i2 = self.value2index(v2)
-        else:
-            if v1 is not None and v2 is not None and v1 < v2:
-                raise ValueError(
-                    f"{error_message} decreasing order: v1 ({v1}) "
-                    f"must be greater than v2 ({v2})."
-                )
-
-            if v1 is not None and self.high_value > v1 >= self.low_value:
-                i1 = self.value2index(v1)
-            if v2 is not None and self.low_value < v2 <= self.high_value:
-                i2 = self.value2index(v2)
-        return i1, i2
 
     def update_from(self, axis, attributes):
         """Copy values of specified axes fields from the passed AxesManager.
@@ -728,41 +452,6 @@ class BaseDataAxis(t.HasTraits):
             self.trait_set(**changed)
             any_changes = True
         return any_changes
-
-    def convert_to_uniform_axis(self):
-        """Convert to an uniform axis."""
-        scale = (self.high_value - self.low_value) / self.size
-        d = self.get_axis_dictionary()
-        axes_manager = self.axes_manager
-        del d["axis"]
-        if len(self.axis) > 1:
-            scale_err = max(self.axis[1:] - self.axis[:-1]) - scale
-            _logger.warning("The maximum scale error is {}.".format(scale_err))
-        d["_type"] = "UniformDataAxis"
-        self.__class__ = UniformDataAxis
-        self.__init__(**d, size=self.size, scale=scale, offset=self.low_value)
-        self.axes_manager = axes_manager
-
-    @property
-    def _is_increasing_order(self):
-        """
-        Determine if the axis has an increasing, decreasing order or no order
-        at all.
-
-        Returns
-        -------
-        True if order is increasing, False if order is decreasing, None
-        otherwise.
-
-        """
-        steps = self.axis[1:] - self.axis[:-1]
-        if np.all(steps > 0):
-            return True
-        elif np.all(steps < 0):
-            return False
-        else:
-            # the axis is not ordered
-            return None
 
 
 class DataAxis(BaseDataAxis):
@@ -811,7 +500,6 @@ class DataAxis(BaseDataAxis):
             **kwargs,
         )
         self.axis = axis
-        self.update_axis()
 
     def _slice_me(self, slice_):
         """Returns a slice to slice the corresponding data axis and set the

--- a/hyperspy/axes.py
+++ b/hyperspy/axes.py
@@ -465,7 +465,7 @@ class DataAxis(BaseDataAxis):
        of a DataAxis object will result in an error.
 
        The array can be indexed using direct references to objects in the axis array,
-       integer indexes or if `_is_increasing_order` is not None, float values.
+       integer indexes or if ``_is_increasing_order`` is not None, float values.
 
        As this can be any array, the property
        ``is_uniform`` is automatically set to ``False``.
@@ -482,7 +482,6 @@ class DataAxis(BaseDataAxis):
     low_index
     high_value
     low_value
-    _is_increasing_order
     index : int
         The current index for the axis. This is used for interactive plotting and
         model fitting
@@ -733,16 +732,18 @@ class DataAxis(BaseDataAxis):
 
         Parameters
         ----------
-        value : number or numpy array
-        rounding : function
+        value : float, int
+            The value to convert to index otherwise the closest index is returned
+            if not exact.
+        rounding : :std:term:`function`
                 Handling of values intermediate between two axis points:
-                If `rounding=round`, use round-half-away-from-zero strategy to find closest value.
-                If `rounding=math.floor`, round to the next lower value.
-                If `round=math.ceil`, round to the next higher value.
+                If ``rounding=round``, use round-half-away-from-zero strategy to find closest value.
+                If ``rounding=math.floor``, round to the next lower value.
+                If ``round=math.ceil``, round to the next higher value.
 
         Returns
         -------
-        index : integer or numpy array
+        int, numpy.ndarray
 
         Raises
         ------
@@ -1251,7 +1252,7 @@ class UniformDataAxis(DataAxis, UnitConversion):
 
         Returns
         -------
-        int or numpy.ndarray
+            int or numpy.ndarray
 
         Raises
         ------

--- a/hyperspy/axes.py
+++ b/hyperspy/axes.py
@@ -2119,6 +2119,11 @@ class AxesManager(t.HasTraits):
         for axis in self._axes:
             axis.axes_manager = self
 
+    @property
+    def _getitem_tuple(self):
+        getitem_tuple = tuple([a.slice if a.slice is not None else a.index for a in self._axes])
+        return getitem_tuple
+
     def _on_index_changed(self):
         self.events.indices_changed.trigger(obj=self)
 
@@ -2160,10 +2165,10 @@ class AxesManager(t.HasTraits):
     @property
     def navigation_size(self):
         """The size of the navigation space."""
-        if self.signal_shape == ():
+        if self.navigation_shape == ():
             return 0
         else:
-            return np.prod(self.signal_shape)
+            return np.prod(self.navigation_shape)
 
     @property
     def navigation_dimension(self):

--- a/hyperspy/axes.py
+++ b/hyperspy/axes.py
@@ -29,9 +29,9 @@ import numpy as np
 import pint
 import traits.api as t
 from sympy.utilities.lambdify import lambdify
-from traits.trait_errors import TraitError
 from traits.api import observe
 from traits.observation.api import trait
+from traits.trait_errors import TraitError
 
 from hyperspy._components.expression import _parse_substitutions
 from hyperspy.api_nogui import _ureg
@@ -273,12 +273,9 @@ class BaseDataAxis(t.HasTraits):
     navigate = t.Bool(False)
     is_binned = t.Bool(False)
 
-    def __init__(self,
-                 name=None,
-                 units=None,
-                 navigate=False,
-                 is_binned=False,
-                 **kwargs):
+    def __init__(
+        self, name=None, units=None, navigate=False, is_binned=False, **kwargs
+    ):
         super().__init__()
         if name is None:
             name = t.Undefined
@@ -392,10 +389,12 @@ class BaseDataAxis(t.HasTraits):
 
     def __repr__(self):
         if hasattr(self, "size"):
-            text = '<%s axis, size: %i' % (self._get_name(),
-                                           self.size,)
+            text = "<%s axis, size: %i" % (
+                self._get_name(),
+                self.size,
+            )
         else:
-            text = '<%s axis, size: None' % (self._get_name(),)
+            text = "<%s axis, size: None" % (self._get_name(),)
         if self.navigate is True and hasattr(self, "index"):
             text += ", index: %i" % self.index
         text += ">"
@@ -500,6 +499,7 @@ class DataAxis(BaseDataAxis):
     'is_binned': False,
     'axis': array([  0,   1,   4,   9,  16,  25,  36,  49,  64,  81, 100])}
     """
+
     axis = t.Array()  # Axis added as trait to track changes to axis
     _index = t.Int(0)
 
@@ -540,7 +540,6 @@ class DataAxis(BaseDataAxis):
         self.axis = self.axis[my_slice]
         return my_slice
 
-
     def get_axis_dictionary(self):
         d = super().get_axis_dictionary()
         d.update({"axis": self.axis})
@@ -553,7 +552,10 @@ class DataAxis(BaseDataAxis):
         elif self._is_increasing_order is False:
             return self.axis[-1]
         else:
-            raise NotImplementedError("The axis is not ordered so there is no high/low value")
+            raise NotImplementedError(
+                "The axis is not ordered so there is no high/low value"
+            )
+
     @property
     def value(self):
         return self.axis[self.index]
@@ -569,7 +571,9 @@ class DataAxis(BaseDataAxis):
         elif self._is_increasing_order is False:
             return self.axis[0]
         else:
-            raise NotImplementedError("The axis is not ordered so there is no high/low value")
+            raise NotImplementedError(
+                "The axis is not ordered so there is no high/low value"
+            )
 
     @property
     def index(self):
@@ -615,7 +619,9 @@ class DataAxis(BaseDataAxis):
             else:
                 # the axis is not ordered
                 return None
-        except np.core._exceptions._UFuncNoLoopError:  # subtracting array of objects/strings will fail
+        except (
+            np.core._exceptions._UFuncNoLoopError
+        ):  # subtracting array of objects/strings will fail
             return None
 
     def _get_array_slices(self, slice_):
@@ -632,8 +638,7 @@ class DataAxis(BaseDataAxis):
         """
         if isinstance(slice_, slice):
             if not self.is_uniform and isfloat(slice_.step):
-                raise ValueError(
-                    "Float steps are only supported for uniform axes.")
+                raise ValueError("Float steps are only supported for uniform axes.")
 
         v2i = self.value2index
 
@@ -664,8 +669,9 @@ class DataAxis(BaseDataAxis):
                     # The start value is above the axis limit
                     raise IndexError(
                         "Start value above axis high bound for  axis %s."
-                        "value: %f high_bound: %f" % (repr(self), start,
-                                                      self.high_value))
+                        "value: %f high_bound: %f"
+                        % (repr(self), start, self.high_value)
+                    )
                 else:
                     # The start value is below the axis limit,
                     # we slice from the start.
@@ -678,8 +684,8 @@ class DataAxis(BaseDataAxis):
                     # The stop value is below the axis limits
                     raise IndexError(
                         "Stop value below axis low bound for  axis %s."
-                        "value: %f low_bound: %f" % (repr(self), stop,
-                                                     self.low_value))
+                        "value: %f low_bound: %f" % (repr(self), stop, self.low_value)
+                    )
                 else:
                     # The stop value is below the axis limit,
                     # we slice until the end.
@@ -691,11 +697,11 @@ class DataAxis(BaseDataAxis):
         return slice(start, stop, step)
 
     def _parse_value_from_string(self, value):
-        """Return calibrated value from a suitable string """
+        """Return calibrated value from a suitable string"""
         if len(value) == 0:
             raise ValueError("Cannot index with an empty string")
         # Starting with 'rel', it must be relative slicing
-        elif value.startswith('rel'):
+        elif value.startswith("rel"):
             try:
                 relative_value = float(value[3:])
             except ValueError:
@@ -709,8 +715,9 @@ class DataAxis(BaseDataAxis):
             if self.is_uniform:
                 value = self._get_value_from_value_with_units(value)
             else:
-                raise ValueError("Unit conversion is only supported for "
-                                 "uniform axis.")
+                raise ValueError(
+                    "Unit conversion is only supported for " "uniform axis."
+                )
         else:
             raise ValueError(f"`{value}` is not a suitable string for slicing.")
 
@@ -756,44 +763,44 @@ class DataAxis(BaseDataAxis):
         else:
             value = np.asarray(value)
 
-        #Should evaluate on both arrays and scalars. Raises error if there are
-        #nan values in array
-        if np.all((value >= self.low_value)*(value <= self.high_value)):
-            #Only if all values will evaluate correctly do we implement rounding
-            #function. Rounding functions will strictly operate on numpy arrays
-            #and only evaluate self.axis - v input, v a scalar within value.
+        # Should evaluate on both arrays and scalars. Raises error if there are
+        # nan values in array
+        if np.all((value >= self.low_value) * (value <= self.high_value)):
+            # Only if all values will evaluate correctly do we implement rounding
+            # function. Rounding functions will strictly operate on numpy arrays
+            # and only evaluate self.axis - v input, v a scalar within value.
             if rounding is round:
-                #Use argmin(abs) which will return the closest value
+                # Use argmin(abs) which will return the closest value
                 # rounding_index = lambda x: np.abs(x).argmin()
-                index = numba_closest_index_round(self.axis,value).astype(int)
+                index = numba_closest_index_round(self.axis, value).astype(int)
             elif rounding is math.ceil:
-                #Ceiling means finding index of the closest xi with xi - v >= 0
-                #we look for argmin of strictly non-negative part of self.axis-v.
-                #The trick is to replace strictly negative values with +np.inf
-                index = numba_closest_index_ceil(self.axis,value).astype(int)
+                # Ceiling means finding index of the closest xi with xi - v >= 0
+                # we look for argmin of strictly non-negative part of self.axis-v.
+                # The trick is to replace strictly negative values with +np.inf
+                index = numba_closest_index_ceil(self.axis, value).astype(int)
             elif rounding is math.floor:
-                #flooring means finding index of the closest xi with xi - v <= 0
-                #we look for armgax of strictly non-positive part of self.axis-v.
-                #The trick is to replace strictly positive values with -np.inf
-                index = numba_closest_index_floor(self.axis,value).astype(int)
+                # flooring means finding index of the closest xi with xi - v <= 0
+                # we look for armgax of strictly non-positive part of self.axis-v.
+                # The trick is to replace strictly positive values with -np.inf
+                index = numba_closest_index_floor(self.axis, value).astype(int)
             else:
                 raise ValueError(
-                    'Non-supported rounding function. Use '
-                    '`round`, `math.ceil` or `math.floor`.'
-                    )
-            #initialise the index same dimension as input, force type to int
+                    "Non-supported rounding function. Use "
+                    "`round`, `math.ceil` or `math.floor`."
+                )
+            # initialise the index same dimension as input, force type to int
             # index = np.empty_like(value,dtype=int)
-            #assign on flat, iterate on flat.
+            # assign on flat, iterate on flat.
             # for i,v in enumerate(value):
-                # index.flat[i] = rounding_index(self.axis - v)
-            #Squeezing to get a scalar out if scalar in. See squeeze doc
+            # index.flat[i] = rounding_index(self.axis - v)
+            # Squeezing to get a scalar out if scalar in. See squeeze doc
             return np.squeeze(index)[()]
         else:
             raise ValueError(
-                f'The value {value} is out of the limits '
-                f'[{self.low_value:.3g}-{self.high_value:.3g}] of the '
+                f"The value {value} is out of the limits "
+                f"[{self.low_value:.3g}-{self.high_value:.3g}] of the "
                 f'"{self._get_name()}" axis.'
-                )
+            )
 
     def index2value(self, index):
         if isinstance(index, da.Array):
@@ -826,8 +833,10 @@ class DataAxis(BaseDataAxis):
         error_message = "Wrong order of the values: for axis with"
         if self._is_increasing_order:
             if v1 is not None and v2 is not None and v1 > v2:
-                raise ValueError(f"{error_message} increasing order, v2 ({v2}) "
-                                 f"must be greater than v1 ({v1}).")
+                raise ValueError(
+                    f"{error_message} increasing order, v2 ({v2}) "
+                    f"must be greater than v1 ({v1})."
+                )
 
             if v1 is not None and self.low_value < v1 <= self.high_value:
                 i1 = self.value2index(v1)
@@ -835,8 +844,10 @@ class DataAxis(BaseDataAxis):
                 i2 = self.value2index(v2)
         else:
             if v1 is not None and v2 is not None and v1 < v2:
-                raise ValueError(f"{error_message} decreasing order: v1 ({v1}) "
-                                 f"must be greater than v2 ({v2}).")
+                raise ValueError(
+                    f"{error_message} decreasing order: v1 ({v1}) "
+                    f"must be greater than v2 ({v2})."
+                )
 
             if v1 is not None and self.high_value > v1 >= self.low_value:
                 i1 = self.value2index(v1)
@@ -897,18 +908,14 @@ class DataAxis(BaseDataAxis):
         d = self.get_axis_dictionary()
         if len(self.axis) > 1:
             scale_err = max(self.axis[1:] - self.axis[:-1]) - scale
-            _logger.warning('The maximum scale error is {}.'.format(scale_err))
-        d["_type"] = 'UniformDataAxis'
+            _logger.warning("The maximum scale error is {}.".format(scale_err))
+        d["_type"] = "UniformDataAxis"
         if self.axes_manager is not None:
-            self.axes_manager[self] = UniformDataAxis(**d,
-                                                      size=size,
-                                                      scale=scale,
-                                                      offset=offset)
+            self.axes_manager[self] = UniformDataAxis(
+                **d, size=size, scale=scale, offset=offset
+            )
         else:
-            return UniformDataAxis(**d,
-                                   size=size,
-                                   scale=scale,
-                                   offset=offset)
+            return UniformDataAxis(**d, size=size, scale=scale, offset=offset)
 
 
 class FunctionalDataAxis(DataAxis):
@@ -972,27 +979,34 @@ class FunctionalDataAxis(DataAxis):
     'a': 100,
     'b': 10}
     """
+
     x = t.Instance(DataAxis)
     parameters = t.Dict()
-    axis = t.Property(t.Array,
-                      depends_on="x.axis, parameters",)
-    def __init__(self,
-                 expression,
-                 x=None,
-                 index_in_array=None,
-                 name=None,
-                 units=None,
-                 navigate=False,
-                 size=1,
-                 is_binned=False,
-                 **parameters):
+    axis = t.Property(
+        t.Array,
+        depends_on="x.axis, parameters",
+    )
+
+    def __init__(
+        self,
+        expression,
+        x=None,
+        index_in_array=None,
+        name=None,
+        units=None,
+        navigate=False,
+        size=1,
+        is_binned=False,
+        **parameters,
+    ):
         super(DataAxis, self).__init__(
             index_in_array=index_in_array,
             name=name,
             units=units,
             navigate=navigate,
             is_binned=is_binned,
-            **parameters)
+            **parameters,
+        )
         if x is None:
             self.x = UniformDataAxis(scale=1, offset=0, size=size)
         else:
@@ -1006,8 +1020,9 @@ class FunctionalDataAxis(DataAxis):
         # Compile function
         expr = _parse_substitutions(self._expression)
         variables = ["x"]
-        expr_parameters = [symbol for symbol in expr.free_symbols
-                           if symbol.name not in variables]
+        expr_parameters = [
+            symbol for symbol in expr.free_symbols if symbol.name not in variables
+        ]
 
         if set(parameters) != set([parameter.name for parameter in expr_parameters]):
             raise ValueError(
@@ -1015,7 +1030,8 @@ class FunctionalDataAxis(DataAxis):
                 f"must be given as keywords: {set(expr_parameters) - set(parameters)}"
             )
         self._function = lambdify(
-            variables + expr_parameters, expr.evalf(), dummify=False)
+            variables + expr_parameters, expr.evalf(), dummify=False
+        )
         self.parameters = parameters
 
     @t.cached_property
@@ -1046,7 +1062,9 @@ class FunctionalDataAxis(DataAxis):
 
         """
         if attributes is None:
-            attributes = ["parameters", ]
+            attributes = [
+                "parameters",
+            ]
         return super().update_from(axis, attributes)
 
     def calibrate(self, *args, **kwargs):
@@ -1054,9 +1072,17 @@ class FunctionalDataAxis(DataAxis):
 
     def get_axis_dictionary(self):
         d = super(DataAxis, self).get_axis_dictionary()
-        d['expression'] = self._expression
-        d.update({'size': _parse_axis_attribute(self.size), })
-        d.update({'x': self.x.get_axis_dictionary(), })
+        d["expression"] = self._expression
+        d.update(
+            {
+                "size": _parse_axis_attribute(self.size),
+            }
+        )
+        d.update(
+            {
+                "x": self.x.get_axis_dictionary(),
+            }
+        )
         d.update(self.parameters)
         return d
 
@@ -1084,6 +1110,7 @@ class FunctionalDataAxis(DataAxis):
         """
         slice_ = self._get_array_slices(slice(start, end))
         self.x.crop(start=slice_.start, end=slice_.stop)
+
     crop.__doc__ = DataAxis.crop.__doc__
 
     def _slice_me(self, slice_):
@@ -1105,12 +1132,12 @@ class FunctionalDataAxis(DataAxis):
 
     def convert_to_uniform_axis(self):
         """Convert to an uniform axis."""
-        scale = (self.high_value - self.low_value) / (self.size-1)
+        scale = (self.high_value - self.low_value) / (self.size - 1)
         offset = self.low_value
         d = self.get_axis_dictionary()
         if len(self.axis) > 1:
             scale_err = max(self.axis[1:] - self.axis[:-1]) - scale
-            _logger.warning('The maximum scale error is {}.'.format(scale_err))
+            _logger.warning("The maximum scale error is {}.".format(scale_err))
         d["_type"] = "UniformDataAxis"
 
         if self.axes_manager is not None:
@@ -1121,7 +1148,7 @@ class FunctionalDataAxis(DataAxis):
     def convert_to_non_uniform_axis(self):
         """Convert to a non-uniform axis."""
         d = super().get_axis_dictionary()
-        d["_type"] = 'DataAxis'
+        d["_type"] = "DataAxis"
         if self.axes_manager is not None:
             self.axes_manager[self] = DataAxis(**d)
         else:
@@ -1163,29 +1190,34 @@ class UniformDataAxis(DataAxis, UnitConversion):
      'scale': 1.0,
      'offset': 300.0}
     """
+
     scale = t.Float(1)
     offset = t.Float(0)
     _size = t.Int(1)
-    axis = t.Property(observe=["scale", "offset", "_size"])  # overwrites axis in DataAxis
+    axis = t.Property(
+        observe=["scale", "offset", "_size"]
+    )  # overwrites axis in DataAxis
 
-    def __init__(self,
-                 index_in_array=None,
-                 name=None,
-                 units=None,
-                 navigate=False,
-                 size=1,
-                 scale=1.,
-                 offset=0.,
-                 is_binned=False,
-                 **kwargs):
+    def __init__(
+        self,
+        index_in_array=None,
+        name=None,
+        units=None,
+        navigate=False,
+        size=1,
+        scale=1.0,
+        offset=0.0,
+        is_binned=False,
+        **kwargs,
+    ):
         super(DataAxis, self).__init__(
             index_in_array=index_in_array,
             name=name,
             units=units,
             navigate=navigate,
             is_binned=is_binned,
-            **kwargs
-            )
+            **kwargs,
+        )
         self.scale = scale
         self.offset = offset
         self.size = size
@@ -1231,9 +1263,7 @@ class UniformDataAxis(DataAxis, UnitConversion):
 
     def get_axis_dictionary(self):
         d = super(DataAxis, self).get_axis_dictionary()
-        d.update({'size': self.size,
-                  'scale': self.scale,
-                  'offset': self.offset})
+        d.update({"size": self.size, "scale": self.scale, "offset": self.offset})
         return d
 
     def value2index(self, value, rounding=round):
@@ -1377,7 +1407,9 @@ class UniformDataAxis(DataAxis, UnitConversion):
     def offset_as_quantity(self, value):
         self._set_quantity(value, "offset")
 
-    def convert_to_functional_data_axis(self, expression, units=None, name=None, **kwargs):
+    def convert_to_functional_data_axis(
+        self, expression, units=None, name=None, **kwargs
+    ):
         d = super(DataAxis, self).get_axis_dictionary()
         if units:
             d["units"] = units
@@ -1387,22 +1419,21 @@ class UniformDataAxis(DataAxis, UnitConversion):
         this_kwargs = self.get_axis_dictionary()
         d["_type"] = "FunctionalDataAxis"
         if self.axes_manager is not None:
-            self.axes_manager[self] = FunctionalDataAxis(expression=expression,
-                                                         x=UniformDataAxis(**this_kwargs),
-                                                         **d)
+            self.axes_manager[self] = FunctionalDataAxis(
+                expression=expression, x=UniformDataAxis(**this_kwargs), **d
+            )
         else:
-            return FunctionalDataAxis(expression=expression,
-                                      x=UniformDataAxis(**this_kwargs),
-                                      **d)
+            return FunctionalDataAxis(
+                expression=expression, x=UniformDataAxis(**this_kwargs), **d
+            )
 
     def convert_to_non_uniform_axis(self):
         d = super().get_axis_dictionary()
-        d["_type"] = 'DataAxis'
+        d["_type"] = "DataAxis"
         if self.axes_manager is not None:
             self.axes_manager[self] = DataAxis(**d)
         else:
             return DataAxis(**d)
-
 
 
 def _serpentine_iter(shape):
@@ -1527,7 +1558,7 @@ class AxesManager(t.HasTraits):
     _step = t.Int(1)
 
     def __init__(self, axes_list):
-        self._ragged =False
+        self._ragged = False
         super().__init__()
         self.events = Events()
         self.events.indices_changed = Event(
@@ -1572,18 +1603,13 @@ class AxesManager(t.HasTraits):
         return self._ragged
 
     def _update_trait_handlers(self, remove=False):
-        self.on_trait_change(self._on_index_changed,
-                             name='_axes._index', remove=remove)
-        self.on_trait_change(self._on_axes_changed,
-                             name='_axes._size', remove=remove)
-        self.on_trait_change(self._on_axes_changed,
-                             name='_axes._scale', remove=remove)
-        self.on_trait_change(self._on_axes_changed,
-                             name='_axes._offset', remove=remove)
+        self.on_trait_change(self._on_index_changed, name="_axes._index", remove=remove)
+        self.on_trait_change(self._on_axes_changed, name="_axes._size", remove=remove)
+        self.on_trait_change(self._on_axes_changed, name="_axes._scale", remove=remove)
+        self.on_trait_change(self._on_axes_changed, name="_axes._offset", remove=remove)
 
     def __setitem__(self, y, value):
-        """x.__getitem__(y) <==> x[y]
-        """
+        """x.__getitem__(y) <==> x[y]"""
         if isinstance(y, str) or not np.iterable(y):
             ax = self._axes_getter(y)
             self.axes[self.axes.index(ax)] = value
@@ -1970,9 +1996,8 @@ class AxesManager(t.HasTraits):
         axis = create_axis(**kwargs)
         self._axes.append(axis)
 
-    def convert_units(self, axes=None, units=None, same_units=True,
-                      factor=0.25):
-        """ Convert the scale and the units of the selected axes. If the unit
+    def convert_units(self, axes=None, units=None, same_units=True, factor=0.25):
+        """Convert the scale and the units of the selected axes. If the unit
         of measure is not supported by the pint library, the scale and units
         are not changed.
 
@@ -2122,7 +2147,9 @@ class AxesManager(t.HasTraits):
 
     @property
     def _getitem_tuple(self):
-        getitem_tuple = tuple([a.slice if a.slice is not None else a.index for a in self._axes])
+        getitem_tuple = tuple(
+            [a.slice if a.slice is not None else a.index for a in self._axes]
+        )
         return getitem_tuple
 
     def _on_index_changed(self):
@@ -2144,8 +2171,9 @@ class AxesManager(t.HasTraits):
     @property
     def signal_shape(self):
         """The shape of the signal space."""
-        return tuple([axis.size if hasattr(axis, "size")
-                       else None for axis in self.signal_axes])
+        return tuple(
+            [axis.size if hasattr(axis, "size") else None for axis in self.signal_axes]
+        )
 
     @property
     def navigation_shape(self):

--- a/hyperspy/models/model1d.py
+++ b/hyperspy/models/model1d.py
@@ -26,7 +26,7 @@ import hyperspy.drawing.signal1d
 from hyperspy.decorators import interactive_range_selector
 from hyperspy.drawing.widgets import LabelWidget, VerticalLineWidget
 from hyperspy.events import EventSuppressor
-from hyperspy.exceptions import SignalDimensionError
+from hyperspy.exceptions import SignalDimensionError, WrongObjectError
 from hyperspy.misc.utils import dummy_context_manager
 from hyperspy.model import BaseModel, ModelComponents
 from hyperspy.signal_tools import SpanSelectorInSignal1D
@@ -277,10 +277,11 @@ class Model1D(BaseModel):
     @signal.setter
     def signal(self, value):
         from hyperspy._signals.signal1d import Signal1D
+
         if isinstance(value, Signal1D):
             self._signal = value
         else:
-            raise WrongObjectError(str(type(value)), 'Signal1D')
+            raise WrongObjectError(str(type(value)), "Signal1D")
 
     @property
     def axis(self):
@@ -290,7 +291,8 @@ class Model1D(BaseModel):
     def axis(self, value):
         if value._is_increasing_order is None:
             raise ValueError(
-                "The axes must be DataAxis with an increasing or decreasing order")
+                "The axes must be DataAxis with an increasing or decreasing order"
+            )
         self._axis = value
 
     def append(self, thing):

--- a/hyperspy/models/model1d.py
+++ b/hyperspy/models/model1d.py
@@ -238,6 +238,7 @@ class Model1D(BaseModel):
         self._suspend_update = False
         self._model_line = None
         self._residual_line = None
+        self._axis = None
         self.axis = self.axes_manager.signal_axes[0]
         self.axes_manager.events.indices_changed.connect(self._on_navigating, [])
         self._channel_switches = np.array([True] * len(self.axis.axis))
@@ -268,6 +269,29 @@ class Model1D(BaseModel):
             "chisq.data": "inav",
             "dof.data": "inav",
         }
+
+    @property
+    def signal(self):
+        return self._signal
+
+    @signal.setter
+    def signal(self, value):
+        from hyperspy._signals.signal1d import Signal1D
+        if isinstance(value, Signal1D):
+            self._signal = value
+        else:
+            raise WrongObjectError(str(type(value)), 'Signal1D')
+
+    @property
+    def axis(self):
+        return self._axis
+
+    @axis.setter
+    def axis(self, value):
+        if value._is_increasing_order is None:
+            raise ValueError(
+                "The axes must be DataAxis with an increasing or decreasing order")
+        self._axis = value
 
     def append(self, thing):
         """

--- a/hyperspy/models/model2d.py
+++ b/hyperspy/models/model2d.py
@@ -20,7 +20,11 @@ import copy
 
 import numpy as np
 
-from hyperspy.model import BaseModel, ModelComponents
+from hyperspy._signals.signal2d import Signal2D
+from hyperspy.exceptions import WrongObjectError
+from hyperspy.model import BaseModel, ModelComponents, ModelSpecialSlicers
+from hyperspy.axes import DataAxis
+
 
 _SIGNAL_RANGE_VALUES = """x1, x2 : None or float
             Start and end of the range in the first axis (horizontal)
@@ -91,6 +95,11 @@ class Model2D(BaseModel):
         self._plot_components = False
         self._suspend_update = False
         self._model_line = None
+        if (self.signal.axes_manager.signal_axes[0]._is_increasing_order is None or
+            self.signal.axes_manager.signal_axes[1]._is_increasing_order is None):
+            raise ValueError(
+                "The axes must be DataAxis with an increasing or decreasing order")
+
         self.xaxis, self.yaxis = np.meshgrid(
             self.axes_manager.signal_axes[0].axis, self.axes_manager.signal_axes[1].axis
         )

--- a/hyperspy/models/model2d.py
+++ b/hyperspy/models/model2d.py
@@ -20,11 +20,7 @@ import copy
 
 import numpy as np
 
-from hyperspy._signals.signal2d import Signal2D
-from hyperspy.exceptions import WrongObjectError
-from hyperspy.model import BaseModel, ModelComponents, ModelSpecialSlicers
-from hyperspy.axes import DataAxis
-
+from hyperspy.model import BaseModel, ModelComponents
 
 _SIGNAL_RANGE_VALUES = """x1, x2 : None or float
             Start and end of the range in the first axis (horizontal)
@@ -95,10 +91,13 @@ class Model2D(BaseModel):
         self._plot_components = False
         self._suspend_update = False
         self._model_line = None
-        if (self.signal.axes_manager.signal_axes[0]._is_increasing_order is None or
-            self.signal.axes_manager.signal_axes[1]._is_increasing_order is None):
+        if (
+            self.signal.axes_manager.signal_axes[0]._is_increasing_order is None
+            or self.signal.axes_manager.signal_axes[1]._is_increasing_order is None
+        ):
             raise ValueError(
-                "The axes must be DataAxis with an increasing or decreasing order")
+                "The axes must be DataAxis with an increasing or decreasing order"
+            )
 
         self.xaxis, self.yaxis = np.meshgrid(
             self.axes_manager.signal_axes[0].axis, self.axes_manager.signal_axes[1].axis

--- a/hyperspy/signal.py
+++ b/hyperspy/signal.py
@@ -3325,7 +3325,7 @@ class BaseSignal(
                 if not axis.is_uniform:  # Axis must be uniform to set the size
                     axis.convert_to_uniform_axis()
                     _logger.warning(f"converting axis: {axis} to a UniformDataAxis")
-                    axis.size = int(dc.shape[axis.index_in_array])
+                axis.size = int(dc.shape[axis.index_in_array])
 
     def crop(self, axis, start=None, end=None, convert_units=False):
         """Crops the data in a given axis. The range is given in pixels.

--- a/hyperspy/signal.py
+++ b/hyperspy/signal.py
@@ -2772,7 +2772,6 @@ class BaseSignal(
             for index in axes:
                 axis = {"index_in_array": index, "size": self.data.shape[index]}
                 self.axes_manager._append_axis(**axis)
-            self.axes_manager._update_attributes()
 
         self.axes_manager._ragged = value
 
@@ -3321,7 +3320,12 @@ class BaseSignal(
         """
         dc = self.data
         for axis in self.axes_manager._axes:
-            axis.size = int(dc.shape[axis.index_in_array])
+            new_size = int(dc.shape[axis.index_in_array])
+            if axis.size != new_size:  # Do nothing if already set
+                if not axis.is_uniform:  # Axis must be uniform to set the size
+                    axis.convert_to_uniform_axis()
+                    _logger.warning(f"converting axis: {axis} to a UniformDataAxis")
+                    axis.size = int(dc.shape[axis.index_in_array])
 
     def crop(self, axis, start=None, end=None, convert_units=False):
         """Crops the data in a given axis. The range is given in pixels.
@@ -3453,12 +3457,10 @@ class BaseSignal(
         am._update_trait_handlers(remove=True)
         c1 = am._axes[axis1]
         c2 = am._axes[axis2]
-        c1.slice, c2.slice = c2.slice, c1.slice
         c1.navigate, c2.navigate = c2.navigate, c1.navigate
         c1.is_binned, c2.is_binned = c2.is_binned, c1.is_binned
         am._axes[axis1] = c2
         am._axes[axis2] = c1
-        am._update_attributes()
         am._update_trait_handlers(remove=False)
         if optimize:
             s._make_sure_data_is_contiguous()
@@ -3509,9 +3511,9 @@ class BaseSignal(
 
         s = self._deepcopy_with_new_data(self.data.transpose(new_axes_indices))
         s.axes_manager._axes = rollelem(
-            s.axes_manager._axes, index=axis, to_index=to_index
-        )
-        s.axes_manager._update_attributes()
+            s.axes_manager._axes,
+            index=axis,
+            to_index=to_index)
         if optimize:
             s._make_sure_data_is_contiguous()
         return s
@@ -6753,7 +6755,6 @@ class BaseSignal(
 
         # reconfigure the axes of the axesmanager:
         ram = res.axes_manager
-        ram._update_trait_handlers(remove=True)
         # _axes are ordered in array order
         ram._axes = [ram._axes[i] for i in array_order]
         for i, ax in enumerate(ram._axes):
@@ -6761,8 +6762,6 @@ class BaseSignal(
                 ax.navigate = True
             else:
                 ax.navigate = False
-        ram._update_attributes()
-        ram._update_trait_handlers(remove=False)
         res._assign_subclass()
 
         var = res.get_noise_variance()

--- a/hyperspy/signal.py
+++ b/hyperspy/signal.py
@@ -5093,8 +5093,7 @@ class BaseSignal(
             else:
                 hist_spec.data = hist
 
-        if isinstance(bins, str) and bins == "blocks":
-            hist_spec.axes_manager.signal_axes[0].axis = bin_edges[:-1]
+        if isinstance(bins, str) and bins == 'blocks':
             warnings.warn(
                 "The option `bins='blocks'` is not fully supported in this "
                 "version of HyperSpy. It should be used for plotting purposes "

--- a/hyperspy/signal.py
+++ b/hyperspy/signal.py
@@ -3511,9 +3511,8 @@ class BaseSignal(
 
         s = self._deepcopy_with_new_data(self.data.transpose(new_axes_indices))
         s.axes_manager._axes = rollelem(
-            s.axes_manager._axes,
-            index=axis,
-            to_index=to_index)
+            s.axes_manager._axes, index=axis, to_index=to_index
+        )
         if optimize:
             s._make_sure_data_is_contiguous()
         return s
@@ -5093,7 +5092,7 @@ class BaseSignal(
             else:
                 hist_spec.data = hist
 
-        if isinstance(bins, str) and bins == 'blocks':
+        if isinstance(bins, str) and bins == "blocks":
             warnings.warn(
                 "The option `bins='blocks'` is not fully supported in this "
                 "version of HyperSpy. It should be used for plotting purposes "

--- a/hyperspy/tests/axes/test_axes_manager.py
+++ b/hyperspy/tests/axes/test_axes_manager.py
@@ -21,13 +21,8 @@ from unittest import mock
 import numpy as np
 import pytest
 
-from hyperspy.axes import (
-    AxesManager,
-    BaseDataAxis,
-    GeneratorLen,
-    _flyback_iter,
-    _serpentine_iter,
-)
+
+from hyperspy.axes import AxesManager, _serpentine_iter, _flyback_iter, GeneratorLen, BaseDataAxis,UniformDataAxis
 from hyperspy.defaults_parser import preferences
 from hyperspy.signals import BaseSignal, Signal1D, Signal2D
 
@@ -135,6 +130,20 @@ class TestAxesManager:
         am.set_axis(axis, 2)
         assert am[-2].offset == am[-1].offset
         assert am[-2].scale == am[-1].scale
+
+    def test_setitem_axis(self):
+        am = self.am
+        am[("a", "b")] = (UniformDataAxis(scale=1,
+                                      offset=0,
+                                      size=10,
+                                      name="test1"),
+                           UniformDataAxis(scale=1,
+                                      offset=0,
+                                      size=10,
+                                      name="test2"))
+        assert am[3].name == "test1"
+        assert am[2].name == "test2"
+
 
     def test_all_uniform(self):
         assert self.am.all_uniform is True

--- a/hyperspy/tests/axes/test_axes_manager.py
+++ b/hyperspy/tests/axes/test_axes_manager.py
@@ -84,6 +84,26 @@ class TestAxesManager:
         repr(self.am)
         self.am._repr_html_
 
+    def test_inclusion(self):
+        am = self.am
+        assert all([a.axes_manager == am for a in am._axes])
+
+    def test_changing_axes(self):
+        am = self.am
+
+        new_axis = BaseDataAxis("test1")
+        am._axes.append(new_axis)
+        assert len(am._axes) == 5
+        assert all([a.axes_manager == am for a in am._axes])
+
+    def test_changing_axes_insertion(self):
+        am = self.am
+
+        new_axis = BaseDataAxis("test1")
+        am._axes[2] = new_axis
+        assert len(am._axes) == 4
+        assert all([a.axes_manager == am for a in am._axes])
+
     def test_update_from(self):
         am = self.am
         am2 = self.am.deepcopy()

--- a/hyperspy/tests/axes/test_axes_manager.py
+++ b/hyperspy/tests/axes/test_axes_manager.py
@@ -124,6 +124,12 @@ class TestAxesManager:
         assert am[-3].offset == am[-1].offset
         assert am[-3].scale == am[-1].scale
 
+    def test_axes_setter(self):
+        self.am.axes = [BaseDataAxis(name="test1"), BaseDataAxis(name="test2")]
+        assert len(self.am.axes) == 2
+        assert self.am.axes[0].name == "test1"
+        assert self.am.axes[1].name == "test2"
+
     def test_set_axis(self):
         am = self.am
         axis = am[-1].copy()
@@ -144,6 +150,9 @@ class TestAxesManager:
         assert am[3].name == "test1"
         assert am[2].name == "test2"
 
+    def test_getitem_axis_fail(self):
+        with pytest.raises(TypeError):
+            self.am[3.3]
 
     def test_all_uniform(self):
         assert self.am.all_uniform is True

--- a/hyperspy/tests/axes/test_axes_manager.py
+++ b/hyperspy/tests/axes/test_axes_manager.py
@@ -21,8 +21,14 @@ from unittest import mock
 import numpy as np
 import pytest
 
-
-from hyperspy.axes import AxesManager, _serpentine_iter, _flyback_iter, GeneratorLen, BaseDataAxis,UniformDataAxis
+from hyperspy.axes import (
+    AxesManager,
+    BaseDataAxis,
+    GeneratorLen,
+    UniformDataAxis,
+    _flyback_iter,
+    _serpentine_iter,
+)
 from hyperspy.defaults_parser import preferences
 from hyperspy.signals import BaseSignal, Signal1D, Signal2D
 
@@ -139,14 +145,10 @@ class TestAxesManager:
 
     def test_setitem_axis(self):
         am = self.am
-        am[("a", "b")] = (UniformDataAxis(scale=1,
-                                      offset=0,
-                                      size=10,
-                                      name="test1"),
-                           UniformDataAxis(scale=1,
-                                      offset=0,
-                                      size=10,
-                                      name="test2"))
+        am[("a", "b")] = (
+            UniformDataAxis(scale=1, offset=0, size=10, name="test1"),
+            UniformDataAxis(scale=1, offset=0, size=10, name="test2"),
+        )
         assert am[3].name == "test1"
         assert am[2].name == "test2"
 

--- a/hyperspy/tests/axes/test_conversion_units.py
+++ b/hyperspy/tests/axes/test_conversion_units.py
@@ -37,15 +37,15 @@ class TestUnitConversion:
         self.uc.size = size
 
     def test_units_setter(self):
-        self.uc.units = ' m'
-        assert self.uc.units == ' m'
-        self.uc.units = 'um'
-        assert self.uc.units == 'um'
-        self.uc.units = 'µm'
-        assert self.uc.units == 'µm'
-        self.uc.units = 'km'
-        assert self.uc.units == 'km'
-        self.uc.units = ''
+        self.uc.units = " m"
+        assert self.uc.units == " m"
+        self.uc.units = "um"
+        assert self.uc.units == "um"
+        self.uc.units = "µm"
+        assert self.uc.units == "µm"
+        self.uc.units = "km"
+        assert self.uc.units == "km"
+        self.uc.units = ""
         assert self.uc.units is t.Undefined
 
     def test_ignore_conversion(self):

--- a/hyperspy/tests/axes/test_conversion_units.py
+++ b/hyperspy/tests/axes/test_conversion_units.py
@@ -37,14 +37,16 @@ class TestUnitConversion:
         self.uc.size = size
 
     def test_units_setter(self):
-        self.uc.units = " m"
-        assert self.uc.units == " m"
-        self.uc.units = "um"
-        assert self.uc.units == "um"
-        self.uc.units = "µm"
-        assert self.uc.units == "µm"
-        self.uc.units = "km"
-        assert self.uc.units == "km"
+        self.uc.units = ' m'
+        assert self.uc.units == ' m'
+        self.uc.units = 'um'
+        assert self.uc.units == 'um'
+        self.uc.units = 'µm'
+        assert self.uc.units == 'µm'
+        self.uc.units = 'km'
+        assert self.uc.units == 'km'
+        self.uc.units = ''
+        assert self.uc.units is t.Undefined
 
     def test_ignore_conversion(self):
         assert self.uc._ignore_conversion(t.Undefined)

--- a/hyperspy/tests/axes/test_data_axis.py
+++ b/hyperspy/tests/axes/test_data_axis.py
@@ -21,10 +21,8 @@ import math
 import platform
 from unittest import mock
 
-import numpy as np
 import dask.array as da
-from numpy.testing import assert_allclose
-import traits.api as t
+import numpy as np
 import pytest
 import traits.api as t
 from numpy.testing import assert_allclose
@@ -74,19 +72,20 @@ class TestBaseDataAxis:
         with pytest.raises(NotImplementedError):
             self.axis._slice_me(1)
         with pytest.raises(AttributeError):
-            self.axis._parse_value_from_string('')
+            self.axis._parse_value_from_string("")
         with pytest.raises(AttributeError):
-            self.axis._parse_value_from_string('spam')
+            self.axis._parse_value_from_string("spam")
 
     def test_repr_BaseDataAxis(self):
-         assert self.axis.__repr__() == "<Unnamed axis, size: None>"
+        assert self.axis.__repr__() == "<Unnamed axis, size: None>"
 
-    #Note: The following methods from BaseDataAxis rely on the self.axis.axis
-    #numpy array to be initialized, and are tested in the subclasses:
-    #BaseDataAxis.value2index --> tested in FunctionalDataAxis
-    #BaseDataAxis.index2value --> NOT EXPLICITLY TESTED
-    #BaseDataAxis.value_range_to_indices --> tested in UniformDataAxis
-    #BaseDataAxis.update_from --> tested in DataAxis and FunctionalDataAxis
+    # Note: The following methods from BaseDataAxis rely on the self.axis.axis
+    # numpy array to be initialized, and are tested in the subclasses:
+    # BaseDataAxis.value2index --> tested in FunctionalDataAxis
+    # BaseDataAxis.index2value --> NOT EXPLICITLY TESTED
+    # BaseDataAxis.value_range_to_indices --> tested in UniformDataAxis
+    # BaseDataAxis.update_from --> tested in DataAxis and FunctionalDataAxis
+
 
 class TestDataAxis:
     def setup_method(self, method):
@@ -130,7 +129,6 @@ class TestDataAxis:
         axis = DataAxis(axis=values)
         assert_allclose(axis.axis, values)
         assert axis._is_increasing_order is None
-
 
     def test_index_changed_event(self):
         ax = self.axis
@@ -287,8 +285,7 @@ class TestDataAxis:
         if attributes is None:
             assert ax2.units == self.axis.units
         else:
-            assert ((ax2.units, ax2.name) ==
-                    (self.axis.units, self.axis.name))
+            assert (ax2.units, ax2.name) == (self.axis.units, self.axis.name)
 
     def test_update_from_all(self):
         ax2 = DataAxis(units="plumage", name="parrot", axis=np.arange(16))
@@ -316,6 +313,7 @@ class TestUnorderedDataAxis:
     def test_increasing_order(self):
         assert self.axis._is_increasing_order is None
 
+
 class TestFunctionalDataAxis:
     def setup_method(self, method):
         expression = "x ** power"
@@ -328,18 +326,12 @@ class TestFunctionalDataAxis:
     def test_initialisation_parameters(self):
         axis = self.axis
         assert axis.parameters["power"] == 2
-        np.testing.assert_allclose(
-            axis.axis,
-            np.arange(10)**2)
-
-    def test_low_value(self):
-        assert self.axis.low_value == 0
+        np.testing.assert_allclose(axis.axis, np.arange(10) ** 2)
 
     def test_initialisation_error(self):
         expression = "x ** power"
         with pytest.raises(t.TraitError):
-            axis = FunctionalDataAxis(expression=expression,
-                                      power=2, size=t.undefined)
+            FunctionalDataAxis(expression=expression, power=2, size=t.undefined)
 
     def test_low_value(self):
         assert self.axis.low_value == 0
@@ -357,16 +349,16 @@ class TestFunctionalDataAxis:
             )
 
     def test_change_parameters(self):
-         axis = self.axis
-         axis.parameters["power"] = 1
-         np.testing.assert_allclose(axis.axis, np.arange(10))
-         axis.parameters["power"] = 3
-         np.testing.assert_allclose(axis.axis, np.arange(10)**3)
+        axis = self.axis
+        axis.parameters["power"] = 1
+        np.testing.assert_allclose(axis.axis, np.arange(10))
+        axis.parameters["power"] = 3
+        np.testing.assert_allclose(axis.axis, np.arange(10) ** 3)
 
     def test_change_x(self):
         axis = self.axis
         axis.x.scale = 2
-        np.testing.assert_allclose(axis.axis, (np.arange(10)*2)**2)
+        np.testing.assert_allclose(axis.axis, (np.arange(10) * 2) ** 2)
         axis.x.scale = 4
         np.testing.assert_allclose(axis.axis, (np.arange(10) * 4) ** 2)
 
@@ -414,7 +406,7 @@ class TestFunctionalDataAxis:
         assert uniform_axis.axes_manager is None
 
     def test_convert_to_uniform_axis(self):
-        axis = np.copy(self.axis.axis)
+        np.copy(self.axis.axis)
         is_binned = self.axis.is_binned
         navigate = self.axis.navigate
         self.axis.name = "parrot"
@@ -444,12 +436,13 @@ class TestFunctionalDataAxis:
         assert isinstance(uniform_axis, UniformDataAxis)
         assert uniform_axis.axes_manager is None
 
-
     def test_update_from(self):
         ax2 = FunctionalDataAxis(size=2, units="nm", expression="x ** power", power=3)
         self.axis.update_from(ax2, attributes=("units", "parameters"))
-        assert ((ax2.units, ax2.parameters["power"]) ==
-                (self.axis.units, self.axis.parameters["power"]))
+        assert (ax2.units, ax2.parameters["power"]) == (
+            self.axis.units,
+            self.axis.parameters["power"],
+        )
 
     def test_update_from_none(self):
         ax2 = FunctionalDataAxis(size=2, units="nm", expression="x ** power", power=3)
@@ -519,7 +512,10 @@ class TestReciprocalDataAxis:
     def _test_initialisation_parameters(self, axis):
         assert axis.parameters["a"] == 0.1
         assert axis.parameters["b"] == 10
-        def func(x): return 0.1 / (x + 1) + 10
+
+        def func(x):
+            return 0.1 / (x + 1) + 10
+
         np.testing.assert_allclose(axis.axis, func(np.arange(10)))
 
     def test_initialisation_parameters(self):
@@ -749,7 +745,7 @@ class TestUniformDataAxis:
         assert navigate == s.axes_manager[0].navigate
 
     def test_convert_to_functional_data_axis_no_axes_manager(self):
-        uniform_axis = self.axis.convert_to_functional_data_axis(expression='x**2')
+        uniform_axis = self.axis.convert_to_functional_data_axis(expression="x**2")
         assert isinstance(uniform_axis, FunctionalDataAxis)
         assert uniform_axis.axes_manager is None
 

--- a/hyperspy/tests/axes/test_data_axis.py
+++ b/hyperspy/tests/axes/test_data_axis.py
@@ -189,6 +189,13 @@ class TestDataAxis:
         assert is_binned == s.axes_manager[0].is_binned
         assert navigate == s.axes_manager[0].navigate
 
+    def test_convert_to_uniform_axis(self):
+        self.axis.name = "parrot"
+        self.axis.units = "plumage"
+        uniform_axis = self.axis.convert_to_uniform_axis()
+        assert isinstance(uniform_axis, UniformDataAxis)
+
+
     def test_value2index(self):
         assert self.axis.value2index(10.15) == 3
         assert self.axis.value2index(60) == 8
@@ -269,7 +276,7 @@ class TestDataAxis:
             self.axis._get_array_slices(slice_=slice(225.1, 0, 1))
 
     @pytest.mark.parametrize("attributes", (("units", "name"), None))
-    def test_update_from(self,attributes):
+    def test_update_from(self, attributes):
         ax2 = DataAxis(units="plumage", name="parrot", axis=np.arange(16))
         self.axis.update_from(ax2, attributes=attributes)
         if attributes is None:
@@ -277,6 +284,11 @@ class TestDataAxis:
         else:
             assert ((ax2.units, ax2.name) ==
                     (self.axis.units, self.axis.name))
+
+    def test_update_from_all(self):
+        ax2 = DataAxis(units="plumage", name="parrot", axis=np.arange(16))
+        self.axis.update_from(ax2)
+        assert ax2.units == self.axis.units
 
     def test_calibrate(self):
         with pytest.raises(TypeError, match="only for uniform axes"):
@@ -397,6 +409,7 @@ class TestFunctionalDataAxis:
         navigate = self.axis.navigate
         self.axis.name = "parrot"
         self.axis.units = "plumage"
+
         s = Signal1D(np.arange(10), axes=[self.axis])
         index_in_array = s.axes_manager[0].index_in_array
         s.axes_manager[0].convert_to_uniform_axis()
@@ -415,6 +428,7 @@ class TestFunctionalDataAxis:
         assert index_in_array == s.axes_manager[0].index_in_array
         assert is_binned == s.axes_manager[0].is_binned
         assert navigate == s.axes_manager[0].navigate
+
 
     def test_convert_to_uniform_axis(self):
         axis = np.copy(self.axis.axis)
@@ -446,6 +460,11 @@ class TestFunctionalDataAxis:
         self.axis.update_from(ax2, attributes=("units", "parameters"))
         assert ((ax2.units, ax2.parameters["power"]) ==
                 (self.axis.units, self.axis.parameters["power"]))
+
+    def test_update_from_none(self):
+        ax2 = FunctionalDataAxis(size=2, units="nm", expression="x ** power", power=3)
+        self.axis.update_from(ax2)
+        assert ax2.parameters == self.axis.parameters
 
     def test_slice_me(self):
         assert self.axis._slice_me(slice(1, 5)) == slice(1, 5)

--- a/hyperspy/tests/axes/test_data_axis.py
+++ b/hyperspy/tests/axes/test_data_axis.py
@@ -107,20 +107,17 @@ class TestDataAxis:
     def test_update_axes(self):
         values = np.arange(20) ** 2
         self.axis.axis = values.tolist()
-        self.axis.update_axis()
         assert self.axis.size == 20
         assert_allclose(self.axis.axis, values)
 
     def test_update_axes2(self):
         values = np.array([3, 4, 10, 40])
         self.axis.axis = values
-        self.axis.update_axis()
         assert_allclose(self.axis.axis, values)
 
     def test_update_axis_from_list(self):
         values = np.arange(16) ** 2
         self.axis.axis = values.tolist()
-        self.axis.update_axis()
         assert_allclose(self.axis.axis, values)
 
     def test_unsorted_axis(self):

--- a/hyperspy/tests/model/test_model.py
+++ b/hyperspy/tests/model/test_model.py
@@ -28,11 +28,12 @@ from hyperspy.misc.utils import slugify
 
 class TestModelJacobians:
     def setup_method(self, method):
-        s = hs.signals.Signal1D(np.zeros(1))
+        s = hs.signals.Signal1D(np.zeros(2))
         m = s.create_model()
         self.weights = 0.3
-        m.axis.axis = np.array([1, 0])
-        m._channel_switches = np.array([0, 1], dtype=bool)
+        m.axis.scale = -1
+        m.axis.offset = 1
+        m.channel_switches = np.array([0, 1], dtype=bool)
         m.append(hs.model.components1D.Gaussian())
         m[0].A.value = 1
         m[0].centre.value = 2.0
@@ -43,8 +44,8 @@ class TestModelJacobians:
         m = self.model
         jac = m._jacobian((1, 2, 3), None, weights=self.weights)
         np.testing.assert_array_almost_equal(
-            jac.squeeze(),
-            self.weights
+            jac.squeeze()[:, 1],
+            self.weights,
             * np.array([m[0].A.grad(0), m[0].sigma.grad(0) + m[0].centre.grad(0)]),
         )
         assert m[0].A.value == 1

--- a/hyperspy/tests/model/test_model.py
+++ b/hyperspy/tests/model/test_model.py
@@ -46,7 +46,7 @@ class TestModelJacobians:
         np.testing.assert_array_almost_equal(
             jac.squeeze()[:, 1],
             self.weights,
-            * np.array([m[0].A.grad(0), m[0].sigma.grad(0) + m[0].centre.grad(0)]),
+            *np.array([m[0].A.grad(0), m[0].sigma.grad(0) + m[0].centre.grad(0)]),
         )
         assert m[0].A.value == 1
         assert m[0].centre.value == 2

--- a/hyperspy/tests/model/test_model.py
+++ b/hyperspy/tests/model/test_model.py
@@ -186,6 +186,13 @@ class TestModel1D:
         m = s.create_model()
         self.model = m
 
+    def test_fail_to_set_axis(self):
+        s = hs.signals.Signal1D(np.empty(4))
+        s.axes_manager[0].convert_to_non_uniform_axis()
+        s.axes_manager[0].axis = [1, 2, 0, 3]
+        with pytest.raises(ValueError):
+            s.create_model()
+
     def test_errfunc(self):
         m = self.model
         m._model_function = mock.MagicMock()

--- a/hyperspy/tests/model/test_model2d.py
+++ b/hyperspy/tests/model/test_model2d.py
@@ -49,6 +49,13 @@ class TestModel2D:
         )
         self.m.append(gt)
 
+    def test_fail_to_set_axis(self):
+        s = hs.signals.Signal2D(np.empty((4,4)))
+        s.axes_manager[0].convert_to_non_uniform_axis()
+        s.axes_manager[0].axis = [1, 2, 0, 3]
+        with pytest.raises(ValueError):
+            s.create_model()
+
     def _check_model_values(self, model, expected, **kwargs):
         print(
             f"({self.m.p0[0]:.7f}, {self.m.p0[1]:.7f}, {self.m.p0[2]:.7f}, {self.m.p0[3]:.7f}, {self.m.p0[4]:.7f})"

--- a/hyperspy/tests/model/test_model2d.py
+++ b/hyperspy/tests/model/test_model2d.py
@@ -50,7 +50,7 @@ class TestModel2D:
         self.m.append(gt)
 
     def test_fail_to_set_axis(self):
-        s = hs.signals.Signal2D(np.empty((4,4)))
+        s = hs.signals.Signal2D(np.empty((4, 4)))
         s.axes_manager[0].convert_to_non_uniform_axis()
         s.axes_manager[0].axis = [1, 2, 0, 3]
         with pytest.raises(ValueError):


### PR DESCRIPTION
### Description of the change
This set of changes supersedes #3012 and #2876 in the hope of creating small incremental changes to how Axes and slicing occurs before fully supporting vector signals.  @ericpre sorry about the confusion, but the changes to how the slicing works are rather larger than anticipated so I wanted to do this slow and incrementally.  

This change better defines what are the key attributes of an axes and focuses on only allowing changes to those attributes. 

- BaseDataAxis: The base class it has only a name and unit as well as attributes related to interfacing with the AxesManager.
- DataAxis: The most flexible of the Axes.  It has an axes attribute which is a 1 dimensional array. This can be increasing order, decreasing order or arbitrarily ordered.  (Note the last case does not support any kind of indexing yet)
- FunctionalDataAxis: Has an axis property that is calculated from x and the given function.
- UniformDataAxis: Has an axis property calculated from the size, offset and scale.
- AxesManager: Properties in the axes manager are directly pulled from the axes in the list.

These changes help to stop a lot of small bugs within the axes code.  Things like being able to set the size of a DataAxis don't make sense when the size is directly related to the axis.  Similarly with the UniformDataAxis, directly setting the Axis should throw an error. 

This also adds in some limited support for unordered (or unorderable axes) which are necessary for vector applications.  

### Progress of the PR
- [x] Change implemented (can be split into several points),
- [x] add tests,
- [x] ready for review.

### Minimal example of the bug fix or the new feature
```python
import hyperspy.api as hs

ax = hs.axes.DataAxis(["a", "b", "c"]) # No longer throws an error
ax.size = 10 # Throws AttributeError

ax = hs.axes.UniformDataAxis(size=10, scale=3, offset=1) 
ax.size = 10
ax.axis = [10,12,13,14] # Throws AttributeError
```