### PR TITLE
Change rechunk function parameter from default True, to default False

### DIFF
--- a/doc/user_guide/big_data.rst
+++ b/doc/user_guide/big_data.rst
@@ -374,12 +374,12 @@ method can be used:
     >>> s.get_chunk_size(0) # The first navigation axis
     ((200,),)
 
-.. versionadded:: 1.3.2
+.. versionadded:: 2.0.0
 
-By default, HyperSpy tries to optimize the chunking for most operations. However,
-it is sometimes possible to manually set a more optimal chunking manually. Therefore,
-many operations take a ``rechunk`` or ``optimize`` keyword argument to disable
-automatic rechunking.
+Starting in version 2.0.0 HyperSpy does not automatically rechunk datasets as
+this can lead to reduced performance. The ``rechunk`` or ``optimize`` keyword argument
+can be set to ``True`` to let HyperSpy automatically change the chunking which
+could potentially speed up operations.
 
 .. versionadded:: 1.7.0
 

--- a/hyperspy/_signals/eds.py
+++ b/hyperspy/_signals/eds.py
@@ -167,10 +167,10 @@ class EDSSpectrum(Signal1D):
                 xray_lines_not_in_range.append(xray_line)
         return xray_lines_in_range, xray_lines_not_in_range
 
-    def sum(self, axis=None, out=None):
+    def sum(self, axis=None, out=None, rechunk=False):
         if axis is None:
             axis = self.axes_manager.navigation_axes
-        s = super().sum(axis=axis, out=out)
+        s = super().sum(axis=axis, out=out, rechunk=rechunk)
         s = out or s
 
         # Update live time by the change in navigation axes dimensions

--- a/hyperspy/_signals/lazy.py
+++ b/hyperspy/_signals/lazy.py
@@ -703,11 +703,11 @@ class LazySignal(BaseSignal):
 
     diff.__doc__ = BaseSignal.diff.__doc__
 
-    def integrate_simpson(self, axis, out=None):
+    def integrate_simpson(self, axis, out=None, rechunk=False):
         axis = self.axes_manager[axis]
         from scipy import integrate
         axis = self.axes_manager[axis]
-        data = self._lazy_data(axis=axis, rechunk=True)
+        data = self._lazy_data(axis=axis, rechunk=rechunk)
         new_data = data.map_blocks(
             integrate.simps,
             x=axis.axis,

--- a/hyperspy/_signals/lazy.py
+++ b/hyperspy/_signals/lazy.py
@@ -469,7 +469,7 @@ class LazySignal(BaseSignal):
     def _make_lazy(self, axis=None, rechunk=False, dtype=None):
         self.data = self._lazy_data(axis=axis, rechunk=rechunk, dtype=dtype)
 
-    def change_dtype(self, dtype, rechunk=True):
+    def change_dtype(self, dtype, rechunk=False):
         # To be consistent with the rechunk argument of other method, we use
         # 'dask_auto' in favour of a chunking which doesn't split signal space.
         if rechunk:
@@ -483,7 +483,7 @@ class LazySignal(BaseSignal):
 
     change_dtype.__doc__ = BaseSignal.change_dtype.__doc__
 
-    def _lazy_data(self, axis=None, rechunk=True, dtype=None):
+    def _lazy_data(self, axis=None, rechunk=False, dtype=None):
         """Return the data as a dask array, rechunked if necessary.
 
         Parameters
@@ -521,7 +521,7 @@ class LazySignal(BaseSignal):
         return res
 
     def _apply_function_on_data_and_remove_axis(self, function, axes,
-                                                out=None, rechunk=True):
+                                                out=None, rechunk=False):
         def get_dask_function(numpy_name):
             # Translate from the default numpy to dask functions
             translations = {'amax': 'max', 'amin': 'min'}
@@ -625,7 +625,7 @@ class LazySignal(BaseSignal):
         return value
 
     def rebin(self, new_shape=None, scale=None,
-              crop=False, dtype=None, out=None, rechunk=True):
+              crop=False, dtype=None, out=None, rechunk=False):
         factors = self._validate_rebin_args_and_get_factors(
             new_shape=new_shape,
             scale=scale)
@@ -652,7 +652,7 @@ class LazySignal(BaseSignal):
     def _make_sure_data_is_contiguous(self):
         self._make_lazy(rechunk=True)
 
-    def diff(self, axis, order=1, out=None, rechunk=True):
+    def diff(self, axis, order=1, out=None, rechunk=False):
         if not self.axes_manager[axis].is_uniform:
             raise NotImplementedError(
             "Performing a numerical difference on a non-uniform axis "
@@ -729,7 +729,7 @@ class LazySignal(BaseSignal):
 
     integrate_simpson.__doc__ = BaseSignal.integrate_simpson.__doc__
 
-    def valuemax(self, axis, out=None, rechunk=True):
+    def valuemax(self, axis, out=None, rechunk=False):
         idx = self.indexmax(axis, rechunk=rechunk)
         old_data = idx.data
         data = old_data.map_blocks(
@@ -743,7 +743,7 @@ class LazySignal(BaseSignal):
 
     valuemax.__doc__ = BaseSignal.valuemax.__doc__
 
-    def valuemin(self, axis, out=None, rechunk=True):
+    def valuemin(self, axis, out=None, rechunk=False):
         idx = self.indexmin(axis, rechunk=rechunk)
         old_data = idx.data
         data = old_data.map_blocks(
@@ -757,7 +757,7 @@ class LazySignal(BaseSignal):
 
     valuemin.__doc__ = BaseSignal.valuemin.__doc__
 
-    def get_histogram(self, bins='fd', out=None, rechunk=True, **kwargs):
+    def get_histogram(self, bins='fd', out=None, rechunk=False, **kwargs):
         if 'range_bins' in kwargs:
             _logger.warning("'range_bins' argument not supported for lazy "
                             "signals")
@@ -806,7 +806,7 @@ class LazySignal(BaseSignal):
 
     # _get_signal_signal.__doc__ = BaseSignal._get_signal_signal.__doc__
 
-    def _calculate_summary_statistics(self, rechunk=True):
+    def _calculate_summary_statistics(self, rechunk=False):
         if rechunk is True:
             # Use dask auto rechunk instead of HyperSpy's one, what should be
             # better for these operations

--- a/hyperspy/docstrings/signal.py
+++ b/hyperspy/docstrings/signal.py
@@ -57,7 +57,8 @@ OPTIMIZE_ARG = \
 
 RECHUNK_ARG = \
     """rechunk: bool
-           Only has effect when operating on lazy signal. If ``True`` (default),
+           Only has effect when operating on lazy signal. Default ``False``,
+           which means the chunking structure will be retained. If ``True``,
            the data may be automatically rechunked before performing this
            operation."""
 

--- a/hyperspy/signal.py
+++ b/hyperspy/signal.py
@@ -4241,13 +4241,14 @@ class BaseSignal(FancySlicing,
             return self._deepcopy_with_new_data(der_data)
     derivative.__doc__ %= (ONE_AXIS_PARAMETER, OUT_ARG)
 
-    def integrate_simpson(self, axis, out=None):
+    def integrate_simpson(self, axis, out=None, rechunk=False):
         """Calculate the integral of a Signal along an axis using
         `Simpson's rule <https://en.wikipedia.org/wiki/Simpson%%27s_rule>`_.
 
         Parameters
         ----------
         axis %s
+        %s
         %s
 
         Returns
@@ -4280,7 +4281,7 @@ class BaseSignal(FancySlicing,
             s.data = data
             s._remove_axis(axis.index_in_axes_manager)
             return s
-    integrate_simpson.__doc__ %= (ONE_AXIS_PARAMETER, OUT_ARG)
+    integrate_simpson.__doc__ %= (ONE_AXIS_PARAMETER, OUT_ARG, RECHUNK_ARG)
 
     def fft(self, shift=False, apodization=False, real_fft_only=False, **kwargs):
         """Compute the discrete Fourier Transform.
@@ -4463,7 +4464,7 @@ class BaseSignal(FancySlicing,
             axis.offset = 0.
         return im_ifft
 
-    def integrate1D(self, axis, out=None):
+    def integrate1D(self, axis, out=None, rechunk=False):
         """Integrate the signal over the given axis.
 
         The integration is performed using
@@ -4475,6 +4476,7 @@ class BaseSignal(FancySlicing,
         Parameters
         ----------
         axis %s
+        %s
         %s
 
         Returns
@@ -4497,11 +4499,11 @@ class BaseSignal(FancySlicing,
 
         """
         if self.axes_manager[axis].is_binned:
-            return self.sum(axis=axis, out=out)
+            return self.sum(axis=axis, out=out, rechunk=rechunk)
         else:
-            return self.integrate_simpson(axis=axis, out=out)
+            return self.integrate_simpson(axis=axis, out=out, rechunk=rechunk)
 
-    integrate1D.__doc__ %= (ONE_AXIS_PARAMETER, OUT_ARG)
+    integrate1D.__doc__ %= (ONE_AXIS_PARAMETER, OUT_ARG, RECHUNK_ARG)
 
     def indexmin(self, axis, out=None, rechunk=False):
         """Returns a signal with the index of the minimum along an axis.

--- a/hyperspy/signal.py
+++ b/hyperspy/signal.py
@@ -3832,7 +3832,7 @@ class BaseSignal(FancySlicing,
             s._remove_axis([ax.index_in_axes_manager for ax in axes])
             return s
 
-    def sum(self, axis=None, out=None, rechunk=True):
+    def sum(self, axis=None, out=None, rechunk=False):
         """Sum the data over the given axes.
 
         Parameters
@@ -3885,7 +3885,7 @@ class BaseSignal(FancySlicing,
             np.sum, axis, out=out, rechunk=rechunk)
     sum.__doc__ %= (MANY_AXIS_PARAMETER, OUT_ARG, RECHUNK_ARG)
 
-    def max(self, axis=None, out=None, rechunk=True):
+    def max(self, axis=None, out=None, rechunk=False):
         """Returns a signal with the maximum of the signal along at least one
         axis.
 
@@ -3921,7 +3921,7 @@ class BaseSignal(FancySlicing,
             np.max, axis, out=out, rechunk=rechunk)
     max.__doc__ %= (MANY_AXIS_PARAMETER, OUT_ARG, RECHUNK_ARG)
 
-    def min(self, axis=None, out=None, rechunk=True):
+    def min(self, axis=None, out=None, rechunk=False):
         """Returns a signal with the minimum of the signal along at least one
         axis.
 
@@ -3957,7 +3957,7 @@ class BaseSignal(FancySlicing,
             np.min, axis, out=out, rechunk=rechunk)
     min.__doc__ %= (MANY_AXIS_PARAMETER, OUT_ARG, RECHUNK_ARG)
 
-    def mean(self, axis=None, out=None, rechunk=True):
+    def mean(self, axis=None, out=None, rechunk=False):
         """Returns a signal with the average of the signal along at least one
         axis.
 
@@ -3993,7 +3993,7 @@ class BaseSignal(FancySlicing,
             np.mean, axis, out=out, rechunk=rechunk)
     mean.__doc__ %= (MANY_AXIS_PARAMETER, OUT_ARG, RECHUNK_ARG)
 
-    def std(self, axis=None, out=None, rechunk=True):
+    def std(self, axis=None, out=None, rechunk=False):
         """Returns a signal with the standard deviation of the signal along
         at least one axis.
 
@@ -4029,7 +4029,7 @@ class BaseSignal(FancySlicing,
             np.std, axis, out=out, rechunk=rechunk)
     std.__doc__ %= (MANY_AXIS_PARAMETER, OUT_ARG, RECHUNK_ARG)
 
-    def var(self, axis=None, out=None, rechunk=True):
+    def var(self, axis=None, out=None, rechunk=False):
         """Returns a signal with the variances of the signal along at least one
         axis.
 
@@ -4065,7 +4065,7 @@ class BaseSignal(FancySlicing,
             np.var, axis, out=out, rechunk=rechunk)
     var.__doc__ %= (MANY_AXIS_PARAMETER, OUT_ARG, RECHUNK_ARG)
 
-    def nansum(self, axis=None, out=None, rechunk=True):
+    def nansum(self, axis=None, out=None, rechunk=False):
         """%s
         """
         if axis is None:
@@ -4082,7 +4082,7 @@ class BaseSignal(FancySlicing,
             np.nansum, axis, out=out, rechunk=rechunk)
     nansum.__doc__ %= (NAN_FUNC.format('sum'))
 
-    def nanmax(self, axis=None, out=None, rechunk=True):
+    def nanmax(self, axis=None, out=None, rechunk=False):
         """%s
         """
         if axis is None:
@@ -4091,7 +4091,7 @@ class BaseSignal(FancySlicing,
             np.nanmax, axis, out=out, rechunk=rechunk)
     nanmax.__doc__ %= (NAN_FUNC.format('max'))
 
-    def nanmin(self, axis=None, out=None, rechunk=True):
+    def nanmin(self, axis=None, out=None, rechunk=False):
         """%s"""
         if axis is None:
             axis = self.axes_manager.navigation_axes
@@ -4099,7 +4099,7 @@ class BaseSignal(FancySlicing,
             np.nanmin, axis, out=out, rechunk=rechunk)
     nanmin.__doc__ %= (NAN_FUNC.format('min'))
 
-    def nanmean(self, axis=None, out=None, rechunk=True):
+    def nanmean(self, axis=None, out=None, rechunk=False):
         """%s """
         if axis is None:
             axis = self.axes_manager.navigation_axes
@@ -4107,7 +4107,7 @@ class BaseSignal(FancySlicing,
             np.nanmean, axis, out=out, rechunk=rechunk)
     nanmean.__doc__ %= (NAN_FUNC.format('mean'))
 
-    def nanstd(self, axis=None, out=None, rechunk=True):
+    def nanstd(self, axis=None, out=None, rechunk=False):
         """%s"""
         if axis is None:
             axis = self.axes_manager.navigation_axes
@@ -4115,7 +4115,7 @@ class BaseSignal(FancySlicing,
             np.nanstd, axis, out=out, rechunk=rechunk)
     nanstd.__doc__ %= (NAN_FUNC.format('std'))
 
-    def nanvar(self, axis=None, out=None, rechunk=True):
+    def nanvar(self, axis=None, out=None, rechunk=False):
         """%s"""
         if axis is None:
             axis = self.axes_manager.navigation_axes
@@ -4123,7 +4123,7 @@ class BaseSignal(FancySlicing,
             np.nanvar, axis, out=out, rechunk=rechunk)
     nanvar.__doc__ %= (NAN_FUNC.format('var'))
 
-    def diff(self, axis, order=1, out=None, rechunk=True):
+    def diff(self, axis, order=1, out=None, rechunk=False):
         """Returns a signal with the `n`-th order discrete difference along
         given axis. `i.e.` it calculates the difference between consecutive
         values in the given axis: `out[n] = a[n+1] - a[n]`. See
@@ -4503,7 +4503,7 @@ class BaseSignal(FancySlicing,
 
     integrate1D.__doc__ %= (ONE_AXIS_PARAMETER, OUT_ARG)
 
-    def indexmin(self, axis, out=None, rechunk=True):
+    def indexmin(self, axis, out=None, rechunk=False):
         """Returns a signal with the index of the minimum along an axis.
 
         Parameters
@@ -4535,7 +4535,7 @@ class BaseSignal(FancySlicing,
             np.argmin, axis, out=out, rechunk=rechunk)
     indexmin.__doc__ %= (ONE_AXIS_PARAMETER, OUT_ARG, RECHUNK_ARG)
 
-    def indexmax(self, axis, out=None, rechunk=True):
+    def indexmax(self, axis, out=None, rechunk=False):
         """Returns a signal with the index of the maximum along an axis.
 
         Parameters
@@ -4567,7 +4567,7 @@ class BaseSignal(FancySlicing,
             np.argmax, axis, out=out, rechunk=rechunk)
     indexmax.__doc__ %= (ONE_AXIS_PARAMETER, OUT_ARG, RECHUNK_ARG)
 
-    def valuemax(self, axis, out=None, rechunk=True):
+    def valuemax(self, axis, out=None, rechunk=False):
         """Returns a signal with the value of coordinates of the maximum along
         an axis.
 
@@ -4607,7 +4607,7 @@ class BaseSignal(FancySlicing,
             out.events.data_changed.trigger(obj=out)
     valuemax.__doc__ %= (ONE_AXIS_PARAMETER, OUT_ARG, RECHUNK_ARG)
 
-    def valuemin(self, axis, out=None, rechunk=True):
+    def valuemin(self, axis, out=None, rechunk=False):
         """Returns a signal with the value of coordinates of the minimum along
         an axis.
 
@@ -5192,7 +5192,7 @@ class BaseSignal(FancySlicing,
         """
         return copy.deepcopy(self)
 
-    def change_dtype(self, dtype, rechunk=True):
+    def change_dtype(self, dtype, rechunk=False):
         """Change the data type of a Signal.
 
         Parameters
@@ -5830,7 +5830,7 @@ class BaseSignal(FancySlicing,
         """
         self.metadata.Signal.signal_origin = origin
 
-    def print_summary_statistics(self, formatter="%.3g", rechunk=True):
+    def print_summary_statistics(self, formatter="%.3g", rechunk=False):
         """Prints the five-number summary statistics of the data, the mean, and
         the standard deviation.
 

--- a/hyperspy/tests/signals/test_lazy_tools.py
+++ b/hyperspy/tests/signals/test_lazy_tools.py
@@ -22,26 +22,37 @@ import numpy as np
 from hyperspy.signals import Signal1D, Signal2D
 
 
-def test_lazy_changetype_rechunk_default():
+def test_lazy_changetype_rechunk_True():
     ar = da.ones((50, 50, 512, 512), chunks=(5, 5, 128, 128), dtype="uint8")
     s = Signal2D(ar).as_lazy()
     s._make_lazy(rechunk=True)
     assert s.data.dtype is np.dtype("uint8")
     chunks_old = s.data.chunks
-    s.change_dtype("float")
+    s.change_dtype("float", rechunk=True)
     assert s.data.dtype is np.dtype("float")
     chunks_new = s.data.chunks
     # We expect more chunks
     assert len(chunks_old[0]) * len(chunks_old[1]) < len(chunks_new[0]) * len(
         chunks_new[1]
     )
-    s.change_dtype("uint8")
+    s.change_dtype("uint8", rechunk=True)
     assert s.data.dtype is np.dtype("uint8")
     chunks_newest = s.data.chunks
     # We expect less chunks
     assert len(chunks_newest[0]) * len(chunks_newest[1]) < len(chunks_new[0]) * len(
         chunks_new[1]
     )
+
+
+def test_lazy_changetype_rechunk_default():
+    ar = da.ones((50, 50, 256, 256), chunks=(5, 5, 256, 256), dtype="uint8")
+    s = Signal2D(ar).as_lazy()
+    s._make_lazy(rechunk=True)
+    assert s.data.dtype is np.dtype("uint8")
+    chunks_old = s.data.chunks
+    s.change_dtype("float")
+    assert s.data.dtype is np.dtype("float")
+    assert chunks_old == s.data.chunks
 
 
 def test_lazy_changetype_rechunk_False():
@@ -74,16 +85,51 @@ def test_lazy_reduce_rechunk():
         s.valuemax,
         s.valuemin,
     )
+
     for rm in reduce_methods:
-        assert rm(axis=0).data.chunks == ((100,),)  # The data has been rechunked
+        assert rm(axis=0, rechunk=True).data.chunks == ((100,),)  # The data has been rechunked
         assert rm(axis=0, rechunk=False).data.chunks == (
             (2,) * 50,
         )  # The data has not been rechunked
+        assert rm(axis=0).data.chunks == (
+            (2,) * 50,
+        )  # Default, which is not to rechunk
+
+def test_lazy_reduce_rechunk_same_values():
+    data = np.arange(40).reshape(2, 2, 10)
+    s = Signal2D(da.from_array(data, chunks=(1, 1, 1))).as_lazy()
+
+    reduce_methods = (
+        s.sum,
+        s.mean,
+        s.max,
+        s.std,
+        s.var,
+        s.nansum,
+        s.nanmax,
+        s.nanmin,
+        s.nanmean,
+        s.nanstd,
+        s.nanvar,
+        s.indexmin,
+        s.indexmax,
+        s.valuemax,
+        s.valuemin,
+    )
+
+    for rm in reduce_methods:
+        s_rm_rechunk = rm(axis=-2, rechunk=True)
+        s_rm_not_rechunk = rm(axis=-2, rechunk=False)
+        s_rm_rechunk.compute(scheduler="single-threaded")
+        s_rm_not_rechunk.compute(scheduler="single-threaded")
+        assert np.all(s_rm_rechunk.data == s_rm_not_rechunk.data)
 
 
 def test_lazy_diff_rechunk():
     s = Signal1D(da.ones((10, 100), chunks=(1, 2))).as_lazy()
     # The data has been rechunked
-    assert s.diff(axis=-1).data.chunks == ((10,), (99,))
-    assert s.diff(axis=-1, rechunk=False).data.chunks == ((1,) *
-                                                      10, (1,) * 99)  # The data has not been rechunked
+    assert s.diff(axis=-1, rechunk=True).data.chunks == ((10,), (99,))
+    # The data has not been rechunked
+    assert s.diff(axis=-1, rechunk=False).data.chunks == ((1,) * 10, (1,) * 99)
+    # The default, which is not to rechunk
+    assert s.diff(axis=-1).data.chunks == ((1,) * 10, (1,) * 99)

--- a/upcoming_changes/3166.api.rst
+++ b/upcoming_changes/3166.api.rst
@@ -1,0 +1,1 @@
+For all functions with the ``rechunk`` parameter, the default has been changed from ``True`` to ``False``. This means HyperSpy will not automatically try to change the chunking for lazy signals. The old behaviour could lead to a reduction in performance when working with large lazy datasets, for example 4D-STEM data.


### PR DESCRIPTION
This pull request changes the default value for the `rechunk` parameter in all(?) functions from `True` to `False`. This to improve processing performance for large lazy datasets, as changing the chunking "structure" of large datasets can really be detrimental to performance.

For more information about this, see https://github.com/hyperspy/hyperspy/issues/3107

### Description of the change

- For all function parameters: change `rechunk=True`, to `rechunk=False`

### Progress of the PR
- [x] Change implemented (can be split into several points),
- [x] update docstring,
- [x] update user guide,
- [x] add an changelog entry in the `upcoming_changes` folder
- [x] Check formatting changelog entry in the `readthedocs` doc build of this PR (link in github checks)
- [x] add tests,
- [x] ready for review.

### Minimal example of the bug fix or the new feature

Make some test data
```python
import dask.array as da
import hyperspy.api as hs

data = da.arange(256*256*256*256).reshape(256, 256, 256, 256)
s = hs.signals.Signal2D(data).as_lazy()
s.save("testdata.zspy", chunks=(32, 32, 32 ,32))
```
Then run this for processing:
```python
s = hs.load("testdata.zspy", lazy=True)
s_sum_rechunk = s.sum(rechunk=True)
s_sum_not_rechunk = s.sum(rechunk=False)

s_sum_rechunk.compute() # 12.41 s
s_sum_not_rechunk.compute() # 3.7 s
```
I'm not really sure if this is the best example, as it might be a bit hardware dependent.

-----

There is one function which automatically does rechunking internally in the function, [integrate_simpson](https://github.com/hyperspy/hyperspy/blob/RELEASE_next_major/hyperspy/_signals/lazy.py#L706). This one should probably be changed as well, but since it didn't involve the `rechunk` parameter in its function call, I didn't change it in this pull request.

----------

@CSSFrancis 