### PR TITLE
check array type before explicit to_numpy conversion

### DIFF
--- a/hyperspy/signal.py
+++ b/hyperspy/signal.py
@@ -2716,7 +2716,7 @@ class BaseSignal(FancySlicing,
             value = self._get_cache_dask_chunk(indices)
         else:
             value = self.data.__getitem__(indices)
-        if as_numpy:
+        if as_numpy and not isinstance(value,np.ndarray):
             value = to_numpy(value)
         value = np.atleast_1d(value)
         if fft_shift:


### PR DESCRIPTION
### Description of the change
I run a `cProfile `test of `multifit `and realized that in a simple case (single gaussian peak fit) close to 30% of the time is spent calling `hyperspy.misc.utils.to_numpy`. See the pink block in the screenshot below.

<img width="691" alt="perfshot_b4" src="https://user-images.githubusercontent.com/123734179/218751211-e14a38cc-49e1-43cb-931e-ac9fa43ae38d.PNG">

By explicitly checking if the data is of type `np.ndarray` in `signal.__call__` before calling `to_numpy` execution time goes down from 3.44 to 2.37 seconds (31% improvement) and tests pass. See screenshot below

<img width="691" alt="perfshot_after" src="https://user-images.githubusercontent.com/123734179/218752644-57fdd3af-1451-417c-950c-1e0ceac2fba8.PNG">

Let me know if I am missing on something there but if not I think I can identify other performance improvements along these lines in the multifit procedure. 

### Progress of the PR
- [x] Change implemented (can be split into several points),
- [ ] add an changelog entry in the `upcoming_changes` folder (see [`upcoming_changes/README.rst`](https://github.com/hyperspy/hyperspy/blob/RELEASE_next_minor/upcoming_changes/README.rst)),
- [ ] Check formatting changelog entry in the `readthedocs` doc build of this PR (link in github checks)
- [x] add tests (No tests needed)
- [x] ready for review.

### Minimal example of the bug fix or the new feature
Performance profiling code. The generated `perf_multifit.prof` can be then visualised with `snakeviz`

```python
from hyperspy.datasets.artificial_data import get_luminescence_signal
from hyperspy._components.gaussian import Gaussian
import cProfile
import pstats

# import matplotlib.pyplot as plt
with cProfile.Profile() as pr:
    for i in range(10):
        s = get_luminescence_signal(navigation_dimension=2, uniform=True)
        m = s.create_model()
        g = Gaussian(A = 10000, centre = 300.0)
        m.append(g)
        m.multifit(iterpath='serpentine')

stats = pstats.Stats(pr)
stats.dump_stats(filename='perf_multifit.prof')
```
