### PR TITLE
Deprecation removal

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -52,7 +52,7 @@ migration of the IO plugins to `RosettaSciIO
 Machine Learning
 ----------------
 
-- The ``polyfit`` keyword argument has been removed. uUse ``var_func`` instead.
+- The ``polyfit`` keyword argument has been removed. Use ``var_func`` instead.
 - The list of possible values for the ``algorithm`` argument of the :py:meth:`~.learn.mva.MVA.decomposition` method
   has been changed according to the following table:
 
@@ -175,7 +175,7 @@ Signal
   followed by :py:meth:`~.signal.BaseSignal.integrate1D` instead.
 - The ``progressbar`` keyword argument of the :py:meth:`~._signals.lazy.LazySignal.compute` method
   has been removed, use ``show_progressbar`` instead.
-- The deprecated ``comp_label`` argument of the :py:meth:`~.signal.MVATools.plot_decomposition_loadings`,
+- The deprecated ``comp_label`` argument of the methods :py:meth:`~.signal.MVATools.plot_decomposition_loadings`,
   :py:meth:`~.signal.MVATools.plot_decomposition_factors`, :py:meth:`~.signal.MVATools.plot_bss_loadings`,
   :py:meth:`~.signal.MVATools.plot_bss_factors`, :py:meth:`~.signal.MVATools.plot_clusters_distances`, 
   :py:meth:`~.signal.MVATools.plot_cluster_labels` has been removed, use the ``title`` argument instead.

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -53,7 +53,7 @@ Machine Learning
 ----------------
 
 - The ``polyfit`` keyword argument has been removed. uUse ``var_func`` instead.
-- The list of possible values for the ``algorithm`` argument of the :py:meth:`~.learn.mva.decomposition` method
+- The list of possible values for the ``algorithm`` argument of the :py:meth:`~.learn.mva.MVA.decomposition` method
   has been changed according to the following table:
 
   .. list-table:: Change of the ``algorithm`` argument
@@ -77,7 +77,7 @@ Machine Learning
 
 - The argument ``learning_rate`` of the ``ORPCA`` algorithm has been renamed to ``subspace_learning_rate``.
 - The argument ``momentum`` of the ``ORPCA`` algorithm has been renamed to ``subspace_momentum``.
-- The list of possible values for the ``centre`` keyword argument of the :py:meth:`~.learn.mva.decomposition` method
+- The list of possible values for the ``centre`` keyword argument of the :py:meth:`~.learn.mva.MVA.decomposition` method
   when using the ``SVD`` algorithm has been changed according to the following table:
 
   .. list-table:: Change of the ``centre`` argument
@@ -91,7 +91,7 @@ Machine Learning
      * - variables
        - signal
 - For lazy signals, a possible value of the ``algorithm`` keyword argument of the
-  :py:meth:`~._signals.lazy.decomposition` method has been changed
+  :py:meth:`~._signals.lazy.LazySignal.decomposition` method has been changed
   from ``"ONMF"`` to ``"ORNMF"``.
 - Setting the ``metadata`` and ``original_metadata`` attribute of signals is removed, use
   the :py:meth:`~.misc.utils.DictionaryTreeBrowser.set_item` and
@@ -151,6 +151,8 @@ Model fitting
   :py:meth:`~.misc.utils.DictionaryTreeBrowser.add_dictionary` methods of the
   ``metadata`` attribute instead.
 
+- The deprecated ``twin_function`` and ``twin_inverse_function`` have been privatized.
+
 Signal
 ------
 - ``metadata.Signal.binned`` is removed, use the ``is_binned`` axis attribute
@@ -169,10 +171,18 @@ Signal
      * - freedman
        - fd
 
-- The ``integrate_in_range`` method is removed, use :py:class:`~.roi.SpanRoi`
+- The ``integrate_in_range`` method is removed, use :py:class:`~.roi.SpanROI`
   followed by :py:meth:`~.signal.BaseSignal.integrate1D` instead.
-- The ``progressbar`` keyword argument of the :py:meth:`~._signals.lazy.compute` method
+- The ``progressbar`` keyword argument of the :py:meth:`~._signals.lazy.LazySignal.compute` method
   has been removed, use ``show_progressbar`` instead.
+- The deprecated ``comp_label`` argument of the :py:meth:`~.signal.MVATools.plot_decomposition_loadings`,
+  :py:meth:`~.signal.MVATools.plot_decomposition_factors`, :py:meth:`~.signal.MVATools.plot_bss_loadings`,
+  :py:meth:`~.signal.MVATools.plot_bss_factors`, :py:meth:`~.signal.MVATools.plot_clusters_distances`, 
+  :py:meth:`~.signal.MVATools.plot_cluster_labels` has been removed, use the ``title`` argument instead.
+- The :py:meth:`~.signal.BaseSignal.set_signal_type` now raises an error when passing
+  ``None`` to the ``signal_type`` argument. Use ``signal_type=""`` instead.
+- Passing an "iterating over navigation argument" to the :py:meth:`~.signal.BaseSignal.map`
+  method is removed, pass a HyperSpy signal with suitable navigation and signal shape instead.  
 
 Preferences
 -----------

--- a/hyperspy/component.py
+++ b/hyperspy/component.py
@@ -125,7 +125,7 @@ class Parameter(t.HasTraits):
     _twin_function_expr = ""
     _twin_inverse_function_expr = ""
     _twin_function = None
-    # The inverse function is store in one of the two following attribute
+    # The inverse function is stored in one of the two following attributes
     # depending on whether it was set manually or calculated with sympy
     __twin_inverse_function = None
     _twin_inverse_sympy = None
@@ -244,7 +244,7 @@ class Parameter(t.HasTraits):
                 _logger.warning(
                     f"The function {value} is not invertible. Setting the "
                     f"value of {self} will raise an AttributeError unless "
-                    "you set manually ``twin_inverse_function_expr``. "
+                    "you manually set ``twin_inverse_function_expr``. "
                     "Otherwise, set the value of its twin parameter instead."
                     )
 

--- a/hyperspy/component.py
+++ b/hyperspy/component.py
@@ -125,6 +125,8 @@ class Parameter(t.HasTraits):
     _twin_function_expr = ""
     _twin_inverse_function_expr = ""
     _twin_function = None
+    # The inverse function is store in one of the two following attribute
+    # depending on whether it was set manually or calculated with sympy
     __twin_inverse_function = None
     _twin_inverse_sympy = None
 
@@ -225,8 +227,7 @@ class Parameter(t.HasTraits):
         if len(expr.free_symbols) > 1:
             raise ValueError("The expression must contain only one variable.")
         elif len(expr.free_symbols) == 0:
-            raise ValueError("The expression must contain one variable, "
-                             "it contains none.")
+            raise ValueError("The expression must contain one variable.")
         x = tuple(expr.free_symbols)[0]
         self._twin_function = lambdify(x, expr.evalf())
         self._twin_function_expr = value
@@ -241,10 +242,11 @@ class Parameter(t.HasTraits):
                 self.__twin_inverse_function = None
                 self._twin_inverse_sympy = None
                 _logger.warning(
-                    "The function {} is not invertible. Setting the value of "
-                    "{} will raise an AttributeError unless you set manually "
-                    "``twin_inverse_function_expr``. Otherwise, set the "
-                    "value of its twin parameter instead.".format(value, self))
+                    f"The function {value} is not invertible. Setting the "
+                    f"value of {self} will raise an AttributeError unless "
+                    "you set manually ``twin_inverse_function_expr``. "
+                    "Otherwise, set the value of its twin parameter instead."
+                    )
 
     @property
     def twin_inverse_function_expr(self):
@@ -271,8 +273,8 @@ class Parameter(t.HasTraits):
 
     @property
     def _twin_inverse_function(self):
-        if (not self.twin_inverse_function_expr and
-                self.twin_function_expr and self._twin_inverse_sympy):
+        if (self.twin_function_expr and self._twin_inverse_sympy and
+                not self.twin_inverse_function_expr):
             return lambda x: self._twin_inverse_sympy(x).pop()
         else:
             return self.__twin_inverse_function

--- a/hyperspy/component.py
+++ b/hyperspy/component.py
@@ -132,7 +132,7 @@ class Parameter(t.HasTraits):
     bmax = t.Property(NoneFloat(), label="Upper bounds")
     _twin_function_expr = ""
     _twin_inverse_function_expr = ""
-    twin_function = None
+    _twin_function = None
     _twin_inverse_function = None
     _twin_inverse_sympy = None
 
@@ -224,7 +224,7 @@ class Parameter(t.HasTraits):
     @twin_function_expr.setter
     def twin_function_expr(self, value):
         if not value:
-            self.twin_function = None
+            self._twin_function = None
             self.twin_inverse_function = None
             self._twin_function_expr = ""
             self._twin_inverse_sympy = None
@@ -236,7 +236,7 @@ class Parameter(t.HasTraits):
             raise ValueError("The expression must contain one variable, "
                              "it contains none.")
         x = tuple(expr.free_symbols)[0]
-        self.twin_function = lambdify(x, expr.evalf())
+        self._twin_function = lambdify(x, expr.evalf())
         self._twin_function_expr = value
         if not self.twin_inverse_function:
             y = sympy.Symbol(x.name + "2")
@@ -293,8 +293,8 @@ class Parameter(t.HasTraits):
         if self.twin is None:
             return self.__value
         else:
-            if self.twin_function:
-                return self.twin_function(self.twin.value)
+            if self._twin_function:
+                return self._twin_function(self.twin.value)
             else:
                 return self.twin.value
 
@@ -318,7 +318,7 @@ class Parameter(t.HasTraits):
         old_value = self.__value
 
         if self.twin is not None:
-            if self.twin_function is not None:
+            if self._twin_function is not None:
                 if self.twin_inverse_function is not None:
                     self.twin.value = self.twin_inverse_function(value)
                     return

--- a/hyperspy/signal.py
+++ b/hyperspy/signal.py
@@ -873,7 +873,7 @@ class MVATools(object):
             not scaled. Default is ``True``.
         title : str
             Title of the matplotlib plot or label of the line in the legend
-            when the factors dimension is 1 and ``same_window`` is ``True``.
+            when the dimension of factors is 1 and ``same_window`` is ``True``.
         cmap : :py:class:`~matplotlib.colors.Colormap`
             The colormap used for the factor images, or for peak
             characteristics. Default is the matplotlib gray colormap
@@ -950,7 +950,7 @@ class MVATools(object):
             not scaled. Default is ``True``.
         title : str
             Title of the matplotlib plot or label of the line in the legend
-            when the factors dimension is 1 and ``same_window`` is ``True``.
+            when the dimension of factors is 1 and ``same_window`` is ``True``.
         cmap : :py:class:`~matplotlib.colors.Colormap`
             The colormap used for the factor images, or for peak
             characteristics. Default is the matplotlib gray colormap
@@ -1023,7 +1023,7 @@ class MVATools(object):
             not scaled. Default is ``True``.
         title : str
             Title of the matplotlib plot or label of the line in the legend
-            when the loadings dimension is 1 and ``same_window`` is ``True``.
+            when the dimension of loadings is 1 and ``same_window`` is ``True``.
         with_factors : bool
             If ``True``, also returns figure(s) with the factors for the
             given comp_ids.
@@ -1125,7 +1125,7 @@ class MVATools(object):
             not scaled. Default is ``True``.
         title : str
             Title of the matplotlib plot or label of the line in the legend
-            when the loading dimension is 1 and ``same_window`` is ``True``.
+            when the dimension of loadings is 1 and ``same_window`` is ``True``.
         with_factors : bool
             If `True`, also returns figure(s) with the factors for the
             given `comp_ids`.
@@ -1877,7 +1877,7 @@ class MVATools(object):
             not scaled.
         title : str
             Title of the matplotlib plot or label of the line in the legend
-            when the loadings dimension is 1 and ``same_window`` is ``True``.
+            when the dimension of loadings is 1 and ``same_window`` is ``True``.
         per_row : int
             the number of plots in each row, when the same_window parameter is
             True.
@@ -1945,7 +1945,7 @@ class MVATools(object):
             not scaled. Default is True.
         title : str
             Title of the matplotlib plot or label of the line in the legend
-            when the labels dimension is 1 and ``same_window`` is ``True``.
+            when the dimension of labels is 1 and ``same_window`` is ``True``.
         with_centers : bool
             If True, also returns figure(s) with the cluster centers for the
             given cluster_ids.
@@ -2017,7 +2017,7 @@ class MVATools(object):
         """Plot the euclidian distances to the centroid of each cluster.
 
         In case of 1D navigation axis, each line can be toggled on and
-        off by clicking on the legended line.
+        off by clicking on the corresponding line in the legend.
 
         Parameters
         ----------
@@ -2037,7 +2037,7 @@ class MVATools(object):
             not scaled. Default is True.
         title : str
             Title of the matplotlib plot or label of the line in the legend
-            when the distance dimension is 1 and ``same_window`` is ``True``.
+            when the dimension of distance is 1 and ``same_window`` is ``True``.
         with_centers : bool
             If True, also returns figure(s) with the cluster centers for the
             given cluster_ids.
@@ -2300,7 +2300,7 @@ class BaseSignal(FancySlicing,
         return string
 
     def _binary_operator_ruler(self, other, op_name):
-        exception_message = ("Invalid dimensions for this operation")
+        exception_message = ("Invalid dimensions for this operation.")
         if isinstance(other, BaseSignal):
             # Both objects are signals
             oam = other.axes_manager

--- a/hyperspy/signal.py
+++ b/hyperspy/signal.py
@@ -872,7 +872,8 @@ class MVATools(object):
             If ``True``, plots each factor to the same window.  They are
             not scaled. Default is ``True``.
         title : str
-            Title of the plot.
+            Title of the matplotlib plot or label of the line in the legend
+            when the factors dimension is 1 and ``same_window`` is ``True``.
         cmap : :py:class:`~matplotlib.colors.Colormap`
             The colormap used for the factor images, or for peak
             characteristics. Default is the matplotlib gray colormap
@@ -905,9 +906,7 @@ class MVATools(object):
             else:
                 raise ValueError(
                     "Please provide the number of components to plot via the "
-                    "`comp_ids` argument")
-        comp_label = kwargs.get("comp_label", None)
-        title = _change_API_comp_label(title, comp_label)
+                    "`comp_ids` argument.")
         if title is None:
             title = self._get_plot_title('Decomposition factors of',
                                          same_window=same_window)
@@ -950,7 +949,8 @@ class MVATools(object):
             if ``True``, plots each factor to the same window.  They are
             not scaled. Default is ``True``.
         title : str
-            Title of the plot.
+            Title of the matplotlib plot or label of the line in the legend
+            when the factors dimension is 1 and ``same_window`` is ``True``.
         cmap : :py:class:`~matplotlib.colors.Colormap`
             The colormap used for the factor images, or for peak
             characteristics. Default is the matplotlib gray colormap
@@ -977,8 +977,6 @@ class MVATools(object):
         if same_window is None:
             same_window = True
         factors = self.learning_results.bss_factors
-        comp_label = kwargs.get("comp_label", None)
-        title = _change_API_comp_label(title, comp_label)
         if title is None:
             title = self._get_plot_title('BSS factors of',
                                          same_window=same_window)
@@ -1024,7 +1022,8 @@ class MVATools(object):
             if ``True``, plots each factor to the same window. They are
             not scaled. Default is ``True``.
         title : str
-            Title of the plot.
+            Title of the matplotlib plot or label of the line in the legend
+            when the loadings dimension is 1 and ``same_window`` is ``True``.
         with_factors : bool
             If ``True``, also returns figure(s) with the factors for the
             given comp_ids.
@@ -1125,10 +1124,9 @@ class MVATools(object):
         same_window : bool
             If ``True``, plots each factor to the same window. They are
             not scaled. Default is ``True``.
-        comp_label : str
-            Will be deprecated in 2.0, please use `title` instead
         title : str
-            Title of the plot.
+            Title of the matplotlib plot or label of the line in the legend
+            when the loading dimension is 1 and ``same_window`` is ``True``.
         with_factors : bool
             If `True`, also returns figure(s) with the factors for the
             given `comp_ids`.
@@ -1166,8 +1164,6 @@ class MVATools(object):
                                "performed first.")
         if same_window is None:
             same_window = True
-        comp_label = kwargs.get("comp_label", None)
-        title = _change_API_comp_label(title, comp_label)
         if title is None:
             title = self._get_plot_title(
                 'BSS loadings of', same_window=same_window)
@@ -1861,7 +1857,7 @@ class MVATools(object):
         cluster_ids=None,
         calibrate=True,
         same_window=True,
-        comp_label="Cluster centers",
+        title=None,
         per_row=3):
         """Plot centers from a cluster analysis.
 
@@ -1880,10 +1876,9 @@ class MVATools(object):
         same_window : bool
             if True, plots each center to the same window.  They are
             not scaled.
-        comp_label : string
-            the label that is either the plot title (if plotting in
-            separate windows) or the label in the legend (if plotting
-            in the same window)
+        title : str
+            Title of the matplotlib plot or label of the line in the legend
+            when the loadings dimension is 1 and ``same_window`` is ``True``.
         per_row : int
             the number of plots in each row, when the same_window parameter is
             True.
@@ -1900,14 +1895,19 @@ class MVATools(object):
         if same_window is None:
             same_window = True
         factors = cs.T
+
         if cluster_ids is None:
             cluster_ids = range(factors.shape[1])
+
+        if title is None:
+            title = self._get_plot_title(
+                'Cluster centers of', same_window=same_window)
 
         return self._plot_factors_or_pchars(factors,
                                             comp_ids=cluster_ids,
                                             calibrate=calibrate,
                                             same_window=same_window,
-                                            comp_label=comp_label,
+                                            comp_label=title,
                                             per_row=per_row)
     plot_cluster_signals.__doc__ %= (CLUSTER_SIGNALS_ARG)
 
@@ -1944,8 +1944,9 @@ class MVATools(object):
         same_window : bool
             if True, plots each factor to the same window.  They are
             not scaled. Default is True.
-        title : string
-            Title of the plot.
+        title : str
+            Title of the matplotlib plot or label of the line in the legend
+            when the labels dimension is 1 and ``same_window`` is ``True``.
         with_centers : bool
             If True, also returns figure(s) with the cluster centers for the
             given cluster_ids.
@@ -1986,8 +1987,6 @@ class MVATools(object):
         if cluster_ids is None:
             cluster_ids = range(labels.shape[0])
 
-        comp_label = kwargs.get("comp_label", None)
-        title = _change_API_comp_label(title, comp_label)
         if title is None:
             title = self._get_plot_title(
                 'Cluster labels of', same_window=same_window)
@@ -2018,9 +2017,8 @@ class MVATools(object):
         **kwargs):
         """Plot the euclidian distances to the centroid of each cluster.
 
-        In case of 1D navigation axis,
-        each line can be toggled on and off by clicking on the legended
-        line.
+        In case of 1D navigation axis, each line can be toggled on and
+        off by clicking on the legended line.
 
         Parameters
         ----------
@@ -2038,8 +2036,9 @@ class MVATools(object):
         same_window : bool
             if True, plots each factor to the same window.  They are
             not scaled. Default is True.
-        title : string
-            Title of the plot.
+        title : str
+            Title of the matplotlib plot or label of the line in the legend
+            when the distance dimension is 1 and ``same_window`` is ``True``.
         with_centers : bool
             If True, also returns figure(s) with the cluster centers for the
             given cluster_ids.
@@ -2165,21 +2164,6 @@ def _plot_x_results(factors, loadings, factors_navigator, loadings_navigator,
         factors_navigator = "auto"
     loadings.plot(navigator=loadings_navigator)
     factors.plot(navigator=factors_navigator)
-
-
-def _change_API_comp_label(title, comp_label):
-    if comp_label is not None:
-        if title is None:
-            title = comp_label
-            warnings.warn("The 'comp_label' argument will be deprecated "
-                          "in 2.0, please use 'title' instead",
-                          VisibleDeprecationWarning)
-        else:
-            warnings.warn("The 'comp_label' argument will be deprecated "
-                          "in 2.0, Since you are already using the 'title'",
-                          "argument, 'comp_label' is ignored.",
-                          VisibleDeprecationWarning)
-    return title
 
 
 class SpecialSlicersSignal(SpecialSlicers):

--- a/hyperspy/signal.py
+++ b/hyperspy/signal.py
@@ -2511,16 +2511,6 @@ class BaseSignal(FancySlicing,
         """The original metadata of the signal."""
         return self._original_metadata
 
-    @original_metadata.setter
-    def original_metadata(self, d):
-        warnings.warn(
-            "Setting the `original_metadata` attribute is deprecated and will be removed "
-            "removed in HyperSpy 2.0. Use the `set_item` and `add_dictionary` "
-            "methods of the `original_metadata` attribute instead.")
-        if isinstance(d, dict):
-            d = DictionaryTreeBrowser(d)
-        self._original_metadata = d
-
     @property
     def ragged(self):
         return self.axes_manager._ragged

--- a/hyperspy/tests/model/test_model_as_dictionary.py
+++ b/hyperspy/tests/model/test_model_as_dictionary.py
@@ -102,8 +102,8 @@ class TestParameterDictionary:
 
         rn = np.random.random()
         np.testing.assert_equal(
-            p.twin_function(rn),
-            self.par.twin_function(rn))
+            p._twin_function(rn),
+            self.par._twin_function(rn))
         np.testing.assert_equal(
             p.twin_inverse_function(rn),
             self.par.twin_inverse_function(rn))

--- a/hyperspy/tests/model/test_model_as_dictionary.py
+++ b/hyperspy/tests/model/test_model_as_dictionary.py
@@ -105,8 +105,8 @@ class TestParameterDictionary:
             p._twin_function(rn),
             self.par._twin_function(rn))
         np.testing.assert_equal(
-            p.twin_inverse_function(rn),
-            self.par.twin_inverse_function(rn))
+            p._twin_inverse_function(rn),
+            self.par._twin_inverse_function(rn))
 
     def test_invalid_name(self):
         d = self.par.as_dictionary()
@@ -166,10 +166,10 @@ class TestComponentDictionary:
 
         for pn, pc in zip(n.parameters, c.parameters):
             rn = np.random.random()
-            assert pn.twin_function(rn) == pc.twin_function(rn)
+            assert pn._twin_function(rn) == pc._twin_function(rn)
             assert (
-                pn.twin_inverse_function(rn) ==
-                pc.twin_inverse_function(rn))
+                pn._twin_inverse_function(rn) ==
+                pc._twin_inverse_function(rn))
             dn = pn.as_dictionary()
             del dn['self']
             dc = pc.as_dictionary()

--- a/hyperspy/tests/model/test_parameter.py
+++ b/hyperspy/tests/model/test_parameter.py
@@ -265,7 +265,7 @@ class TestParameterTwin:
         assert self.p2.value == self.p2.bmax
 
     def test_twin_function(self):
-        self.p2.twin_function = lambda x: x + 2
+        self.p2._twin_function = lambda x: x + 2
         self.p2.twin_inverse_function = lambda x: x - 2
         self.p2.twin = self.p1
         assert self.p1.value == self.p2.value - 2

--- a/hyperspy/tests/model/test_parameter.py
+++ b/hyperspy/tests/model/test_parameter.py
@@ -265,8 +265,8 @@ class TestParameterTwin:
         assert self.p2.value == self.p2.bmax
 
     def test_twin_function(self):
-        self.p2._twin_function = lambda x: x + 2
-        self.p2.twin_inverse_function = lambda x: x - 2
+        self.p2.twin_function_expr = "x + 2"
+        self.p2.twin_inverse_function_expr = "x - 2"
         self.p2.twin = self.p1
         assert self.p1.value == self.p2.value - 2
         self.p2.value = 10

--- a/hyperspy/tests/signals/test_assign_subclass.py
+++ b/hyperspy/tests/signals/test_assign_subclass.py
@@ -165,11 +165,8 @@ class TestConvertSignal1D:
         self.s.set_signal_type("")
         assert isinstance(self.s, hs.signals.Signal1D)
 
-    def test_deprecated(self):
-        with pytest.warns(
-            VisibleDeprecationWarning,
-            match=r"is deprecated. Use ",
-        ):
+    def test_error_None(self):
+        with pytest.raises(TypeError):
             self.s.set_signal_type(None)
 
 


### PR DESCRIPTION
### Progress of the PR
- [x] Remove setting `original_metadata` - leftover or incorrect rebase?
- [x] remove deprecated ``comp_label`` argument,
- [x] remove deprecate usage of `None` in `set_signal_type`,
- [x] privatise `twin_function` and `twin_inverse_function` as per deprecation,
- [x] improve docstring 
- [n/a] update user guide (if appropriate),
- [x] add an changelog entry in the `upcoming_changes` folder (see [`upcoming_changes/README.rst`](https://github.com/hyperspy/hyperspy/blob/RELEASE_next_minor/upcoming_changes/README.rst)),
- [x] Check formatting changelog entry in the `readthedocs` doc build of this PR (link in github checks)
- [n/a] add tests,
- [x] ready for review.


