### PR TITLE
Fix linkchecker documentation

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -41,14 +41,18 @@ extensions = [
 ]
 
 linkcheck_ignore = [
-    'https://www.jstor.org/stable/24307705',  # 403 Client Error: Forbidden for url
-    'https://anaconda.org',  # 403 Client Error: Forbidden for url
+    "https://anaconda.org",  # 403 Client Error: Forbidden for url
+    "https://doi.org/10.1021/acs.nanolett.5b00449",  # 403 Client Error: Forbidden for url
+    "https://onlinelibrary.wiley.com",  # 403 Client Error: Forbidden for url
 ]
 
 linkcheck_exclude_documents = [
     'user_guide/io/*',
     'api/hyperspy.io_plugins*',
     ]
+
+# Specify a standard user agent, as Sphinx default is blocked on some sites
+user_agent = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/108.0.0.0 Safari/537.36 Edg/108.0.1462.54"
 
 try:
     import sphinxcontrib.spelling

--- a/doc/user_guide/bibliography.rst
+++ b/doc/user_guide/bibliography.rst
@@ -79,7 +79,7 @@ Bibliography
    M. Keenan and P. Kotula, "Accounting for Poisson noise in
    the multivariate analysis of ToF-SIMS spectrum images," *Surf.
    Interface Anal* 36(3) (2004): 203–212
-   [`<https://doi.org/10.1002/sia.1657>`_].
+   [`<https://onlinelibrary.wiley.com/doi/10.1002/sia.1657>`_].
 
 .. _MacArthur2016:
 
@@ -96,7 +96,7 @@ Bibliography
    M. McCartney and D. Smith, "Electron
    holography: phase imaging with nanometer resolution," *Annu. Rev. Mater.
    Res.* 37 (2007): 729-767
-   [`<https://doi.org/10.1146/annurev.matsci.37.052506.084219>`_].
+   [`<https://onlinelibrary.wiley.com/doi/10.1146/annurev.matsci.37.052506.084219>`_].
 
 .. _[Nicoletti2013]:
 
@@ -145,7 +145,7 @@ Bibliography
    M. Watanabe and D. Williams, "The
    quantitative analysis of thin specimens: a review of progress from the
    Cliff-Lorimer to the new zeta-factor methods," *J. Microsc.* 221 (2006):
-   89–109 [`<https://doi.org/10.1111/j.1365-2818.2006.01549.x>`_].
+   89–109 [`<https://onlinelibrary.wiley.com/doi/10.1111/j.1365-2818.2006.01549.x>`_].
 
 .. _Williams2009:
 
@@ -210,7 +210,7 @@ Bibliography
     - Iakoubovskii, K., K. Mitsuishi, Y. Nakayama, and K. Furuya.
       ‘Thickness Measurements with Electron Energy Loss Spectroscopy’.
       Microscopy Research and Technique 71, no. 8 (2008): 626–31.
-      [`<https://doi.org/10.1002/jemt.20597>`_].
+      [`<https://onlinelibrary.wiley.com/doi/10.1002/jemt.20597>`_].
 
 .. _White2009:
 

--- a/doc/user_guide/model.rst
+++ b/doc/user_guide/model.rst
@@ -1549,7 +1549,7 @@ when fitting multi-dimensional datasets.
 The algorithm will be described in full when accompanying paper is published,
 but we are making the implementation available now, with additional details
 available in the following `conference proceeding
-<https://doi.org/10.1002/9783527808465.EMC2016.6233>`_.
+<https://onlinelibrary.wiley.com/doi/10.1002/9783527808465.EMC2016.6233>`_.
 
 The idea
 ^^^^^^^^

--- a/hyperspy/misc/eds/ffast_mac.py
+++ b/hyperspy/misc/eds/ffast_mac.py
@@ -1,5 +1,5 @@
 # Mass absoption coefficient Chantler2005
-# See https://physics.nist.gov/ffast
+# See https://dx.doi.org/10.18434/T4HS32
 # Chantler, C.T., Olsen, K., Dragoset, R.A., Kishore, A.R., Kotochigova,
 # S.A., and Zucker, D.S. (2005), X-Ray Form Factor, Attenuation and
 # Scattering Tables (version 2.1).

--- a/hyperspy/misc/eels/electron_inelastic_mean_free_path.py
+++ b/hyperspy/misc/eels/electron_inelastic_mean_free_path.py
@@ -42,7 +42,7 @@ def iMFP_Iakoubovskii(density, electron_energy):
     .. [*] Iakoubovskii, K., K. Mitsuishi, Y. Nakayama, and K. Furuya.
        ‘Thickness Measurements with Electron Energy Loss Spectroscopy’.
        Microscopy Research and Technique 71, no. 8 (2008): 626–31.
-       https://doi.org/10.1002/jemt.20597
+       https://onlinelibrary.wiley.com/doi/10.1002/jemt.20597
 
     Returns
     -------
@@ -84,7 +84,7 @@ def iMFP_TPP2M(electron_energy, density, M, N_v, E_g):
        the 50 EV to 200 KeV Range with the Relativistic Full Penn Algorithm:
        Calculations of Electron Inelastic Mean Free Paths. X’. Surface and
        Interface Analysis 47, no. 9 (September 2015): 871–88.
-       https://doi.org/10.1002/sia.5789
+       https://onlinelibrary.wiley.com/doi/10.1002/sia.5789
     """
     E = electron_energy * 1e3
     rho = density
@@ -117,7 +117,7 @@ def iMFP_angular_correction(density, beam_energy, alpha, beta):
     .. [*] Iakoubovskii, K., K. Mitsuishi, Y. Nakayama, and K. Furuya.
        ‘Thickness Measurements with Electron Energy Loss Spectroscopy’.
        Microscopy Research and Technique 71, no. 8 (2008): 626–31.
-       https://doi.org/10.1002/jemt.20597
+       https://onlinelibrary.wiley.com/doi/10.1002/jemt.20597
     """
     theta_C = 20 # mrad
     A = alpha ** 2 + beta ** 2 + 2 * _theta_E(density, beam_energy) ** 2 + abs(alpha ** 2 - beta ** 2)

--- a/hyperspy/misc/material.py
+++ b/hyperspy/misc/material.py
@@ -312,7 +312,7 @@ def mass_absorption_coefficient(element, energies):
 
     Note
     ----
-    See https://physics.nist.gov/ffast
+    See https://dx.doi.org/10.18434/T4HS32
     Chantler, C.T., Olsen, K., Dragoset, R.A., Kishore, A.R., Kotochigova,
     S.A., and Zucker, D.S. (2005), X-Ray Form Factor, Attenuation and
     Scattering Tables (version 2.1).
@@ -371,7 +371,7 @@ def _mass_absorption_mixture(weight_percent,
 
     Note
     ----
-    See https://physics.nist.gov/ffast
+    See https://dx.doi.org/10.18434/T4HS32
     Chantler, C.T., Olsen, K., Dragoset, R.A., Kishore, A.R., Kotochigova,
     S.A., and Zucker, D.S. (2005), X-Ray Form Factor, Attenuation and
     Scattering Tables (version 2.1).
@@ -434,7 +434,7 @@ def mass_absorption_mixture(weight_percent,
 
     Note
     ----
-    See https://physics.nist.gov/ffast
+    See https://dx.doi.org/10.18434/T4HS32
     Chantler, C.T., Olsen, K., Dragoset, R.A., Kishore, A.R., Kotochigova,
     S.A., and Zucker, D.S. (2005), X-Ray Form Factor, Attenuation and
     Scattering Tables (version 2.1).

--- a/upcoming_changes/3108.maintenance.rst
+++ b/upcoming_changes/3108.maintenance.rst
@@ -1,0 +1,1 @@
+Fix checking links in documentation for domain, which aren't compatible with sphinx linkcheck 


### PR DESCRIPTION
We can't use the linkchecker with `onlinelibrary.wiley.com` because of "403 Client Error: Forbidden for url" errors and to be able to filter this domain with `linkcheck_ignore` configuration parameter, the DOI needs to be change to the url containing the domain name - see https://github.com/sphinx-doc/sphinx/issues/11233.

Backport some of #3088.

### Progress of the PR
- [x] Fix linkchecker documentation,
- [x] update docstring (if appropriate),
- [x] update user guide (if appropriate),
- [x] add an changelog entry in the `upcoming_changes` folder (see [`upcoming_changes/README.rst`](https://github.com/hyperspy/hyperspy/blob/RELEASE_next_minor/upcoming_changes/README.rst)),
- [x] Check formatting changelog entry in the `readthedocs` doc build of this PR (link in github checks)
- [n/a] add tests,
- [x] ready for review.

