### PR TITLE
Add explicit support for python 3.11

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -40,6 +40,9 @@ jobs:
           - os: ubuntu
             PYTHON_VERSION: '3.10'
             PIP_SELECTOR: '[all, tests, coverage]'
+          - os: ubuntu
+            PYTHON_VERSION: '3.11'
+            PIP_SELECTOR: '[all, tests, coverage]'
 
     steps:
       - uses: actions/checkout@v3
@@ -53,6 +56,13 @@ jobs:
         run: |
           python --version
           pip --version
+
+      - name: Install numba rc
+        if: contains(matrix.PYTHON_VERSION, '3.11')
+        # Require for python 3.11 support, remove when numba 0.57 is release
+        shell: bash
+        run: |
+          pip install numba --pre
 
       - name: Install oldest supported version
         if: ${{ matrix.OLDEST_SUPPORTED_VERSION }}

--- a/setup.py
+++ b/setup.py
@@ -421,6 +421,7 @@ with update_version_when_dev() as version:
             "Programming Language :: Python :: 3.8",
             "Programming Language :: Python :: 3.9",
             "Programming Language :: Python :: 3.10",
+            "Programming Language :: Python :: 3.11",
             "Development Status :: 4 - Beta",
             "Environment :: Console",
             "Intended Audience :: Science/Research",

--- a/upcoming_changes/3134.maintenance.rst
+++ b/upcoming_changes/3134.maintenance.rst
@@ -1,0 +1,1 @@
+Add support for python 3.11


### PR DESCRIPTION
Now that numba has support for python 3.11, we can test hyperspy against python 3.11.

### Progress of the PR
- [x] Specify support for python 3.11,
- [n/a] update docstring (if appropriate),
- [n/a] update user guide (if appropriate),
- [x] add an changelog entry in the `upcoming_changes` folder (see [`upcoming_changes/README.rst`](https://github.com/hyperspy/hyperspy/blob/RELEASE_next_minor/upcoming_changes/README.rst)),
- [x] Check formatting changelog entry in the `readthedocs` doc build of this PR (link in github checks)
- [n/a] add tests,
- [x] ready for review.

