### PR TITLE
Fix getting random state dask following last dask release (2022.10.0)

### DIFF
--- a/upcoming_changes/3049.maintenance.rst
+++ b/upcoming_changes/3049.maintenance.rst
@@ -1,0 +1,1 @@
+Fix getting random state dask for dask>=2022.10.0


### PR DESCRIPTION
Fix a function using dask private attribute, which has been changed in dask version (2022.10.0) - in this [dask PR](https://github.com/dask/dask/pull/9475).
The approach of the function introduced in https://github.com/hyperspy/hyperspy/pull/2461 uses a numpy/dask private attribute is not wrong in itself, as the use the numpy private attribute as it has been blessed in [NEP-19](https://numpy.org/neps/nep-0019-rng-policy.html), however, for its dask counterpart, it is a different story! I would suggest to use this fix in the medium term and revisit the approach later because it doesn't that this story is settle anyway and this may be subject to further change: https://github.com/numpy/numpy/issues/15322.

### Progress of the PR
- [x] Update private attribute for newer version of dask,
- [n/a] update docstring (if appropriate),
- [n/a] update user guide (if appropriate),
- [x] add an changelog entry in the `upcoming_changes` folder (see [`upcoming_changes/README.rst`](https://github.com/hyperspy/hyperspy/blob/RELEASE_next_minor/upcoming_changes/README.rst)),
- [x] Check formatting changelog entry in the `readthedocs` doc build of this PR (link in github checks)
- [n/a] add tests,
- [x] ready for review.

