### PR TITLE
Make IPython and IParallel optional

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -165,6 +165,10 @@ Model fitting
   ``metadata`` attribute instead.
 
 - The deprecated ``twin_function`` and ``twin_inverse_function`` have been privatized.
+- Remove ``fancy`` argument of :meth:`~.model.BaseModel.print_current_values` and :meth:`~.component.Component.print_current_values`,
+  which wasn't changing the output rendering.
+
+
 
 Signal
 ------

--- a/conda_environment.yml
+++ b/conda_environment.yml
@@ -5,8 +5,6 @@ dependencies:
 - dask-core >=2021.3.1
 - dill
 - importlib-metadata
-- ipyparallel
-- ipython !=8.0.*
 - jinja2
 - matplotlib-base >=3.1.3
 - natsort
@@ -15,7 +13,7 @@ dependencies:
 - numpy >=1.20
 - packaging
 - pint >=0.10
-- prettytable
+- prettytable >=2.3
 - python-dateutil >=2.5.0
 - pyyaml
 - requests

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -295,20 +295,20 @@ towncrier_draft_include_empty = False
 towncrier_draft_working_directory = ".."
 
 # Add the hyperspy website to the intersphinx domains
-intersphinx_mapping = {'rsciio': ('https://hyperspy.org/rosettasciio/', None),
-                       'cupy': ('https://docs.cupy.dev/en/stable', None),
-                       'python': ('https://docs.python.org/3', None),
-                       'h5py': ('https://docs.h5py.org/en/stable', None),
-                       'hyperspyweb': ('https://hyperspy.org/', None),
-                       'matplotlib': ('https://matplotlib.org', None),
-                       'numpy': ('https://docs.scipy.org/doc/numpy', None),
-                       'scipy': ('https://docs.scipy.org/doc/scipy/reference', None),
-                       'dask': ('https://docs.dask.org/en/latest', None),
-                       'astroML': ('https://www.astroml.org/', None),
-                       'sklearn': ('https://scikit-learn.org/stable', None),
-                       'skimage': ('https://scikit-image.org/docs/stable', None),
-                       'zarr': ('https://zarr.readthedocs.io/en/stable', None),
-                       }
+intersphinx_mapping = {
+    'cupy': ('https://docs.cupy.dev/en/stable', None),
+    'dask': ('https://docs.dask.org/en/latest', None),
+    'h5py': ('https://docs.h5py.org/en/stable', None),
+    'IPython': ('https://ipython.readthedocs.io/en/stable', None),
+    'matplotlib': ('https://matplotlib.org', None),
+    'numpy': ('https://docs.scipy.org/doc/numpy', None),
+    'python': ('https://docs.python.org/3', None),
+    'rsciio': ('https://hyperspy.org/rosettasciio/', None),
+    'scipy': ('https://docs.scipy.org/doc/scipy/reference', None),
+    'skimage': ('https://scikit-image.org/docs/stable', None),
+    'sklearn': ('https://scikit-learn.org/stable', None),
+    'zarr': ('https://zarr.readthedocs.io/en/stable', None),
+}
 
 # -- Sphinx-Gallery---------------
 

--- a/doc/user_guide/model/fitting_model.rst
+++ b/doc/user_guide/model/fitting_model.rst
@@ -390,7 +390,7 @@ on the ``centre`` parameter.
     >>> g1.centre.bmin = 7
     >>> g1.centre.bmax = 14
     >>> m.fit(optimizer="lm", bounded=True)
-    >>> m.print_current_values(fancy=False)
+    >>> m.print_current_values()
     Model1D:  histogram
     Gaussian: Gaussian
     Active: True

--- a/doc/user_guide/model/model_parameters.rst
+++ b/doc/user_guide/model/model_parameters.rst
@@ -9,8 +9,7 @@ Getting parameter values
 :py:meth:`~.model.BaseModel.print_current_values()` prints the properties of the
 parameters of the components in the current coordinates. In the Jupyter Notebook,
 the default view is HTML-formatted, which allows for formatted copying
-into other software, such as Excel. This can be changed to a standard
-terminal view with the argument ``fancy=False``. One can also filter for only active
+into other software, such as Excel. One can also filter for only active
 components and only showing component with free parameters with the arguments
 ``only_active`` and ``only_free``, respectively.
 
@@ -24,7 +23,7 @@ The current values of a particular component can be printed using the
     >>> m = s.create_model()
     >>> m.fit()
     >>> G = m[1]
-    >>> G.print_current_values(fancy=False)
+    >>> G.print_current_values()
     Gaussian: Al_Ka
     Active: True
     Parameter Name |  Free |      Value |        Std |        Min
@@ -144,7 +143,7 @@ The value of a parameter can be coupled to the value of another by setting the
     >>> gaussian.centre.free = False # Fix the centre
     >>> gaussian.free_parameters  # Print the free parameters
     [<Parameter A of Carbon component>, <Parameter sigma of Carbon component>]
-    >>> m.print_current_values(only_free=True, fancy=False) # Print the values of all free parameters.
+    >>> m.print_current_values(only_free=True) # Print the values of all free parameters.
     Model1D:
     Gaussian: Carbon
     Active: True
@@ -172,7 +171,7 @@ The value of a parameter can be coupled to the value of another by setting the
     >>> # Couple the A parameter of gaussian2 to the A parameter of gaussian 3:
     >>> gaussian2.A.twin = gaussian3.A
     >>> gaussian2.A.value = 10 # Set the gaussian2 A value to 10
-    >>> gaussian3.print_current_values(fancy=False)
+    >>> gaussian3.print_current_values()
     Gaussian: Nitrogen
     Active: True
     Parameter Name |  Free |      Value |        Std |        Min |        Max
@@ -182,7 +181,7 @@ The value of a parameter can be coupled to the value of another by setting the
             centre |  True |        0.0 |       None |       None |       None
 
     >>> gaussian3.A.value = 5 # Set the gaussian1 centre value to 5
-    >>> gaussian2.print_current_values(fancy=False)
+    >>> gaussian2.print_current_values()
     Gaussian: Long Hydrogen name
     Active: True
     Parameter Name |  Free |      Value |        Std |        Min |        Max
@@ -213,7 +212,7 @@ example:
     >>> gaussian2.A.twin_function_expr = "x**2"
     >>> gaussian2.A.twin_inverse_function_expr = "sqrt(abs(x))"
     >>> gaussian2.A.value = 4
-    >>> gaussian3.print_current_values(fancy=False)
+    >>> gaussian3.print_current_values()
     Gaussian: Nitrogen
     Active: True
     Parameter Name |  Free |      Value |        Std |        Min |        Max
@@ -225,7 +224,7 @@ example:
 .. code-block:: python
 
     >>> gaussian3.A.value = 4
-    >>> gaussian2.print_current_values(fancy=False)
+    >>> gaussian2.print_current_values()
     Gaussian: Long Hydrogen name
     Active: True
     Parameter Name |  Free |      Value |        Std |        Min |        Max
@@ -244,4 +243,3 @@ on individual components.
 * :py:meth:`~.model.BaseModel.set_parameters_not_free`
 * :py:meth:`~.model.BaseModel.set_parameters_free`
 * :py:meth:`~.model.BaseModel.set_parameters_value`
-

--- a/hyperspy/_signals/eels.py
+++ b/hyperspy/_signals/eels.py
@@ -33,7 +33,7 @@ from hyperspy.misc.label_position import SpectrumLabelPosition
 import hyperspy.axes
 from hyperspy.defaults_parser import preferences
 from hyperspy.components1d import PowerLaw
-from hyperspy.misc.utils import isiterable, underline, print_html
+from hyperspy.misc.utils import display, isiterable, underline
 from hyperspy.misc.math_tools import optimal_fft_size
 from hyperspy.misc.eels.tools import get_edges_near_energy
 from hyperspy.misc.eels.electron_inelastic_mean_free_path import iMFP_Iakoubovskii, iMFP_angular_correction
@@ -208,8 +208,7 @@ class EELSSpectrum(Signal1D):
             er = EdgesRange(self)
             return er.gui(display=display, toolkit=toolkit)
         else:
-            return self.print_edges_near_energy(energy, width, only_major,
-                                                order)
+            self.print_edges_near_energy(energy, width, only_major, order)
 
     @staticmethod
     def print_edges_near_energy(energy=None, width=10, only_major=False,
@@ -270,8 +269,7 @@ class EELSSpectrum(Signal1D):
         # this ensures the html version try its best to mimick the ASCII one
         table.format = True
 
-        return print_html(f_text=table.get_string,
-                          f_html=table.get_html_string)
+        display(table)
 
     def estimate_zero_loss_peak_centre(self, mask=None):
         """Estimate the position of the zero-loss peak.

--- a/hyperspy/component.py
+++ b/hyperspy/component.py
@@ -25,14 +25,14 @@ from sympy.utilities.lambdify import lambdify
 from pathlib import Path
 
 from hyperspy.misc.utils import slugify
-from rsciio.utils.tools import (incremental_filename,
-                                    append2pathname,)
-from hyperspy.misc.export_dictionary import export_to_dictionary, \
-    load_from_dictionary
+from rsciio.utils.tools import incremental_filename, append2pathname
+from hyperspy.misc.export_dictionary import (
+    export_to_dictionary,
+    load_from_dictionary,
+    )
 from hyperspy.events import Events, Event
 from hyperspy.ui_registry import add_gui_method
-from IPython.display import display_pretty, display
-from hyperspy.misc.model_tools import current_component_values
+from hyperspy.misc.model_tools import CurrentComponentValues
 from hyperspy.misc.utils import get_object_package_info
 
 import logging
@@ -1275,7 +1275,7 @@ class Component(t.HasTraits):
             raise ValueError("_id_name of component and dictionary do not match, \ncomponent._id_name = %s\
                     \ndictionary['_id_name'] = %s" % (self._id_name, dic['_id_name']))
 
-    def print_current_values(self, only_free=False, fancy=True):
+    def print_current_values(self, only_free=False):
         """
         Prints the current values of the component's parameters.
 
@@ -1283,13 +1283,8 @@ class Component(t.HasTraits):
         ----------
         only_free : bool
             If True, only free parameters will be printed.
-        fancy : bool
-            If True, attempts to print using html rather than text in the notebook.
         """
-        if fancy:
-            display(current_component_values(self, only_free=only_free))
-        else:
-            display_pretty(current_component_values(self, only_free=only_free))
+        return CurrentComponentValues(self, only_free=only_free)
 
     @property
     def _constant_term(self):

--- a/hyperspy/component.py
+++ b/hyperspy/component.py
@@ -33,7 +33,7 @@ from hyperspy.misc.export_dictionary import (
 from hyperspy.events import Events, Event
 from hyperspy.ui_registry import add_gui_method
 from hyperspy.misc.model_tools import CurrentComponentValues
-from hyperspy.misc.utils import get_object_package_info
+from hyperspy.misc.utils import display, get_object_package_info
 
 import logging
 
@@ -1284,7 +1284,7 @@ class Component(t.HasTraits):
         only_free : bool
             If True, only free parameters will be printed.
         """
-        return CurrentComponentValues(self, only_free=only_free)
+        display(CurrentComponentValues(self, only_free=only_free))
 
     @property
     def _constant_term(self):

--- a/hyperspy/misc/ipython_tools.py
+++ b/hyperspy/misc/ipython_tools.py
@@ -23,6 +23,7 @@ from time import strftime
 from pathlib import Path
 
 
+
 def get_ipython():
     """Get the global InteractiveShell instance.
 
@@ -30,14 +31,10 @@ def get_ipython():
     """
     if is_it_running_from_ipython is False:
         return None
+
     import IPython
-    if Version(IPython.__version__) < Version("0.11"):
-        ip = IPython.ipapi.get()
-    elif Version(IPython.__version__) < Version("1.0"):
-        ip = IPython.core.ipapi.get()
-    else:
-        ip = IPython.get_ipython()
-    return ip
+
+    return IPython.get_ipython()
 
 
 def is_it_running_from_ipython():

--- a/hyperspy/misc/model_tools.py
+++ b/hyperspy/misc/model_tools.py
@@ -27,7 +27,7 @@ def _format_string(val):
     return "{:6g}".format(val) if val is not None else ""
 
 
-class current_component_values():
+class CurrentComponentValues():
     """
     Convenience class that makes use of __repr__ methods for nice printing in
     the notebook of the properties of parameters of a component.
@@ -38,7 +38,7 @@ class current_component_values():
     only_free : bool, default False
         If True: Only include the free parameters in the view
     only_active : bool, default False
-        If True: Helper for current_model_values. Only include active
+        If True: Helper for ``CurrentModelValues``. Only include active
         components in the view. Always shows values if used on an individual
         component.
      """
@@ -116,7 +116,7 @@ class current_component_values():
         return text
 
 
-class current_model_values():
+class CurrentModelValues():
     """
     Convenience class that makes use of __repr__ methods for nice printing in
     the notebook of the properties of parameters in components in a model.
@@ -143,7 +143,7 @@ class current_model_values():
         for comp in self.component_list:
             if not self.only_active or self.only_active and comp.active:
                 if not self.only_free or comp.free_parameters and self.only_free:
-                    text += current_component_values(
+                    text += CurrentComponentValues(
                         component=comp,
                         only_free=self.only_free,
                         only_active=self.only_active
@@ -157,7 +157,7 @@ class current_model_values():
         for comp in self.component_list:
             if not self.only_active or self.only_active and comp.active:
                 if not self.only_free or comp.free_parameters and self.only_free:
-                    html += current_component_values(
+                    html += CurrentComponentValues(
                         component=comp,
                         only_free=self.only_free,
                         only_active=self.only_active

--- a/hyperspy/misc/utils.py
+++ b/hyperspy/misc/utils.py
@@ -1518,19 +1518,6 @@ def get_object_package_info(obj):
     return dic
 
 
-def print_html(f_text, f_html):
-    """Print html version when in Jupyter Notebook"""
-
-    class PrettyText:
-        def __repr__(self):
-            return f_text()
-
-        def _repr_html_(self):
-            return f_html()
-
-    return PrettyText()
-
-
 def is_hyperspy_signal(input_object):
     """
     Check if an object is a Hyperspy Signal

--- a/hyperspy/misc/utils.py
+++ b/hyperspy/misc/utils.py
@@ -1642,3 +1642,20 @@ def get_array_module(array):
         pass
 
     return module
+
+
+def display(obj):
+    """
+    Convenience funtion to display an obj using IPython rendering if
+    installed, otherwise, fall back to python ``print``
+
+    Parameters
+    ----------
+    obj : python object
+        Python object to be displayed
+    """
+    try:
+        from IPython import display
+        display.display(obj)
+    except ImportError:
+        print(obj)

--- a/hyperspy/misc/utils.py
+++ b/hyperspy/misc/utils.py
@@ -34,7 +34,7 @@ import dask.array as da
 import numpy as np
 
 from hyperspy.misc.signal_tools import broadcast_signals
-from hyperspy.exceptions import LazyCupyConversion
+from hyperspy.exceptions import VisibleDeprecationWarning
 from hyperspy.docstrings.signal import SHOW_PROGRESSBAR_ARG
 from hyperspy.docstrings.utils import STACK_METADATA_ARG
 
@@ -363,7 +363,7 @@ class DictionaryTreeBrowser:
         return string
 
     def _get_html_print_items(self, padding="", max_len=78, recursive_level=0):
-        """Recursive method that creates a html string for fancy display
+        """Recursive method that creates a html string for html display
         of metadata.
         """
         recursive_level += 1

--- a/hyperspy/model.py
+++ b/hyperspy/model.py
@@ -30,7 +30,6 @@ import numpy as np
 import dask.array as da
 from dask.diagnostics import ProgressBar
 import scipy.odr as odr
-from IPython.display import display, display_pretty
 from scipy.linalg import svd
 from scipy.optimize import (
     differential_evolution,
@@ -54,16 +53,13 @@ from hyperspy.misc.export_dictionary import (
     parse_flag_string,
     reconstruct_object
     )
-from hyperspy.misc.model_tools import (
-    current_model_values,
-    _calculate_covariance,
-    )
+from hyperspy.misc.model_tools import CurrentModelValues, _calculate_covariance
 from hyperspy.misc.slicing import copy_slice_from_whitelist
 from hyperspy.misc.utils import (
     dummy_context_manager,
     shorten_name,
     slugify,
-    stash_active_state
+    stash_active_state,
     )
 from hyperspy.signal import BaseSignal
 from hyperspy.ui_registry import add_gui_method
@@ -2089,7 +2085,7 @@ class BaseModel(list):
             component.plot(only_free=only_free)
 
     def print_current_values(self, only_free=False, only_active=False,
-                             component_list=None, fancy=True):
+                             component_list=None):
         """Prints the current values of the parameters of all components.
 
         Parameters
@@ -2101,17 +2097,10 @@ class BaseModel(list):
             If True, only values of active components will be printed
         component_list : None or list of components.
             If None, print all components.
-        fancy : bool
-            If True, attempts to print using html rather than text in the notebook.
         """
-        if fancy:
-            display(current_model_values(
-                model=self, only_free=only_free, only_active=only_active,
-                component_list=component_list))
-        else:
-            display_pretty(current_model_values(
-                model=self, only_free=only_free, only_active=only_active,
-                component_list=component_list))
+        return CurrentModelValues(
+            model=self, only_free=only_free, only_active=only_active,
+            component_list=component_list)
 
     def set_parameters_not_free(self, component_list=None,
                                 parameter_name_list=None,

--- a/hyperspy/model.py
+++ b/hyperspy/model.py
@@ -56,6 +56,7 @@ from hyperspy.misc.export_dictionary import (
 from hyperspy.misc.model_tools import CurrentModelValues, _calculate_covariance
 from hyperspy.misc.slicing import copy_slice_from_whitelist
 from hyperspy.misc.utils import (
+    display,
     dummy_context_manager,
     shorten_name,
     slugify,
@@ -2098,9 +2099,11 @@ class BaseModel(list):
         component_list : None or list of components.
             If None, print all components.
         """
-        return CurrentModelValues(
-            model=self, only_free=only_free, only_active=only_active,
-            component_list=component_list)
+        display(
+            CurrentModelValues(
+                model=self, only_free=only_free, only_active=only_active,
+                component_list=component_list)
+            )
 
     def set_parameters_not_free(self, component_list=None,
                                 parameter_name_list=None,

--- a/hyperspy/tests/component/test_component_print_current.py
+++ b/hyperspy/tests/component/test_component_print_current.py
@@ -18,9 +18,11 @@
 import pytest
 
 from hyperspy.datasets.example_signals import EDS_SEM_Spectrum
-from hyperspy.misc.model_tools import (_format_string,
-                                       current_component_values,
-                                       current_model_values)
+from hyperspy.misc.model_tools import (
+    _format_string,
+    CurrentComponentValues,
+    CurrentModelValues,
+    )
 
 
 class TestSetParameters:
@@ -40,8 +42,8 @@ class TestSetParameters:
     @pytest.mark.parametrize("only_free, only_active", [(True, False), (True, False)])
     def test_component_current_component_values(self, only_free, only_active):
         "Many decimals aren't printed, few decimals are"
-        string_representation = str(current_component_values(self.component, only_free, only_active).__repr__())
-        html_representation = str(current_component_values(self.component, only_free, only_active)._repr_html_())
+        string_representation = str(CurrentComponentValues(self.component, only_free, only_active).__repr__())
+        html_representation = str(CurrentComponentValues(self.component, only_free, only_active)._repr_html_())
         assert "1.234" in string_representation
         assert "1.23456789012" not in string_representation
         assert "1.234" in html_representation
@@ -49,16 +51,16 @@ class TestSetParameters:
 
     def test_component_current_component_values_only_free(self, only_free=True, only_active=False):
         "Parameters with free=False values should not be present in repr"
-        string_representation = str(current_component_values(self.component_not_free, only_free, only_active).__repr__())
-        html_representation = str(current_component_values(self.component_not_free, only_free, only_active)._repr_html_())
+        string_representation = str(CurrentComponentValues(self.component_not_free, only_free, only_active).__repr__())
+        html_representation = str(CurrentComponentValues(self.component_not_free, only_free, only_active)._repr_html_())
         assert "9.87" not in string_representation
         assert "9.87" not in html_representation
 
     @pytest.mark.parametrize("only_free, only_active", [(True, False), (True, False)])
     def test_component_current_model_values(self, only_free, only_active):
         "Many decimals aren't printed, few decimals are"
-        string_representation = str(current_model_values(self.model, only_free, only_active).__repr__())
-        html_representation = str(current_model_values(self.model, only_free, only_active)._repr_html_())
+        string_representation = str(CurrentModelValues(self.model, only_free, only_active).__repr__())
+        html_representation = str(CurrentModelValues(self.model, only_free, only_active)._repr_html_())
         assert "1.234" in string_representation
         assert "1.23456789012" not in string_representation
         assert "1.234" in html_representation
@@ -76,8 +78,8 @@ class TestSetParameters:
     @pytest.mark.parametrize("only_free, only_active", [(True, False), (True, False)])
     def test_component_current_model_values_comp_list(self, only_free, only_active):
         comp_list = [self.component, self.component_not_free, self.component_inactive]
-        string_representation = str(current_model_values(self.model, only_free, only_active, comp_list).__repr__())
-        html_representation = str(current_model_values(self.model, only_free, only_active, comp_list)._repr_html_())
+        string_representation = str(CurrentModelValues(self.model, only_free, only_active, comp_list).__repr__())
+        html_representation = str(CurrentModelValues(self.model, only_free, only_active, comp_list)._repr_html_())
         assert "1.234" in string_representation
         assert "1.23456789012" not in string_representation
         assert "1.234" in html_representation
@@ -90,28 +92,25 @@ class TestSetParameters:
             assert "5.67" not in string_representation
             assert "5.67" not in html_representation
 
-    @pytest.mark.parametrize("fancy", (True, False))
-    def test_model_current_model_values(self, fancy):
-        self.model.print_current_values(fancy=fancy)
+    def test_model_current_model_values(self):
+        self.model.print_current_values()
 
-    @pytest.mark.parametrize("fancy", (True, False))
-    def test_component_print_current_values(self, fancy):
-        self.model[0].print_current_values(fancy=fancy)
+    def test_component_print_current_values(self):
+        self.model[0].print_current_values()
 
-    @pytest.mark.parametrize("fancy", (True, False))
-    def test_model_print_current_values(self, fancy):
-        self.model.print_current_values(fancy=fancy)
+    def test_model_print_current_values(self):
+        self.model.print_current_values()
 
-    def test_zero_in_fancy_print(self):
+    def test_zero_in_html_print(self):
         "Ensure parameters with value=0 are printed too"
-        assert "<td>a1</td><td>True</td><td>     0</td>" in current_component_values(self.model[0])._repr_html_()
+        assert "<td>a1</td><td>True</td><td>     0</td>" in CurrentComponentValues(self.model[0])._repr_html_()
 
     def test_zero_in_normal_print(self):
         "Ensure parameters with value=0 are printed too"
-        assert "            a0 |    True |          0 |" in str(current_component_values(self.model[0]).__repr__)
+        assert "            a0 |    True |          0 |" in str(CurrentComponentValues(self.model[0]).__repr__)
 
     def test_twinned_in_print(self):
-        assert "             A | Twinned |" in str(current_component_values(self.model[2]).__repr__()).split('\n')[4]
+        assert "             A | Twinned |" in str(CurrentComponentValues(self.model[2]).__repr__()).split('\n')[4]
 
     def test_related_tools(self):
         assert _format_string(None) == ""

--- a/hyperspy/tests/misc/test_utils.py
+++ b/hyperspy/tests/misc/test_utils.py
@@ -18,7 +18,9 @@
 
 import dask.array as da
 import numpy as np
+from prettytable import PrettyTable
 import pytest
+
 
 from hyperspy import signals
 from hyperspy.misc.utils import (
@@ -33,7 +35,7 @@ from hyperspy.misc.utils import (
     shorten_name,
     is_cupy_array,
     to_numpy,
-    get_array_module
+    get_array_module,
 )
 
 

--- a/hyperspy/tests/signals/test_eels.py
+++ b/hyperspy/tests/signals/test_eels.py
@@ -432,17 +432,17 @@ class Test_Estimate_Thickness:
             self.s.estimate_thickness(zlp=self.zlp, density=3.6)
 
 
-class Test_Print_Edges_Near_Energy:
+class TestPrintEdgesNearEnergy:
     def setup_method(self, method):
         # Create an empty spectrum
         s = hs.signals.EELSSpectrum(np.ones((4, 2, 1024)))
         self.signal = s
 
-    def test_at_532eV(self):
+    def test_at_532eV(self, capsys):
         s = self.signal
-        table_ascii = s.print_edges_near_energy(532)
-
-        assert table_ascii.__repr__() == (
+        s.print_edges_near_energy(532)
+        captured = capsys.readouterr()
+        expected_out = (
             '+-------+-------------------+-----------+-----------------+\n'
             '|  edge | onset energy (eV) | relevance |   description   |\n'
             '+-------+-------------------+-----------+-----------------+\n'
@@ -451,23 +451,24 @@ class Test_Print_Edges_Near_Energy:
             '| At_N5 |       533.0       |   Minor   |                 |\n'
             '| Sb_M5 |       528.0       |   Major   | Delayed maximum |\n'
             '| Sb_M4 |       537.0       |   Major   | Delayed maximum |\n'
-            '+-------+-------------------+-----------+-----------------+'
-            )
+            '+-------+-------------------+-----------+-----------------+\n'
+        )
+        assert captured.out == expected_out
 
-    def test_sequence_edges(self):
+    def test_sequence_edges(self, capsys):
         s = self.signal
-        table_ascii = s.print_edges_near_energy(123,
-                                                edges=['Mn_L2', 'O_K', 'Fe_L2'])
-
-        assert table_ascii.__repr__() == (
+        s.print_edges_near_energy(123, edges=['Mn_L2', 'O_K', 'Fe_L2'])
+        captured = capsys.readouterr()
+        expected_out = (
             '+-------+-------------------+-----------+-----------------------------+\n'
             '|  edge | onset energy (eV) | relevance |         description         |\n'
             '+-------+-------------------+-----------+-----------------------------+\n'
             '| Mn_L2 |       651.0       |   Major   | Sharp peak. Delayed maximum |\n'
             '|  O_K  |       532.0       |   Major   |         Abrupt onset        |\n'
             '| Fe_L2 |       721.0       |   Major   | Sharp peak. Delayed maximum |\n'
-            '+-------+-------------------+-----------+-----------------------------+'
+            '+-------+-------------------+-----------+-----------------------------+\n'
             )
+        assert captured.out == expected_out
 
     def test_no_energy_and_edges(self):
         s = self.signal
@@ -481,20 +482,21 @@ class Test_Edges_At_Energy:
         s = hs.signals.EELSSpectrum(np.ones((4, 2, 1024)))
         self.signal = s
 
-    def test_at_532eV(self):
+    def test_at_532eV(self, capsys):
         s = self.signal
-        table_ascii = s.edges_at_energy(532, width=20, only_major=True,
-                                        order='ascending')
+        s.edges_at_energy(532, width=20, only_major=True, order='ascending')
+        captured = capsys.readouterr()
 
-        assert table_ascii.__repr__() == (
+        expected_out = (
             '+-------+-------------------+-----------+-----------------+\n'
             '|  edge | onset energy (eV) | relevance |   description   |\n'
             '+-------+-------------------+-----------+-----------------+\n'
             '| Sb_M5 |       528.0       |   Major   | Delayed maximum |\n'
             '|  O_K  |       532.0       |   Major   |   Abrupt onset  |\n'
             '| Sb_M4 |       537.0       |   Major   | Delayed maximum |\n'
-            '+-------+-------------------+-----------+-----------------+'
+            '+-------+-------------------+-----------+-----------------+\n'
             )
+        assert captured.out == expected_out
 
 
 class Test_Get_Complementary_Edges:

--- a/hyperspy/tests/utils/test_parallel_pool.py
+++ b/hyperspy/tests/utils/test_parallel_pool.py
@@ -1,0 +1,40 @@
+# Copyright 2007-2022 The HyperSpy developers
+#
+# This file is part of HyperSpy.
+#
+# HyperSpy is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# HyperSpy is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with HyperSpy. If not, see <https://www.gnu.org/licenses/#GPL>.
+
+import pytest
+
+from hyperspy.utils.parallel_pool import ParallelPool
+
+
+def test_parallel_pool_multiprocessing():
+    pool = ParallelPool(ipyparallel=False)
+    assert pool.is_multiprocessing
+    assert not pool.is_ipyparallel
+
+
+def test_parallel_pool_ipyparallel_not_installed():
+    pool = ParallelPool()
+    try:
+        import ipyparallel
+        # ipyparallel is installed, use it as default
+    except ImportError:
+        # ipyparallel is installed, use multiprocessing instead
+        assert pool.is_multiprocessing
+        assert not pool.is_ipyparallel
+
+        with pytest.raises(ValueError):
+            ParallelPool(ipyparallel=True)

--- a/hyperspy/tests/utils/test_print_known_signal_types.py
+++ b/hyperspy/tests/utils/test_print_known_signal_types.py
@@ -1,11 +1,9 @@
 from hyperspy.utils import print_known_signal_types
 
 
-class TestPrintKnownSignalTypes:
-    def test_text_output(self):
-        obj = print_known_signal_types()
-        assert obj.__repr__()
-
-    def test_html_output(self):
-        obj = print_known_signal_types()
-        assert obj._repr_html_()
+def test_text_output(capsys):
+    print_known_signal_types()
+    captured = capsys.readouterr()
+    assert 'signal_type' in captured.out
+    # the output will be str, not html
+    assert '<p>' not in captured.out

--- a/hyperspy/utils/__init__.py
+++ b/hyperspy/utils/__init__.py
@@ -59,7 +59,7 @@ def print_known_signal_types():
     """
     from hyperspy.ui_registry import ALL_EXTENSIONS
     from prettytable import PrettyTable
-    from hyperspy.misc.utils import print_html
+    from hyperspy.misc.utils import display, print_html
     table = PrettyTable()
     table.field_names = [
         "signal_type",
@@ -76,8 +76,9 @@ def print_known_signal_types():
         package = sdict["module"].split(".")[0]
         table.add_row([sdict["signal_type"], aliases, sclass, package])
         table.sortby = "class name"
-    return print_html(f_text=table.get_string,
-                      f_html=table.get_html_string)
+    display(
+        print_html(f_text=table.get_string, f_html=table.get_html_string)
+        )
 
 
 __all__ = [

--- a/hyperspy/utils/__init__.py
+++ b/hyperspy/utils/__init__.py
@@ -59,7 +59,7 @@ def print_known_signal_types():
     """
     from hyperspy.ui_registry import ALL_EXTENSIONS
     from prettytable import PrettyTable
-    from hyperspy.misc.utils import display, print_html
+    from hyperspy.misc.utils import display
     table = PrettyTable()
     table.field_names = [
         "signal_type",
@@ -76,9 +76,7 @@ def print_known_signal_types():
         package = sdict["module"].split(".")[0]
         table.add_row([sdict["signal_type"], aliases, sclass, package])
         table.sortby = "class name"
-    display(
-        print_html(f_text=table.get_string, f_html=table.get_html_string)
-        )
+    display(table)
 
 
 __all__ = [

--- a/hyperspy/utils/parallel_pool.py
+++ b/hyperspy/utils/parallel_pool.py
@@ -22,13 +22,21 @@ import time
 from multiprocessing import Pool, cpu_count
 from multiprocessing.pool import Pool as Pool_type
 
+try:
+    import ipyparallel as ipp
+
+    _ipyparallel_installed = True
+except ImportError:
+    _ipyparallel_installed = False
+
+
 import numpy as np
 
 _logger = logging.getLogger(__name__)
 
 
 class ParallelPool:
-    """ Creates a ParallelPool by either looking for a ipyparallel client and
+    """Creates a ParallelPool by either looking for a ipyparallel client and
     then creating a load_balanced_view, or by creating a multiprocessing pool
 
     Attributes
@@ -50,8 +58,7 @@ class ParallelPool:
 
     _timestep = 0
 
-    def __init__(self, num_workers=None, ipython_kwargs=None,
-                 ipyparallel=None):
+    def __init__(self, num_workers=None, ipython_kwargs=None, ipyparallel=None):
         """Creates the ParallelPool and sets it up.
 
         Parameters
@@ -70,8 +77,8 @@ class ParallelPool:
             ipython_kwargs = {}
         else:
             ipyparallel = True
-        self.timeout = 15.
-        self.ipython_kwargs = {'timeout': self.timeout}
+        self.timeout = 15.0
+        self.ipython_kwargs = {"timeout": self.timeout}
         self.ipython_kwargs.update(ipython_kwargs)
         self.pool = None
         if num_workers is None:
@@ -87,15 +94,14 @@ class ParallelPool:
         value = np.abs(value)
         self._timestep = value
 
-    timestep = property(lambda s: s._timestep_get(),
-                        lambda s, v: s._timestep_set(v))
+    timestep = property(lambda s: s._timestep_get(), lambda s, v: s._timestep_set(v))
 
     @property
     def is_ipyparallel(self):
         """bool: Return ``True`` if the pool is ipyparallel-based else
         ``False``
         """
-        return hasattr(self.pool, 'client')
+        return hasattr(self.pool, "client")
 
     @property
     def is_multiprocessing(self):
@@ -109,24 +115,21 @@ class ParallelPool:
         """bool: Return ``True`` if the pool is ready and set-up else
         ``False``
         """
-        return self.is_ipyparallel or self.is_multiprocessing and \
-            self.pool._state == 0
+        return self.is_ipyparallel or self.is_multiprocessing and self.pool._state == 0
 
     def _setup_ipyparallel(self):
-        import ipyparallel as ipp
-        _logger.debug('Calling _setup_ipyparallel')
+        _logger.debug("Calling _setup_ipyparallel")
         try:
             ipyclient = ipp.Client(**self.ipython_kwargs)
             self.num_workers = min(self.num_workers, len(ipyclient))
-            self.pool = ipyclient.load_balanced_view(
-                range(self.num_workers))
+            self.pool = ipyclient.load_balanced_view(range(self.num_workers))
             return True
         except OSError:
-            _logger.debug('Failed to find ipyparallel pool')
+            _logger.debug("Failed to find ipyparallel pool")
             return False
 
     def _setup_multiprocessing(self):
-        _logger.debug('Calling _setup_multiprocessing')
+        _logger.debug("Calling _setup_multiprocessing")
         self.num_workers = min(self.num_workers, cpu_count() - 1)
         self.pool = Pool(processes=self.num_workers)
         return True
@@ -141,22 +144,29 @@ class ParallelPool:
             the multiprocessing. If None, first tries ipyparallel, and it does
             not succeed, then multiprocessing.
         """
-        _logger.debug('Calling setup with ipyparallel={}'.format(ipyparallel))
+        _logger.debug("Calling setup with ipyparallel={}".format(ipyparallel))
         if not self.has_pool:
+            if not _ipyparallel_installed:
+                if ipyparallel is True:
+                    raise ValueError("ipyparralel must be installed")
+                else:
+                    _logger.info(
+                        "ipyparallel is not installed, "
+                        "a multiprocessing pool will be used."
+                    )
+                    ipyparallel = False
             if ipyparallel is True:
                 if self._setup_ipyparallel():
                     return
                 else:
-                    raise ValueError('Could not connect to the ipyparallel'
-                                     ' Client')
+                    raise ValueError("Could not connect to the ipyparallel" " Client")
+            elif ipyparallel is False:
+                self._setup_multiprocessing()
             elif ipyparallel is None:
                 _ = self._setup_ipyparallel() or self._setup_multiprocessing()
                 return
-            elif ipyparallel is False:
-                self._setup_multiprocessing()
             else:
-                raise ValueError('ipyparallel has to be True, False or None '
-                                 'type')
+                raise ValueError("ipyparallel has to be True, False or None " "type")
 
     def sleep(self, howlong=None):
         """Sleeps for the required number of seconds.

--- a/setup.py
+++ b/setup.py
@@ -49,9 +49,7 @@ install_req = [
     'packaging',
     'pint>=0.10',
     'pooch',
-    # prettytable and ptable are API compatible
-    # prettytable is maintained and ptable is an unmaintained fork
-    'prettytable',
+    'prettytable>=2.3',
     'python-dateutil>=2.5.0',
     'pyyaml',
     'requests',

--- a/setup.py
+++ b/setup.py
@@ -39,8 +39,6 @@ install_req = [
     # included in stdlib since v3.8, but this required version requires Python 3.10
     # We can remove this requirement when the minimum supported version becomes Python 3.10
     'importlib-metadata>=3.6',
-    # https://github.com/ipython/ipython/pull/13466
-    'ipython!=8.0.*',
     'jinja2',
     'matplotlib>=3.1.3',
     'natsort',
@@ -67,6 +65,7 @@ install_req = [
 
 
 extras_require = {
+	"ipython": ["IPython>7.0, !=8.0", "ipyparallel"],
     "learning": ["scikit-learn>=1.0.1"],
     "gui-jupyter": ["hyperspy_gui_ipywidgets>=1.1.0", "ipympl"],
     # UPDATE BEFORE RELEASE

--- a/upcoming_changes/3145.api.rst
+++ b/upcoming_changes/3145.api.rst
@@ -1,0 +1,2 @@
+Fix behaviour of :meth:`~.model.BaseModel.print_current_values`, :meth:`~.component.Component.print_current_values`
+and :func:`~.api.print_known_signal_types`, which were not printing when running from a script - they were only printing when running in notebook or qtconsole. Now all print_* functions behave consistently: they all print the output instead of returning an object (string or html). The :func:`IPython.display.display` will pick a suitable rendering when running in an "ipython" context, for example notebook, qtconsole.

--- a/upcoming_changes/3145.maintenance.rst
+++ b/upcoming_changes/3145.maintenance.rst
@@ -1,0 +1,1 @@
+IPython and IParallel are now optional dependencies


### PR DESCRIPTION
### Progress of the PR
- [x] Make ipyparallel and ipython optional dependencies,
- [x] Fix behaviour of some `print_*`  functions, which were not printing when running from a script, they were only printing when running in notebook or qtconsole. Now all `print_*` functions behave consistently: they all print the output and doesn't return an object, which was an str or html. The ipython `display` will pick the correct rendering when running in an "ipython" context, for example notebook, qtconsole.
- [x] Remove `fancy` to some `print_*` functions, which wasn't doing anything,  
- [x] Bump prettytable to 2.3 to simplify code, 
- [x] update docstring (if appropriate),
- [x] update user guide (if appropriate),
- [x] add an changelog entry in the `upcoming_changes` folder (see [`upcoming_changes/README.rst`](https://github.com/hyperspy/hyperspy/blob/RELEASE_next_minor/upcoming_changes/README.rst)),
- [x] Check formatting changelog entry in the `readthedocs` doc build of this PR (link in github checks)
- [x] add tests,
- [x] ready for review.

### Minimal example of the bug fix or the new feature

To test the `print_*` funtions:
```python
import hyperspy.api as hs

hs.print_known_signal_types()

s = hs.datasets.example_signals.EDS_TEM_Spectrum()
m = s.create_model()
m.print_current_values()
```
