### PR TITLE
Bugfix. Do not raise AttributeError when loading markers

### DIFF
--- a/hyperspy/io.py
+++ b/hyperspy/io.py
@@ -758,7 +758,6 @@ def dict2signal(signal_dict, lazy=False):
         markers_dict = markers_metadata_dict_to_markers(
             mp['Markers'],
             axes_manager=signal.axes_manager)
-        del signal.metadata.Markers
         signal.metadata.Markers = markers_dict
     return signal
 


### PR DESCRIPTION
### Description of the change
- Bugfix. Do not raise AttributeError when loading markers

### Progress of the PR
- [x] Change implemented (can be split into several points),
- [ ] update docstring (if appropriate),
- [ ] update user guide (if appropriate),
- [ ] add an changelog entry in the `upcoming_changes` folder (see [`upcoming_changes/README.rst`](https://github.com/hyperspy/hyperspy/blob/RELEASE_next_minor/upcoming_changes/README.rst)),
- [ ] Check formatting changelog entry in the `readthedocs` doc build of this PR (link in github checks)
- [ ] add tests,
- [x] ready for review.

### Minimal example of the bug fix or the new feature
depends on marker reader in rosettasciio