### PR TITLE
Release v1.7.3

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,6 +8,24 @@ https://hyperspy.readthedocs.io/en/latest/user_guide/changes.html
 
 .. towncrier release notes start
 
+Hyperspy 1.7.3 (2022-10-29)
+===========================
+
+Bug Fixes
+---------
+
+- Fix error when reading Velox containing FFT with odd number of pixels (`#3040 <https://github.com/hyperspy/hyperspy/issues/3040>`_)
+- Fix pint Unit for pint>=0.20 (`#3052 <https://github.com/hyperspy/hyperspy/issues/3052>`_)
+
+
+Maintenance
+-----------
+
+- Fix deprecated import of scipy ``ascent`` in docstrings and the test suite (`#3032 <https://github.com/hyperspy/hyperspy/issues/3032>`_)
+- Fix error handling when trying to convert a ragged signal to non-ragged for numpy >=1.24 (`#3033 <https://github.com/hyperspy/hyperspy/issues/3033>`_)
+- Fix getting random state dask for dask>=2022.10.0 (`#3049 <https://github.com/hyperspy/hyperspy/issues/3049>`_)
+
+
 Hyperspy 1.7.2 (2022-09-17)
 ===========================
 

--- a/hyperspy/Release.py
+++ b/hyperspy/Release.py
@@ -25,7 +25,7 @@ name = 'hyperspy'
 # When running setup.py the ".dev" string will be replaced (if possible)
 # by the output of "git describe" if git is available or the git
 # hash if .git is present.
-version = "1.7.3"
+version = "1.7.4.dev0"
 __version__ = version
 description = "Multidimensional data analysis toolbox"
 license = 'GPL v3'

--- a/hyperspy/Release.py
+++ b/hyperspy/Release.py
@@ -25,7 +25,7 @@ name = 'hyperspy'
 # When running setup.py the ".dev" string will be replaced (if possible)
 # by the output of "git describe" if git is available or the git
 # hash if .git is present.
-version = "1.7.3.dev0"
+version = "1.7.3"
 __version__ = version
 description = "Multidimensional data analysis toolbox"
 license = 'GPL v3'

--- a/upcoming_changes/3032.maintenance.rst
+++ b/upcoming_changes/3032.maintenance.rst
@@ -1,1 +1,0 @@
-Fix deprecated import of scipy ``ascent`` in docstrings and the test suite

--- a/upcoming_changes/3033.maintenance..rst
+++ b/upcoming_changes/3033.maintenance..rst
@@ -1,1 +1,0 @@
-Fix error handling when trying to convert a ragged signal to non-ragged for numpy >=1.24

--- a/upcoming_changes/3040.bugfix.rst
+++ b/upcoming_changes/3040.bugfix.rst
@@ -1,1 +1,0 @@
-Fix error when reading Velox containing FFT with odd number of pixels

--- a/upcoming_changes/3049.maintenance.rst
+++ b/upcoming_changes/3049.maintenance.rst
@@ -1,1 +1,0 @@
-Fix getting random state dask for dask>=2022.10.0

--- a/upcoming_changes/3052.bugfix.rst
+++ b/upcoming_changes/3052.bugfix.rst
@@ -1,1 +1,0 @@
-Fix pint Unit for pint>=0.20


### PR DESCRIPTION
As this is a straightforward bug fix releases which add support for pint>= 0.20 and dask>=2022.10.0, I will do the release ASAP.

https://github.com/hyperspy/hyperspy/blob/RELEASE_next_minor/releasing_guide.md:

### Progress of the PR
- [x] Bump version,
- [x] Update and check changelog in CHANGES.rst: run towncrier build,


