### PR TITLE
Horizontal Plotting using widgets

### DIFF
--- a/doc/user_guide/visualisation.rst
+++ b/doc/user_guide/visualisation.rst
@@ -283,6 +283,12 @@ The same example with the feature disabled:
 
 .. _plot.customize_navigator:
 
+.. versionadded:: 2.0.0
+   ``plot_style`` keyword argument to allow for "horizontal" or "vertical" plotting when using the `ipympl` or
+`widget` backends. A default value can also be set using
+:ref:`HyperSpy plot preferences <configuring-hyperspy-label>`.
+
+
 Customizing the "navigator"
 ===========================
 

--- a/doc/user_guide/visualisation.rst
+++ b/doc/user_guide/visualisation.rst
@@ -284,8 +284,8 @@ The same example with the feature disabled:
 .. _plot.customize_navigator:
 
 .. versionadded:: 2.0.0
-   ``plot_style`` keyword argument to allow for "horizontal" or "vertical" plotting when using the
-   `ipympl` or `widget` backends. A default value can also be set using
+   ``plot_style`` keyword argument to allow for "horizontal" or "vertical" alignment of subplots (e.g. navigator 
+   and signal) when using the `ipympl` or `widget` backends. A default value can also be set using the
    :ref:`HyperSpy plot preferences <configuring-hyperspy-label>`.
 
 

--- a/doc/user_guide/visualisation.rst
+++ b/doc/user_guide/visualisation.rst
@@ -284,9 +284,9 @@ The same example with the feature disabled:
 .. _plot.customize_navigator:
 
 .. versionadded:: 2.0.0
-   ``plot_style`` keyword argument to allow for "horizontal" or "vertical" plotting when using the `ipympl` or
-`widget` backends. A default value can also be set using
-:ref:`HyperSpy plot preferences <configuring-hyperspy-label>`.
+   ``plot_style`` keyword argument to allow for "horizontal" or "vertical" plotting when using the
+   `ipympl` or `widget` backends. A default value can also be set using
+   :ref:`HyperSpy plot preferences <configuring-hyperspy-label>`.
 
 
 Customizing the "navigator"

--- a/hyperspy/defaults_parser.py
+++ b/hyperspy/defaults_parser.py
@@ -138,6 +138,9 @@ class PlotConfig(t.HasTraits):
     # Don't use t.Enum to list all possible matplotlib colormap to
     # avoid importing matplotlib and building the list of colormap
     # when importing hyperpsy
+    widget_plot_style = t.Enum(
+        ['horizontal', 'vertical'],
+        label='Widget plot style: (only with ipympl)')
     cmap_navigator = t.Str('gray',
                            label='Color map navigator',
                            desc='Set the default color map for the navigator.',

--- a/hyperspy/drawing/mpl_he.py
+++ b/hyperspy/drawing/mpl_he.py
@@ -20,10 +20,11 @@ from functools import partial
 import logging
 
 from traits.api import Undefined
+import matplotlib as mpl
 
 from hyperspy.drawing import widgets, signal1d, image
 from hyperspy.defaults_parser import preferences
-
+import warnings
 
 _logger = logging.getLogger(__name__)
 
@@ -180,6 +181,15 @@ class MPL_HyperExplorer(object):
         for key in ['power_spectrum', 'fft_shift']:
             if key in kwargs:
                 self.signal_data_function_kwargs[key] = kwargs.pop(key)
+        backend = mpl.get_backend()
+        if not "ipympl" in backend and "plot_style" in kwargs:
+            warnings.warn("The `plot_style` keyword is only used when the `ipympl` or `widget`"
+                          "plotting backends are used.")
+        plot_style = kwargs.pop("plot_style", None)
+        # matplotlib plotting backend
+        if "ipympl" in backend:
+            import matplotlib.pyplot as plt
+            plt.ioff()  # plot ioff to hold plotting
         if self.pointer is None:
             pointer = self.assign_pointer()
             if pointer is not None:
@@ -191,6 +201,21 @@ class MPL_HyperExplorer(object):
                 self.navigator_plot.events.closed.connect(
                     self.pointer.disconnect, [])
         self.plot_signal(**kwargs)
+        if "ipympl" in backend:
+            if plot_style not in ["vertical", "horizontal", None]:
+                raise ValueError("plot_style must be one of ['vertical', 'horizontal', None]")
+            if plot_style is None:
+                plot_style = preferences.Plot.widget_plot_style
+            # If widgets do not already exist, we will `display` them at the end
+            from ipywidgets.widgets import HBox, VBox
+            from IPython.display import display
+            if not self.navigator_plot:
+                display(self.signal_plot.figure.canvas)
+            elif plot_style == "horizontal":
+                display(HBox([self.navigator_plot.figure.canvas,self.signal_plot.figure.canvas]))
+            else: # plot_style == "vertical":
+                display(VBox([self.navigator_plot.figure.canvas, self.signal_plot.figure.canvas]))
+
 
     def assign_pointer(self):
         if self.navigator_data_function is None:

--- a/hyperspy/tests/drawing/test_horizontal_plotting.py
+++ b/hyperspy/tests/drawing/test_horizontal_plotting.py
@@ -1,0 +1,58 @@
+# Copyright 2007-2022 The HyperSpy developers
+#
+# This file is part of HyperSpy.
+#
+# HyperSpy is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# HyperSpy is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with HyperSpy. If not, see <https://www.gnu.org/licenses/#GPL>.
+import pytest
+
+import hyperspy.api as hs
+import numpy as np
+import matplotlib
+
+ipympl = pytest.importorskip("ipympl")
+ipywidgets = pytest.importorskip("ipywidgets")
+
+class TestIPYMPL:
+    def test_horizontal(self, capsys):
+        matplotlib.use("module://ipympl.backend_nbagg")
+        s = hs.signals.Signal2D(np.random.random((4, 4, 2, 2)))
+        s.plot(plot_style="horizontal")
+        captured = capsys.readouterr()
+        assert("HBox(children=(Canvas(" in captured.out)
+
+    def test_vertical(self,capsys):
+        matplotlib.use("module://ipympl.backend_nbagg")
+        s = hs.signals.Signal2D(np.random.random((4, 4, 2, 2)))
+        s.plot(plot_style="vertical")
+        captured = capsys.readouterr()
+
+        assert("VBox(children=(Canvas(" in captured.out)
+
+    def test_only_signal(self,capsys):
+        matplotlib.use("module://ipympl.backend_nbagg")
+        s = hs.signals.Signal2D(np.random.random(( 2, 2)))
+        s.plot()
+        captured = capsys.readouterr()
+        assert("Canvas(toolbar=Toolbar(" in captured.out)
+
+    def test_warnings(self,):
+        with pytest.warns(UserWarning):
+            s = hs.signals.Signal2D(np.random.random(( 4, 2, 2)))
+            s.plot(plot_style="vertical")
+
+    def test_misspelling(self, ):
+        matplotlib.use("module://ipympl.backend_nbagg")
+        with pytest.raises(ValueError):
+            s = hs.signals.Signal2D(np.random.random((4, 2, 2)))
+            s.plot(plot_style="Vert")

--- a/setup.py
+++ b/setup.py
@@ -68,7 +68,7 @@ install_req = [
 
 extras_require = {
     "learning": ["scikit-learn>=1.0.1"],
-    "gui-jupyter": ["hyperspy_gui_ipywidgets>=1.1.0"],
+    "gui-jupyter": ["hyperspy_gui_ipywidgets>=1.1.0", "ipympl"],
     # UPDATE BEFORE RELEASE
     "gui-traitsui": ["hyperspy_gui_traitsui @ git+https://github.com/hyperspy/hyperspy_gui_traitsui#egg=hyperspy_gui_traitsui"],
     #"gui-traitsui": ["hyperspy_gui_traitsui>=1.1.0"],

--- a/upcoming_changes/3140.new.rst
+++ b/upcoming_changes/3140.new.rst
@@ -1,0 +1,3 @@
+Changes to :meth:`~.api.signals.BaseSignal.plot`:
+- Allow Horizontal plotting using the `ipympl` or `widget` backends
+- Add in gui preferences to set a default to horizontal or vertical plotting


### PR DESCRIPTION
### Overview
This is an extension to #2338.  It fixes the bug related to passing arguments to super that aren't in the original function.  By having those arguments implicitly handled by `**kwargs` it seems to fix the problem. This is built on the work previously done by @thomasaarholt 

## To Do:

- [x] Rebased on ReleaseNextMinor
- [x] Fix duplicating navigation axis
- [x] Add examples to the Documentation
- [x] Add tests?  I need to look into how to test widgets

This also allows more custom widget views which would be useful for things like plotting multiple signals. 

  ## Example:

```python

%matplotlib widget
import hyperspy.api as hs
import numpy as np

s = hs.signals.Signal2D(np.random.random((4,4,2,2)))
s.plot(plot_style="horizontal")
```
![image](https://user-images.githubusercontent.com/41125831/235217671-f3c1a804-dcf9-4b97-bad5-f40562631fd9.png)

```python
%matplotlib widget
import hyperspy.api as hs
import numpy as np
from ipywidgets import Output, HBox, VBox, Layout
o = Output()
o2 = Output()
o3 = Output()
o4 = Output()
margin = "auto 0px auto 0px"
o.layout.margin = margin
o2.layout.margin = margin
o3.layout.margin = margin


s = hs.signals.Signal2D(np.random.random((4,4,2,2)))
s.plot(widget=o2, navigator_kwds={"widget":o})

s.isig[0,1].T.plot(widget=o3)

VBox([HBox([o, o3]), o2],layout=Layout(width='100%', display='flex' ,
align_items='center'))
```
![image](https://user-images.githubusercontent.com/41125831/235217568-4c1898c8-24cb-4073-bc42-8395cc1f39d4.png)


