### PR TITLE
Metadata mapping and signal assignment from .sur Signal format

### DIFF
--- a/hyperspy/tests/io/test_sur.py
+++ b/hyperspy/tests/io/test_sur.py
@@ -17,148 +17,152 @@
 # along with HyperSpy. If not, see <https://www.gnu.org/licenses/#GPL>.
 
 import os
+import importlib.util
 
 import numpy as np
 
 from hyperspy.io import load
+from hyperspy.io_plugins import sur
 
 MY_PATH = os.path.dirname(__file__)
 
 header_keys = ['H01_Signature',
-                 'H02_Format',
-                 'H03_Number_of_Objects',
-                 'H04_Version',
-                 'H05_Object_Type',
-                 'H06_Object_Name',
-                 'H07_Operator_Name',
-                 'H08_P_Size',
-                 'H09_Acquisition_Type',
-                 'H10_Range_Type',
-                 'H11_Special_Points',
-                 'H12_Absolute',
-                 'H13_Gauge_Resolution',
-                 'H14_W_Size',
-                 'H15_Size_of_Points',
-                 'H16_Zmin',
-                 'H17_Zmax',
-                 'H18_Number_of_Points',
-                 'H19_Number_of_Lines',
-                 'H20_Total_Nb_of_Pts',
-                 'H21_X_Spacing',
-                 'H22_Y_Spacing',
-                 'H23_Z_Spacing',
-                 'H24_Name_of_X_Axis',
-                 'H25_Name_of_Y_Axis',
-                 'H26_Name_of_Z_Axis',
-                 'H27_X_Step_Unit',
-                 'H28_Y_Step_Unit',
-                 'H29_Z_Step_Unit',
-                 'H30_X_Length_Unit',
-                 'H31_Y_Length_Unit',
-                 'H32_Z_Length_Unit',
-                 'H33_X_Unit_Ratio',
-                 'H34_Y_Unit_Ratio',
-                 'H35_Z_Unit_Ratio',
-                 'H36_Imprint',
-                 'H37_Inverted',
-                 'H38_Levelled',
-                 'H39_Obsolete',
-                 'H40_Seconds',
-                 'H41_Minutes',
-                 'H42_Hours',
-                 'H43_Day',
-                 'H44_Month',
-                 'H45_Year',
-                 'H46_Day_of_week',
-                 'H47_Measurement_duration',
-                 'H48_Compressed_data_size',
-                 'H49_Obsolete',
-                 'H50_Comment_size',
-                 'H51_Private_size',
-                 'H52_Client_zone',
-                 'H53_X_Offset',
-                 'H54_Y_Offset',
-                 'H55_Z_Offset',
-                 'H56_T_Spacing',
-                 'H57_T_Offset',
-                 'H58_T_Axis_Name',
-                 'H59_T_Step_Unit',
-                 'H60_Comment',
-                 ]
+               'H02_Format',
+               'H03_Number_of_Objects',
+               'H04_Version',
+               'H05_Object_Type',
+               'H06_Object_Name',
+               'H07_Operator_Name',
+               'H08_P_Size',
+               'H09_Acquisition_Type',
+               'H10_Range_Type',
+               'H11_Special_Points',
+               'H12_Absolute',
+               'H13_Gauge_Resolution',
+               'H14_W_Size',
+               'H15_Size_of_Points',
+               'H16_Zmin',
+               'H17_Zmax',
+               'H18_Number_of_Points',
+               'H19_Number_of_Lines',
+               'H20_Total_Nb_of_Pts',
+               'H21_X_Spacing',
+               'H22_Y_Spacing',
+               'H23_Z_Spacing',
+               'H24_Name_of_X_Axis',
+               'H25_Name_of_Y_Axis',
+               'H26_Name_of_Z_Axis',
+               'H27_X_Step_Unit',
+               'H28_Y_Step_Unit',
+               'H29_Z_Step_Unit',
+               'H30_X_Length_Unit',
+               'H31_Y_Length_Unit',
+               'H32_Z_Length_Unit',
+               'H33_X_Unit_Ratio',
+               'H34_Y_Unit_Ratio',
+               'H35_Z_Unit_Ratio',
+               'H36_Imprint',
+               'H37_Inverted',
+               'H38_Levelled',
+               'H39_Obsolete',
+               'H40_Seconds',
+               'H41_Minutes',
+               'H42_Hours',
+               'H43_Day',
+               'H44_Month',
+               'H45_Year',
+               'H46_Day_of_week',
+               'H47_Measurement_duration',
+               'H48_Compressed_data_size',
+               'H49_Obsolete',
+               'H50_Comment_size',
+               'H51_Private_size',
+               'H52_Client_zone',
+               'H53_X_Offset',
+               'H54_Y_Offset',
+               'H55_Z_Offset',
+               'H56_T_Spacing',
+               'H57_T_Offset',
+               'H58_T_Axis_Name',
+               'H59_T_Step_Unit',
+               'H60_Comment',
+               ]
 
 atto_head_keys = ['WAFER',
-                            'SITE IMAGE',
-                            'SEM',
-                            'CHANNELS',
-                            'SPECTROMETER',
-                            'SCAN',
-                            ]
+                  'SITE IMAGE',
+                  'SEM',
+                  'CHANNELS',
+                  'SPECTROMETER',
+                  'SCAN',
+                  ]
 
 atto_wafer_keys = ['Lot Number',
-                     'ID',
-                     'Type',
-                     'Center Position X',
-                     'Center Position X_units',
-                     'Center Position Y',
-                     'Center Position Y_units',
-                     'Orientation',
-                     'Orientation_units',
-                     'Diameter',
-                     'Diameter_units',
-                     'Flat Length',
-                     'Flat Length_units',
-                     'Edge Exclusion',
-                     'Edge Exclusion_units',
-                     ]
+                   'ID',
+                   'Type',
+                   'Center Position X',
+                   'Center Position X_units',
+                   'Center Position Y',
+                   'Center Position Y_units',
+                   'Orientation',
+                   'Orientation_units',
+                   'Diameter',
+                   'Diameter_units',
+                   'Flat Length',
+                   'Flat Length_units',
+                   'Edge Exclusion',
+                   'Edge Exclusion_units',
+                   ]
 
 atto_scan_keys = ['Mode',
-                 'HYP Dwelltime',
-                 'HYP Dwelltime_units',
-                 'Resolution_X',
-                 'Resolution_X_units',
-                 'Resolution_Y',
-                 'Resolution_Y_units',
-                 'Reference_Size_X',
-                 'Reference_Size_Y',
-                 'Voltage Calibration Range_X',
-                 'Voltage Calibration Range_X_units',
-                 'Voltage Calibration Range_Y',
-                 'Voltage Calibration Range_Y_units',
-                 'Start_X',
-                 'Size_X',
-                 'Start_Y',
-                 'Size_Y',
-                 'Rotate',
-                 'Rotate_units',
-                 ]
+                  'HYP Dwelltime',
+                  'HYP Dwelltime_units',
+                  'Resolution_X',
+                  'Resolution_X_units',
+                  'Resolution_Y',
+                  'Resolution_Y_units',
+                  'Reference_Size_X',
+                  'Reference_Size_Y',
+                  'Voltage Calibration Range_X',
+                  'Voltage Calibration Range_X_units',
+                  'Voltage Calibration Range_Y',
+                  'Voltage Calibration Range_Y_units',
+                  'Start_X',
+                  'Size_X',
+                  'Start_Y',
+                  'Size_Y',
+                  'Rotate',
+                  'Rotate_units',
+                  ]
+
 
 def test_load_profile():
-    #Signal loading
+    # Signal loading
     fname = os.path.join(MY_PATH, "sur_data",
                          "test_profile.pro")
     s = load(fname)
 
-    #Verifying signal shape and axes dimensions, navigation (not data themselves)
+    # Verifying signal shape and axes dimensions, navigation (not data themselves)
     assert s.data.shape == (128,)
     assert s.data.dtype == np.dtype(float)
-    np.testing.assert_allclose(s.axes_manager[0].scale,8.252197e-05)
-    np.testing.assert_allclose(s.axes_manager[0].offset,0.0)
+    np.testing.assert_allclose(s.axes_manager[0].scale, 8.252197e-05)
+    np.testing.assert_allclose(s.axes_manager[0].offset, 0.0)
     assert s.axes_manager[0].name == 'Width'
     assert s.axes_manager[0].units == 'mm'
     assert s.axes_manager[0].size == 128
-    assert s.axes_manager[0].navigate == False
+    assert s.axes_manager[0].navigate is False
 
-    #Metadata verification
+    # Metadata verification
     md = s.metadata
     assert md.Signal.quantity == 'CL Intensity (a.u.)'
 
-    #Original metadata. We verify that the correct structure is given
-    #and the right headers but not the values
+    # Original metadata. We verify that the correct structure is given
+    # and the right headers but not the values
     omd = s.original_metadata
     assert list(omd.as_dictionary().keys()) == ['Object_0_Channel_0']
     assert list(omd.Object_0_Channel_0.as_dictionary().keys()) == ['Header']
     assert list(omd.Object_0_Channel_0.Header.as_dictionary().keys()) \
-                                                            == header_keys
+           == header_keys
+
 
 def test_load_RGB():
     fname = os.path.join(MY_PATH, "sur_data",
@@ -167,18 +171,18 @@ def test_load_RGB():
     assert s.data.shape == (200, 200)
     assert s.data.dtype == np.dtype([('R', 'u1'), ('G', 'u1'), ('B', 'u1')])
 
-    np.testing.assert_allclose(s.axes_manager[0].scale,0.35277777)
-    np.testing.assert_allclose(s.axes_manager[0].offset,208.8444519)
-    np.testing.assert_allclose(s.axes_manager[1].scale,0.35277777)
-    np.testing.assert_allclose(s.axes_manager[1].offset,210.608337)
+    np.testing.assert_allclose(s.axes_manager[0].scale, 0.35277777)
+    np.testing.assert_allclose(s.axes_manager[0].offset, 208.8444519)
+    np.testing.assert_allclose(s.axes_manager[1].scale, 0.35277777)
+    np.testing.assert_allclose(s.axes_manager[1].offset, 210.608337)
     assert s.axes_manager[0].name == 'X'
     assert s.axes_manager[0].units == 'mm'
     assert s.axes_manager[1].name == 'Y'
     assert s.axes_manager[1].units == 'mm'
     assert s.axes_manager[0].size == 200
-    assert s.axes_manager[0].navigate == False
+    assert s.axes_manager[0].navigate is False
     assert s.axes_manager[1].size == 200
-    assert s.axes_manager[1].navigate == False
+    assert s.axes_manager[1].navigate is False
 
     md = s.metadata
     assert md.Signal.quantity == 'Z'
@@ -189,6 +193,7 @@ def test_load_RGB():
                                                 'Object_0_Channel_2']
     assert list(omd.Object_0_Channel_0.as_dictionary().keys()) == ['Header']
     assert list(omd.Object_0_Channel_0.Header.as_dictionary().keys()) == header_keys
+
 
 def test_load_spectra():
     fname = os.path.join(MY_PATH, "sur_data",
@@ -209,15 +214,16 @@ def test_load_spectra():
     assert s.axes_manager[1].name == 'Wavelength'
     assert s.axes_manager[1].units == 'mm'
     assert s.axes_manager[0].size == 65
-    assert s.axes_manager[0].navigate == True
+    assert s.axes_manager[0].navigate is True
     assert s.axes_manager[1].size == 512
-    assert s.axes_manager[1].navigate == False
+    assert s.axes_manager[1].navigate is False
 
     omd = s.original_metadata
-    assert list(omd.as_dictionary().keys()) == ['Object_0_Channel_0',]
+    assert list(omd.as_dictionary().keys()) == ['Object_0_Channel_0', ]
     assert list(omd.Object_0_Channel_0.as_dictionary().keys()) == ['Header']
     assert list(omd.Object_0_Channel_0.Header.as_dictionary().keys()) \
-                                                                == header_keys
+           == header_keys
+
 
 def test_load_spectral_map_compressed():
     fname = os.path.join(MY_PATH, "sur_data",
@@ -227,14 +233,21 @@ def test_load_spectral_map_compressed():
     assert s.data.shape == (12, 10, 281)
     assert s.data.dtype == np.dtype('float64')
 
+    #Easy way to test for both configurations, with/without lumispy installed.
+    lumispy_found = importlib.util.find_spec("lumispy") is not None
+    if lumispy_found:
+        assert type(s)._signal_type == 'CL'
+    else:
+        assert type(s)._signal_type == ''
+
     md = s.metadata
     assert md.Signal.quantity == 'CL Intensity (a.u.)'
-    np.testing.assert_allclose(s.axes_manager[0].scale,8.252198e-05)
-    np.testing.assert_allclose(s.axes_manager[0].offset,0.005694016348570585)
-    np.testing.assert_allclose(s.axes_manager[1].scale,8.252198e-05)
-    np.testing.assert_allclose(s.axes_manager[1].offset,0.0054464503191411495)
-    np.testing.assert_allclose(s.axes_manager[2].scale,1.084000246009964e-06)
-    np.testing.assert_allclose(s.axes_manager[2].offset,0.00034411484375596046)
+    np.testing.assert_allclose(s.axes_manager[0].scale, 8.252198e-05)
+    np.testing.assert_allclose(s.axes_manager[0].offset, 0.005694016348570585)
+    np.testing.assert_allclose(s.axes_manager[1].scale, 8.252198e-05)
+    np.testing.assert_allclose(s.axes_manager[1].offset, 0.0054464503191411495)
+    np.testing.assert_allclose(s.axes_manager[2].scale, 1.084000246009964e-06)
+    np.testing.assert_allclose(s.axes_manager[2].offset, 0.00034411484375596046)
     assert s.axes_manager[0].name == 'Width'
     assert s.axes_manager[0].units == 'mm'
     assert s.axes_manager[1].name == 'Height'
@@ -242,27 +255,27 @@ def test_load_spectral_map_compressed():
     assert s.axes_manager[2].name == 'Wavelength'
     assert s.axes_manager[2].units == 'mm'
     assert s.axes_manager[0].size == 10
-    assert s.axes_manager[0].navigate == True
+    assert s.axes_manager[0].navigate is True
     assert s.axes_manager[1].size == 12
-    assert s.axes_manager[1].navigate == True
+    assert s.axes_manager[1].navigate is True
     assert s.axes_manager[2].size == 281
-    assert s.axes_manager[2].navigate == False
+    assert s.axes_manager[2].navigate is False
 
     omd = s.original_metadata
-    assert list(omd.as_dictionary().keys()) == ['Object_0_Channel_0',]
+    assert list(omd.as_dictionary().keys()) == ['Object_0_Channel_0', ]
     assert list(omd.Object_0_Channel_0.as_dictionary().keys()) \
-                                                            == ['Header','Parsed']
+           == ['Header', 'Parsed']
     assert list(omd.Object_0_Channel_0.Header.as_dictionary().keys()) \
-                                                            == header_keys
+           == header_keys
 
     assert list(omd.Object_0_Channel_0.Parsed.as_dictionary().keys()) \
-                                                            == atto_head_keys
+           == atto_head_keys
 
     assert list(omd.Object_0_Channel_0.Parsed.WAFER.as_dictionary().keys()) \
-                                                            == atto_wafer_keys
+           == atto_wafer_keys
 
     assert list(omd.Object_0_Channel_0.Parsed.SCAN.as_dictionary().keys()) \
-                                                            == atto_scan_keys
+           == atto_scan_keys
 
 def test_load_spectral_map():
     fname = os.path.join(MY_PATH, "sur_data",
@@ -272,14 +285,20 @@ def test_load_spectral_map():
     assert s.data.shape == (12, 10, 310)
     assert s.data.dtype == np.dtype('float64')
 
+    lumispy_found = importlib.util.find_spec("lumispy") is not None
+    if lumispy_found:
+        assert type(s)._signal_type == 'CL'
+    else:
+        assert type(s)._signal_type == ''
+
     md = s.metadata
     assert md.Signal.quantity == 'CL Intensity (a.u.)'
-    np.testing.assert_allclose(s.axes_manager[0].scale,8.252197585534304e-05)
-    np.testing.assert_allclose(s.axes_manager[0].offset,0.00701436772942543)
-    np.testing.assert_allclose(s.axes_manager[1].scale,8.252197585534304e-05)
-    np.testing.assert_allclose(s.axes_manager[1].offset,0.003053313121199608)
-    np.testing.assert_allclose(s.axes_manager[2].scale,1.084000246009964e-6)
-    np.testing.assert_allclose(s.axes_manager[2].offset,0.0003332748601678759)
+    np.testing.assert_allclose(s.axes_manager[0].scale, 8.252197585534304e-05)
+    np.testing.assert_allclose(s.axes_manager[0].offset, 0.00701436772942543)
+    np.testing.assert_allclose(s.axes_manager[1].scale, 8.252197585534304e-05)
+    np.testing.assert_allclose(s.axes_manager[1].offset, 0.003053313121199608)
+    np.testing.assert_allclose(s.axes_manager[2].scale, 1.084000246009964e-6)
+    np.testing.assert_allclose(s.axes_manager[2].offset, 0.0003332748601678759)
     assert s.axes_manager[0].name == 'Width'
     assert s.axes_manager[0].units == 'mm'
     assert s.axes_manager[1].name == 'Height'
@@ -287,27 +306,27 @@ def test_load_spectral_map():
     assert s.axes_manager[2].name == 'Wavelength'
     assert s.axes_manager[2].units == 'mm'
     assert s.axes_manager[0].size == 10
-    assert s.axes_manager[0].navigate == True
+    assert s.axes_manager[0].navigate is True
     assert s.axes_manager[1].size == 12
-    assert s.axes_manager[1].navigate == True
+    assert s.axes_manager[1].navigate is True
     assert s.axes_manager[2].size == 310
-    assert s.axes_manager[2].navigate == False
-
+    assert s.axes_manager[2].navigate is False
 
     omd = s.original_metadata
-    assert list(omd.as_dictionary().keys()) == ['Object_0_Channel_0',]
-    assert list(omd.Object_0_Channel_0.as_dictionary().keys()) == ['Header','Parsed']
+    assert list(omd.as_dictionary().keys()) == ['Object_0_Channel_0', ]
+    assert list(omd.Object_0_Channel_0.as_dictionary().keys()) == ['Header', 'Parsed']
     assert list(omd.Object_0_Channel_0.Header.as_dictionary().keys()) \
-                                                               == header_keys
+           == header_keys
 
     assert list(omd.Object_0_Channel_0.Parsed.as_dictionary().keys()) \
-                                                            == atto_head_keys
+           == atto_head_keys
 
     assert list(omd.Object_0_Channel_0.Parsed.WAFER.as_dictionary().keys()) \
-                                                            == atto_wafer_keys
+           == atto_wafer_keys
 
-    assert list(omd.Object_0_Channel_0.Parsed.SCAN.as_dictionary().keys())  \
-                                                            == atto_scan_keys
+    assert list(omd.Object_0_Channel_0.Parsed.SCAN.as_dictionary().keys()) \
+           == atto_scan_keys
+
 
 def test_load_spectrum_compressed():
     fname = os.path.join(MY_PATH, "sur_data",
@@ -316,25 +335,26 @@ def test_load_spectrum_compressed():
     md = s.metadata
     assert md.Signal.quantity == 'CL Intensity (a.u.)'
     assert s.data.shape == (512,)
-    #np.testing.assert_allclose(s.axes_manager[0].scale,1.0)
-    #np.testing.assert_allclose(s.axes_manager[0].offset,0.0)
-    np.testing.assert_allclose(s.axes_manager[0].scale,1.084000246009964e-6)
-    np.testing.assert_allclose(s.axes_manager[0].offset,172.84281784668565e-6)
+    # np.testing.assert_allclose(s.axes_manager[0].scale,1.0)
+    # np.testing.assert_allclose(s.axes_manager[0].offset,0.0)
+    np.testing.assert_allclose(s.axes_manager[0].scale, 1.084000246009964e-6)
+    np.testing.assert_allclose(s.axes_manager[0].offset, 172.84281784668565e-6)
 
-    #assert s.axes_manager[0].name == 'T'
-    #assert s.axes_manager[0].units == ''
+    # assert s.axes_manager[0].name == 'T'
+    # assert s.axes_manager[0].units == ''
     assert s.axes_manager[0].name == 'Wavelength'
     assert s.axes_manager[0].units == 'mm'
-    #assert s.axes_manager[0].size == 1
-    #assert s.axes_manager[0].navigate == True
+    # assert s.axes_manager[0].size == 1
+    # assert s.axes_manager[0].navigate == True
     assert s.axes_manager[0].size == 512
-    assert s.axes_manager[0].navigate == False
+    assert s.axes_manager[0].navigate is False
 
     omd = s.original_metadata
     assert list(omd.as_dictionary().keys()) == ['Object_0_Channel_0']
     assert list(omd.Object_0_Channel_0.as_dictionary().keys()) == ['Header']
     assert list(omd.Object_0_Channel_0.Header.as_dictionary().keys()) \
-                                                                == header_keys
+           == header_keys
+
 
 def test_load_spectrum():
     fname = os.path.join(MY_PATH, "sur_data",
@@ -344,25 +364,26 @@ def test_load_spectrum():
 
     md = s.metadata
     assert md.Signal.quantity == 'CL Intensity (a.u.)'
-    #np.testing.assert_allclose(s.axes_manager[0].scale,1.0)
-    #np.testing.assert_allclose(s.axes_manager[0].offset,0.0)
-    np.testing.assert_allclose(s.axes_manager[0].scale,1.084000246009964e-6)
-    np.testing.assert_allclose(s.axes_manager[0].offset,172.84281784668565e-6)
+    # np.testing.assert_allclose(s.axes_manager[0].scale,1.0)
+    # np.testing.assert_allclose(s.axes_manager[0].offset,0.0)
+    np.testing.assert_allclose(s.axes_manager[0].scale, 1.084000246009964e-6)
+    np.testing.assert_allclose(s.axes_manager[0].offset, 172.84281784668565e-6)
 
-    #assert s.axes_manager[0].name == 'T'
-    #assert s.axes_manager[0].units == ''
+    # assert s.axes_manager[0].name == 'T'
+    # assert s.axes_manager[0].units == ''
     assert s.axes_manager[0].name == 'Wavelength'
     assert s.axes_manager[0].units == 'mm'
-    #assert s.axes_manager[0].size == 1
-    #assert s.axes_manager[0].navigate == True
+    # assert s.axes_manager[0].size == 1
+    # assert s.axes_manager[0].navigate == True
     assert s.axes_manager[0].size == 512
-    assert s.axes_manager[0].navigate == False
+    assert s.axes_manager[0].navigate is False
 
     omd = s.original_metadata
     assert list(omd.as_dictionary().keys()) == ['Object_0_Channel_0']
     assert list(omd.Object_0_Channel_0.as_dictionary().keys()) == ['Header']
     assert list(omd.Object_0_Channel_0.Header.as_dictionary().keys()) \
-                                                                == header_keys
+           == header_keys
+
 
 def test_load_surface():
     fname = os.path.join(MY_PATH, "sur_data",
@@ -370,23 +391,67 @@ def test_load_surface():
     s = load(fname)
     md = s.metadata
     assert md.Signal.quantity == 'CL Intensity (a.u.)'
-    assert s.data.shape == (128,128)
-    np.testing.assert_allclose(s.axes_manager[0].scale,8.252198e-05)
-    np.testing.assert_allclose(s.axes_manager[0].offset,0.0)
-    np.testing.assert_allclose(s.axes_manager[1].scale,8.252198e-05)
-    np.testing.assert_allclose(s.axes_manager[1].offset,0.0)
+    assert s.data.shape == (128, 128)
+    np.testing.assert_allclose(s.axes_manager[0].scale, 8.252198e-05)
+    np.testing.assert_allclose(s.axes_manager[0].offset, 0.0)
+    np.testing.assert_allclose(s.axes_manager[1].scale, 8.252198e-05)
+    np.testing.assert_allclose(s.axes_manager[1].offset, 0.0)
 
     assert s.axes_manager[0].name == 'Width'
     assert s.axes_manager[0].units == 'mm'
     assert s.axes_manager[1].name == 'Height'
     assert s.axes_manager[1].units == 'mm'
     assert s.axes_manager[0].size == 128
-    assert s.axes_manager[0].navigate == False
+    assert s.axes_manager[0].navigate is False
     assert s.axes_manager[1].size == 128
-    assert s.axes_manager[1].navigate == False
+    assert s.axes_manager[1].navigate is False
 
     omd = s.original_metadata
     assert list(omd.as_dictionary().keys()) == ['Object_0_Channel_0']
     assert list(omd.Object_0_Channel_0.as_dictionary().keys()) == ['Header']
     assert list(omd.Object_0_Channel_0.Header.as_dictionary().keys()) \
-                                                            == header_keys
+           == header_keys
+
+def test_choose_signal_type():
+    reader = sur.DigitalSurfHandler()
+
+    #Empty dict should not raise error but return empty string
+    mock_dict = {}
+    assert not reader._choose_signal_type(mock_dict)
+    #Correct behaviour
+    mock_dict = {'_26_Name_of_Z_Axis': "CL Intensity"}
+    assert reader._choose_signal_type(mock_dict) == "CL"
+    #Other behaviour
+    mock_dict = {'_26_Name_of_Z_Axis': "Hairy Monster"}
+    assert not reader._choose_signal_type(mock_dict)
+
+def test_metadata_mapping():
+    fname = os.path.join(MY_PATH, "sur_data",
+                         "test_spectral_map_compressed.sur")
+
+    #Initialize  reader
+    reader = sur.DigitalSurfHandler(fname)
+    reader._read_sur_file()
+    assert not reader.signal_dict['metadata']
+
+    dict_from_sur_object = reader._list_sur_file_content[0]
+
+    # reader._build_sur_dict()
+    generic_metadata = reader._build_generic_metadata(dict_from_sur_object)
+    #By default no signal specific metadata should be created
+    assert "General" in generic_metadata
+    assert "Signal" in generic_metadata
+    assert "Acquisition Instrument" not in generic_metadata
+
+    #Fake a generic signal
+    dict_from_sur_object['_26_Name_of_Z_Axis'] = 'NothingSpecial1D'
+    reader._set_metadata_and_original_metadata(dict_from_sur_object)
+    assert not reader.signal_dict['metadata']['Signal']['signal_type']
+    assert 'Acquisition Instrument' not in reader.signal_dict['metadata']
+
+    #Now with a CL signal
+    dict_from_sur_object['_26_Name_of_Z_Axis'] = 'CL Intensity'
+    reader._set_metadata_and_original_metadata(dict_from_sur_object)
+    assert reader.signal_dict['metadata']['Signal']['signal_type'] == "CL"
+    assert 'Acquisition_instrument' in reader.signal_dict['metadata']
+    assert reader.signal_dict['metadata']['Acquisition_instrument']['Spectrometer']['exit_slit_width'] == 7000

--- a/upcoming_changes/3120.new.rst
+++ b/upcoming_changes/3120.new.rst
@@ -1,0 +1,1 @@
+Add instantiation of .sur files in CL signal types if classes are available and metadata parsing


### PR DESCRIPTION
### Description of the change
This PR expands metadata parsing and signal assignments from .sur files. If an extension implementing "CL" as a signal type is found, the data is instantiated in this format and metadata are parsed, according to this specification:
https://docs.lumispy.org/en/latest/user_guide/metadata_structure.html

Implemented upon @jlaehne request

### Progress of the PR
- [x] Change implemented (can be split into several points),
- [x] add an changelog entry in the `upcoming_changes` folder (see [`upcoming_changes/README.rst`](https://github.com/hyperspy/hyperspy/blob/RELEASE_next_minor/upcoming_changes/README.rst)),
- [x] Check formatting changelog entry in the `readthedocs` doc build of this PR (link in github checks)
- [x] add tests,
- [x] ready for review.

### Minimal example of the bug fix or the new feature
```python
import hyperspy.api as hs
import numpy as np
import pathlib
import hyperspy.tests.io as iotests

testmap = pathlib.Path(iotests.__file__).parent.joinpath('sur_data/test_spectral_map.sur')
sig = hs.load(testmap)

sig.medata
```



