### PR TITLE
NewFeature: Added jump click to plotting

### DIFF
--- a/doc/user_guide/visualisation.rst
+++ b/doc/user_guide/visualisation.rst
@@ -83,6 +83,10 @@ Hotkeys and modifier keys for navigating the plot can be set in the
 Note that some combinations will not work for all platforms, as some systems reserve them for
 other purposes.
 
+If you want to jump to some point in the dataset.  In that case you can hold the ``Shift`` key
+and click the point you are interested in.  That will automatically take you to that point in the
+data.  This also helps with lazy data as you don't have to load every chunk in between.
+
 .. figure::  images/second_pointer.png
    :align:   center
    :width:   500

--- a/hyperspy/drawing/_widgets/horizontal_line.py
+++ b/hyperspy/drawing/_widgets/horizontal_line.py
@@ -49,3 +49,7 @@ class HorizontalLineWidget(Widget1DBase):
         """on mouse motion draw the cursor if picked"""
         if self.picked is True and event.inaxes:
             self.position = (event.ydata,)
+
+    def _onjumpclick(self, event):
+        if event.key == "shift" and event.inaxes and self.is_pointer:
+            self.position = (event.ydata,)

--- a/hyperspy/drawing/_widgets/rectangles.py
+++ b/hyperspy/drawing/_widgets/rectangles.py
@@ -40,6 +40,11 @@ class SquareWidget(Widget2DBase):
     def __init__(self, axes_manager, **kwargs):
         super(SquareWidget, self).__init__(axes_manager, **kwargs)
 
+    def connect(self, ax):
+        super(SquareWidget, self).connect(ax)
+        canvas = ax.figure.canvas
+        canvas.mpl_connect('button_press_event', self._onjumpclick)
+
     def _set_patch(self):
         """Sets the patch to a matplotlib Rectangle with the correct geometry.
         The geometry is defined by _get_patch_xy, and get_size_in_axes.
@@ -54,6 +59,11 @@ class SquareWidget(Widget2DBase):
             alpha=self.alpha,
             picker=True,)]
         super(SquareWidget, self)._set_patch()
+
+    def _onjumpclick(self, event):
+        # Callback for MPL pick event
+        if event.key=="shift":
+            self.position = (event.xdata, event.ydata)
 
     def _onmousemove(self, event):
         """on mouse motion move the patch if picked"""

--- a/hyperspy/drawing/_widgets/rectangles.py
+++ b/hyperspy/drawing/_widgets/rectangles.py
@@ -70,12 +70,10 @@ class SquareWidget(Widget2DBase):
         relevant events, and updates the patch position.
         """
         if self._navigating:
-            with (self.axes_manager.events.indices_changed.suppress_callback(
-                  self._on_navigate) or
-                  self.axes_manager.events.indices_changed.suppress_callback(
-                  self._onjumpclick)):
+            with self.axes_manager.events.indices_changed.suppress():
                 for i in range(len(self.axes)):
                     self.axes[i].value = self._pos[i]
+            self.axes_manager.events.indices_changed.trigger(obj=self.axes_manager)
         self.events.moved.trigger(self)
         self.events.changed.trigger(self)
         self._update_patch_position()

--- a/hyperspy/drawing/_widgets/rectangles.py
+++ b/hyperspy/drawing/_widgets/rectangles.py
@@ -40,10 +40,6 @@ class SquareWidget(Widget2DBase):
     def __init__(self, axes_manager, **kwargs):
         super(SquareWidget, self).__init__(axes_manager, **kwargs)
 
-    def connect(self, ax):
-        super(SquareWidget, self).connect(ax)
-        canvas = ax.figure.canvas
-
     def _set_patch(self):
         """Sets the patch to a matplotlib Rectangle with the correct geometry.
         The geometry is defined by _get_patch_xy, and get_size_in_axes.

--- a/hyperspy/drawing/_widgets/rectangles.py
+++ b/hyperspy/drawing/_widgets/rectangles.py
@@ -65,6 +65,18 @@ class SquareWidget(Widget2DBase):
         if event.key=="shift" and event.inaxes:
             self.position = (event.xdata, event.ydata)
 
+    def _pos_changed(self):
+        """Call when the position of the widget has changed. It triggers the
+        relevant events, and updates the patch position.
+        """
+        if self._navigating:
+            with self.axes_manager.events.indices_changed.suppress():
+                for i in range(len(self.axes)):
+                    self.axes[i].value = self._pos[i]
+        self.events.moved.trigger(self)
+        self.events.changed.trigger(self)
+        self._update_patch_position()
+
     def _onmousemove(self, event):
         """on mouse motion move the patch if picked"""
         if self.picked is True and event.inaxes:

--- a/hyperspy/drawing/_widgets/rectangles.py
+++ b/hyperspy/drawing/_widgets/rectangles.py
@@ -43,7 +43,6 @@ class SquareWidget(Widget2DBase):
     def connect(self, ax):
         super(SquareWidget, self).connect(ax)
         canvas = ax.figure.canvas
-        canvas.mpl_connect('button_press_event', self._onjumpclick)
 
     def _set_patch(self):
         """Sets the patch to a matplotlib Rectangle with the correct geometry.
@@ -61,22 +60,8 @@ class SquareWidget(Widget2DBase):
         super(SquareWidget, self)._set_patch()
 
     def _onjumpclick(self, event):
-        # Callback for MPL pick event
-        if event.key == "shift" and event.inaxes:
+        if event.key == "shift" and event.inaxes and self.is_pointer:
             self.position = (event.xdata, event.ydata)
-
-    def _pos_changed(self):
-        """Call when the position of the widget has changed. It triggers the
-        relevant events, and updates the patch position.
-        """
-        if self._navigating:
-            with self.axes_manager.events.indices_changed.suppress():
-                for i in range(len(self.axes)):
-                    self.axes[i].value = self._pos[i]
-            self.axes_manager.events.indices_changed.trigger(obj=self.axes_manager)
-        self.events.moved.trigger(self)
-        self.events.changed.trigger(self)
-        self._update_patch_position()
 
     def _onmousemove(self, event):
         """on mouse motion move the patch if picked"""

--- a/hyperspy/drawing/_widgets/rectangles.py
+++ b/hyperspy/drawing/_widgets/rectangles.py
@@ -62,7 +62,7 @@ class SquareWidget(Widget2DBase):
 
     def _onjumpclick(self, event):
         # Callback for MPL pick event
-        if event.key=="shift" and event.inaxes:
+        if event.key == "shift" and event.inaxes:
             self.position = (event.xdata, event.ydata)
 
     def _pos_changed(self):
@@ -70,7 +70,10 @@ class SquareWidget(Widget2DBase):
         relevant events, and updates the patch position.
         """
         if self._navigating:
-            with self.axes_manager.events.indices_changed.suppress():
+            with (self.axes_manager.events.indices_changed.suppress_callback(
+                  self._on_navigate) or
+                  self.axes_manager.events.indices_changed.suppress_callback(
+                  self._onjumpclick)):
                 for i in range(len(self.axes)):
                     self.axes[i].value = self._pos[i]
         self.events.moved.trigger(self)

--- a/hyperspy/drawing/_widgets/rectangles.py
+++ b/hyperspy/drawing/_widgets/rectangles.py
@@ -62,7 +62,7 @@ class SquareWidget(Widget2DBase):
 
     def _onjumpclick(self, event):
         # Callback for MPL pick event
-        if event.key=="shift":
+        if event.key=="shift" and event.inaxes:
             self.position = (event.xdata, event.ydata)
 
     def _onmousemove(self, event):

--- a/hyperspy/drawing/_widgets/vertical_line.py
+++ b/hyperspy/drawing/_widgets/vertical_line.py
@@ -45,6 +45,10 @@ class VerticalLineWidget(Widget1DBase):
             ax.axvline(self._pos[0], color=self.color, alpha=self.alpha, **kwargs)
             ]
 
+    def _onjumpclick(self, event):
+        if event.key == "shift" and event.inaxes and self.is_pointer:
+            self.position = (event.xdata,)
+
     def _onmousemove(self, event):
         """on mouse motion draw the cursor if picked"""
         if self.picked is True and event.inaxes:

--- a/hyperspy/drawing/mpl_he.py
+++ b/hyperspy/drawing/mpl_he.py
@@ -192,6 +192,7 @@ class MPL_HyperExplorer(object):
                 pointer = self.assign_pointer()
                 if pointer is not None:
                     self.pointer = pointer(self.axes_manager)
+                    self.pointer.is_pointer = True
                     self.pointer.color = 'red'
                     self.pointer.connect_navigate()
                 self.plot_navigator(**kwargs.pop('navigator_kwds', {}))

--- a/hyperspy/drawing/widget.py
+++ b/hyperspy/drawing/widget.py
@@ -384,7 +384,8 @@ class DraggableWidgetBase(WidgetBase):
         relevant events, and updates the patch position.
         """
         if self._navigating:
-            with self.axes_manager.events.indices_changed.suppress():
+            with self.axes_manager.events.indices_changed.suppress_callback(
+                    self._on_navigate):
                 for i in range(len(self.axes)):
                     self.axes[i].value = self._pos[i]
         self.events.moved.trigger(self)

--- a/hyperspy/drawing/widget.py
+++ b/hyperspy/drawing/widget.py
@@ -463,9 +463,6 @@ class DraggableWidgetBase(WidgetBase):
     def _onjumpclick(self, event):
         """This method must be provided by subclasses"""
         pass
-        if event.key == "shift" and event.inaxes:
-            self.position = (event.xdata, event.ydata)
-
 
     def _on_navigate(self, axes_manager):
         if axes_manager is self.axes_manager:

--- a/hyperspy/drawing/widget.py
+++ b/hyperspy/drawing/widget.py
@@ -384,8 +384,7 @@ class DraggableWidgetBase(WidgetBase):
         relevant events, and updates the patch position.
         """
         if self._navigating:
-            with self.axes_manager.events.indices_changed.suppress_callback(
-                    self._on_navigate):
+            with self.axes_manager.events.indices_changed.suppress():
                 for i in range(len(self.axes)):
                     self.axes[i].value = self._pos[i]
         self.events.moved.trigger(self)

--- a/hyperspy/misc/test_utils.py
+++ b/hyperspy/misc/test_utils.py
@@ -137,16 +137,3 @@ def mock_event(fig, canvas,
     event.name = 'MockEvent'
     event.artist = artist
     return event
-
-def mock_click_drag_event(object, start, end,):
-
-    event = mock.Mock()
-    event.button = None
-    event.key = None
-    event.xdata, event.ydata = xdata, ydata
-    event.inaxes = inaxes
-    event.fig = fig
-    event.canvas = canvas
-    event.guiEvent = None
-    event.name = 'MockEvent'
-    return event

--- a/hyperspy/misc/test_utils.py
+++ b/hyperspy/misc/test_utils.py
@@ -122,7 +122,10 @@ def check_running_tests_in_CI():
     if "CI" in os.environ:
         return os.environ.get("CI")
 
-def mock_event(fig, canvas, button=None, key=None, xdata=None, ydata=None,  inaxes=True):
+def mock_event(fig, canvas,
+               button=None, key=None,
+               xdata=None, ydata=None,
+               inaxes=True, artist=None):
     event = mock.Mock()
     event.button = button
     event.key = key
@@ -132,5 +135,18 @@ def mock_event(fig, canvas, button=None, key=None, xdata=None, ydata=None,  inax
     event.canvas = canvas
     event.guiEvent = None
     event.name = 'MockEvent'
+    event.artist = artist
+    return event
 
+def mock_click_drag_event(object, start, end,):
+
+    event = mock.Mock()
+    event.button = None
+    event.key = None
+    event.xdata, event.ydata = xdata, ydata
+    event.inaxes = inaxes
+    event.fig = fig
+    event.canvas = canvas
+    event.guiEvent = None
+    event.name = 'MockEvent'
     return event

--- a/hyperspy/misc/test_utils.py
+++ b/hyperspy/misc/test_utils.py
@@ -21,7 +21,7 @@ from contextlib import contextmanager
 import warnings
 
 import numpy as np
-
+from unittest import mock
 
 @contextmanager
 def ignore_warning(message="", category=None):
@@ -121,3 +121,16 @@ def sanitize_dict(dictionary):
 def check_running_tests_in_CI():
     if "CI" in os.environ:
         return os.environ.get("CI")
+
+def mock_event(fig, canvas, button=None, key=None, xdata=None, ydata=None,  inaxes=True):
+    event = mock.Mock()
+    event.button = button
+    event.key = key
+    event.xdata, event.ydata = xdata, ydata
+    event.inaxes = inaxes
+    event.fig = fig
+    event.canvas = canvas
+    event.guiEvent = None
+    event.name = 'MockEvent'
+
+    return event

--- a/upcoming_changes/3175.new.rst
+++ b/upcoming_changes/3175.new.rst
@@ -1,0 +1,2 @@
+Added in the `_onjumpclick` method to pointer widgets which allows the user to quickly go to some position
+in the data.

--- a/upcoming_changes/3175.new.rst
+++ b/upcoming_changes/3175.new.rst
@@ -1,2 +1,2 @@
-Added in the `_onjumpclick` method to pointer widgets which allows the user to quickly go to some position
+Add functionality to select navigation position using ``shift`` + click in the navigator.
 in the data.


### PR DESCRIPTION
### Description of the change
This is just a quick change to the plotting to allow for jumping.   I think we might want to make it possible to change which key is used with the jump.

I can make this a little more robust and we could potentially add it to all of the widgets but the main problem is if you have multiple widgets I don't know how it should work. Same with handing two singles overlaid in 1D.

### Progress of the PR
- [x] Change implemented (can be split into several points),
- [x] update docstring (if appropriate),
- [x] update user guide (if appropriate),
- [x] add an changelog entry in the `upcoming_changes` folder (see [`upcoming_changes/README.rst`](https://github.com/hyperspy/hyperspy/blob/RELEASE_next_minor/upcoming_changes/README.rst)),
- [ ] Check formatting changelog entry in the `readthedocs` doc build of this PR (link in github checks)
- [x] add tests,
- [x] ready for review.

### Minimal example of the bug fix or the new feature
```python
%matplotlib ipympl
import hyperspy.api as hs
import dask.array as da
s = hs.signals.Signal2D(np.random.random((100,100,100,100))).as_lazy()
s.plot()
```


https://github.com/hyperspy/hyperspy/assets/41125831/3e9918e6-b63e-46da-8775-4b1288ac3889


