### PR TITLE
Bugfix: Do not raise AttributeError when loading markers

### DIFF
--- a/hyperspy/io.py
+++ b/hyperspy/io.py
@@ -33,7 +33,6 @@ from rsciio.utils.tools import overwrite as overwrite_method
 from rsciio import IO_PLUGINS
 
 from hyperspy import __version__ as hs_version
-from hyperspy.drawing.marker import markers_metadata_dict_to_markers
 from hyperspy.exceptions import VisibleDeprecationWarning
 from hyperspy.misc.utils import strlist2enumeration, get_object_package_info
 from hyperspy.misc.utils import stack as stack_method
@@ -812,12 +811,6 @@ def dict2signal(signal_dict, lazy=False):
                     value = function(value)
                 if value is not None:
                     signal.metadata.set_item(mpattr, value)
-    if "metadata" in signal_dict and "Markers" in mp:
-        markers_dict = markers_metadata_dict_to_markers(
-            mp['Markers'],
-            axes_manager=signal.axes_manager)
-        del signal.metadata.Markers
-        signal.metadata.Markers = markers_dict
     return signal
 
 

--- a/upcoming_changes/3070.bugfix.rst
+++ b/upcoming_changes/3070.bugfix.rst
@@ -1,0 +1,1 @@
+Bugfix deleting uninitialized marker_dict when loading files with markers


### PR DESCRIPTION
### Description of the change
- Do not raise AttributeError when loading markers
### Progress of the PR
- [x] Change implemented (can be split into several points),
- [ ] update docstring (if appropriate),
- [ ] update user guide (if appropriate),
- [x] add an changelog entry in the `upcoming_changes` folder (see [`upcoming_changes/README.rst`](https://github.com/hyperspy/hyperspy/blob/RELEASE_next_minor/upcoming_changes/README.rst)),
- [ ] Check formatting changelog entry in the `readthedocs` doc build of this PR (link in github checks)
- [ ] add tests,
- [ ] ready for review.

### Minimal example of the bug fix or the new feature
need Markers from rosettasciio