### PR TITLE
Speed up `to_numpy` to fix fitting slowdown

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,6 +47,7 @@ hyperspy/misc/etc/test_compilers.obj
 *nbi
 hyperspy/tests/io/edax_files.zip
 .python-version
+*__pycache__
 
 ### Code ###
 # Visual Studio Code - https://code.visualstudio.com/

--- a/hyperspy/misc/utils.py
+++ b/hyperspy/misc/utils.py
@@ -1586,17 +1586,21 @@ def to_numpy(array):
 
     Raises
     ------
-    ValueError
-        If the provided array is a dask array
-
+    TypeError
+        When the input array type is not supported.
     """
-    if isinstance(array, da.Array):
-        raise LazyCupyConversion
-    if is_cupy_array(array):
+    if isinstance(array, np.ndarray):
+        return array
+    elif isinstance(array, da.Array):
+        raise TypeError(
+            "Implicit conversion of dask array to numpy array is not "
+            "supported, conversion needs to be done explicitely."
+            )
+    elif is_cupy_array(array):  # pragma: no cover
         import cupy as cp
-        array = cp.asnumpy(array)
-
-    return array
+        return cp.asnumpy(array)
+    else:
+        raise TypeError("Unsupported array type.")
 
 
 def get_array_module(array):

--- a/hyperspy/tests/misc/test_utils.py
+++ b/hyperspy/tests/misc/test_utils.py
@@ -167,13 +167,20 @@ def test_to_numpy():
 
 def test_to_numpy_error():
     da_array = da.array([0, 1, 2])
-    with pytest.raises(LazyCupyConversion):
+    with pytest.raises(TypeError):
         to_numpy(da_array)
+
+    list_array = [[0, 1, 2]]
+    with pytest.raises(TypeError):
+        to_numpy(list_array)
+
+
+def test_get_array_module():
+    np_array = np.array([0, 1, 2])
+    assert get_array_module(np_array) == np
 
 
 @skip_cupy
-def test_get_array_module():
+def test_get_array_module_cupy():
     cp_array = cp.array([0, 1, 2])
-    np_array = np.array([0, 1, 2])
     assert get_array_module(cp_array) == cp
-    assert get_array_module(np_array) == np

--- a/upcoming_changes/3109.bugfix.rst
+++ b/upcoming_changes/3109.bugfix.rst
@@ -1,0 +1,1 @@
+Speed up :py:func:`~.misc.utils.to_numpy` function to avoid slow down when used repeatedly, typically during fitting


### PR DESCRIPTION
Slightly more generic alternative to https://github.com/hyperspy/hyperspy/pull/3101. This is happening when calling the `to_numpy` function many times, typically when fitting.

### Progress of the PR
- [x] check if array is of a `numpy.ndarray`  instance first to avoid going through the slower branch of the functions
- [n/a] update docstring (if appropriate),
- [n/a] update user guide (if appropriate),
- [x] add an changelog entry in the `upcoming_changes` folder (see [`upcoming_changes/README.rst`](https://github.com/hyperspy/hyperspy/blob/RELEASE_next_minor/upcoming_changes/README.rst)),
- [x] Check formatting changelog entry in the `readthedocs` doc build of this PR (link in github checks)
- [x] add tests,
- [x] ready for review.

