### PR TITLE
Find peaks2d refactor

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -190,6 +190,10 @@ Signal
 - Passing an "iterating over navigation argument" to the :py:meth:`~.signal.BaseSignal.map`
   method is removed, pass a HyperSpy signal with suitable navigation and signal shape instead.
 
+Signal2D
+--------
+- :meth:`~.api.signals.Signal2D.find_peaks` now return lazy signals in case of lazy input signal.
+
 Preferences
 -----------
 - The ``warn_if_guis_are_missing`` HyperSpy preferences setting has been removed,

--- a/hyperspy/_signals/signal2d.py
+++ b/hyperspy/_signals/signal2d.py
@@ -1039,7 +1039,8 @@ class Signal2D(BaseSignal, CommonSignal2D):
                              parallel=parallel, inplace=False, ragged=True,
                              max_workers=max_workers, **kwargs)
             peaks.metadata.add_node("Peaks") # add information about the signal Axes
-            peaks.metadata.Peaks.signal_axes = self.axes_manager.signal_axes
+        from copy import deepcopy
+        peaks.metadata.Peaks.signal_axes = tuple([deepcopy(s) for s in self.axes_manager.signal_axes])
         return peaks
 
     find_peaks.__doc__ %= (SHOW_PROGRESSBAR_ARG, PARALLEL_ARG, MAX_WORKERS_ARG,

--- a/hyperspy/_signals/signal2d.py
+++ b/hyperspy/_signals/signal2d.py
@@ -1030,10 +1030,6 @@ class Signal2D(BaseSignal, CommonSignal2D):
             peaks = self.map(method_func, show_progressbar=show_progressbar,
                              parallel=parallel, inplace=False, ragged=True,
                              max_workers=max_workers, **kwargs)
-            if peaks._lazy:
-                peaks.compute()
-
-
 
         return peaks
 

--- a/hyperspy/_signals/signal2d.py
+++ b/hyperspy/_signals/signal2d.py
@@ -969,9 +969,10 @@ class Signal2D(BaseSignal, CommonSignal2D):
             If True, the method parameter can be adjusted interactively.
             If False, the results will be returned.
         current_index : bool
-            if True, the computation will be performed for the current index.
+            If True, the computation will be performed for the current index.
         get_intensity : bool
-            if True, the value of the peak will be returned as a separate column.
+            If True, the intensity of the peak will be returned as an additional column,
+            the last one.
         %s
         %s
         %s

--- a/hyperspy/_signals/signal2d.py
+++ b/hyperspy/_signals/signal2d.py
@@ -22,6 +22,7 @@ import numpy.ma as ma
 import dask.array as da
 import logging
 import warnings
+from copy import deepcopy
 
 from functools import partial
 
@@ -1040,8 +1041,7 @@ class Signal2D(BaseSignal, CommonSignal2D):
                              parallel=parallel, inplace=False, ragged=True,
                              max_workers=max_workers, **kwargs)
             peaks.metadata.add_node("Peaks") # add information about the signal Axes
-        from copy import deepcopy
-        peaks.metadata.Peaks.signal_axes = tuple([deepcopy(s) for s in self.axes_manager.signal_axes])
+            peaks.metadata.Peaks.signal_axes = tuple([deepcopy(s) for s in self.axes_manager.signal_axes])
         return peaks
 
     find_peaks.__doc__ %= (SHOW_PROGRESSBAR_ARG, PARALLEL_ARG, MAX_WORKERS_ARG,

--- a/hyperspy/_signals/signal2d.py
+++ b/hyperspy/_signals/signal2d.py
@@ -23,6 +23,8 @@ import dask.array as da
 import logging
 import warnings
 
+from functools import partial
+
 from scipy import ndimage
 try:
     # For scikit-image >= 0.17.0
@@ -50,7 +52,8 @@ from hyperspy.docstrings.signal import (
 from hyperspy.ui_registry import DISPLAY_DT, TOOLKIT_DT
 from hyperspy.utils.peakfinders2D import (
         find_local_max, find_peaks_max, find_peaks_minmax, find_peaks_zaefferer,
-        find_peaks_stat, find_peaks_log, find_peaks_dog, find_peaks_xc)
+        find_peaks_stat, find_peaks_log, find_peaks_dog, find_peaks_xc,
+        _get_intensity)
 
 
 _logger = logging.getLogger(__name__)
@@ -916,6 +919,7 @@ class Signal2D(BaseSignal, CommonSignal2D):
     def find_peaks(self, method='local_max', interactive=True,
                    current_index=False, show_progressbar=None,
                    parallel=None, max_workers=None, display=True, toolkit=None,
+                   get_intensity=False,
                    **kwargs):
         """Find peaks in a 2D signal.
 
@@ -966,6 +970,8 @@ class Signal2D(BaseSignal, CommonSignal2D):
             If False, the results will be returned.
         current_index : bool
             if True, the computation will be performed for the current index.
+        get_intensity : bool
+            if True, the value of the peak will be returned as a separate column.
         %s
         %s
         %s
@@ -1015,6 +1021,8 @@ class Signal2D(BaseSignal, CommonSignal2D):
             raise NotImplementedError(f"The method `{method}` is not "
                                       "implemented. See documentation for "
                                       "available implementations.")
+        if get_intensity:
+            method_func = partial(_get_intensity, f=method_func, )
         if interactive:
             # Create a peaks signal with the same navigation shape as a
             # placeholder for the output

--- a/hyperspy/_signals/signal2d.py
+++ b/hyperspy/_signals/signal2d.py
@@ -53,7 +53,7 @@ from hyperspy.ui_registry import DISPLAY_DT, TOOLKIT_DT
 from hyperspy.utils.peakfinders2D import (
         find_local_max, find_peaks_max, find_peaks_minmax, find_peaks_zaefferer,
         find_peaks_stat, find_peaks_log, find_peaks_dog, find_peaks_xc,
-        _get_intensity)
+        _get_peak_position_and_intensity)
 
 
 _logger = logging.getLogger(__name__)
@@ -1022,7 +1022,7 @@ class Signal2D(BaseSignal, CommonSignal2D):
                                       "implemented. See documentation for "
                                       "available implementations.")
         if get_intensity:
-            method_func = partial(_get_intensity, f=method_func, )
+            method_func = partial(_get_peak_position_and_intensity, f=method_func, )
         if interactive:
             # Create a peaks signal with the same navigation shape as a
             # placeholder for the output

--- a/hyperspy/_signals/signal2d.py
+++ b/hyperspy/_signals/signal2d.py
@@ -1038,7 +1038,8 @@ class Signal2D(BaseSignal, CommonSignal2D):
             peaks = self.map(method_func, show_progressbar=show_progressbar,
                              parallel=parallel, inplace=False, ragged=True,
                              max_workers=max_workers, **kwargs)
-
+        peaks.metadata.add_node("Peaks")
+        peaks.metadata.Peaks.signal_axes = self.axes_manager.signal_axes
         return peaks
 
     find_peaks.__doc__ %= (SHOW_PROGRESSBAR_ARG, PARALLEL_ARG, MAX_WORKERS_ARG,

--- a/hyperspy/_signals/signal2d.py
+++ b/hyperspy/_signals/signal2d.py
@@ -1041,7 +1041,7 @@ class Signal2D(BaseSignal, CommonSignal2D):
                              parallel=parallel, inplace=False, ragged=True,
                              max_workers=max_workers, **kwargs)
             peaks.metadata.add_node("Peaks") # add information about the signal Axes
-            peaks.metadata.Peaks.signal_axes = tuple([deepcopy(s) for s in self.axes_manager.signal_axes])
+            peaks.metadata.Peaks.signal_axes = deepcopy(self.axes_manager.signal_axes)
         return peaks
 
     find_peaks.__doc__ %= (SHOW_PROGRESSBAR_ARG, PARALLEL_ARG, MAX_WORKERS_ARG,

--- a/hyperspy/_signals/signal2d.py
+++ b/hyperspy/_signals/signal2d.py
@@ -1038,8 +1038,8 @@ class Signal2D(BaseSignal, CommonSignal2D):
             peaks = self.map(method_func, show_progressbar=show_progressbar,
                              parallel=parallel, inplace=False, ragged=True,
                              max_workers=max_workers, **kwargs)
-        peaks.metadata.add_node("Peaks")
-        peaks.metadata.Peaks.signal_axes = self.axes_manager.signal_axes
+            peaks.metadata.add_node("Peaks") # add information about the signal Axes
+            peaks.metadata.Peaks.signal_axes = self.axes_manager.signal_axes
         return peaks
 
     find_peaks.__doc__ %= (SHOW_PROGRESSBAR_ARG, PARALLEL_ARG, MAX_WORKERS_ARG,

--- a/hyperspy/tests/signals/test_find_peaks2D.py
+++ b/hyperspy/tests/signals/test_find_peaks2D.py
@@ -191,20 +191,25 @@ class TestFindPeaks2D:
 
     @pytest.mark.parametrize('method', PEAK_METHODS)
     @pytest.mark.parametrize('parallel', [True, False])
-    def test_gets_right_answer(self, method, parallel):
+    @pytest.mark.parametrize("get_intensity", [True, False])
+    def test_gets_right_answer(self, method, parallel, get_intensity):
         if method == 'stat':
             pytest.importorskip("sklearn")
         ans = np.empty((1,), dtype=object)
-        ans[0] = np.array([[self.xref, self.yref]])
+        if get_intensity:
+            ans[0] = np.array([[self.xref, self.yref, np.max(self.ref.data)]])
+        else:
+            ans[0] = np.array([[self.xref, self.yref]])
         if method == 'template_matching':
             disc = np.zeros((5, 5))
             disc[1:4, 1:4] = 0.5
             disc[2,2] = 1
             peaks = self.ref.find_peaks(method=method, parallel=parallel,
-                                        interactive=False, template=disc)
+                                        interactive=False, template=disc,
+                                        get_intensity=get_intensity)
         else:
             peaks = self.ref.find_peaks(method=method, parallel=parallel,
-                                        interactive=False)
+                                        interactive=False, get_intensity=get_intensity)
         np.testing.assert_allclose(peaks.data[0], ans[0])
 
     def test_return_peaks(self):

--- a/hyperspy/tests/signals/test_find_peaks2D.py
+++ b/hyperspy/tests/signals/test_find_peaks2D.py
@@ -154,6 +154,21 @@ class TestFindPeaks2D:
         else:
             peaks.data[first_ind]
             assert peaks.data[first_ind].shape[-1] == 2
+        assert peaks.metadata.Peaks.signal_axes[0].scale == dataset.axes_manager.signal_axes[0].scale
+        assert peaks.metadata.Peaks.signal_axes[1].scale == dataset.axes_manager.signal_axes[1].scale
+
+        assert peaks.metadata.Peaks.signal_axes[0].name == dataset.axes_manager.signal_axes[0].name
+        assert peaks.metadata.Peaks.signal_axes[1].name == dataset.axes_manager.signal_axes[1].name
+
+        assert peaks.metadata.Peaks.signal_axes[0].offset == dataset.axes_manager.signal_axes[0].offset
+        assert peaks.metadata.Peaks.signal_axes[1].offset == dataset.axes_manager.signal_axes[1].offset
+
+        dataset.axes_manager.signal_axes[0].scale =25
+        assert peaks.metadata.Peaks.signal_axes[0].scale != dataset.axes_manager.signal_axes[0].scale
+        dataset.axes_manager.signal_axes[0].scale =1
+
+
+
 
     @pytest.mark.parametrize('parallel', [True, False])
     def test_ordering_results(self, parallel):

--- a/hyperspy/tests/signals/test_find_peaks2D.py
+++ b/hyperspy/tests/signals/test_find_peaks2D.py
@@ -133,7 +133,11 @@ class TestFindPeaks2D:
                                        interactive=False,
                                        get_intensity=get_intensity)
         assert isinstance(peaks, BaseSignal)
-        assert not isinstance(peaks, LazySignal)
+        if isinstance(dataset,LazySignal):
+            assert isinstance(peaks, LazySignal)
+            peaks.compute()
+        else:
+            assert not isinstance(peaks, LazySignal)
 
         # Check navigation shape
         np.testing.assert_equal(dataset.axes_manager.navigation_shape,
@@ -145,8 +149,10 @@ class TestFindPeaks2D:
         assert peaks.data.shape == shape
         first_ind = (0,)*len(shape)
         if get_intensity:
+            peaks.data[first_ind]
             assert peaks.data[first_ind].shape[-1] == 3
         else:
+            peaks.data[first_ind]
             assert peaks.data[first_ind].shape[-1] == 2
 
     @pytest.mark.parametrize('parallel', [True, False])

--- a/hyperspy/tests/signals/test_find_peaks2D.py
+++ b/hyperspy/tests/signals/test_find_peaks2D.py
@@ -115,7 +115,8 @@ class TestFindPeaks2D:
     @pytest.mark.parametrize('method', PEAK_METHODS)
     @pytest.mark.parametrize('dataset_name', DATASETS_NAME)
     @pytest.mark.parametrize('parallel', [True, False])
-    def test_find_peaks(self, method, dataset_name, parallel):
+    @pytest.mark.parametrize('get_intensity', [True, False])
+    def test_find_peaks(self, method, dataset_name, parallel, get_intensity):
         if method == 'stat':
             pytest.importorskip("sklearn")
         dataset = getattr(self, dataset_name)
@@ -125,10 +126,12 @@ class TestFindPeaks2D:
 
         if method == 'template_matching':
             peaks = dataset.find_peaks(method=method, parallel=parallel,
-                                       interactive=False, template=DISC)
+                                       interactive=False, template=DISC,
+                                       get_intensity=get_intensity)
         else:
             peaks = dataset.find_peaks(method=method, parallel=parallel,
-                                       interactive=False)
+                                       interactive=False,
+                                       get_intensity=get_intensity)
         assert isinstance(peaks, BaseSignal)
         assert not isinstance(peaks, LazySignal)
 
@@ -140,7 +143,11 @@ class TestFindPeaks2D:
         else:
             shape = dataset.axes_manager.navigation_shape[::-1]
         assert peaks.data.shape == shape
-        assert peaks.data[0].shape[-1] == 2
+        first_ind = (0,)*len(shape)
+        if get_intensity:
+            assert peaks.data[first_ind].shape[-1] == 3
+        else:
+            assert peaks.data[first_ind].shape[-1] == 2
 
     @pytest.mark.parametrize('parallel', [True, False])
     def test_ordering_results(self, parallel):

--- a/hyperspy/utils/peakfinders2D.py
+++ b/hyperspy/utils/peakfinders2D.py
@@ -53,7 +53,8 @@ def _get_peak_position_and_intensity(X, f, **kwargs):
     if np.any(np.isnan(peaks)): #handle no peaks
         return np.array([[np.nan, np.nan,np.nan]])
     else:
-        maxima = tuple([tuple(np.round(peaks[:, d]).astype(int)) for d in range(2)])
+        rounded_peaks = np.round(peaks).astype(int)
+        maxima = tuple([tuple(rounded_peaks[:,d]) for d in range(2)])
         intensity = X[maxima]
         return np.concatenate([peaks, intensity[:, np.newaxis]], axis=1)
 

--- a/hyperspy/utils/peakfinders2D.py
+++ b/hyperspy/utils/peakfinders2D.py
@@ -53,9 +53,9 @@ def _get_peak_position_and_intensity(X, f, **kwargs):
     if np.any(np.isnan(peaks)): #handle no peaks
         return np.array([[np.nan, np.nan,np.nan]])
     else:
-        rounded_peaks = np.round(peaks).astype(int)
-        maxima = tuple([tuple(rounded_peaks[:,d]) for d in range(2)])
-        intensity = X[maxima]
+        peaks_indices = np.round(peaks).astype(int)
+        intensity = X[peaks_indices[:, 0], peaks_indices[:, 1]]
+
         return np.concatenate([peaks, intensity[:, np.newaxis]], axis=1)
 
 

--- a/hyperspy/utils/peakfinders2D.py
+++ b/hyperspy/utils/peakfinders2D.py
@@ -27,6 +27,16 @@ from hyperspy.misc.machine_learning import import_sklearn
 
 NO_PEAKS = np.array([[np.nan, np.nan]])
 
+def _get_intensity(X, f, **kwargs):
+    peaks = f(X, **kwargs)
+
+    if np.any(np.isnan(peaks)): #handle no peaks
+        return np.array([[np.nan, np.nan,np.nan]])
+    else:
+        maxima = tuple([tuple(np.round(peaks[:, d]).astype(int)) for d in range(2)])
+        intensity = X[maxima]
+        return np.concatenate([peaks, intensity[:, np.newaxis]], axis=1)
+
 
 @njit(cache=True)
 def _fast_mean(X):  # pragma: no cover

--- a/hyperspy/utils/peakfinders2D.py
+++ b/hyperspy/utils/peakfinders2D.py
@@ -27,7 +27,27 @@ from hyperspy.misc.machine_learning import import_sklearn
 
 NO_PEAKS = np.array([[np.nan, np.nan]])
 
-def _get_intensity(X, f, **kwargs):
+def _get_peak_position_and_intensity(X, f, **kwargs):
+    """
+    Take some function, f, and apply it to the 2d array X returning a list
+    of peak positions.  The intensity at each peak position is then appended
+    to the returned list of peaks
+
+    Parameters
+    ----------
+    X: 2-D array-like
+        The input image used to find peaks
+    f: func
+        The passed function to find peaks
+    kwargs:
+        Any additional keyword arguments passed to f
+
+    Returns
+    -------
+        peaks:array-like
+            A 2d array with columns [x, y, intensity]
+
+    """
     peaks = f(X, **kwargs)
 
     if np.any(np.isnan(peaks)): #handle no peaks

--- a/upcoming_changes/3142.new.rst
+++ b/upcoming_changes/3142.new.rst
@@ -1,0 +1,4 @@
+Changes to :meth:`~.api.signals.Signal2D.find_peaks`:
+- Lazy signals return lazy peaks signals
+- ``get_intensity`` argument added to get the intensity of the peaks
+- Signal axes saved in ``metadata.Peaks.signal_axes`` of the peaks signal.

--- a/upcoming_changes/3142.new.rst
+++ b/upcoming_changes/3142.new.rst
@@ -1,0 +1,1 @@
+Changes to `Signal2D.find_peaks`  1.Lazy signals return lazy peaks 2. `get_intensity` kwarg added to get the intensity for some peaks 3.Signal axes preserved in metadata.


### PR DESCRIPTION
### Description of the change
This changes a couple of things about find peaks2d

1. Interactive is False by default
2. Lazy signals return lazy peaks
3. `get_intensity` kwarg added to get the intensity for some peaks
4. Signal axes preserved in metadata. 

### Progress of the PR
- [x] Change implemented (can be split into several points),
- [x] update docstring (if appropriate),
- [x] update user guide (if appropriate),
- [x] add an changelog entry in the `upcoming_changes` folder (see [`upcoming_changes/README.rst`](https://github.com/hyperspy/hyperspy/blob/RELEASE_next_minor/upcoming_changes/README.rst)),
- [x] Check formatting changelog entry in the `readthedocs` doc build of this PR (link in github checks)
- [x] add tests,
- [x] ready for review.

### Minimal example of the bug fix or the new feature
```python
import hyperspy.api as hs
import numpy as np
s = hs.signals.Signal2D(np.random.random((10,10,10,10)))
pks = s.find_peaks(threshold_abs=100, get_intensity=True)
```
