### PR TITLE
Metadata descriptors

### DIFF
--- a/hyperspy/misc/descriptors.py
+++ b/hyperspy/misc/descriptors.py
@@ -1,0 +1,27 @@
+# -*- coding: utf-8 -*-
+# Copyright 2007-2023 The HyperSpy developers
+#
+# This file is part of HyperSpy.
+#
+# HyperSpy is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# HyperSpy is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with HyperSpy. If not, see <https://www.gnu.org/licenses/#GPL>.
+
+class AttributeDescriptor:
+    def __init__(self, metadata_path=None):
+        self.metadata_path = metadata_path
+
+    def __get__(self, instance, owner):
+        return instance.metadata.get_item(self.metadata_path)
+
+    def __set__(self, instance, value):
+        instance.metadata.set_item(self.metadata_path, value)

--- a/hyperspy/misc/descriptors.py
+++ b/hyperspy/misc/descriptors.py
@@ -16,6 +16,7 @@
 # You should have received a copy of the GNU General Public License
 # along with HyperSpy. If not, see <https://www.gnu.org/licenses/#GPL>.
 
+
 class AttributeDescriptor:
     def __init__(self, metadata_path=None):
         self.metadata_path = metadata_path

--- a/hyperspy/tests/misc/test_descriptors.py
+++ b/hyperspy/tests/misc/test_descriptors.py
@@ -1,0 +1,55 @@
+# -*- coding: utf-8 -*-
+# Copyright 2007-2023 The HyperSpy developers
+#
+# This file is part of HyperSpy.
+#
+# HyperSpy is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# HyperSpy is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with HyperSpy. If not, see <https://www.gnu.org/licenses/#GPL>.
+
+
+from hyperspy.signal import BaseSignal
+from hyperspy.misc.descriptors import AttributeDescriptor
+import pytest
+import numpy as np
+
+
+class TestSignal(BaseSignal):
+    title = AttributeDescriptor("General.title")
+    test = AttributeDescriptor("General.test")
+    test_layered = AttributeDescriptor("testbranch1.testbranch2")
+
+
+class TestAttributeDescriptor:
+    @pytest.fixture
+    def s(self):
+        return TestSignal(np.ones((10, 10, 10)))
+
+    def test_get_title(self, s):
+        assert s.title == ""
+        s.title = "Test"
+        assert s.title == "Test"
+        assert s.metadata.General.title == "Test"
+
+    def test_get_set_test(self, s):
+        assert not hasattr(s.metadata.General, "test")
+        assert s.test is None
+        s.test = "Test"
+        assert s.test == "Test"
+        assert s.metadata.General.test == "Test"
+
+    def test_get_set_test_layered(self, s):
+        assert not hasattr(s.metadata, "testbranch1")
+        assert s.test_layered is None
+        s.test_layered = "Test"
+        assert s.test_layered == "Test"
+        assert s.metadata.testbranch1.testbranch2 == "Test"


### PR DESCRIPTION
### Description of the change
This adds the `MetadataAttribute` class to hyperspy which maps metadata to an attribute of a class:

### Progress of the PR
- [x] Change implemented (can be split into several points),
- [ ] update developer guide (if appropriate),
- [ ] add an changelog entry in the `upcoming_changes` folder (see [`upcoming_changes/README.rst`](https://github.com/hyperspy/hyperspy/blob/RELEASE_next_minor/upcoming_changes/README.rst)),
- [x] add tests,
- [x] ready for review.

### Minimal example of the bug fix or the new feature
```python
class MySignal2D(Signal2D):
    self.title = AttributeDescriptor("General.title")

    def __init__(self,....): 
        # Initialize the signal etc....


s = MySignal2D(np.ones((2,2,2)))

print(s.title) # ""
 s.title = "test"
print(s.title) # "test"
print(s.metadata.General.title) # "test"
```

#3122 for reference
