### PR TITLE
Fix test class in `test_plot_signal1d.py`

### DIFF
--- a/conda_environment_dev.yml
+++ b/conda_environment_dev.yml
@@ -14,3 +14,4 @@ dependencies:
 - pytest-xdist
 - pytest-rerunfailures
 - pytest-instafail
+- pooch

--- a/hyperspy/signal.py
+++ b/hyperspy/signal.py
@@ -2784,6 +2784,13 @@ class BaseSignal(FancySlicing,
         elif self.tmp_parameters.has_item('filename'):
             self._plot.signal_title = self.tmp_parameters.filename
 
+        def sum_wrapper(s, axis):
+            with warnings.catch_warnings():
+                warnings.filterwarnings(
+                    "ignore", category=UserWarning, module='hyperspy'
+                    )
+                return s.sum(axis)
+
         def get_static_explorer_wrapper(*args, **kwargs):
             if np.issubdtype(navigator.data.dtype, np.complexfloating):
                 return abs(navigator(as_numpy=True))
@@ -2791,16 +2798,11 @@ class BaseSignal(FancySlicing,
                 return navigator(as_numpy=True)
 
         def get_1D_sum_explorer_wrapper(*args, **kwargs):
-            navigator = self
             # Sum over all but the first navigation axis.
-            am = navigator.axes_manager
-            with warnings.catch_warnings():
-                warnings.filterwarnings("ignore", category=UserWarning,
-                                        module='hyperspy'
-                                        )
-                navigator = navigator.sum(
-                    am.signal_axes + am.navigation_axes[1:]
-                    )
+            am = self.axes_manager
+            navigator = sum_wrapper(
+                self, am.signal_axes + am.navigation_axes[1:]
+                )
             return np.nan_to_num(to_numpy(navigator.data)).squeeze()
 
         def get_dynamic_explorer_wrapper(*args, **kwargs):
@@ -2831,21 +2833,26 @@ class BaseSignal(FancySlicing,
                     navigator = self.deepcopy()
                 else:
                     navigator = interactive(
-                        self.sum,
-                        self.events.data_changed,
-                        self.axes_manager.events.any_axis_changed,
-                        self.axes_manager.signal_axes)
+                        f=sum_wrapper,
+                        event=self.events.data_changed,
+                        recompute_out_event=self.axes_manager.events.any_axis_changed,
+                        s=self,
+                        axis=self.axes_manager.signal_axes,
+                        )
                 if navigator.axes_manager.navigation_dimension == 1:
                     navigator = interactive(
-                        navigator.as_signal1D,
-                        navigator.events.data_changed,
-                        navigator.axes_manager.events.any_axis_changed, 0)
+                        f=navigator.as_signal1D,
+                        event=navigator.events.data_changed,
+                        recompute_out_event=navigator.axes_manager.events.any_axis_changed,
+                        spectral_axis=0,
+                        )
                 else:
                     navigator = interactive(
-                        navigator.as_signal2D,
-                        navigator.events.data_changed,
-                        navigator.axes_manager.events.any_axis_changed,
-                        (0, 1))
+                        f=navigator.as_signal2D,
+                        event=navigator.events.data_changed,
+                        recompute_out_event=navigator.axes_manager.events.any_axis_changed,
+                        image_axes=(0, 1),
+                        )
             else:
                 navigator = None
         # Navigator properties

--- a/hyperspy/tests/drawing/test_plot_markers.py
+++ b/hyperspy/tests/drawing/test_plot_markers.py
@@ -571,11 +571,11 @@ def test_plot_add_background_windows():
 def test_iterate_markers():
     from skimage.feature import peak_local_max
     try:
+        # scipy >=1.10
+        from scipy.datasets import face
+    except ImportError:
         # scipy <1.10
         from scipy.misc import face
-    except:
-        # scipy >=1.10
-        from scipy.dataset import face
     ims = BaseSignal(face()).as_signal2D([1, 2])
     index = np.array([peak_local_max(im.data, min_distance=100,
                                      num_peaks=4) for im in ims])

--- a/hyperspy/tests/drawing/test_plot_roi_widgets.py
+++ b/hyperspy/tests/drawing/test_plot_roi_widgets.py
@@ -68,7 +68,6 @@ class TestPlotROI():
         self.im.plot()
         p = roi.Point1DROI(0.5)
         p.add_widget(signal=self.im, axes=0, color="cyan")
-        return self.im._plot.navigator_plot.figure
 
     @pytest.mark.mpl_image_compare(baseline_dir=BASELINE_DIR,
                                    tolerance=DEFAULT_TOL, style=STYLE_PYTEST_MPL)

--- a/hyperspy/tests/drawing/test_plot_signal1d.py
+++ b/hyperspy/tests/drawing/test_plot_signal1d.py
@@ -25,7 +25,7 @@ import numpy as np
 import pytest
 try:
     # scipy >=1.10
-    from scipy.dataset import ascent, face
+    from scipy.datasets import ascent, face
 except ImportError:
     # scipy <1.10
     from scipy.misc import ascent, face

--- a/hyperspy/tests/drawing/test_plot_signal1d.py
+++ b/hyperspy/tests/drawing/test_plot_signal1d.py
@@ -92,12 +92,15 @@ def setup_teardown(request, scope="class"):
 @pytest.mark.usefixtures("setup_teardown")
 class TestPlotSpectra():
 
-    s = hs.signals.Signal1D(ascent()[100:160:10])
+    def setup_method(self, method):
+        s = hs.signals.Signal1D(ascent()[100:160:10])
 
-    # Add a test signal with decreasing axis
-    s_reverse = s.deepcopy()
-    s_reverse.axes_manager[1].offset = 512
-    s_reverse.axes_manager[1].scale = -1
+        # Add a test signal with decreasing axis
+        s_reverse = s.deepcopy()
+        s_reverse.axes_manager[1].offset = 512
+        s_reverse.axes_manager[1].scale = -1
+        self.s = s
+        self.s_reverse = s_reverse
 
     def _generate_parameters(style):
         parameters = []
@@ -202,7 +205,7 @@ class TestPlotSpectra():
 
 class TestPlotNonLinearAxis:
 
-    def setup_method(self):
+    def setup_method(self, method):
         dict0 = {'size': 10, 'name': 'Axis0', 'units': 'A', 'scale': 0.2,
                  'offset': 1, 'navigate': True}
         dict1 = {'axis': np.arange(100)**3, 'name': 'Axis1', 'units': 'O',

--- a/hyperspy/tests/drawing/test_plot_signal2d.py
+++ b/hyperspy/tests/drawing/test_plot_signal2d.py
@@ -23,7 +23,7 @@ import pytest
 import scipy.ndimage
 try:
     # scipy >=1.10
-    from scipy.dataset import ascent, face
+    from scipy.datasets import ascent, face
 except ImportError:
     # scipy <1.10
     from scipy.misc import ascent, face

--- a/hyperspy/tests/drawing/test_plot_signal2d.py
+++ b/hyperspy/tests/drawing/test_plot_signal2d.py
@@ -374,6 +374,7 @@ def test_plot_images_cmap_multi_signal():
     test_plot1 = _TestIteratedSignal()
 
     test_plot2 = _TestIteratedSignal()
+    test_plot2.signal.change_dtype(float)
     test_plot2.signal *= 2  # change scale of second signal
     test_plot2.signal = test_plot2.signal.inav[::-1]
     test_plot2.signal.metadata.General.title = 'Descent'
@@ -391,6 +392,7 @@ def test_plot_images_cmap_multi_w_rgb():
     test_plot1 = _TestIteratedSignal()
 
     test_plot2 = _TestIteratedSignal()
+    test_plot2.signal.change_dtype(float)
     test_plot2.signal *= 2  # change scale of second signal
     test_plot2.signal.metadata.General.title = 'Ascent-2'
 

--- a/hyperspy/tests/drawing/test_plot_signal2d.py
+++ b/hyperspy/tests/drawing/test_plot_signal2d.py
@@ -235,7 +235,7 @@ class _TestIteratedSignal:
         return axes_manager
 
 
-class TestPlotNonLinearAxis:
+class TestPlotNonUniformAxis:
 
     def setup_method(self):
         dict0 = {'axis': np.arange(10)**0.5, 'name':'Non uniform 0', 'units':'A',
@@ -445,7 +445,6 @@ def test_plot_images_multi_signal_w_axes_replot():
         tests.append(np.allclose(imi, plt.gca().images[0].get_array().data))
         plt.close(fn)
     assert np.alltrue(tests)
-    return f
 
 
 @pytest.mark.parametrize("percentile", [("2.5th", "97.5th"),

--- a/setup.py
+++ b/setup.py
@@ -97,7 +97,16 @@ extras_require = {
     "scalebar": ["matplotlib-scalebar"],
     # bug in pip: matplotib is ignored here because it is already present in
     # install_requires.
-    "tests": ["pytest>=3.6", "pytest-mpl", "pytest-xdist", "pytest-rerunfailures", "pytest-instafail", "matplotlib>=3.1"],
+    "tests": [
+        "pytest>=3.6",
+        "pytest-mpl",
+        "pytest-xdist",
+        "pytest-rerunfailures",
+        "pytest-instafail",
+        "matplotlib>=3.1",
+        # optional dependency of scipy to use scipy.datasets
+        "pooch",
+        ],
     "coverage":["pytest-cov"],
     # required to build the docs
     "build-doc": [

--- a/upcoming_changes/3079.maintenance.rst
+++ b/upcoming_changes/3079.maintenance.rst
@@ -1,0 +1,1 @@
+Add pooch as test dependency, as it is required to use scipy.dataset in latest scipy (1.10) and update plotting test. Fix warning when plotting non-uniform axis


### PR DESCRIPTION
- Backpot https://github.com/hyperspy/hyperspy/pull/3079 to fix test suite,
- Fix formatting test to avoid error during tests collection.

See for example:

```python
gw0 I / gw1 I
============================= test session starts ==============================
platform linux -- Python 3.10.8, pytest-7.2.1, pluggy-1.0.0
rootdir: /home/runner/work/hyperspy-extensions-list/hyperspy-extensions-list
plugins: xdist-3.1.0, rerunfailures-11.0, instafail-0.4.1
_____________ ERROR collecting tests/drawing/test_plot_signal1d.py _____________
/usr/share/miniconda3/lib/python3.10/site-packages/hyperspy/tests/drawing/test_plot_signal1d.py:93: in <module>
    class TestPlotSpectra():
/usr/share/miniconda3/lib/python3.10/site-packages/hyperspy/tests/drawing/test_plot_signal1d.py:95: in TestPlotSpectra
    s = hs.signals.Signal1D(ascent()[100:160:10])
/usr/share/miniconda3/lib/python3.10/site-packages/scipy/_lib/deprecation.py:18: in call
    warnings.warn(msg, category=DeprecationWarning,
E   DeprecationWarning: scipy.misc.ascent has been deprecated in SciPy v1.10.0; and will be completely removed in SciPy v1.[12](https://github.com/hyperspy/hyperspy-extensions-list/actions/runs/4099566900/jobs/7069599923#step:14:13).0. Dataset methods have moved into the scipy.datasets module. Use scipy.datasets.ascent instead.
_____________ ERROR collecting tests/drawing/test_plot_signal1d.py _____________
/usr/share/miniconda3/lib/python3.10/site-packages/hyperspy/tests/drawing/test_plot_signal1d.py:93: in <module>
    class TestPlotSpectra():
/usr/share/miniconda3/lib/python3.10/site-packages/hyperspy/tests/drawing/test_plot_signal1d.py:95: in TestPlotSpectra
    s = hs.signals.Signal1D(ascent()[100:[16](https://github.com/hyperspy/hyperspy-extensions-list/actions/runs/4099566900/jobs/7069599923#step:14:17)0:10])
/usr/share/miniconda3/lib/python3.10/site-packages/scipy/_lib/deprecation.py:[18](https://github.com/hyperspy/hyperspy-extensions-list/actions/runs/4099566900/jobs/7069599923#step:14:19): in call
    warnings.warn(msg, category=DeprecationWarning,
E   DeprecationWarning: scipy.misc.ascent has been deprecated in SciPy v1.10.0; and will be completely removed in SciPy v1.12.0. Dataset methods have moved into the scipy.datasets module. Use scipy.datasets.ascent instead.
gw0 [52[19](https://github.com/hyperspy/hyperspy-extensions-list/actions/runs/4099566900/jobs/7069599923#step:14:20)] / gw1 [5[21](https://github.com/hyperspy/hyperspy-extensions-list/actions/runs/4099566900/jobs/7069599923#step:14:22)9]


tests/component/test_voigt.py .                                          [  0%]
tests/test_events.py ................                                    [  0%]
tests/component/test_voigt.py                                            [  0%]
```