### PR TITLE
Fix plotting boolean array with `hs.plot.plot_images`

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -23,7 +23,7 @@ jobs:
             PYTHON_VERSION: '3.7'
             PIP_SELECTOR: '[all, tests, coverage]'
             OLDEST_SUPPORTED_VERSION: true
-            DEPENDENCIES: matplotlib==3.1.3 numpy==1.17.1 scipy==1.4 imagecodecs==2020.1.31 tifffile==2020.2.16 dask==2.11.0 distributed==2.11.0 scikit-image==0.15 numba==0.52 scikit-learn==1.0.1
+            DEPENDENCIES: matplotlib==3.1.3 numpy==1.19.0 scipy==1.4 imagecodecs==2020.1.31 tifffile==2020.2.16 dask==2.11.0 distributed==2.11.0 scikit-image==0.15 numba==0.52 scikit-learn==1.0.1
             LABEL: -oldest
           # test minimum requirement
           - os: ubuntu

--- a/hyperspy/drawing/utils.py
+++ b/hyperspy/drawing/utils.py
@@ -69,6 +69,10 @@ def contrast_stretching(data, vmin=None, vmax=None):
         calculation (in case of string values).
 
     """
+    if np.issubdtype(data.dtype, bool):
+        # in case of boolean, simply return 0, 1
+        return 0, 1
+
     def _parse_value(value, value_name):
         if value is None:
             if value_name == "vmin":

--- a/hyperspy/tests/drawing/test_plot_signal2d.py
+++ b/hyperspy/tests/drawing/test_plot_signal2d.py
@@ -711,3 +711,10 @@ def test_plot_scalebar_list():
     ax0, ax1 = hs.plot.plot_images([s, s], scalebar=[0])
     assert hasattr(ax0, 'scalebar')
     assert not hasattr(ax1, 'scalebar')
+
+
+def test_plot_images_bool():
+    data = np.arange(100).reshape((10, 10)) > 50
+    s = hs.signals.Signal2D(data)
+
+    hs.plot.plot_images(s)

--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,7 @@ setup_path = os.path.dirname(__file__)
 
 install_req = ['scipy>=1.4.0',
                'matplotlib>=3.1.3',
-               'numpy>=1.17.1',
+               'numpy>=1.19.0',
                'traits>=4.5.0',
                'natsort',
                'requests',

--- a/upcoming_changes/3118.bugfix.rst
+++ b/upcoming_changes/3118.bugfix.rst
@@ -1,0 +1,1 @@
+Fix plotting boolean array with :py:func:`~.drawing.utils.plot_images`


### PR DESCRIPTION
### Progress of the PR
- [x] Fix plotting boolean array in `hs.plot.plot_images`,
- [x] bump numpy to 1.19 to avoid test failure
- [n/a] update docstring (if appropriate),
- [n/a] update user guide (if appropriate),
- [x] add an changelog entry in the `upcoming_changes` folder (see [`upcoming_changes/README.rst`](https://github.com/hyperspy/hyperspy/blob/RELEASE_next_minor/upcoming_changes/README.rst)),
- [x] Check formatting changelog entry in the `readthedocs` doc build of this PR (link in github checks)
- [x] add tests,
- [x] ready for review.

### Minimal example of the bug fix or the new feature
```python
import hyperspy.api as hs
import numpy as np

data = np.arange(100).reshape((10, 10)) > 50
s = hs.signals.Signal2D(data)

hs.plot.plot_images(s)
```

