### PR TITLE
Fix error handling when trying to convert a ragged signal to non-ragged

### DIFF
--- a/hyperspy/signal.py
+++ b/hyperspy/signal.py
@@ -2507,7 +2507,7 @@ class BaseSignal(FancySlicing,
                     # and in the future, it will raise an error
                     data = np.array(self.data.tolist())
             except:
-                _logger.error(error)
+                raise ValueError(error)
 
             if data.dtype == object:
                 raise ValueError(error)

--- a/upcoming_changes/3033.maintenance..rst
+++ b/upcoming_changes/3033.maintenance..rst
@@ -1,0 +1,1 @@
+Fix error handling when trying to convert a ragged signal to non-ragged for numpy >=1.24


### PR DESCRIPTION
From https://github.com/hyperspy/hyperspy-extensions-list/actions/runs/3118835797/jobs/5058399926:

```python
___________________________ test_create_ragged_array ___________________________
[gw1] linux -- Python 3.10.6 /usr/share/miniconda3/bin/python

    def test_create_ragged_array():
        data = np.array([[0, 1], [2, 3, 4]], dtype=object)
        s = hs.signals.BaseSignal(data, ragged=True)
        assert s.axes_manager.ragged
    
        with pytest.raises(ValueError):
>           s.ragged = False

/usr/share/miniconda3/lib/python3.10/site-packages/hyperspy/tests/signals/test_ragged_signal.py:[101](https://github.com/hyperspy/hyperspy-extensions-list/actions/runs/3118835797/jobs/5058399926#step:13:102): 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

self = <BaseSignal, title: , dimensions: (2|ragged)>, value = False

    @ragged.setter
    def ragged(self, value):
        # nothing needs to be done!
        if self.ragged == value:
            return
    
        if value:
            if self.data.dtype != object:
                raise ValueError("The array is not ragged.")
            axes = [axis for axis in self.axes_manager.signal_axes
                    if axis.index_in_array not in list(range(self.data.ndim))]
            self.axes_manager.remove(axes)
            self.axes_manager._set_signal_dimension(0)
        else:
            if self._lazy:
                raise NotImplementedError(
                    "Conversion of a lazy ragged signal to its non-ragged "
                    "counterpart is not supported. Make the required "
                    "non-ragged dask array manually and make a new lazy "
                    "signal."
                    )
    
            error = "The signal can't be converted to a non-ragged signal."
            try:
                # Check that we can actually make a non-ragged array
                with warnings.catch_warnings():
                    warnings.simplefilter("ignore")
                    # As of numpy 1.20, it raises a VisibleDeprecationWarning
                    # and in the future, it will raise an error
                    data = np.array(self.data.tolist())
            except:
                _logger.error(error)
    
>           if data.dtype == object:
E           UnboundLocalError: local variable 'data' referenced before assignment

/usr/share/miniconda3/lib/python3.10/site-packages/hyperspy/signal.py:2512: UnboundLocalError
------------------------------ Captured log call -------------------------------
ERROR    hyperspy.signal:signal.py:2510 The signal can't be converted to a non-ragged signal.
```


### Progress of the PR
- [x] Fix error handling,
- [n/a] update docstring (if appropriate),
- [n/a] update user guide (if appropriate),
- [x] add an changelog entry in the `upcoming_changes` folder (see [`upcoming_changes/README.rst`](https://github.com/hyperspy/hyperspy/blob/RELEASE_next_minor/upcoming_changes/README.rst)),
- [x] Check formatting changelog entry in the `readthedocs` doc build of this PR (link in github checks)
- [n/a] add tests,
- [x] ready for review.
