### PR TITLE
Fix test with scipy1.11 and update deprecated `scipy.interpolate.interp2d`

### DIFF
--- a/hyperspy/signal.py
+++ b/hyperspy/signal.py
@@ -4890,14 +4890,14 @@ class BaseSignal(FancySlicing,
             # inspect.
             _logger.warning(error)
 
+        # If the function has an `axes` or `axis` argument
+        # we suppose that it can operate on the full array and we don't
+        # iterate over the coordinates.
         if not ndkwargs and not lazy_output and (self.axes_manager.signal_dimension == 1 and
                              "axis" in fargs):
             kwargs['axis'] = self.axes_manager.signal_axes[-1].index_in_array
 
             result = self._map_all(function, inplace=inplace, **kwargs)
-        # If the function has an axes argument
-        # we suppose that it can operate on the full array and we don't
-        # iterate over the coordinates.
         elif not ndkwargs and not lazy_output and "axes" in fargs and not parallel:
             kwargs['axes'] = tuple([axis.index_in_array for axis in
                                     self.axes_manager.signal_axes])

--- a/hyperspy/tests/misc/test_utils.py
+++ b/hyperspy/tests/misc/test_utils.py
@@ -36,7 +36,7 @@ from hyperspy.misc.utils import (
     to_numpy,
     get_array_module
 )
-from hyperspy.exceptions import VisibleDeprecationWarning, LazyCupyConversion
+from hyperspy.exceptions import VisibleDeprecationWarning
 
 try:
     import cupy as cp

--- a/hyperspy/tests/signals/test_hologram_image.py
+++ b/hyperspy/tests/signals/test_hologram_image.py
@@ -21,7 +21,7 @@ import gc
 import matplotlib.pyplot as plt
 import numpy as np
 import pytest
-from scipy.interpolate import interp2d
+from scipy.interpolate import RectBivariateSpline
 
 import hyperspy.api as hs
 from hyperspy.decorators import lazifyTestClass
@@ -192,16 +192,16 @@ def test_reconstruct_phase_nonstandard(lazy):
     # interpolate reconstructed phase to compare with the input (reference
     # phase):
     interp_x = np.arange(output_shape[0])
-    phase_interp0 = interp2d(
-        interp_x, interp_x, wave_image2.inav[0].unwrapped_phase().data, kind="cubic",
+    phase_interp0 = RectBivariateSpline(
+        interp_x, interp_x, wave_image2.inav[0].unwrapped_phase().data,
     )
     phase_new0 = phase_interp0(
         np.linspace(0, output_shape[0], img_size),
         np.linspace(0, output_shape[0], img_size),
     )
 
-    phase_interp1 = interp2d(
-        interp_x, interp_x, wave_image2.inav[1].unwrapped_phase().data, kind="cubic",
+    phase_interp1 = RectBivariateSpline(
+        interp_x, interp_x, wave_image2.inav[1].unwrapped_phase().data,
     )
     phase_new1 = phase_interp1(
         np.linspace(0, output_shape[0], img_size),

--- a/upcoming_changes/3124.bugfix.rst
+++ b/upcoming_changes/3124.bugfix.rst
@@ -1,0 +1,1 @@
+Fix test with scipy1.11 and update deprecated ``scipy.interpolate.interp2d`` in the test suite


### PR DESCRIPTION
### Progress of the PR
- [x] Fix tests failing with scipy 1.11 following addition of `axes` argument to `scipy.ndfilters.gaussian_filter` - see https://github.com/scipy/scipy/pull/18016,
- [x] Replace deprecated `scipy.interpolate.interp2d` with `scipy.interpolate.RectBivariateSpline`
- [n/a] update docstring (if appropriate),
- [n/a] update user guide (if appropriate),
- [x] add an changelog entry in the `upcoming_changes` folder (see [`upcoming_changes/README.rst`](https://github.com/hyperspy/hyperspy/blob/RELEASE_next_minor/upcoming_changes/README.rst)),
- [x] Check formatting changelog entry in the `readthedocs` doc build of this PR (link in github checks)
- [x] update tests,
- [x] ready for review.


