### PR TITLE
Refactor find peaks 1d

### DIFF
--- a/doc/user_guide/eds.rst
+++ b/doc/user_guide/eds.rst
@@ -351,7 +351,7 @@ database:
 .. code-block:: python
 
     >>> s = hs.datasets.example_signals.EDS_SEM_Spectrum()
-    >>> P = s.find_peaks1D_ohaver(maxpeakn=1)[0]
+    >>> P = s.find_peaks(maxpeakn=1)[0]
     >>> hs.eds.get_xray_lines_near_energy(P['position'], only_lines=['a', 'b'])
     ['C_Ka', 'Ca_La', 'B_Ka']
 

--- a/doc/user_guide/eds.rst
+++ b/doc/user_guide/eds.rst
@@ -352,7 +352,7 @@ database:
 
     >>> s = hs.datasets.example_signals.EDS_SEM_Spectrum()
     >>> P = s.find_peaks(maxpeakn=1)[0]
-    >>> hs.eds.get_xray_lines_near_energy(P['position'], only_lines=['a', 'b'])
+    >>> hs.eds.get_xray_lines_near_energy(P[:,1], only_lines=['a', 'b'])
     ['C_Ka', 'Ca_La', 'B_Ka']
 
 The lines are returned in order of distance from the specified energy, and can

--- a/doc/user_guide/eds.rst
+++ b/doc/user_guide/eds.rst
@@ -351,8 +351,8 @@ database:
 .. code-block:: python
 
     >>> s = hs.datasets.example_signals.EDS_SEM_Spectrum()
-    >>> P = s.find_peaks(maxpeakn=1)[0]
-    >>> hs.eds.get_xray_lines_near_energy(P[:,1], only_lines=['a', 'b'])
+    >>> P = s.find_peaks(maxpeakn=1)
+    >>> hs.eds.get_xray_lines_near_energy(P.data[0][:,1], only_lines=['a', 'b'])
     ['C_Ka', 'Ca_La', 'B_Ka']
 
 The lines are returned in order of distance from the specified energy, and can

--- a/doc/user_guide/eels.rst
+++ b/doc/user_guide/eels.rst
@@ -121,7 +121,7 @@ The
 :py:meth:`~._signals.eels.EELSSpectrum.estimate_zero_loss_peak_centre`
 can be used to estimate the position of the zero-loss peak (ZLP). The method assumes
 that the ZLP is the most intense feature in the spectra. For a more general
-approach see :py:meth:`~.signal.Signal1DTools.find_peaks1D_ohaver`.
+approach see :py:meth:`~.signal.Signal1DTools.find_peaks`.
 
 The :py:meth:`~._signals.eels.EELSSpectrum.align_zero_loss_peak` can
 align the ZLP with subpixel accuracy. It is more robust and easy to use for the task

--- a/doc/user_guide/signal1d.rst
+++ b/doc/user_guide/signal1d.rst
@@ -166,7 +166,7 @@ Peak finding
 ------------
 
 A peak finding routine based on the work of T. O'Haver is available in HyperSpy
-through the :py:meth:`~._signals.signal1d.Signal1D.find_peaks1D_ohaver`
+through the :py:meth:`~._signals.signal1d.Signal1D.find_peaks`
 method.
 
 

--- a/hyperspy/_signals/eels.py
+++ b/hyperspy/_signals/eels.py
@@ -657,7 +657,7 @@ class EELSSpectrum(Signal1D):
         --------
 
         estimate_elastic_scattering_intensity,align_zero_loss_peak,
-        find_peaks1D_ohaver, fourier_ratio_deconvolution.
+        find_peaks, fourier_ratio_deconvolution.
 
         Notes
         -----

--- a/hyperspy/_signals/signal1d.py
+++ b/hyperspy/_signals/signal1d.py
@@ -20,6 +20,7 @@ import logging
 import math
 import os
 import warnings
+from copy import deepcopy
 
 import numpy as np
 import dask.array as da
@@ -1274,6 +1275,8 @@ class Signal1D(BaseSignal, CommonSignal1D):
                          ragged=True,
                          inplace=False,
                          **kwargs)
+        peaks.metadata.add_node("Peaks")  # add information about the signal Axes
+        peaks.metadata.Peaks.signal_axes = deepcopy(self.axes_manager.signal_axes)
         return peaks
 
     find_peaks.__doc__ %= (PARALLEL_ARG, MAX_WORKERS_ARG)

--- a/hyperspy/_signals/signal1d.py
+++ b/hyperspy/_signals/signal1d.py
@@ -1208,8 +1208,7 @@ class Signal1D(BaseSignal, CommonSignal1D):
                    medfilt_radius=5,
                    maxpeakn=30000,
                    peakgroup=10,
-                   parallel=None,
-                   max_workers=None):
+                   **kwargs):
         """Find positive peaks along a 1D Signal. It detects peaks by looking
         for downward zero-crossings in the first derivative that exceed
         'slope_thresh'.
@@ -1273,11 +1272,9 @@ class Signal1D(BaseSignal, CommonSignal1D):
                          peakgroup=peakgroup,
                          subchannel=subchannel,
                          ragged=True,
-                         parallel=parallel,
-                         max_workers=max_workers,
                          inplace=False,
-                         lazy_output=False)
-        return peaks.data
+                         **kwargs)
+        return peaks
 
     find_peaks.__doc__ %= (PARALLEL_ARG, MAX_WORKERS_ARG)
 

--- a/hyperspy/tests/signals/test_1D_tools.py
+++ b/hyperspy/tests/signals/test_1D_tools.py
@@ -163,41 +163,41 @@ class TestFindPeaks1D:
         self.signal = s
 
     def test_single_spectrum(self):
-        peaks = self.signal.inav[0].find_peaks()[0]
+        peaks = self.signal.inav[0].find_peaks().data[0]
         if isinstance(peaks,da.Array):
             peaks = peaks.compute()
         np.testing.assert_allclose(
-            peaks['position'], self.peak_positions0, rtol=1e-5, atol=1e-4)
+            peaks[:, 0], self.peak_positions0, rtol=1e-5, atol=1e-4)
 
     def test_two_spectra(self):
-        peaks = self.signal.find_peaks()[1]
+        peaks = self.signal.find_peaks().data[1]
         if isinstance(peaks, da.Array):
             peaks = peaks.compute()
         np.testing.assert_allclose(
-            peaks['position'], self.peak_positions1, rtol=1e-5, atol=1e-4)
+            peaks[:, 0], self.peak_positions1, rtol=1e-5, atol=1e-4)
 
     def test_height(self):
-        peaks = self.signal.find_peaks()[1]
+        peaks = self.signal.find_peaks().data[1]
         if isinstance(peaks,da.Array):
             peaks = peaks.compute()
         np.testing.assert_allclose(
-            peaks['height'], 1.0, rtol=1e-5, atol=1e-4)
+            peaks[:, 1], 1.0, rtol=1e-5, atol=1e-4)
 
     def test_width(self):
-        peaks = self.signal.find_peaks()[1]
+        peaks = self.signal.find_peaks().data[1]
         if isinstance(peaks,da.Array):
             peaks = peaks.compute()
-        np.testing.assert_allclose(peaks['width'], 3.5758, rtol=1e-4, atol=1e-4)
+        np.testing.assert_allclose(peaks[:, 2], 3.5758, rtol=1e-4, atol=1e-4)
 
     def test_n_peaks(self):
-        peaks = self.signal.find_peaks()[1]
+        peaks = self.signal.find_peaks().data[1]
         if isinstance(peaks, da.Array):
             peaks = peaks.compute()
         assert len(peaks) == 8
 
     def test_maxpeaksn(self):
         for n in range(1, 10):
-            peaks = self.signal.find_peaks(maxpeakn=n)[1]
+            peaks = self.signal.find_peaks(maxpeakn=n).data[1]
             if isinstance(peaks, da.Array):
                 peaks=peaks.compute()
             assert len(peaks) == min((8, n))

--- a/hyperspy/tests/signals/test_1D_tools.py
+++ b/hyperspy/tests/signals/test_1D_tools.py
@@ -163,41 +163,41 @@ class TestFindPeaks1D:
         self.signal = s
 
     def test_single_spectrum(self):
-        peaks = self.signal.inav[0].find_peaks1D_ohaver()[0]
+        peaks = self.signal.inav[0].find_peaks()[0]
         if isinstance(peaks,da.Array):
             peaks = peaks.compute()
         np.testing.assert_allclose(
             peaks['position'], self.peak_positions0, rtol=1e-5, atol=1e-4)
 
     def test_two_spectra(self):
-        peaks = self.signal.find_peaks1D_ohaver()[1]
+        peaks = self.signal.find_peaks()[1]
         if isinstance(peaks, da.Array):
             peaks = peaks.compute()
         np.testing.assert_allclose(
             peaks['position'], self.peak_positions1, rtol=1e-5, atol=1e-4)
 
     def test_height(self):
-        peaks = self.signal.find_peaks1D_ohaver()[1]
+        peaks = self.signal.find_peaks()[1]
         if isinstance(peaks,da.Array):
             peaks = peaks.compute()
         np.testing.assert_allclose(
             peaks['height'], 1.0, rtol=1e-5, atol=1e-4)
 
     def test_width(self):
-        peaks = self.signal.find_peaks1D_ohaver()[1]
+        peaks = self.signal.find_peaks()[1]
         if isinstance(peaks,da.Array):
             peaks = peaks.compute()
         np.testing.assert_allclose(peaks['width'], 3.5758, rtol=1e-4, atol=1e-4)
 
     def test_n_peaks(self):
-        peaks = self.signal.find_peaks1D_ohaver()[1]
+        peaks = self.signal.find_peaks()[1]
         if isinstance(peaks, da.Array):
             peaks = peaks.compute()
         assert len(peaks) == 8
 
     def test_maxpeaksn(self):
         for n in range(1, 10):
-            peaks = self.signal.find_peaks1D_ohaver(maxpeakn=n)[1]
+            peaks = self.signal.find_peaks(maxpeakn=n)[1]
             if isinstance(peaks, da.Array):
                 peaks=peaks.compute()
             assert len(peaks) == min((8, n))

--- a/hyperspy/tests/signals/test_find_peaks1D_ohaver.py
+++ b/hyperspy/tests/signals/test_find_peaks1D_ohaver.py
@@ -25,7 +25,7 @@ from hyperspy.exceptions import VisibleDeprecationWarning
 
 
 @lazifyTestClass
-class TestFindPeaks1DOhaver:
+class TestFindPeaks1D:
     def setup_method(self, method):
         with pytest.warns(VisibleDeprecationWarning):
             filepath = (
@@ -37,10 +37,10 @@ class TestFindPeaks1DOhaver:
 
     def test_find_peaks1D_ohaver_high_amp_thres(self):
         signal1D = self.signal
-        peak_list = signal1D.find_peaks1D_ohaver(amp_thresh=10.0)[0]
+        peak_list = signal1D.find_peaks(amp_thresh=10.0)[0]
         assert len(peak_list) == 0
 
     def test_find_peaks1D_ohaver_zero_value_bug(self):
         signal1D = self.signal
-        peak_list = signal1D.find_peaks1D_ohaver()[0]
+        peak_list = signal1D.find_peaks()[0]
         assert len(peak_list) == 48

--- a/hyperspy/tests/signals/test_find_peaks1D_ohaver.py
+++ b/hyperspy/tests/signals/test_find_peaks1D_ohaver.py
@@ -23,6 +23,8 @@ from hyperspy.api import load
 from hyperspy.decorators import lazifyTestClass
 from hyperspy.exceptions import VisibleDeprecationWarning
 
+import dask.array as da
+
 
 @lazifyTestClass
 class TestFindPeaks1D:
@@ -37,10 +39,14 @@ class TestFindPeaks1D:
 
     def test_find_peaks1D_ohaver_high_amp_thres(self):
         signal1D = self.signal
-        peak_list = signal1D.find_peaks(amp_thresh=10.0)[0]
+        peak_list = signal1D.find_peaks(amp_thresh=10.0).data[0]
+        if isinstance(peak_list, da.Array):
+            peak_list = peak_list.compute()
         assert len(peak_list) == 0
 
     def test_find_peaks1D_ohaver_zero_value_bug(self):
         signal1D = self.signal
-        peak_list = signal1D.find_peaks()[0]
+        peak_list = signal1D.find_peaks().data[0]
+        if isinstance(peak_list, da.Array):
+            peak_list = peak_list.compute()
         assert len(peak_list) == 48

--- a/hyperspy/utils/peakfinders1D.py
+++ b/hyperspy/utils/peakfinders1D.py
@@ -1,0 +1,180 @@
+# -*- coding: utf-8 -*-
+# Copyright 2007-2023 The HyperSpy developers
+#
+# This file is part of HyperSpy.
+#
+# HyperSpy is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# HyperSpy is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with HyperSpy. If not, see <https://www.gnu.org/licenses/#GPL>.
+
+import numpy as np
+from scipy.signal import medfilt
+
+
+def find_peaks_1d(y, x=None, slope_thresh=0., amp_thresh=None,
+                      medfilt_radius=5, maxpeakn=30000, peakgroup=10,
+                      subchannel=True,):
+    """Find peaks along a 1D line.
+
+    Function to locate the positive peaks in a noisy x-y data set.
+    Detects peaks by looking for downward zero-crossings in the first
+    derivative that exceed 'slope_thresh'.
+    Returns an array containing position, height, and width of each peak.
+    Sorted by position.
+    'slope_thresh' and 'amp_thresh', control sensitivity: higher values
+    will neglect wider peaks (slope) and smaller features (amp),
+    respectively.
+
+    Parameters
+    ----------
+
+    y : array
+        1D input array, e.g. a spectrum
+    x : array (optional)
+        1D array describing the calibration of y (must have same shape as y)
+    slope_thresh : float (optional)
+                   1st derivative threshold to count the peak;
+                   higher values will neglect broader features;
+                   default is set to 0.
+    amp_thresh : float (optional)
+                 intensity threshold below which peaks are ignored;
+                 higher values will neglect smaller features;
+                 default is set to 10% of max(y).
+    medfilt_radius : int (optional)
+                     median filter window to apply to smooth the data
+                     (see scipy.signal.medfilt);
+                     if 0, no filter will be applied;
+                     default is set to 5.
+    peakgroup : int (optional)
+                number of points around the "top part" of the peak that
+                are taken to estimate the peak height; for spikes or
+                very narrow peaks, keep PeakGroup=1 or 2; for broad or
+                noisy peaks, make PeakGroup larger to reduce the effect
+                of noise;
+                default is set to 10.
+    maxpeakn : int (optional)
+              number of maximum detectable peaks;
+              default is set to 30000.
+    subchannel : bool (optional)
+             default is set to True.
+
+    Returns
+    -------
+    P : structured array of shape (npeaks)
+        contains fields: 'position', 'width', and 'height' for each peak.
+
+    Examples
+    --------
+    >>> x = np.arange(0,50,0.01)
+    >>> y = np.cos(x)
+    >>> peaks = find_peaks_1d(y, x, 0, 0)
+
+    Notes
+    -----
+    Original code from T. C. O'Haver, 1995.
+    Version 2  Last revised Oct 27, 2006 Converted to Python by
+    Michael Sarahan, Feb 2011.
+    Revised to handle edges better.  MCS, Mar 2011
+    """
+
+    if x is None:
+        x = np.arange(len(y), dtype=np.int64)
+    if not amp_thresh:
+        amp_thresh = 0.1 * y.max()
+    peakgroup = np.round(peakgroup)
+    if medfilt_radius:
+        d = np.gradient(medfilt(y, medfilt_radius))
+    else:
+        d = np.gradient(y)
+    n = np.round(peakgroup / 2 + 1)
+    peak_dt = np.dtype([('position', float),
+                        ('height', float),
+                        ('width', float)])
+    P = np.array([], dtype=peak_dt)
+    peak = 0
+    for j in range(len(y) - 4):
+        if np.sign(d[j]) > np.sign(d[j + 1]):  # Detects zero-crossing
+            if np.sign(d[j + 1]) == 0:
+                continue
+            # if slope of derivative is larger than slope_thresh
+            if d[j] - d[j + 1] > slope_thresh:
+                # if height of peak is larger than amp_thresh
+                if y[j] > amp_thresh:
+                    # the next section is very slow, and actually messes
+                    # things up for images (discrete pixels),
+                    # so by default, don't do subchannel precision in the
+                    # 1D peakfind step.
+                    if subchannel:
+                        xx = np.zeros(peakgroup)
+                        yy = np.zeros(peakgroup)
+                        s = 0
+                        for k in range(peakgroup):
+                            groupindex = int(j + k - n + 1)
+                            if groupindex < 1:
+                                xx = xx[1:]
+                                yy = yy[1:]
+                                s += 1
+                                continue
+                            elif groupindex > y.shape[0] - 1:
+                                xx = xx[:groupindex - 1]
+                                yy = yy[:groupindex - 1]
+                                break
+                            xx[k - s] = x[groupindex]
+                            yy[k - s] = y[groupindex]
+                        avg = np.average(xx)
+                        stdev = np.std(xx)
+                        xxf = (xx - avg) / stdev
+                        # Fit parabola to log10 of sub-group with
+                        # centering and scaling
+                        yynz = yy != 0
+                        coef = np.polyfit(
+                            xxf[yynz], np.log10(abs(yy[yynz])), 2)
+                        c1 = coef[2]
+                        c2 = coef[1]
+                        c3 = coef[0]
+                        with np.errstate(invalid='ignore'):
+                            width = np.linalg.norm(stdev * 2.35703 /
+                                                   (np.sqrt(2) * np.sqrt(-1 *
+                                                                         c3)))
+                        # if the peak is too narrow for least-squares
+                        # technique to work  well, just use the max value
+                        # of y in the sub-group of points near peak.
+                        if peakgroup < 7:
+                            height = np.max(yy)
+                            position = xx[np.argmin(abs(yy - height))]
+                        else:
+                            position = - ((stdev * c2 / (2 * c3)) - avg)
+                            height = np.exp(c1 - c3 * (c2 / (2 * c3)) ** 2)
+                    # Fill results array P. One row for each peak
+                    # detected, containing the
+                    # peak position (x-value) and peak height (y-value).
+                    else:
+                        position = x[j]
+                        height = y[j]
+                        # no way to know peak width without
+                        # the above measurements.
+                        width = 0
+                    if (not np.isnan(position) and 0 < position < x[-1]):
+                        P = np.hstack((P,
+                                       np.array([(position, height, width)],
+                                                dtype=peak_dt)))
+                        peak += 1
+    # return only the part of the array that contains peaks
+    # (not the whole maxpeakn x 3 array)
+    if len(P) > maxpeakn:
+        minh = np.sort(P['height'])[-maxpeakn]
+        P = P[P['height'] >= minh]
+
+    # Sorts the values as a function of position
+    P.sort(0)
+
+    return P

--- a/hyperspy/utils/peakfinders1D.py
+++ b/hyperspy/utils/peakfinders1D.py
@@ -96,10 +96,7 @@ def find_peaks_1d(y, x=None, slope_thresh=0., amp_thresh=None,
     else:
         d = np.gradient(y)
     n = np.round(peakgroup / 2 + 1)
-    peak_dt = np.dtype([('position', float),
-                        ('height', float),
-                        ('width', float)])
-    P = np.array([], dtype=peak_dt)
+    peaks = np.empty((0, 3))
     peak = 0
     for j in range(len(y) - 4):
         if np.sign(d[j]) > np.sign(d[j + 1]):  # Detects zero-crossing
@@ -164,17 +161,13 @@ def find_peaks_1d(y, x=None, slope_thresh=0., amp_thresh=None,
                         # the above measurements.
                         width = 0
                     if (not np.isnan(position) and 0 < position < x[-1]):
-                        P = np.hstack((P,
-                                       np.array([(position, height, width)],
-                                                dtype=peak_dt)))
+                        peaks = np.vstack((peaks, np.array([position, height, width],)))
                         peak += 1
     # return only the part of the array that contains peaks
     # (not the whole maxpeakn x 3 array)
-    if len(P) > maxpeakn:
-        minh = np.sort(P['height'])[-maxpeakn]
-        P = P[P['height'] >= minh]
+    if len(peaks) > maxpeakn:
+        minh = np.sort(peaks[:, 1])[-maxpeakn]
+        peaks = peaks[peaks[:, 1] >= minh]
 
-    # Sorts the values as a function of position
-    P.sort(0)
-
-    return P
+    # Sorts the values as a function of position along the x-axis
+    return peaks[np.argsort(peaks[:, 0])]

--- a/upcoming_changes/3196.api.rst
+++ b/upcoming_changes/3196.api.rst
@@ -1,0 +1,6 @@
+The `Signal1D.find_peaks1D_ohaver` method is renamed to `Signal1D.find_peaks` inline with `Signal2D.find_peaks`
+
+Additionally:
+- `Signal1D.find_peaks` now returns RaggedSignal
+- `Signal1D.find_peaks` now returns a lazy signal if s is lazy
+- The returned peaks no longer have a custom dtype (they are now just a numpy array with dtype float)


### PR DESCRIPTION

### Description of the change
Refactor find_peaks1D to copy the find_peaks2D functionality

- Add support for lazy peak finding
- Removed custom dtype (for lazy plotting etc)
- Renamed function for more inline

### Progress of the PR
- [x] Change implemented (can be split into several points),
- [x] update docstring (if appropriate),
- [x] update user guide (if appropriate),
- [x] add an changelog entry in the `upcoming_changes` folder (see [`upcoming_changes/README.rst`](https://github.com/hyperspy/hyperspy/blob/RELEASE_next_minor/upcoming_changes/README.rst)),
- [x] Check formatting changelog entry in the `readthedocs` doc build of this PR (link in github checks)
- [x] add tests,
- [x] ready for review.

### Minimal example of the bug fix or the new feature
```python
import hyperspy.api as hs
import numpy as np
s = hs.signals.Signal1D(np.arange(10))
peaks = s.find_peaks()
```
Note that this example can be useful to update the user guide.

