### PR TITLE
Fix linkchecker documentation

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -45,14 +45,14 @@ extensions = [
 ]
 
 linkcheck_ignore = [
-    'https://www.jstor.org/stable/24307705',  # 403 Client Error: Forbidden for url
-    'https://anaconda.org',  # 403 Client Error: Forbidden for url
+    "https://anaconda.org",  # 403 Client Error: Forbidden for url
+    "https://doi.org/10.1021/acs.nanolett.5b00449",  # 403 Client Error: Forbidden for url
 ]
 
-linkcheck_exclude_documents = [
-    'user_guide/io/*',
-    'api/hyperspy.io_plugins*',
-    ]
+linkcheck_exclude_documents = []
+
+# Specify a standard user agent, as Sphinx default is blocked on some sites
+user_agent = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/108.0.0.0 Safari/537.36 Edg/108.0.1462.54"
 
 try:
     import sphinxcontrib.spelling


### PR DESCRIPTION
### Progress of the PR
- [x] Specify `user_agent" in "conf.py" to avoid "403 Client Error: Forbidden for url" error. It still doesn't work for a DOI but since this is a DOI, this shouldn't change, so not an issue.
- [x] Remove excluding some files in the linkchecker 
- [x] ready for review.
