### PR TITLE
Fix deprecated import of scipy `ascent`

### DIFF
--- a/hyperspy/drawing/_markers/arrow.py
+++ b/hyperspy/drawing/_markers/arrow.py
@@ -44,11 +44,10 @@ class Arrow(MarkerBase):
         Keyword arguments are passed to
         :py:class:`matplotlib.patches.FancyArrowPatch`.
 
-
     Example
     -------
-    >>> import scipy.misc
-    >>> im = hs.signals.Signal2D(scipy.misc.ascent())
+    >>> import skimage
+    >>> im = hs.signals.Signal2D(skimage.data.camera())
     >>> m = hs.plot.markers.arrow(x1=150, y1=100, x2=400, y2=400,
     >>>                           arrowprop={'arrowstyle':'<->', edgecolor='red'})
     >>> im.add_marker(m)
@@ -102,5 +101,3 @@ class Arrow(MarkerBase):
         y2 = self.get_data_position('y2')
         self.marker = self.ax.add_patch(patches.FancyArrowPatch(
             (x1,y1), (x2,y2), **self.marker_properties))
-
-

--- a/hyperspy/drawing/_markers/ellipse.py
+++ b/hyperspy/drawing/_markers/ellipse.py
@@ -46,8 +46,8 @@ class Ellipse(MarkerBase):
 
     Example
     -------
-    >>> import scipy.misc
-    >>> im = hs.signals.Signal2D(scipy.misc.ascent())
+    >>> import skimage
+    >>> im = hs.signals.Signal2D(skimage.data.camera())
     >>> m = hs.plot.markers.ellipse(x=150, y=100, width=400, height=400,
     >>>                             edgecolor='red', facecolor='white', fill=True)
     >>> im.add_marker(m)
@@ -105,4 +105,3 @@ class Ellipse(MarkerBase):
         height = self.get_data_position('y2')
         self.marker = self.ax.add_patch(patches.Ellipse(
             [x1,y1], width, height, **self.marker_properties))
-

--- a/hyperspy/drawing/_markers/point.py
+++ b/hyperspy/drawing/_markers/point.py
@@ -43,28 +43,25 @@ class Point(MarkerBase):
 
     Example
     -------
-    >>> im = hs.signals.Signal2D(np.random.random([10, 50, 50]))
-    >>> m = hs.plot.markers.point(x=range(10), y=range(10)[::-1],
-    >>>                           color='red')
-    >>> im.add_marker(m)
+    Add a marker with the same position for all navigation positions
 
-    Adding a marker permanently to a signal
+    >>> im = hs.signals.Signal2D(np.arange(1000).reshape([10, 10, 10]))
+    >>> m = hs.plot.markers.point(x=1, y=2, color='C0')
+    >>> s.add_marker(m)
+
+    Add a marker, the position of which depends on the navigation positions
+
+    >>> x_position = np.arange(10)
+    >>> y_position = np.arange(10) / 2
+
+    >>> m = hs.plot.markers.point(x=x_position, y=y_position, color='C1')
+    >>> s.add_marker(m)
+
+    Add a marker permanently; the marker is saved in the metadata
 
     >>> im = hs.signals.Signal2D(np.random.random([10, 50, 50]))
     >>> m = hs.plot.markers.point(10, 30, color='blue', size=50)
     >>> im.add_marker(m, permanent=True)
-
-    Markers on local maxima
-
-    >>> from skimage.feature import peak_local_max
-    >>> import scipy.misc
-    >>> im = hs.signals.Signal2D(scipy.misc.ascent()).as_signal2D([2,0])
-    >>> index = array([peak_local_max(i.data, min_distance=100, num_peaks=4)
-    >>>                for i in im])
-    >>> for i in range(4):
-    >>>     m = hs.plot.markers.point(x=index[:, i, 1],
-    >>>                                  y=index[:, i, 0], color='red')
-    >>>     im.add_marker(m)
     """
 
     def __init__(self, x, y, size=20, **kwargs):

--- a/hyperspy/drawing/_markers/rectangle.py
+++ b/hyperspy/drawing/_markers/rectangle.py
@@ -49,8 +49,8 @@ class Rectangle(MarkerBase):
 
     Example
     -------
-    >>> import scipy.misc
-    >>> im = hs.signals.Signal2D(scipy.misc.ascent())
+    >>> import skimage
+    >>> im = hs.signals.Signal2D(skimage.data.camera())
     >>> m = hs.plot.markers.rectangle(x1=150, y1=100, x2=400, y2=400,
     >>>                               color='red')
     >>> im.add_marker(m)
@@ -108,5 +108,3 @@ class Rectangle(MarkerBase):
         self.marker = self.ax.add_patch(patches.Rectangle(
             (self.get_data_position('x1'), self.get_data_position('y1')),
             width, height, **self.marker_properties))
-
-

--- a/hyperspy/misc/tv_denoise.py
+++ b/hyperspy/misc/tv_denoise.py
@@ -163,10 +163,10 @@ def _tv_denoise_2d(im, weight=50, eps=2.e-4, keep_type=False, n_iter_max=200):
 
     Examples
     ---------
-    >>> import scipy
-    >>> ascent = scipy.ascent().astype(float)
-    >>> ascent += 0.5 * ascent.std()*np.random.randn(*ascent.shape)
-    >>> denoised_ascent = tv_denoise(ascent, weight=60.0)
+    >>> import skimage
+    >>> camera = skimage.data.camera().astype(float)
+    >>> camera += 0.5 * camera.std()*np.random.randn(*ascent.shape)
+    >>> denoised_camera = tv_denoise(camera, weight=60.0)
     """
     im_type = im.dtype
     if im_type is not float:
@@ -258,10 +258,10 @@ def _tv_denoise_1d(im, weight=50, eps=2.e-4, keep_type=False, n_iter_max=200):
 
     Examples
     ---------
-    >>> import scipy
-    >>> ascent = scipy.misc.ascent().astype(float)
-    >>> ascent += 0.5 * ascent.std()*np.random.randn(*ascent.shape)
-    >>> denoised_ascent = tv_denoise(ascent, weight=60.0)
+    >>> import skimage
+    >>> camera = skimage.data.camera().astype(float)
+    >>> camera += 0.5 * camera.std()*np.random.randn(*camera.shape)
+    >>> denoised_camera = tv_denoise(camera, weight=60.0)
     """
     im_type = im.dtype
     if im_type is not float:
@@ -356,10 +356,10 @@ def tv_denoise(im, weight=50, eps=2.e-4, keep_type=False, n_iter_max=200):
     Examples
     ---------
     >>> # 2D example using ascent
-    >>> import scipy
-    >>> ascent = scipy.misc.ascent().astype(float)
-    >>> ascent += 0.5 * ascent.std()*np.random.randn(*ascent.shape)
-    >>> denoised_ascent = tv_denoise(ascent, weight=60)
+    >>> import skimage
+    >>> camera = skimage.data.camera().astype(float)
+    >>> camera += 0.5 * camera.std()*np.random.randn(*camera.shape)
+    >>> denoised_camera = tv_denoise(camera, weight=60)
     >>> # 3D example on synthetic data
     >>> x, y, z = np.ogrid[0:40, 0:40, 0:40]
     >>> mask = (x -22)**2 + (y - 20)**2 + (z - 17)**2 < 8**2

--- a/hyperspy/signal.py
+++ b/hyperspy/signal.py
@@ -4292,7 +4292,8 @@ class BaseSignal(FancySlicing,
 
         Examples
         --------
-        >>> im = hs.signals.Signal2D(scipy.misc.ascent())
+        >>> import skimage
+        >>> im = hs.signals.Signal2D(skimage.data.camera())
         >>> im.fft()
         <ComplexSignal2D, title: FFT of , dimensions: (|512, 512)>
 
@@ -4387,8 +4388,8 @@ class BaseSignal(FancySlicing,
 
         Examples
         --------
-        >>> import scipy
-        >>> im = hs.signals.Signal2D(scipy.misc.ascent())
+        >>> import skimage
+        >>> im = hs.signals.Signal2D(skimage.data.camera())
         >>> imfft = im.fft()
         >>> imfft.ifft()
         <Signal2D, title: real(iFFT of FFT of ), dimensions: (|512, 512)>
@@ -5912,8 +5913,8 @@ class BaseSignal(FancySlicing,
 
         Examples
         --------
-        >>> import scipy.misc
-        >>> im = hs.signals.Signal2D(scipy.misc.ascent())
+        >>> import skimage
+        >>> im = hs.signals.Signal2D(skimage.data.camera())
         >>> m = hs.markers.rectangle(x1=150, y1=100, x2=400,
         >>>                                  y2=400, color='red')
         >>> im.add_marker(m)

--- a/hyperspy/tests/drawing/test_plot_markers.py
+++ b/hyperspy/tests/drawing/test_plot_markers.py
@@ -570,8 +570,13 @@ def test_plot_add_background_windows():
 
 def test_iterate_markers():
     from skimage.feature import peak_local_max
-    import scipy.misc
-    ims = BaseSignal(scipy.misc.face()).as_signal2D([1, 2])
+    try:
+        # scipy <1.10
+        from scipy.misc import face
+    except:
+        # scipy >=1.10
+        from scipy.dataset import face
+    ims = BaseSignal(face()).as_signal2D([1, 2])
     index = np.array([peak_local_max(im.data, min_distance=100,
                                      num_peaks=4) for im in ims])
     # Add multiple markers

--- a/hyperspy/tests/drawing/test_plot_signal1d.py
+++ b/hyperspy/tests/drawing/test_plot_signal1d.py
@@ -23,7 +23,12 @@ from pathlib import Path
 import matplotlib.pyplot as plt
 import numpy as np
 import pytest
-import scipy.misc
+try:
+    # scipy <1.10
+    from scipy.misc import ascent, face
+except:
+    # scipy >=1.10
+    from scipy.dataset import ascent, face
 
 import hyperspy.api as hs
 from hyperspy.misc.test_utils import update_close_figure
@@ -87,7 +92,7 @@ def setup_teardown(request, scope="class"):
 @pytest.mark.usefixtures("setup_teardown")
 class TestPlotSpectra():
 
-    s = hs.signals.Signal1D(scipy.misc.ascent()[100:160:10])
+    s = hs.signals.Signal1D(ascent()[100:160:10])
 
     # Add a test signal with decreasing axis
     s_reverse = s.deepcopy()
@@ -148,7 +153,7 @@ class TestPlotSpectra():
     @pytest.mark.mpl_image_compare(baseline_dir=baseline_dir,
                                    tolerance=default_tol, style=style_pytest_mpl)
     def test_plot_spectra_sync(self, figure):
-        s1 = hs.signals.Signal1D(scipy.misc.face()).as_signal1D(0).inav[:, :3]
+        s1 = hs.signals.Signal1D(face()).as_signal1D(0).inav[:, :3]
         s2 = s1.deepcopy() * -1
         hs.plot.plot_signals([s1, s2])
         if figure == '1nav':

--- a/hyperspy/tests/drawing/test_plot_signal2d.py
+++ b/hyperspy/tests/drawing/test_plot_signal2d.py
@@ -21,6 +21,12 @@ import matplotlib.pyplot as plt
 import numpy as np
 import pytest
 import scipy.ndimage
+try:
+    # scipy <1.10
+    from scipy.misc import ascent, face
+except:
+    # scipy >=1.10
+    from scipy.dataset import ascent, face
 import traits.api as t
 
 import hyperspy.api as hs
@@ -37,7 +43,7 @@ def _generate_image_stack_signal():
     image = hs.signals.Signal2D(np.random.random((2, 3, 512, 512)))
     for i in range(2):
         for j in range(3):
-            image.data[i, j, :] = scipy.misc.ascent() * (i + 0.5 + j)
+            image.data[i, j, :] = ascent() * (i + 0.5 + j)
     axes = image.axes_manager
     axes[2].name = "x"
     axes[3].name = "y"
@@ -140,7 +146,7 @@ def test_plot_FFT(fft_shift):
     baseline_dir=baseline_dir, tolerance=default_tol, style=style_pytest_mpl)
 def test_plot_multiple_images_list(vmin, vmax):
     # load red channel of raccoon as an image
-    image0 = hs.signals.Signal2D(scipy.misc.face()[:, :, 0])
+    image0 = hs.signals.Signal2D(face()[:, :, 0])
     image0.metadata.General.title = 'Rocky Raccoon - R'
     axes0 = image0.axes_manager
     axes0[0].name = "x"
@@ -152,7 +158,7 @@ def test_plot_multiple_images_list(vmin, vmax):
     image1 = _generate_image_stack_signal()
 
     # load green channel of raccoon as an image
-    image2 = hs.signals.Signal2D(scipy.misc.face()[:, :, 1])
+    image2 = hs.signals.Signal2D(face()[:, :, 1])
     image2.metadata.General.title = 'Rocky Raccoon - G'
     axes2 = image2.axes_manager
     axes2[0].name = "x"
@@ -161,7 +167,7 @@ def test_plot_multiple_images_list(vmin, vmax):
     axes2[1].units = "mm"
 
     # load rgb imimagesage
-    rgb = hs.signals.Signal1D(scipy.misc.face())
+    rgb = hs.signals.Signal1D(face())
     rgb.change_dtype("rgb8")
     rgb.metadata.General.title = 'RGB'
     axesRGB = rgb.axes_manager
@@ -178,7 +184,7 @@ def test_plot_multiple_images_list(vmin, vmax):
     baseline_dir=baseline_dir, tolerance=default_tol, style=style_pytest_mpl)
 def test_plot_rgb_image():
     # load rgb imimagesage
-    rgb = hs.signals.Signal1D(scipy.misc.face())
+    rgb = hs.signals.Signal1D(face())
     rgb.change_dtype("rgb8")
     rgb.metadata.General.title = 'RGB'
     axesRGB = rgb.axes_manager
@@ -192,7 +198,7 @@ def test_plot_rgb_image():
 class _TestIteratedSignal:
 
     def __init__(self):
-        s = hs.signals.Signal2D([scipy.misc.ascent()] * 6)
+        s = hs.signals.Signal2D([ascent()] * 6)
         angles = hs.signals.BaseSignal(range(00, 60, 10))
         s.map(scipy.ndimage.rotate, angle=angles.T, reshape=False)
         # prevent values outside of integer range
@@ -229,8 +235,8 @@ class _TestIteratedSignal:
         return axes_manager
 
 
-class TestPlotNonLinearAxis:   
-    
+class TestPlotNonLinearAxis:
+
     def setup_method(self):
         dict0 = {'axis': np.arange(10)**0.5, 'name':'Non uniform 0', 'units':'A',
                  'navigate':True}
@@ -388,7 +394,7 @@ def test_plot_images_cmap_multi_w_rgb():
     test_plot2.signal *= 2  # change scale of second signal
     test_plot2.signal.metadata.General.title = 'Ascent-2'
 
-    rgb_sig = hs.signals.Signal1D(scipy.misc.face())
+    rgb_sig = hs.signals.Signal1D(face())
     rgb_sig.change_dtype('rgb8')
     rgb_sig.metadata.General.title = 'Racoon!'
 
@@ -661,7 +667,7 @@ def test_plot_images_overlay_figsize():
     hs.plot.plot_images([s, s], overlay=True, scalebar='all', axes_decor='off')
     f = plt.gcf()
     np.testing.assert_allclose((f.get_figwidth(), f.get_figheight()), (6.4, 3.2))
-    
+
     # aspect_ratio is 0.5
     s = hs.signals.Signal2D(np.random.random((20, 10)))
     hs.plot.plot_images([s, s], overlay=True, scalebar='all', axes_decor='off')
@@ -672,7 +678,7 @@ def test_plot_images_overlay_figsize():
 def test_plot_images_overlay_vmin_warning(caplog):
     s = hs.signals.Signal2D(np.arange(100).reshape(10, 10))
     with caplog.at_level(logging.WARNING):
-        hs.plot.plot_images([s, s], overlay=True, vmin=0)  
+        hs.plot.plot_images([s, s], overlay=True, vmin=0)
 
     assert "`vmin` is ignored when overlaying images." in caplog.text
 

--- a/hyperspy/tests/misc/test_tv_denoise.py
+++ b/hyperspy/tests/misc/test_tv_denoise.py
@@ -16,10 +16,13 @@
 # You should have received a copy of the GNU General Public License
 # along with HyperSpy. If not, see <https://www.gnu.org/licenses/#GPL>.
 
+from packaging.version import Version
+
 import numpy as np
 import pytest
+import skimage
+
 from hyperspy.misc.tv_denoise import tv_denoise
-from scipy.misc import ascent
 
 
 def test_tv_denoise_error():
@@ -27,17 +30,19 @@ def test_tv_denoise_error():
         _ = tv_denoise(np.array([1, 2, 3]))
 
 
+@pytest.mark.skipif(Version(skimage.__version__) < Version("0.18"),
+                   reason="This test requires scikit-image >= 0.18")
 def test_2d_tv_denoise():
     rng = np.random.RandomState(123)
-    data = ascent().astype(float)
+    data = skimage.data.camera().astype(float)
     data_noisy = data + data.std() * rng.randn(*data.shape)
     data_clean = tv_denoise(data, weight=60)
 
     norm_noisy = np.linalg.norm(data - data_noisy) / np.linalg.norm(data)
     norm_clean = np.linalg.norm(data - data_clean) / np.linalg.norm(data)
 
-    np.testing.assert_allclose(norm_noisy, 0.48604971)
-    np.testing.assert_allclose(norm_clean, 0.10888393)
+    np.testing.assert_allclose(norm_noisy, 0.49466990)
+    np.testing.assert_allclose(norm_clean, 0.06453270)
 
 
 def test_3d_tv_denoise():

--- a/hyperspy/tests/signals/test_2D_tools.py
+++ b/hyperspy/tests/signals/test_2D_tools.py
@@ -20,7 +20,12 @@ from unittest import mock
 import numpy as np
 import numpy.testing as npt
 import pytest
-from scipy.misc import ascent, face
+try:
+    # scipy <1.10
+    from scipy.misc import ascent, face
+except:
+    # scipy >=1.10
+    from scipy.dataset import ascent, face
 from scipy.ndimage import fourier_shift
 
 import hyperspy.api as hs

--- a/hyperspy/utils/markers.py
+++ b/hyperspy/utils/markers.py
@@ -21,8 +21,8 @@
 Example
 -------
 
->>> import scipy.misc
->>> im = hs.signals.Signal2D(scipy.misc.ascent())
+>>> import skimage
+>>> im = hs.signals.Signal2D(skimage.data.camera()
 >>> m = hs.plot.markers.rectangle(x1=150, y1=100, x2=400, y2=400, color='red')
 >>> im.add_marker(m)
 

--- a/upcoming_changes/3032.maintenance.rst
+++ b/upcoming_changes/3032.maintenance.rst
@@ -1,0 +1,1 @@
+Fix deprecated import of scipy ``ascent`` in docstrings and the test suite


### PR DESCRIPTION
Fix for a API change in the development version of scipy - see https://scipy.github.io/devdocs/reference/generated/scipy.misc.face.html

This only concerns docstring and test. Docstring, the deprecated `scipy.misc.ascent` is replaced by `skimage.data.camera`, so that the docstring works will all version of all version of scipy without having to use a `try`/`except` import block.

From https://github.com/hyperspy/hyperspy-extensions-list/actions/runs/3116825006

```python
gw0 I / gw1 I
============================= test session starts ==============================
platform linux -- Python 3.10.6, pytest-7.1.3, pluggy-1.0.0
rootdir: /home/runner/work/hyperspy-extensions-list/hyperspy-extensions-list
plugins: rerunfailures-10.2, xdist-2.5.0, instafail-0.4.2, forked-1.4.0
_____________ ERROR collecting tests/drawing/test_plot_signal1d.py _____________
/usr/share/miniconda3/lib/python3.10/site-packages/hyperspy/tests/drawing/test_plot_signal1d.py:88: in <module>
    class TestPlotSpectra():
/usr/share/miniconda3/lib/python3.10/site-packages/hyperspy/tests/drawing/test_plot_signal1d.py:90: in TestPlotSpectra
    s = hs.signals.Signal1D(scipy.misc.ascent()[100:160:10])
/usr/share/miniconda3/lib/python3.10/site-packages/scipy/_lib/deprecation.py:18: in call
    warnings.warn(msg, category=DeprecationWarning,
E   DeprecationWarning: scipy.misc.ascent has been deprecated in SciPy v1.10.0; and will be completely removed in SciPy v1.[12](https://github.com/ericpre/hyperspy-extensions-list/actions/runs/3118194936/jobs/5057318644#step:13:13).0. Dataset methods have moved into the scipy.datasets module. Use scipy.datasets.ascent instead.
_____________ ERROR collecting tests/drawing/test_plot_signal1d.py _____________
/usr/share/miniconda3/lib/python3.10/site-packages/hyperspy/tests/drawing/test_plot_signal1d.py:88: in <module>
    class TestPlotSpectra():
/usr/share/miniconda3/lib/python3.10/site-packages/hyperspy/tests/drawing/test_plot_signal1d.py:90: in TestPlotSpectra
    s = hs.signals.Signal1D(scipy.misc.ascent()[100:[16](https://github.com/ericpre/hyperspy-extensions-list/actions/runs/3118194936/jobs/5057318644#step:13:17)0:10])
/usr/share/miniconda3/lib/python3.10/site-packages/scipy/_lib/deprecation.py:[18](https://github.com/ericpre/hyperspy-extensions-list/actions/runs/3118194936/jobs/5057318644#step:13:19): in call
    warnings.warn(msg, category=DeprecationWarning,
E   DeprecationWarning: scipy.misc.ascent has been deprecated in SciPy v1.10.0; and will be completely removed in SciPy v1.12.0. Dataset methods have moved into the scipy.datasets module. Use scipy.datasets.ascent instead.
```

### Progress of the PR
- [x] Replace deprecated `scipy.misc.ascent` by `skimage.data.camera` in docstring,
- [x] Use `try`/`except` import block to support various version of scipy
- [x] update docstring (if appropriate),
- [n/a] update user guide (if appropriate),
- [x] add an changelog entry in the `upcoming_changes` folder (see [`upcoming_changes/README.rst`](https://github.com/hyperspy/hyperspy/blob/RELEASE_next_minor/upcoming_changes/README.rst)),
- [x] Check formatting changelog entry in the `readthedocs` doc build of this PR (link in github checks)
- [n/a] add tests,
- [x] ready for review.


