### PR TITLE
Pin imageio to <2.28

### DIFF
--- a/conda_environment.yml
+++ b/conda_environment.yml
@@ -7,7 +7,7 @@ dependencies:
 # dask-core < 2021.3.1 doesn't have fsspec as dependency
 - fsspec
 - h5py
-- imageio
+- imageio <2.28
 - ipyparallel
 - ipython !=8.0.*
 - jinja2

--- a/setup.py
+++ b/setup.py
@@ -68,7 +68,7 @@ install_req = ['scipy>=1.4.0',
                'pint>=0.10',
                'numexpr',
                'sparse',
-               'imageio',
+               'imageio<2.28',
                'pyyaml',
                # prettytable and ptable are API compatible
                # prettytable is maintained and ptable is an unmaintained fork

--- a/upcoming_changes/3138.maintenance.rst
+++ b/upcoming_changes/3138.maintenance.rst
@@ -1,0 +1,1 @@
+Pin ``imageio`` to <2.28


### PR DESCRIPTION
Same as https://github.com/hyperspy/rosettasciio/pull/106, but I think that it is not worth backporting it here.

### Progress of the PR
- [x] Pin imageio to <2.28,
- [n/a] update docstring (if appropriate),
- [n/a] update user guide (if appropriate),
- [x] add an changelog entry in the `upcoming_changes` folder (see [`upcoming_changes/README.rst`](https://github.com/hyperspy/hyperspy/blob/RELEASE_next_minor/upcoming_changes/README.rst)),
- [x] Check formatting changelog entry in the `readthedocs` doc build of this PR (link in github checks)
- [n/a] add tests,
- [x] ready for review.
