### PR TITLE
Change order import to avoid deprecation warning

### DIFF
--- a/hyperspy/tests/drawing/test_plot_signal1d.py
+++ b/hyperspy/tests/drawing/test_plot_signal1d.py
@@ -24,11 +24,11 @@ import matplotlib.pyplot as plt
 import numpy as np
 import pytest
 try:
-    # scipy <1.10
-    from scipy.misc import ascent, face
-except:
     # scipy >=1.10
     from scipy.dataset import ascent, face
+except ImportError:
+    # scipy <1.10
+    from scipy.misc import ascent, face
 
 import hyperspy.api as hs
 from hyperspy.misc.test_utils import update_close_figure

--- a/hyperspy/tests/drawing/test_plot_signal2d.py
+++ b/hyperspy/tests/drawing/test_plot_signal2d.py
@@ -22,11 +22,11 @@ import numpy as np
 import pytest
 import scipy.ndimage
 try:
-    # scipy <1.10
-    from scipy.misc import ascent, face
-except:
     # scipy >=1.10
     from scipy.dataset import ascent, face
+except ImportError:
+    # scipy <1.10
+    from scipy.misc import ascent, face
 import traits.api as t
 
 import hyperspy.api as hs

--- a/hyperspy/tests/signals/test_2D_tools.py
+++ b/hyperspy/tests/signals/test_2D_tools.py
@@ -21,11 +21,11 @@ import numpy as np
 import numpy.testing as npt
 import pytest
 try:
-    # scipy <1.10
-    from scipy.misc import ascent, face
-except:
     # scipy >=1.10
     from scipy.dataset import ascent, face
+except ImportError:
+    # scipy <1.10
+    from scipy.misc import ascent, face
 from scipy.ndimage import fourier_shift
 
 import hyperspy.api as hs


### PR DESCRIPTION
Follow up of https://github.com/hyperspy/hyperspy/pull/3032: to avoid the deprecation warning, we need to try first the new import instead of the old one!

