### PR TITLE
Replace imgmath by mathjax sphinx-extension

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -36,7 +36,7 @@ extensions = [
     "sphinx.ext.autosummary",
     "sphinx.ext.githubpages",
     'sphinx.ext.graphviz',
-    'sphinx.ext.imgmath',
+    'sphinx.ext.mathjax',
     'sphinx.ext.inheritance_diagram',
     'sphinx.ext.intersphinx',
     'sphinx.ext.napoleon',

--- a/upcoming_changes/3084.doc.rst
+++ b/upcoming_changes/3084.doc.rst
@@ -1,0 +1,1 @@
+Replace ``sphinx.ext.imgmath`` by ``sphinx.ext.mathjax`` to fix the math rendering in the *ReadTheDocs* build


### PR DESCRIPTION
### Requirements
As mentioned in [brought up in https://github.com/LumiSpy/lumispy/issues/166](https://github.com/hyperspy/hyperspy/pull/3050#issuecomment-1328049783) and reported on [gitter](https://gitter.im/hyperspy/hyperspy), math is not rendering any more in the ReadTheDocs.
As brought up by @hakonanes in https://github.com/hyperspy/hyperspy/pull/3050#issuecomment-1386765990 `sphinx.ext.mathjax` should be working, while `sphinx.ext.imgmath` seems to be broken (in both HyperSpy and LumiSpy, see also https://github.com/LumiSpy/lumispy/pull/172).
Therefore replacing the extension.

### Progress of the PR
- [x] Change implemented (can be split into several points),
- [x] Check `readthedocs` build,
- [x] add an changelog entry in the `upcoming_changes` folder (see [`upcoming_changes/README.rst`](https://github.com/hyperspy/hyperspy/blob/RELEASE_next_minor/upcoming_changes/README.rst)),
- [x] Check formatting changelog entry in the `readthedocs` doc build of this PR (link in github checks)
- [x] ready for review.
