### PR TITLE
Fix rsciio dependency

### DIFF
--- a/hyperspy/misc/eels/eelsdb.py
+++ b/hyperspy/misc/eels/eelsdb.py
@@ -23,8 +23,8 @@ import logging
 from hyperspy.defaults_parser import preferences
 from hyperspy.docstrings.signal import SHOW_PROGRESSBAR_ARG
 from hyperspy.external.progressbar import progressbar
-from rsciio.msa.api import parse_msa_string
 from hyperspy.io import dict2signal
+from rsciio.msa import parse_msa_string
 
 
 _logger = logging.getLogger(__name__)


### PR DESCRIPTION
### Description of the change
A test in https://github.com/hyperspy/rosettasciio/pull/72 (api change for `.msa`) is failing, because in 
`hyperspy/misc/eels/eelsdb.py ` a function is loaded using the old api.

Possibly, we should duplicate that function in HyperSpy to disentangle the packages?
EDIT: The `parse_msa_string` function is too extensive to duplicate it and keep it maintained in two packages and anyway rsciio will be one of the hyperspy-dependencies. Thus, I have added this function to the api of the msa-plugin, so that we do not have to import a private function here.

### Progress of the PR
- [x] Change implemented (can be split into several points),
- [x] ready for review.
