### PR TITLE
Fix test extension workflow

### DIFF
--- a/.github/workflows/tests_extension.yml
+++ b/.github/workflows/tests_extension.yml
@@ -53,6 +53,7 @@ jobs:
 
       - name: Install HyperSpy
         run: |
+          pip install https://github.com/hyperspy/rosettasciio/archive/refs/heads/main.zip
           pip install .
 
       - name: Install Extension Dev

--- a/.github/workflows/tests_extension.yml
+++ b/.github/workflows/tests_extension.yml
@@ -91,10 +91,7 @@ jobs:
         run: |
           python -m pytest --pyargs pyxem
 
-      #  The currently released version of Atomap (0.3.1) does not work with this test
-      #  environment. Thus, only the dev version is currently tested. If a newer version
-      #  of Atomap is released, the "if" can be changed to always().
       - name: Run atomap Test Suite
-        if: contains(matrix.EXTENSION_VERSION, 'dev')
+        if: ${{ always() }}
         run: |
           python -m pytest --pyargs atomap

--- a/.github/workflows/tests_extension.yml
+++ b/.github/workflows/tests_extension.yml
@@ -69,6 +69,11 @@ jobs:
           # required for running kikuchipy test suite
           sudo apt-get install xvfb
 
+      - name: Run RosettaSciIO Test Suite
+        if: ${{ always() }}
+        run: |
+          python -m pytest --pyargs rsciio
+
       - name: Run Kikuchipy Test Suite
         if: ${{ always() }}
         run: |


### PR DESCRIPTION
Update to the `test_extension` workflow to install RosettaSciIO until it is released.

