### PR TITLE
plot residual

### DIFF
--- a/examples/model_fitting/plot_residual.py
+++ b/examples/model_fitting/plot_residual.py
@@ -1,0 +1,36 @@
+"""
+Plot Residual
+=============
+
+Fit an affine function and plot the residual.
+
+"""
+
+import numpy as np
+import hyperspy.api as hs
+
+#%%
+# Create a signal:
+data = np.arange(1000, dtype=np.int64).reshape((10, 100))
+s = hs.signals.Signal1D(data)
+
+#%%
+# Add noise:
+s.add_poissonian_noise(random_state=0)
+
+#%%
+# Create model:
+m = s.create_model()
+line = hs.model.components1D.Expression("a * x + b", name="Affine")
+m.append(line)
+
+#%%
+# Fit for all navigation positions:
+m.multifit()
+
+#%%
+# Plot the fitted model with residual:
+m.plot(plot_residual=True)
+
+#%%
+# sphinx_gallery_thumbnail_number = 2

--- a/hyperspy/models/model1d.py
+++ b/hyperspy/models/model1d.py
@@ -417,10 +417,8 @@ class Model1D(BaseModel):
                 component for component in component_list if component.active]
 
         if self.convolved is False or non_convolved is True:
-            if not ignore_channel_switches:
-                axis = self.axis.axis[self.channel_switches]
-            else:
-                axis = self.axis.axis
+            slice_ = slice(None) if ignore_channel_switches else self.channel_switches
+            axis = self.axis.axis[slice_]
             sum_ = np.zeros(len(axis))
             for component in component_list:
                 sum_ += component.function(axis)
@@ -717,24 +715,12 @@ class Model1D(BaseModel):
             s = ns
         return s
     
-    def _residual_for_plot(self, axes_manager):
-        """From an model1D object, the original signal is subtracted 
+    def _residual_for_plot(self,**kwargs):
+        """From an model1D object, the original signal is subtracted
         by the model signal then returns the residual
         """
 
-        old_axes_manager = None
-        if axes_manager is not self.axes_manager:
-            old_axes_manager = self.axes_manager
-            self.axes_manager = axes_manager
-            self.fetch_stored_values()
-
-        #Residual = Signal - model
-        s = (self.signal.__call__() - self.__call__(ignore_channel_switches = True))
-        if old_axes_manager is not None:
-            self.axes_manager = old_axes_manager
-            self.fetch_stored_values()
-
-        return s
+        return self.signal.__call__() - self.__call__(ignore_channel_switches=True)
     
     def plot(self, plot_components=False,plot_residual=False, **kwargs):
         """Plot the current spectrum to the screen and a map with a

--- a/hyperspy/models/model1d.py
+++ b/hyperspy/models/model1d.py
@@ -258,6 +258,7 @@ class Model1D(BaseModel):
         self._plot_components = False
         self._suspend_update = False
         self._model_line = None
+        self._residual_line = None
         self.axis = self.axes_manager.signal_axes[0]
         self.axes_manager.events.indices_changed.connect(
             self._on_navigating, [])
@@ -377,7 +378,8 @@ class Model1D(BaseModel):
     remove.__doc__ = BaseModel.remove.__doc__
 
     def __call__(self, non_convolved=False, onlyactive=False,
-                 component_list=None, binned=None):
+                 component_list=None, binned=None, 
+                 ignore_channel_switches = False):
         """Returns the corresponding model for the current coordinates
 
         Parameters
@@ -393,6 +395,9 @@ class Model1D(BaseModel):
         binned : bool or None
             Specify whether the binned attribute of the signal axes needs to be
             taken into account.
+        ignore_channel_switches: bool
+            If true, the entire signal axis are returned 
+            without checking channel_switches.
 
         cursor: 1 or 2
 
@@ -412,7 +417,10 @@ class Model1D(BaseModel):
                 component for component in component_list if component.active]
 
         if self.convolved is False or non_convolved is True:
-            axis = self.axis.axis[self.channel_switches]
+            if not ignore_channel_switches:
+                axis = self.axis.axis[self.channel_switches]
+            else:
+                axis = self.axis.axis
             sum_ = np.zeros(len(axis))
             for component in component_list:
                 sum_ += component.function(axis)
@@ -709,23 +717,23 @@ class Model1D(BaseModel):
             s = ns
         return s
     
-    def _residual2plot(self, axes_manager, out_of_range2nans=True):
+    def _residual_for_plot(self, axes_manager):
+        """From an model1D object, the original signal is subtracted 
+        by the model signal then returns the residual
+        """
+
         old_axes_manager = None
         if axes_manager is not self.axes_manager:
             old_axes_manager = self.axes_manager
             self.axes_manager = axes_manager
             self.fetch_stored_values()
+
         #Residual = Signal - model
-        s = (self.signal.__call__() -
-            self.__call__(non_convolved=False, onlyactive=True))
+        s = (self.signal.__call__() - self.__call__(ignore_channel_switches = True))
         if old_axes_manager is not None:
             self.axes_manager = old_axes_manager
             self.fetch_stored_values()
-        if out_of_range2nans is True:
-            ns = np.empty(self.axis.axis.shape)
-            ns.fill(np.nan)
-            ns[np.where(self.channel_switches)] = s
-            s = ns
+
         return s
     
     def plot(self, plot_components=False,plot_residual=False, **kwargs):
@@ -763,18 +771,17 @@ class Model1D(BaseModel):
         self._connect_parameters2update_plot(self)
         
         #Optional to plot the residual of (Signal - Model)
-        if plot_residual is True:
+        if plot_residual:
             l3 = hyperspy.drawing.signal1d.Signal1DLine()
-            #_residual2plot is a function that outputs the residual
-            l3.data_function = self._residual2plot
+            # _residual_for_plot outputs the residual (Signal - Model)
+            l3.data_function = self._residual_for_plot
             l3.set_line_properties(color='green', type='line')
             # Add the line to the figure
             _plot.signal_plot.add_line(l3)
             l3.plot()
-            _plot.signal_plot.events.closed.connect(self._close_plot, [])
+            # Quick access to _residual_line if needed 
+            self._residual_line = l3
 
-            self._plot = self.signal._plot
-            self._connect_parameters2update_plot(self)
 
         if plot_components is True:
             self.enable_plot_components()

--- a/hyperspy/models/model1d.py
+++ b/hyperspy/models/model1d.py
@@ -708,8 +708,27 @@ class Model1D(BaseModel):
             ns[np.where(self.channel_switches)] = s
             s = ns
         return s
-
-    def plot(self, plot_components=False, **kwargs):
+    
+    def _residual2plot(self, axes_manager, out_of_range2nans=True):
+        old_axes_manager = None
+        if axes_manager is not self.axes_manager:
+            old_axes_manager = self.axes_manager
+            self.axes_manager = axes_manager
+            self.fetch_stored_values()
+        #Residual = Signal - model
+        s = (self.signal.__call__() -
+            self.__call__(non_convolved=False, onlyactive=True))
+        if old_axes_manager is not None:
+            self.axes_manager = old_axes_manager
+            self.fetch_stored_values()
+        if out_of_range2nans is True:
+            ns = np.empty(self.axis.axis.shape)
+            ns.fill(np.nan)
+            ns[np.where(self.channel_switches)] = s
+            s = ns
+        return s
+    
+    def plot(self, plot_components=False,plot_residual=False, **kwargs):
         """Plot the current spectrum to the screen and a map with a
         cursor to explore the SI.
 
@@ -717,6 +736,8 @@ class Model1D(BaseModel):
         ----------
         plot_components : bool
             If True, add a line per component to the signal figure.
+        plot_residual : bool
+            If True, add a residual line (Signal - Model) to the signal figure.
         **kwargs : dict
             All extra keyword arguements are passed to
             :py:meth:`~._signals.signal1d.Signal1D.plot`
@@ -740,6 +761,21 @@ class Model1D(BaseModel):
         self._model_line = l2
         self._plot = self.signal._plot
         self._connect_parameters2update_plot(self)
+        
+        #Optional to plot the residual of (Signal - Model)
+        if plot_residual is True:
+            l3 = hyperspy.drawing.signal1d.Signal1DLine()
+            #_residual2plot is a function that outputs the residual
+            l3.data_function = self._residual2plot
+            l3.set_line_properties(color='green', type='line')
+            # Add the line to the figure
+            _plot.signal_plot.add_line(l3)
+            l3.plot()
+            _plot.signal_plot.events.closed.connect(self._close_plot, [])
+
+            self._plot = self.signal._plot
+            self._connect_parameters2update_plot(self)
+
         if plot_components is True:
             self.enable_plot_components()
         else:

--- a/hyperspy/tests/drawing/test_plot_model1d.py
+++ b/hyperspy/tests/drawing/test_plot_model1d.py
@@ -29,7 +29,7 @@ STYLE_PYTEST_MPL = 'default'
 
 class TestModelPlot:
     def setup_method(self, method):
-        s = Signal1D(np.arange(1000).reshape((10, 100)))
+        s = Signal1D(np.arange(1000, dtype=np.int64).reshape((10, 100)))
         s.add_poissonian_noise(random_state=0)
         m = s.create_model()
         line = Expression("a * x", name="line", a=1)
@@ -64,3 +64,6 @@ class TestModelPlot:
     def test_no_navigator(self):
         self.m.plot(navigator=None)
         assert self.m.signal._plot.navigator_plot is None
+
+    def test_plot_residual(self):
+        self.m.plot(plot_residual=True)

--- a/hyperspy/tests/model/test_model.py
+++ b/hyperspy/tests/model/test_model.py
@@ -23,7 +23,6 @@ import pytest
 
 import hyperspy.api as hs
 from hyperspy.decorators import lazifyTestClass
-from hyperspy.misc.test_utils import ignore_warning
 from hyperspy.misc.utils import slugify
 
 

--- a/upcoming_changes/3186.new.rst
+++ b/upcoming_changes/3186.new.rst
@@ -1,0 +1,1 @@
+Added a plot_residual argument to model1d.plot. This argument will plot a residual signal (Signal - Model) to the signal plot.


### PR DESCRIPTION
### Description of the change
A few sentences and/or a bulleted list to describe and motivate the change:

As suggested by @thomasaarholt on gitter, I added a plot_residual argument to model1d.plot. 
This argument will plot a residual signal (Signal - Model) to the signal plot.
Currently, it has a bug when the size of signal and model are not the same. I am not sure what's the best way to do this so any help is appreciated.

### Progress of the PR
- [x] Change implemented (can be split into several points),
- [x] update docstring (if appropriate),
- [ ] update user guide (if appropriate),
- [x] add an changelog entry in the `upcoming_changes` folder (see [`upcoming_changes/README.rst`](https://github.com/hyperspy/hyperspy/blob/RELEASE_next_minor/upcoming_changes/README.rst)),
- [x] Check formatting changelog entry in the `readthedocs` doc build of this PR (link in github checks)
- [ ] add tests,
- [ ] ready for review.

### Minimal example of the bug fix or the new feature
```python
import hyperspy.api as hs
import numpy as np
s = hs.signals.Signal1D(np.tile(np.arctan(np.arange(-500, 500)), (10, 1)),dtype='float64')
s.add_gaussian_noise(std=0.1)
m = s.create_model()
line  = hs.model.components1D.Polynomial(order=2)
m.append(line)
m.fit()
m.plot(plot_residual=True)
```
