### PR TITLE
Pass only positive numbers to closest_nice_number

### DIFF
--- a/hyperspy/drawing/_widgets/scalebar.py
+++ b/hyperspy/drawing/_widgets/scalebar.py
@@ -18,7 +18,7 @@
 
 
 from hyperspy.misc.math_tools import closest_nice_number
-
+import numpy as np
 
 class ScaleBar(object):
 

--- a/hyperspy/drawing/_widgets/scalebar.py
+++ b/hyperspy/drawing/_widgets/scalebar.py
@@ -95,8 +95,8 @@ class ScaleBar(object):
 
     def calculate_size(self, max_size_ratio=0.25):
         ps = self.pixel_size if self.pixel_size is not None else 1
-        size = closest_nice_number(ps * (self.xmax - self.xmin) *
-                                   max_size_ratio)
+        size = closest_nice_number(np.abs(ps * (self.xmax - self.xmin) *
+                                   max_size_ratio))
         self.length = size
 
     def remove(self):

--- a/hyperspy/tests/drawing/test_widget.py
+++ b/hyperspy/tests/drawing/test_widget.py
@@ -69,7 +69,7 @@ def test_remove_widget_line():
     assert len(im._plot.pointer.patch) == 1
 
 def test_calculate_size():
-    s = signal.Signal2D(np.arange(1000).reshape(10,10,10,10))
+    s = signals.Signal2D(np.arange(1000).reshape(10,10,10,10))
 
     #Test that scalebar.calculate_size passes only positive value to closest_nice_number
     s.axes_manager[0].scale = -1

--- a/hyperspy/tests/drawing/test_widget.py
+++ b/hyperspy/tests/drawing/test_widget.py
@@ -67,3 +67,10 @@ def test_remove_widget_line():
     im._plot.pointer.close(render_figure=True)
     assert len(ax.lines) == 1
     assert len(im._plot.pointer.patch) == 1
+
+def test_calculate_size():
+    s = signals.Signal2D(np.arange(1000).reshape(10,10,10,10))
+
+    #Test that scalebar.calculate_size passes only positive value to closest_nice_number
+    s.axes_manager[0].scale = -1
+    s.plot()

--- a/hyperspy/tests/drawing/test_widget.py
+++ b/hyperspy/tests/drawing/test_widget.py
@@ -67,3 +67,10 @@ def test_remove_widget_line():
     im._plot.pointer.close(render_figure=True)
     assert len(ax.lines) == 1
     assert len(im._plot.pointer.patch) == 1
+
+def test_calculate_size():
+    s = signal.Signal2D(np.arange(1000).reshape(10,10,10,10))
+
+    #Test that scalebar.calculate_size passes only positive value to closest_nice_number
+    s.axes_manager[0].scale = -1
+    s.plot()

--- a/hyperspy/tests/drawing/test_widget.py
+++ b/hyperspy/tests/drawing/test_widget.py
@@ -69,7 +69,7 @@ def test_remove_widget_line():
     assert len(im._plot.pointer.patch) == 1
 
 def test_calculate_size():
-    s = signals.Signal2D(np.arange(1000).reshape(10,10,10,10))
+    s = signals.Signal2D(np.arange(10000).reshape(10,10,10,10))
 
     #Test that scalebar.calculate_size passes only positive value to closest_nice_number
     s.axes_manager[0].scale = -1


### PR DESCRIPTION
### Description of the change
closest_nice_number takes a log and so assumes the input is positive. If the x axis scale value is negative (which is the case for some Talos .ser files), self.xmax-self.xmin is negative. I took the absolute value in scalebar.py here so that closest_nice_number does not return a domain error.

### Progress of the PR
- [ ] Change implemented (can be split into several points),
- [ ] update docstring (if appropriate),
- [ ] update user guide (if appropriate),
- [ ] add an changelog entry in the `upcoming_changes` folder (see [`upcoming_changes/README.rst`](https://github.com/hyperspy/hyperspy/blob/RELEASE_next_minor/upcoming_changes/README.rst)),
- [ ] Check formatting changelog entry in the `readthedocs` doc build of this PR (link in github checks)
- [ ] add tests,
- [ ] ready for review.

### Minimal example of the bug fix or the new feature

This would previously return a domain error:
```python
import hyperspy.api as hs
import numpy as np
dp = hs.load(filenames='...')

if dp.axes_manager[0].scale > 0:
    dp.axes_manager[0].scale*=-1
dp.plot()
```
Note that this example can be useful to update the user guide.

