### PR TITLE
Recognise both byte and string object for NXdata tag in NeXus reader

### DIFF
--- a/hyperspy/io_plugins/nexus.py
+++ b/hyperspy/io_plugins/nexus.py
@@ -750,8 +750,8 @@ def _find_data(group, search_keys=None, hardlinks_only=False,
             if isinstance(value, h5py.Group):
                 target = _getlink(group, rootkey, key)
                 if "NX_class" in value.attrs:
-                    if value.attrs["NX_class"] == b"NXdata" \
-                            and "signal" in value.attrs.keys():
+                    if (value.attrs["NX_class"] == b"NXdata" or value.attrs["NX_class"] == "NXdata")\
+                        and "signal" in value.attrs.keys():
                         all_nx_datasets.append(rootkey)
                         if target is None:
                             unique_nx_datasets.append(rootkey)
@@ -880,7 +880,7 @@ def _load_metadata(group, lazy=False, skip_array_metadata=False):
 
             elif type(item) is h5py.Group:
                 if "NX_class" in item.attrs:
-                    if item.attrs["NX_class"] != b"NXdata":
+                    if item.attrs["NX_class"] != b"NXdata" or item.attrs["NX_class"] != 'NXdata':
                         tree[new_key] = find_meta_in_tree(item, rootkey,
                                                           lazy=lazy,
                                       skip_array_metadata=skip_array_metadata)

--- a/upcoming_changes/3137.enhancements.rst
+++ b/upcoming_changes/3137.enhancements.rst
@@ -1,0 +1,1 @@
+Recognise both byte and string object for NXdata tag in NeXus reader


### PR DESCRIPTION
### Description of the change
This PR is a small improvement on the NeXus reader, allowing it to recognise `NXdata` tag as both byte and string object. This increases flexibility and avoid missing genuine `NXdata` dataset when its tag is saved as a string object.

I notice there is now [rosettasciio](https://github.com/hyperspy/rosettasciio), should I also make the change there or it will be synced at some point?


### Progress of the PR
- [x] Change implemented,
- [x] add an changelog entry in the `upcoming_changes` folder (see [`upcoming_changes/README.rst`](https://github.com/hyperspy/hyperspy/blob/RELEASE_next_minor/upcoming_changes/README.rst)),
- [x] Check formatting changelog entry in the `readthedocs` doc build of this PR (link in github checks)
- [x] ready for review.
