### PR TITLE
Pretty logging

### DIFF
--- a/hyperspy/logger.py
+++ b/hyperspy/logger.py
@@ -70,17 +70,26 @@ def set_log_level(level):
     logger.setLevel(level)
 
 class ColoredFormatter(logging.Formatter):
-    """Colored log formatter."""
+    """Colored log formatter.
+
+    This class is used to format the log output. The colors can be changed
+    by changing the ANSI escape codes in the class variables.
+
+    This is a modified version of both this
+    https://github.com/herzog0/best_python_logger
+    and this https://stackoverflow.com/questions/384076/how-can-i-color-python-logging-output/56944256#56944256
+    """
     grey = "\x1b[38;20m"
     yellow = "\x1b[33;20m"
     red = "\x1b[31;20m"
     bold_red = "\x1b[31;1m"
     reset = "\x1b[0m"
+    green = "\x1b[1;32m"
     format = "%(levelname)s | Hyperspy | %(message)s (%(name)s:%(lineno)d)"
 
     FORMATS = {
         logging.DEBUG: grey + format + reset,
-        logging.INFO: grey + format + reset,
+        logging.INFO: green + format + reset,
         logging.WARNING: yellow + format + reset,
         logging.ERROR: red + format + reset,
         logging.CRITICAL: bold_red + format + reset
@@ -104,6 +113,8 @@ def initialize_logger(*args):
     handler.setFormatter(formatter)
 
     _logger = logging.getLogger(*args)
-    _logger.handlers[:] = []
+    # Remove existing handler
+    while len(_logger.handlers):
+        _logger.removeHandler(_logger.handlers[0])
     _logger.addHandler(handler)
     return _logger

--- a/hyperspy/logger.py
+++ b/hyperspy/logger.py
@@ -76,7 +76,7 @@ class ColoredFormatter(logging.Formatter):
     red = "\x1b[31;20m"
     bold_red = "\x1b[31;1m"
     reset = "\x1b[0m"
-    format = "%(levelname)s | Hyperspy | %(asctime)s | %(message)s (%(filename)s:%(lineno)d)"
+    format = "%(levelname)s | Hyperspy | %(message)s (%(name)s:%(lineno)d)"
 
     FORMATS = {
         logging.DEBUG: grey + format + reset,

--- a/upcoming_changes/3173.new.rst
+++ b/upcoming_changes/3173.new.rst
@@ -1,0 +1,1 @@
+Change the logging output so that logging doesn't show up red and look like errors in the counsel.


### PR DESCRIPTION
### Description of the change
This changes the default behavior of the logging module to print to the stdout rather than the stderror.  This gives much more flexibility and (more importantly) allows us to set to color of the outputs so that they __no longer__ look like errors in python. 

### Progress of the PR
- [x] Change implemented (can be split into several points),
- [x] update docstring (if appropriate),
- [ ] add an changelog entry in the `upcoming_changes` folder (see [`upcoming_changes/README.rst`](https://github.com/hyperspy/hyperspy/blob/RELEASE_next_minor/upcoming_changes/README.rst)),
- [ ] Check formatting changelog entry in the `readthedocs` doc build of this PR (link in github checks)
- [ ] add tests,
- [ ] ready for review.

### Minimal example of the bug fix or the new feature

![Screenshot from 2023-06-19 14-53-48](https://github.com/hyperspy/hyperspy/assets/41125831/bf229c7b-a269-4f25-a4cc-7880c4ef10aa)

![Screenshot from 2023-06-19 14-55-09](https://github.com/hyperspy/hyperspy/assets/41125831/09280d4e-b7a1-4318-935d-903927fd92c5)


Similarly things like WARNINGS are now printed in yellow:

![Screenshot from 2023-06-19 15-05-54](https://github.com/hyperspy/hyperspy/assets/41125831/4a6fd7f2-5200-4b63-a1bc-e6754b8c70b6)
