### PR TITLE
Add development branch of RosettaSciIO in `setup.py`

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -13,8 +13,6 @@ steps:
     - lscpu
     - mamba install hyperspy-base --only-deps
     - mamba install scikit-learn pytest pytest-xdist
-    # Need rosettasciio
-    - pip install https://github.com/hyperspy/rosettasciio/archive/refs/heads/main.zip
     - pip install -e .
     - pytest -n 4
 

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -7,7 +7,7 @@ jobs:
     name: Docs (PR comments)
     runs-on: ubuntu-latest
     env:
-      BUILD_DEPS: python3-dev build-essential graphviz
+      BUILD_DEPS: python3-dev build-essential graphviz git
       LATEX_DEPS: dvipng latexmk texlive-latex-recommended texlive-latex-extra texlive-fonts-recommended
 
     steps:
@@ -15,7 +15,7 @@ jobs:
 
       - uses: ericpre/sphinx-action@latest_sphinx
         with:
-          pre-build-command: "apt-get update -y && apt-get install -y ${{ env.BUILD_DEPS }} ${{ env.LATEX_DEPS }} && pip install .[all,build-doc]"
+          pre-build-command: "apt-get update -y && apt-get install -y ${{ env.BUILD_DEPS }} ${{ env.LATEX_DEPS }} && pip install .[build-doc]"
           build-command: make html
           docs-folder: doc/
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -72,17 +72,6 @@ jobs:
         run: |
           pip install ${{ env.PIP_ARGS }} .${{ matrix.PIP_SELECTOR }}
 
-      - name: Install rosettasciio
-        shell: bash
-        run: |
-          pip install https://github.com/hyperspy/rosettasciio/archive/refs/heads/main.zip#egg=rosettasciio${{ matrix.PIP_SELECTOR }}
-
-      - name: Install GUI extension dev branch
-        if: "!contains(matrix.LABEL, 'minimum')"
-        shell: bash
-        run: |
-          pip install https://github.com/hyperspy/hyperspy_gui_traitsui/archive/refs/heads/main.zip
-
       - name: Pip list
         run: |
           pip list

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -57,7 +57,7 @@ pool:
 
 steps:
 - checkout: self
-  fetchDepth: 1 # Fetch only one commit
+  fetchDepth: '1' # Fetch only one commit
 - template: azure_pipelines/clone_ci-scripts_repo.yml@templates
 - template: azure_pipelines/install_mambaforge.yml@templates
 - template: azure_pipelines/activate_conda.yml@templates
@@ -71,17 +71,16 @@ steps:
 
 - bash: |
     source activate $ENV_NAME
-    # don't install pyusid, because pip install pyusid fails
-    #pip install https://github.com/hyperspy/rosettasciio/archive/refs/heads/main.zip#egg=rosettasciio[all]
-    pip install https://github.com/hyperspy/rosettasciio/archive/refs/heads/main.zip#egg=rosettasciio[blockfile,mrcz,blockfile,zspy]
-
-    conda list
-  displayName: Install package (rosettasciio)
+    conda clean --all -y
+  displayName: Clean conda cache
 
 - bash: |
     source activate $ENV_NAME
-    conda clean --all -y
-  displayName: Clean conda cache
+    # don't install pyusid, because pip install pyusid fails
+    pip install https://github.com/hyperspy/rosettasciio/archive/refs/heads/main.zip
+
+    conda list
+  displayName: Install package (rosettasciio)
 
 # Note we must use `-n 2` argument for pytest-xdist due to
 # https://github.com/pytest-dev/pytest-xdist/issues/9.

--- a/setup.py
+++ b/setup.py
@@ -70,6 +70,8 @@ install_req = ['scipy>=1.1',
                 # included in stdlib since v3.8, but this required version requires Python 3.10
                 # We can remove this requirement when the minimum supported version becomes Python 3.10
                'importlib-metadata>=3.6',
+                # UPDATE BEFORE RELEASE
+               'rosettasciio @ git+https://github.com/hyperspy/rosettasciio#egg=rosettasciio',
                ]
 
 extras_require = {
@@ -78,7 +80,9 @@ extras_require = {
     "learning": ['scikit-learn!=1.0.0;sys_platform=="darwin"',
                  'scikit-learn;sys_platform!="darwin"'],
     "gui-jupyter": ["hyperspy_gui_ipywidgets>=1.1.0"],
-    "gui-traitsui": ["hyperspy_gui_traitsui>=1.1.0"],
+    # UPDATE BEFORE RELEASE
+    "gui-traitsui": ["hyperspy_gui_traitsui @ git+https://github.com/hyperspy/hyperspy_gui_traitsui#egg=hyperspy_gui_traitsui"],
+    #"gui-traitsui": ["hyperspy_gui_traitsui>=1.1.0"],
     "tests": ["pytest>=3.6", "pytest-mpl", "pytest-xdist", "pytest-rerunfailures", "pytest-instafail", "matplotlib>=3.1"],
     "coverage":["pytest-cov"],
     # required to build the docs


### PR DESCRIPTION
Following up from https://github.com/hyperspy/hyperspy/pull/3014#discussion_r973573694, this should fix the API documentation on the `RELEASE_next_major` branch.
