### PR TITLE
is_binned optimisation during fit

### DIFF
--- a/upcoming_changes/3126.enhancements.rst
+++ b/upcoming_changes/3126.enhancements.rst
@@ -1,0 +1,1 @@
+Improve performance of `model.multifit` by avoiding `axes.is_binned` repeated evaluation


### PR DESCRIPTION
### Description of the change
The multifit optimisation story goes on.  Currently, up to 40% of the execution time is occupied by the evaluation of the `is_binned` axis property.

![image](https://user-images.githubusercontent.com/123734179/231582673-3c67d802-4f8f-41b3-9fb1-1e12d93b1758.png)

As shown in the screenshot above, this is a problem because it is repeatedly called during evaluation of the model function. I propose to evaluate once before starting `multifit`, temporarily store the result in an instance attribute and reset its value after the multifit is performed. This approach means to be as minimally intrusive as possible to the fitting functions, especially considering that they are so to say _on life support_ until 2.0.

After the changes, here are the performances

![image](https://user-images.githubusercontent.com/123734179/231592928-42617877-2040-4054-85f4-4ac3cdf30390.png)

Execution goes down from 3.89 to 2.38 s

### Progress of the PR
- [x] Change implemented (can be split into several points),
- [ ] add an changelog entry in the `upcoming_changes` folder (see [`upcoming_changes/README.rst`](https://github.com/hyperspy/hyperspy/blob/RELEASE_next_minor/upcoming_changes/README.rst)),
- [ ] Check formatting changelog entry in the `readthedocs` doc build of this PR (link in github checks)
- [ ] ready for review.

### Minimal example of the bug fix or the new feature

Test code has been updated to add shifts and amplitude variations to the gaussian. This way, the multifit is more representative of real data. Performances results can be visualised with snakeviz

```python
from hyperspy.datasets.artificial_data import get_luminescence_signal
from hyperspy._components.gaussian import Gaussian

import numpy as np
import cProfile
import pstats

# creating a luminescence signal
s = get_luminescence_signal(navigation_dimension=3, uniform=True)

#Adding a systematic and random shift
shift = (np.sin(np.arange(1000).reshape((10, 10, 10)) / 10 * 2 * np.pi) + 1.0) * 50
shift = shift + 10 * np.random.random(1000).reshape(10, 10, 10)
s.shift1D(shift)

#Adding a random intensity variation
s.data[:] = s.data * (2 + np.random.random(1000).reshape(10, 10, 10, 1))

#Create a model
m = s.create_model()
g = Gaussian(A=10000, centre=400.0)
m.append(g)

#Fitting with profiling
with cProfile.Profile() as pr:
    m.multifit(iterpath='serpentine')

#Dumping stats
stats = pstats.Stats(pr)
stats.dump_stats(filename='perf_multifit.prof')
```
