### PR TITLE
Fix `__setattr__` of `DictionaryTreeBrowser`

### DIFF
--- a/hyperspy/misc/utils.py
+++ b/hyperspy/misc/utils.py
@@ -272,7 +272,7 @@ class DictionaryTreeBrowser:
         for key, value in dictionary.items():
             if key == "_double_lines":
                 value = double_lines
-            self.__setattr__(key, value)
+            self._setattr(key, value, keep_existing=True)
 
     def process_lazy_attributes(self):
         """Run the DictionaryTreeBrowser machinery for the lazy attributes."""
@@ -300,7 +300,8 @@ class DictionaryTreeBrowser:
         filename : str
             The name of the file without the extension that is
             txt by default
-        encoding : valid encoding str
+        encoding : str
+            The encoding to be used.
 
         """
         self.process_lazy_attributes()
@@ -464,6 +465,27 @@ class DictionaryTreeBrowser:
             return item
 
     def __setattr__(self, key, value):
+        self._setattr(key, value, keep_existing=False)
+
+    def _setattr(self, key, value, keep_existing=False):
+        """
+        Set the value of the given attribute `key`.
+
+        Parameters
+        ----------
+        key : str
+            The key attribute to be set.
+        value : object
+            The value to assign to the given `key` attribute.
+        keep_existing : bool, optional
+            If value is of dictionary type and the node already exists, keep
+            existing leaf of the node being set. The default is False.
+
+        Returns
+        -------
+        None.
+
+        """
         if key in ["_double_lines", "_lazy_attributes"]:
             super().__setattr__(key, value)
             return
@@ -475,7 +497,7 @@ class DictionaryTreeBrowser:
             value = BaseSignal(**value)
         slugified_key = str(slugify(key, valid_variable_name=True))
         if isinstance(value, dict):
-            if slugified_key in self.__dict__.keys():
+            if slugified_key in self.__dict__.keys() and keep_existing:
                 self.__dict__[slugified_key]["_dtb_value_"].add_dictionary(
                     value, double_lines=self._double_lines
                 )
@@ -740,13 +762,15 @@ class DictionaryTreeBrowser:
 
     def set_item(self, item_path, value):
         """Given the path and value, create the missing nodes in
-        the path and assign to the last one the value
+        the path and assign the given value.
 
         Parameters
         ----------
-        item_path : Str
+        item_path : str
             A string describing the path with each item separated by a
-            full stops (periods)
+            full stop (periods)
+        value : object
+            The value to assign to the given path.
 
         Examples
         --------

--- a/hyperspy/signal.py
+++ b/hyperspy/signal.py
@@ -4861,7 +4861,7 @@ class BaseSignal(FancySlicing,
             lazy_output = self._lazy
         if ragged is None:
             ragged = self.ragged
-        
+
         # Separate arguments to pass to the mapping function:
         # ndkwargs dictionary contains iterating arguments which must be signals.
         # kwargs dictionary contains non-iterating arguments
@@ -4947,7 +4947,7 @@ class BaseSignal(FancySlicing,
                 max_workers=max_workers,
                 output_dtype=output_dtype,
                 output_signal_size=output_signal_size,
-                **kwargs, # function argument(s) (non-iterating) 
+                **kwargs, # function argument(s) (non-iterating)
             )
         if not inplace:
             return result
@@ -6050,7 +6050,7 @@ class BaseSignal(FancySlicing,
                 _logger.warning(
                     "plot_marker=False and permanent=False does nothing")
         if permanent:
-            self.metadata.Markers = markers_dict
+            self.metadata.Markers.add_dictionary(markers_dict)
         if plot_marker and render_figure:
             self._render_figure()
 

--- a/hyperspy/tests/misc/test_dictionary_tree_browser.py
+++ b/hyperspy/tests/misc/test_dictionary_tree_browser.py
@@ -83,6 +83,24 @@ class TestDictionaryBrowser:
         tree.add_dictionary({"_double_lines": ""}, double_lines=False)
         assert tree._double_lines == False
 
+    def test_setattr_dictionary(self, tree):
+        d = {"leaf13": 13}
+        tree.Node1 = d
+        assert tree.Node1.as_dictionary() == d
+
+    def test_set_item_dictionary(self, tree):
+        d = {"leaf111": 222}
+        tree.set_item("Node1.Node11", d)
+        assert tree.Node1.Node11.as_dictionary() == d
+
+        d1 = {"Node111": {"leaf1111": 1111}}
+        tree.Node1.Node11.add_dictionary(d1)
+        assert tree.Node1.Node11.as_dictionary() == {**d, **d1}
+
+        d2 = {"leaf111": 333}
+        tree.set_item("Node1.Node11", d2)
+        assert tree.Node1.Node11.as_dictionary() == d2
+
     def test_deepcopy(self, tree):
         a = tree.deepcopy()
         assert a.as_dictionary() == tree.as_dictionary()

--- a/upcoming_changes/3094.bugfix.rst
+++ b/upcoming_changes/3094.bugfix.rst
@@ -1,0 +1,2 @@
+Fix behaviour of  `DictionaryTreeBrowser` setter with value of dictionary type
+


### PR DESCRIPTION
In #3070 and #3091, we were wondering whether `del signal.metadata.Markers` was necessary and it was actually because of the bug in the implementation of `__setattr__` of `DictionaryTreeBrowser`: it was behaving the same as the `add_dictionary` method.

### Progress of the PR
- [x] Fix `__setattr__` of `DictionaryTreeBrowser`,
- [x] update docstring (if appropriate),
- [n/a] update user guide (if appropriate),
- [x] add an changelog entry in the `upcoming_changes` folder (see [`upcoming_changes/README.rst`](https://github.com/hyperspy/hyperspy/blob/RELEASE_next_minor/upcoming_changes/README.rst)),
- [x] Check formatting changelog entry in the `readthedocs` doc build of this PR (link in github checks)
- [x] add tests,
- [x] ready for review.


