### PR TITLE
Fix `plot_spectra` legend for "cascade" style

### DIFF
--- a/hyperspy/drawing/utils.py
+++ b/hyperspy/drawing/utils.py
@@ -1481,7 +1481,7 @@ def plot_spectra(
         _make_cascade_subplot(spectra, ax, color, linestyle, padding=padding,
                               drawstyle=drawstyle)
         if legend is not None:
-            plt.legend(legend, loc=legend_loc)
+            ax.legend(legend, loc=legend_loc)
             _reverse_legend(ax, legend_loc)
             if legend_picking is True:
                 animate_legend(fig=fig, ax=ax)

--- a/hyperspy/tests/drawing/test_plot_signal1d.py
+++ b/hyperspy/tests/drawing/test_plot_signal1d.py
@@ -122,8 +122,10 @@ class TestPlotSpectra():
         if fig:
             fig = plt.figure()
         if ax:
-            fig = plt.figure()
-            ax = fig.add_subplot(111)
+            if fig:
+                ax = fig.add_subplot(111)
+            else:
+                ax = plt.figure().add_subplot(111)
 
         ax = hs.plot.plot_spectra(self.s, style=style, legend='auto',
                                   fig=fig, ax=ax)


### PR DESCRIPTION
### Description of the change

`plot_spectra` does not display the legend when `ax` is given and the style is `"cascade"`. This fixes it.

### Progress of the PR
- [x] Change implemented (can be split into several points),
- [ ] update docstring (if appropriate),
- [ ] update user guide (if appropriate),
- [ ] add an changelog entry in the `upcoming_changes` folder (see [`upcoming_changes/README.rst`](https://github.com/hyperspy/hyperspy/blob/RELEASE_next_minor/upcoming_changes/README.rst)),
- [ ] Check formatting changelog entry in the `readthedocs` doc build of this PR (link in github checks)
- [x] add tests,
- [ ] ready for review.

### Minimal example of the bug fix or the new feature

The following doesn't display the legend without this fix:
```python
s = hs.signals.Signal1D((np.arange(100).reshape((5, 20))))
f = plt.figure()
ax = f.add_subplot(111)
hs.plot.plot_spectra(s, legend="auto", ax=ax, style="cascade")
```


