### PR TITLE
Fix pint import with pint>=0.20

### DIFF
--- a/hyperspy/misc/axis_tools.py
+++ b/hyperspy/misc/axis_tools.py
@@ -17,8 +17,8 @@
 
 
 import numpy as np
-from pint import Unit
-
+#from pint import Unit
+from hyperspy.api_nogui import _ureg  
 
 def check_axes_calibration(ax1, ax2, rtol=1e-7):
     """Check if the calibration of two Axis objects matches.
@@ -43,12 +43,12 @@ def check_axes_calibration(ax1, ax2, rtol=1e-7):
     """
     if ax1.size == ax2.size:
         try:
-            unit1 = Unit(ax1.units)
+            unit1 = _ureg.Unit(ax1.units)
         except:
             unit1 = ax1.units
         try:
             unit2 = ax2.units
-            unit2 = Unit(ax2.units)
+            unit2 = _ureg.Unit(ax2.units)
         except:
             pass
         if np.allclose(ax1.axis, ax2.axis, atol=0, rtol=rtol) and unit1 == unit2:

--- a/hyperspy/misc/axis_tools.py
+++ b/hyperspy/misc/axis_tools.py
@@ -17,8 +17,8 @@
 
 
 import numpy as np
-#from pint import Unit
-from hyperspy.api_nogui import _ureg  
+from hyperspy.api_nogui import _ureg
+
 
 def check_axes_calibration(ax1, ax2, rtol=1e-7):
     """Check if the calibration of two Axis objects matches.

--- a/hyperspy/misc/axis_tools.py
+++ b/hyperspy/misc/axis_tools.py
@@ -17,7 +17,7 @@
 
 
 import numpy as np
-from pint.unit import Unit
+from pint import Unit
 
 
 def check_axes_calibration(ax1, ax2, rtol=1e-7):

--- a/upcoming_changes/3052.bugfix.rst
+++ b/upcoming_changes/3052.bugfix.rst
@@ -1,0 +1,1 @@
+Fix pint Unit for pint>=0.20


### PR DESCRIPTION
### Requirements
* Read the [developer guide](https://hyperspy.org/hyperspy-doc/current/dev_guide/intro.html).
* Base your pull request on the [correct branch](https://hyperspy.org/hyperspy-doc/current/dev_guide/git.html#semantic-versioning-and-hyperspy-main-branches).
* Filling out the template; it helps the review process and it is useful to summarise the PR.
* This template can be updated during the progression of the PR to summarise its status. 

*You can delete this section after you read it.*

### Description of the change
pint module has no longer the attribute unit, which resulted in breaking of the brc code. It can be directly invoked using Unit. 

### Progress of the PR
- [x] Change implemented (can be split into several points),
- [ ] update docstring (if appropriate),
- [ ] update user guide (if appropriate),
- [ ] add an changelog entry in the `upcoming_changes` folder (see [`upcoming_changes/README.rst`](https://github.com/hyperspy/hyperspy/blob/RELEASE_next_minor/upcoming_changes/README.rst)),
- [x] Check formatting changelog entry in the `readthedocs` doc build of this PR (link in github checks)
- [ ] add tests,
- [x] ready for review.

### Minimal example of the bug fix or the new feature
```python
import hyperspy.api as hs
s = hs.load(filename.bcf)
#resulted in an error
# Your new feature...
Corrected hyperspy/misc/axis_tools.py
```
Note that this example can be useful for updating the user guide.

