### PR TITLE
Avoid fitting slowdown

### DIFF
--- a/hyperspy/_components/scalable_fixed_pattern.py
+++ b/hyperspy/_components/scalable_fixed_pattern.py
@@ -134,11 +134,12 @@ class ScalableFixedPattern(Component):
             result = yscale * self.f(x * xscale - shift)
         else:
             result = yscale * self.signal.data
-        if self.signal.axes_manager.signal_axes[0].is_binned:
-            if self.signal.axes_manager.signal_axes[0].is_uniform:
-                return result / self.signal.axes_manager.signal_axes[0].scale
+        axis = self.signal.axes_manager.signal_axes[0]
+        if axis.is_binned:
+            if axis.is_uniform:
+                return result / axis.scale
             else:
-                return result / np.gradient(self.signal.axes_manager.signal_axes[0].axis)
+                return result / np.gradient(axis.axis)
         else:
             return result
 

--- a/hyperspy/models/model1d.py
+++ b/hyperspy/models/model1d.py
@@ -433,13 +433,16 @@ class Model1D(BaseModel):
             to_return = to_return[self.channel_switches]
 
         if binned is None:
-            binned = self.signal.axes_manager[-1].is_binned
+            # use self.axis instead of self.signal.axes_manager[-1]
+            # to avoid small overhead (~10 us) which isn't negligeable when
+            # __call__ is called repeatably, typically when fitting!
+            binned = self.axis.is_binned
 
         if binned:
-            if self.signal.axes_manager[-1].is_uniform:
-                to_return *= self.signal.axes_manager[-1].scale
+            if self.axis.is_uniform:
+                to_return *= self.axis.scale
             else:
-                to_return *= np.gradient(self.signal.axes_manager[-1].axis)
+                to_return *= np.gradient(self.axis.axis)
         return to_return
 
     def _errfunc(self, param, y, weights=None):

--- a/upcoming_changes/3155.bugfix.rst
+++ b/upcoming_changes/3155.bugfix.rst
@@ -1,0 +1,2 @@
+Avoid slowing down fitting by optimising attribute access of model.
+


### PR DESCRIPTION
Follow up of #3130.

### Progress of the PR
- [x] Speed up accessing attribute,
- [n/a] update docstring (if appropriate),
- [n/a] update user guide (if appropriate),
- [x] add an changelog entry in the `upcoming_changes` folder (see [`upcoming_changes/README.rst`](https://github.com/hyperspy/hyperspy/blob/RELEASE_next_minor/upcoming_changes/README.rst)),
- [x] Check formatting changelog entry in the `readthedocs` doc build of this PR (link in github checks)
- [n/a] add tests,
- [x] ready for review.

### Minimal example of the bug fix or the new feature
```python
import hyperspy.api as hs

s = hs.signals.Signal1D([0, 1])
axis = s.axes_manager[-1]

%timeit s.axes_manager[-1].is_binned
# ~10 us
%timeit axis.is_binned
# ~30 ns
```

