### PR TITLE
Add `parallel` parameter to _map_iterate

### DIFF
--- a/hyperspy/signal.py
+++ b/hyperspy/signal.py
@@ -4932,6 +4932,7 @@ class BaseSignal(FancySlicing,
                 show_progressbar=show_progressbar,
                 ragged=ragged,
                 inplace=inplace,
+                parallel=parallel,
                 lazy_output=lazy_output,
                 max_workers=max_workers,
                 output_dtype=output_dtype,
@@ -4973,6 +4974,7 @@ class BaseSignal(FancySlicing,
         inplace=True,
         output_signal_size=None,
         output_dtype=None,
+        parallel=None,
         lazy_output=None,
         max_workers=None,
         **kwargs,
@@ -5060,6 +5062,10 @@ class BaseSignal(FancySlicing,
 
         data_stored = False
 
+        scheduler = None
+        if parallel == False:
+            scheduler = 'single-threaded'
+
         if show_progressbar:
             pbar = ProgressBar()
             pbar.register()
@@ -5079,6 +5085,7 @@ class BaseSignal(FancySlicing,
                     self.data,
                     dtype=mapped.dtype,
                     compute=True,
+                    scheduler=scheduler,
                     num_workers=max_workers,
                 )
                 data_stored = True
@@ -5108,7 +5115,7 @@ class BaseSignal(FancySlicing,
         sig._assign_subclass()
 
         if not lazy_output and not data_stored:
-            sig.data = sig.data.compute(num_workers=max_workers)
+            sig.data = sig.data.compute(num_workers=max_workers, scheduler=scheduler)
 
         if show_progressbar:
             pbar.unregister()


### PR DESCRIPTION
Currently, debugging with `s.map` for certain data processes can be tricky, due to the error output being obscured by the error messages from the dask schedulers.

This pull request passes the parallel parameter to `_map_iterate`. If parallel=None (the default and lazy_output=False), it runs with whatever scheduler is the standard. If parallel=False (and lazy_output=False), it uses the scheduler='single-threaded'.

This 'single-threaded' scheduler is well-suited for debugging, according to the dask documentation: https://docs.dask.org/en/stable/scheduler-overview.html#debugging-the-schedulers

This PR is a subset of a previous https://github.com/hyperspy/hyperspy/pull/3179. That pull request removed `_map_all` in addition to adding the `parallel` parameter to `_map_iterate`.

### Progress of the PR

- [x] Change implemented
- [ ] Add several if/else warnings for incompatible parameters
- [ ] Code cleanup
- [ ] update docstring
- [ ] update user guide
- [ ] add an changelog entry in the `upcoming_changes` folder (see [`upcoming_changes/README.rst`](https://github.com/hyperspy/hyperspy/blob/RELEASE_next_minor/upcoming_changes/README.rst)),
- [ ] Check formatting changelog entry in the `readthedocs` doc build of this PR (link in github checks)
- [ ] add tests,
- [ ] ready for review.

### Example

```python
import numpy as np
from scipy.ndimage import rotate
import hyperspy.api as hs
s = hs.signals.Signal2D(np.random.random((10, 10, 20, 20)))
s1 = s.map(rotate, angle=30, reshape=True, inplace=False, parallel=False, lazy_output=False)
```

### Note

I'm not certain how to best handle the parameters in `map`, as there is a large number of permutations which are possible and fine tuning which the users can potentially do. I think the best way of handling this is by covering the basic and "standard" functionality with `map`, and direct people who want more fine control to use `lazy_output=True` and set their options via `s.compute` or configuring their scheduler on their own.

In any case, I think the `map` docstring should be improved somewhat. But I won't have time to do this before after the summer holiday. So if someone wants to finish this pull request, or make a new pull request with this functionality, feel free to do so.