### PR TITLE
N d navigator

### DIFF
--- a/hyperspy/_signals/lazy.py
+++ b/hyperspy/_signals/lazy.py
@@ -1214,11 +1214,13 @@ class LazySignal(BaseSignal):
         if isinstance(navigator, str):
             if navigator == "spectrum":
                 # We don't support the 'spectrum' option to keep it simple
-                _logger.warning("The `navigator='spectrum'` option is not "
-                                "supported for lazy signals, 'auto' is used "
-                                "instead.")
-                navigator = 'auto'
-            if navigator == 'auto':
+                _logger.warning(
+                    "The `navigator='spectrum'` option is not "
+                    "supported for lazy signals, 'auto' is used "
+                    "instead."
+                )
+                navigator = "auto"
+            if navigator == "auto":
                 if self.navigator is None:
                     self.compute_navigator()
                 navigator = self.navigator

--- a/hyperspy/_signals/lazy.py
+++ b/hyperspy/_signals/lazy.py
@@ -1214,20 +1214,14 @@ class LazySignal(BaseSignal):
         if isinstance(navigator, str):
             if navigator == "spectrum":
                 # We don't support the 'spectrum' option to keep it simple
-                _logger.warning(
-                    "The `navigator='spectrum'` option is not "
-                    "supported for lazy signals, 'auto' is used "
-                    "instead."
-                )
-                navigator = "auto"
-            if navigator == "auto":
-                nav_dim = self.axes_manager.navigation_dimension
-                if nav_dim in [1, 2]:
-                    if self.navigator is None:
-                        self.compute_navigator()
-                    navigator = self.navigator
-                elif nav_dim > 2:
-                    navigator = "slider"
+                _logger.warning("The `navigator='spectrum'` option is not "
+                                "supported for lazy signals, 'auto' is used "
+                                "instead.")
+                navigator = 'auto'
+            if navigator == 'auto':
+                if self.navigator is None:
+                    self.compute_navigator()
+                navigator = self.navigator
         super().plot(navigator=navigator, **kwargs)
 
     def compute_navigator(self, index=None, chunks_number=None, show_progressbar=None):

--- a/hyperspy/signal.py
+++ b/hyperspy/signal.py
@@ -3061,7 +3061,11 @@ class BaseSignal(
             nav_ind = am.indices[2:]  # image at first 2 nav indices
             slices = [slice(None)] * len(am.navigation_axes)
             slices[2:] = nav_ind
-            ind = navigator.isig.__getitem__(slices=slices)  # Get the value from the nav reverse because hyperspy
+            if len(navigator.axes_manager.signal_axes) > 0:
+                new_nav = navigator.transpose(signal_axes=len(am.navigation_axes)) # roll axes to signal axes
+            else:
+                new_nav=navigator
+            ind = new_nav.isig.__getitem__(slices=slices)  # Get the value from the nav reverse because hyperspy
             return np.nan_to_num(to_numpy(ind.data)).squeeze()
 
         def get_dynamic_explorer_wrapper(*args, **kwargs):

--- a/hyperspy/signal.py
+++ b/hyperspy/signal.py
@@ -3061,12 +3061,9 @@ class BaseSignal(
             nav_ind = am.indices[2:]  # image at first 2 nav indices
             slices = [slice(None)] * len(am.navigation_axes)
             slices[2:] = nav_ind
-            if len(navigator.axes_manager.signal_axes) > 0:
-                new_nav = navigator.transpose(
-                    signal_axes=len(am.navigation_axes)
-                )  # roll axes to signal axes
-            else:
-                new_nav = navigator
+            new_nav = navigator.transpose(
+                signal_axes=len(am.navigation_axes)
+            )  # roll axes to signal axes
             ind = new_nav.isig.__getitem__(
                 slices=slices
             )  # Get the value from the nav reverse because hyperspy

--- a/hyperspy/signal.py
+++ b/hyperspy/signal.py
@@ -3151,13 +3151,6 @@ class BaseSignal(
                         self._plot.navigator_data_function = get_dynamic_image_explorer
                     else:
                         self._plot.navigator_data_function = get_static_explorer_wrapper
-                # Dynamic navigator
-                elif (
-                    axes_manager.navigation_shape
-                    == navigator.axes_manager.signal_shape
-                    + navigator.axes_manager.navigation_shape
-                ):
-                    self._plot.navigator_data_function = get_dynamic_explorer_wrapper
                 else:
                     raise ValueError(
                         "The dimensions of the provided (or stored) navigator "

--- a/hyperspy/signal.py
+++ b/hyperspy/signal.py
@@ -3069,16 +3069,6 @@ class BaseSignal(
             )  # Get the value from the nav reverse because hyperspy
             return np.nan_to_num(to_numpy(ind.data)).squeeze()
 
-        def get_dynamic_explorer_wrapper(*args, **kwargs):
-            navigator.axes_manager.indices = self.axes_manager.indices[
-                navigator.axes_manager.signal_dimension :
-            ]
-            navigator.axes_manager._update_attributes()
-            if np.issubdtype(navigator._get_current_data().dtype, np.complexfloating):
-                return abs(navigator._get_current_data(as_numpy=True))
-            else:
-                return navigator(as_numpy=True)
-
         if not isinstance(navigator, BaseSignal) and navigator == "auto":
             if self.navigator is not None:
                 navigator = self.navigator

--- a/hyperspy/signal.py
+++ b/hyperspy/signal.py
@@ -3062,10 +3062,14 @@ class BaseSignal(
             slices = [slice(None)] * len(am.navigation_axes)
             slices[2:] = nav_ind
             if len(navigator.axes_manager.signal_axes) > 0:
-                new_nav = navigator.transpose(signal_axes=len(am.navigation_axes)) # roll axes to signal axes
+                new_nav = navigator.transpose(
+                    signal_axes=len(am.navigation_axes)
+                )  # roll axes to signal axes
             else:
-                new_nav=navigator
-            ind = new_nav.isig.__getitem__(slices=slices)  # Get the value from the nav reverse because hyperspy
+                new_nav = navigator
+            ind = new_nav.isig.__getitem__(
+                slices=slices
+            )  # Get the value from the nav reverse because hyperspy
             return np.nan_to_num(to_numpy(ind.data)).squeeze()
 
         def get_dynamic_explorer_wrapper(*args, **kwargs):
@@ -3133,8 +3137,9 @@ class BaseSignal(
                     )
 
                 # Static navigator
-                if is_shape_compatible(axes_manager.navigation_shape,
-                                       navigator.axes_manager.signal_shape):
+                if is_shape_compatible(
+                    axes_manager.navigation_shape, navigator.axes_manager.signal_shape
+                ):
                     if len(axes_manager.navigation_shape) > 2:
                         self._plot.navigator_data_function = get_dynamic_image_explorer
                     else:
@@ -3175,8 +3180,6 @@ class BaseSignal(
                         )
                 elif navigator == "spectrum":
                     self._plot.navigator_data_function = get_1D_sum_explorer_wrapper
-                elif navigator == "image":
-                    self._plot.navigator_data_function = get_image
             elif navigator is None:
                 self._plot.navigator_data_function = None
             else:

--- a/hyperspy/tests/drawing/test_plot_lazy.py
+++ b/hyperspy/tests/drawing/test_plot_lazy.py
@@ -30,9 +30,9 @@ def test_plot_lazy(ndim):
     s.plot()
 
     if ndim == 0:
-        assert s._plot.navigator_data_function == None
+        assert s._plot.navigator_data_function is None
     else:
-        assert s.navigator.data.shape == tuple([N]*ndim)
+        assert s.navigator.data.shape == tuple([N] * ndim)
         assert isinstance(s.navigator, hs.signals.BaseSignal)
 
 

--- a/hyperspy/tests/drawing/test_plot_lazy.py
+++ b/hyperspy/tests/drawing/test_plot_lazy.py
@@ -30,12 +30,10 @@ def test_plot_lazy(ndim):
     s.plot()
 
     if ndim == 0:
-        assert s._plot.navigator_data_function is None
-    elif ndim in [1, 2]:
-        assert s.navigator.data.shape == tuple([N] * ndim)
-        assert isinstance(s.navigator, hs.signals.BaseSignal)
+        assert s._plot.navigator_data_function == None
     else:
-        assert s._plot.navigator_data_function == "slider"
+        assert s.navigator.data.shape == tuple([N]*ndim)
+        assert isinstance(s.navigator, hs.signals.BaseSignal)
 
 
 @pytest.mark.parametrize(

--- a/hyperspy/tests/drawing/test_plot_signal2d.py
+++ b/hyperspy/tests/drawing/test_plot_signal2d.py
@@ -838,14 +838,39 @@ def test_plot_images_bool():
 @lazifyTestClass
 class TestDynamicNavigatorPlot:
     def setup_method(self, method):
-        self.signal5d2d = hs.signals.Signal2D(np.arange((10**5)).reshape((10, 10, 10, 10, 10,)))
-        self.signal6d2d = hs.signals.Signal2D(np.arange((10**6)).reshape((10, 10, 10, 10, 10, 10)))
-        self.signal4d1d = hs.signals.Signal1D(np.arange((10**4)).reshape((10, 10, 10, 10)))
-        self.signal5d1d = hs.signals.Signal1D(np.arange((10**5)).reshape((10, 10, 10, 10, 10,)))
+        self.signal5d2d = hs.signals.Signal2D(
+            np.arange((10**5)).reshape(
+                (
+                    10,
+                    10,
+                    10,
+                    10,
+                    10,
+                )
+            )
+        )
+        self.signal6d2d = hs.signals.Signal2D(
+            np.arange((10**6)).reshape((10, 10, 10, 10, 10, 10))
+        )
+        self.signal4d1d = hs.signals.Signal1D(
+            np.arange((10**4)).reshape((10, 10, 10, 10))
+        )
+        self.signal5d1d = hs.signals.Signal1D(
+            np.arange((10**5)).reshape(
+                (
+                    10,
+                    10,
+                    10,
+                    10,
+                    10,
+                )
+            )
+        )
 
     def test_plot_5d(self):
         import hyperspy.api as hs
         import numpy as np
+
         s = self.signal5d2d
         nav = hs.signals.BaseSignal(np.arange((10 * 10 * 10)).reshape(10, 10, 10))
         s.plot(navigator=nav)
@@ -860,8 +885,11 @@ class TestDynamicNavigatorPlot:
     def test_plot_6d(self):
         import hyperspy.api as hs
         import numpy as np
+
         s = self.signal6d2d
-        nav = hs.signals.BaseSignal(np.arange((10 * 10 * 10 * 10)).reshape(10, 10, 10,10))
+        nav = hs.signals.BaseSignal(
+            np.arange((10 * 10 * 10 * 10)).reshape(10, 10, 10, 10)
+        )
         s.plot(navigator=nav)
         data1 = s._plot.navigator_plot._current_data
         s.axes_manager.indices = (0, 0, 0, 1)
@@ -874,6 +902,7 @@ class TestDynamicNavigatorPlot:
     def test_plot_4d_1dSignal(self):
         import hyperspy.api as hs
         import numpy as np
+
         s = self.signal4d1d
         nav = hs.signals.BaseSignal(np.arange((10 * 10 * 10)).reshape(10, 10, 10))
         s.plot(navigator=nav)
@@ -888,8 +917,11 @@ class TestDynamicNavigatorPlot:
     def test_plot_5d_1dsignal(self):
         import hyperspy.api as hs
         import numpy as np
+
         s = self.signal5d1d
-        nav = hs.signals.BaseSignal(np.arange((10 * 10 * 10 *10 )).reshape(10, 10, 10, 10))
+        nav = hs.signals.BaseSignal(
+            np.arange((10 * 10 * 10 * 10)).reshape(10, 10, 10, 10)
+        )
         s.plot(navigator=nav)
         data1 = s._plot.navigator_plot._current_data
         s.axes_manager.indices = (0, 0, 0, 1)

--- a/hyperspy/tests/drawing/test_plot_signal2d.py
+++ b/hyperspy/tests/drawing/test_plot_signal2d.py
@@ -888,7 +888,6 @@ class TestDynamicNavigatorPlot:
 
         s = self.signal5d2d
         nav = hs.signals.Signal2D(np.arange((10 * 10 * 10)).reshape(10, 10, 10))
-        nav = nav.transpose(navigation_axes=(0, 1, 2))
         s.plot(navigator=nav)
         data1 = s._plot.navigator_plot._current_data
         s.axes_manager.indices = (0, 0, 1)

--- a/hyperspy/tests/drawing/test_plot_signal2d.py
+++ b/hyperspy/tests/drawing/test_plot_signal2d.py
@@ -882,6 +882,21 @@ class TestDynamicNavigatorPlot:
         data3 = s._plot.navigator_plot._current_data
         assert np.array_equal(data2, data3)
 
+    def test_plot_5d_2(self):
+        import hyperspy.api as hs
+        import numpy as np
+
+        s = self.signal5d2d
+        nav = hs.signals.Signal2D(np.arange((10 * 10 * 10)).reshape(10, 10, 10))
+        s.plot(navigator=nav)
+        data1 = s._plot.navigator_plot._current_data
+        s.axes_manager.indices = (0, 0, 1)
+        data2 = s._plot.navigator_plot._current_data
+        assert not np.array_equal(data1, data2)
+        s.axes_manager.indices = (0, 2, 1)
+        data3 = s._plot.navigator_plot._current_data
+        assert np.array_equal(data2, data3)
+
     def test_plot_6d(self):
         import hyperspy.api as hs
         import numpy as np

--- a/hyperspy/tests/drawing/test_plot_signal2d.py
+++ b/hyperspy/tests/drawing/test_plot_signal2d.py
@@ -835,6 +835,12 @@ def test_plot_images_bool():
     hs.plot.plot_images(s)
 
 
+def test_plot_static_signal_nav():
+    s = hs.signals.Signal2D(np.ones((20, 20, 10, 10)))
+    nav = hs.signals.Signal2D(np.ones((20, 20)))
+    s.plot(navigator=nav)
+
+
 @lazifyTestClass
 class TestDynamicNavigatorPlot:
     def setup_method(self, method):

--- a/hyperspy/tests/drawing/test_plot_signal2d.py
+++ b/hyperspy/tests/drawing/test_plot_signal2d.py
@@ -888,6 +888,7 @@ class TestDynamicNavigatorPlot:
 
         s = self.signal5d2d
         nav = hs.signals.Signal2D(np.arange((10 * 10 * 10)).reshape(10, 10, 10))
+        nav = nav.transpose(navigation_axes=(0, 1, 2))
         s.plot(navigator=nav)
         data1 = s._plot.navigator_plot._current_data
         s.axes_manager.indices = (0, 0, 1)

--- a/hyperspy/tests/drawing/test_plot_signal2d.py
+++ b/hyperspy/tests/drawing/test_plot_signal2d.py
@@ -831,3 +831,60 @@ def test_plot_images_bool():
     s = hs.signals.Signal2D(data)
 
     hs.plot.plot_images(s)
+
+class TestDynamicNavigatorPlot():
+    def test_plot_5d(self):
+        import hyperspy.api as hs
+        import numpy as np
+        s = hs.signals.Signal2D(np.arange((10 * 10 * 10 * 10 * 10)).reshape((10, 10, 10, 10, 10,)))
+        nav = hs.signals.BaseSignal(np.arange((10 * 10 * 10)).reshape(10, 10, 10))
+        s.plot(navigator=nav)
+        data1 = s._plot.navigator_plot._current_data
+        s.axes_manager.indices = (0, 0, 1)
+        data2 = s._plot.navigator_plot._current_data
+        assert not np.array_equal(data1, data2)
+        s.axes_manager.indices = (0, 2, 1)
+        data3 = s._plot.navigator_plot._current_data
+        assert np.array_equal(data2, data3)
+
+    def test_plot_6d(self):
+        import hyperspy.api as hs
+        import numpy as np
+        s = hs.signals.Signal2D(np.arange((10 * 10 * 10 * 10 * 10*10)).reshape((10, 10, 10, 10, 10,10)))
+        nav = hs.signals.BaseSignal(np.arange((10 * 10 * 10 * 10)).reshape(10, 10, 10,10))
+        s.plot(navigator=nav)
+        data1 = s._plot.navigator_plot._current_data
+        s.axes_manager.indices = (0, 0, 0, 1)
+        data2 = s._plot.navigator_plot._current_data
+        assert not np.array_equal(data1, data2)
+        s.axes_manager.indices = (0, 2, 0, 1)
+        data3 = s._plot.navigator_plot._current_data
+        assert np.array_equal(data2, data3)
+
+    def test_plot_5d_1dSignal(self):
+        import hyperspy.api as hs
+        import numpy as np
+        s = hs.signals.Signal1D(np.arange((10 * 10 * 10 * 10)).reshape((10, 10, 10, 10,)))
+        nav = hs.signals.BaseSignal(np.arange((10 * 10 * 10)).reshape(10, 10, 10))
+        s.plot(navigator=nav)
+        data1 = s._plot.navigator_plot._current_data
+        s.axes_manager.indices = (0, 0, 1)
+        data2 = s._plot.navigator_plot._current_data
+        assert not np.array_equal(data1, data2)
+        s.axes_manager.indices = (0, 2, 1)
+        data3 = s._plot.navigator_plot._current_data
+        assert np.array_equal(data2, data3)
+
+    def test_plot_6d_1dsignal(self):
+        import hyperspy.api as hs
+        import numpy as np
+        s = hs.signals.Signal1D(np.arange((10 * 10 * 10 * 10 * 10)).reshape((10, 10, 10, 10, 10)))
+        nav = hs.signals.BaseSignal(np.arange((10 * 10 * 10 *10 )).reshape(10, 10, 10, 10))
+        s.plot(navigator=nav)
+        data1 = s._plot.navigator_plot._current_data
+        s.axes_manager.indices = (0, 0, 0, 1)
+        data2 = s._plot.navigator_plot._current_data
+        assert not np.array_equal(data1, data2)
+        s.axes_manager.indices = (0, 2, 0, 1)
+        data3 = s._plot.navigator_plot._current_data
+        assert np.array_equal(data2, data3)

--- a/hyperspy/tests/drawing/test_plot_signal2d.py
+++ b/hyperspy/tests/drawing/test_plot_signal2d.py
@@ -36,6 +36,8 @@ import traits.api as t
 import hyperspy.api as hs
 from hyperspy.drawing.utils import make_cmap, plot_RGB_map
 from hyperspy.tests.drawing.test_plot_signal import _TestPlot
+from hyperspy.decorators import lazifyTestClass
+
 
 scalebar_color = "blue"
 default_tol = 2.0
@@ -832,11 +834,19 @@ def test_plot_images_bool():
 
     hs.plot.plot_images(s)
 
-class TestDynamicNavigatorPlot():
+
+@lazifyTestClass
+class TestDynamicNavigatorPlot:
+    def setup_method(self, method):
+        self.signal5d2d = hs.signals.Signal2D(np.arange((10**5)).reshape((10, 10, 10, 10, 10,)))
+        self.signal6d2d = hs.signals.Signal2D(np.arange((10**6)).reshape((10, 10, 10, 10, 10, 10)))
+        self.signal4d1d = hs.signals.Signal1D(np.arange((10**4)).reshape((10, 10, 10, 10)))
+        self.signal5d1d = hs.signals.Signal1D(np.arange((10**5)).reshape((10, 10, 10, 10, 10,)))
+
     def test_plot_5d(self):
         import hyperspy.api as hs
         import numpy as np
-        s = hs.signals.Signal2D(np.arange((10 * 10 * 10 * 10 * 10)).reshape((10, 10, 10, 10, 10,)))
+        s = self.signal5d2d
         nav = hs.signals.BaseSignal(np.arange((10 * 10 * 10)).reshape(10, 10, 10))
         s.plot(navigator=nav)
         data1 = s._plot.navigator_plot._current_data
@@ -850,7 +860,7 @@ class TestDynamicNavigatorPlot():
     def test_plot_6d(self):
         import hyperspy.api as hs
         import numpy as np
-        s = hs.signals.Signal2D(np.arange((10 * 10 * 10 * 10 * 10*10)).reshape((10, 10, 10, 10, 10,10)))
+        s = self.signal6d2d
         nav = hs.signals.BaseSignal(np.arange((10 * 10 * 10 * 10)).reshape(10, 10, 10,10))
         s.plot(navigator=nav)
         data1 = s._plot.navigator_plot._current_data
@@ -861,10 +871,10 @@ class TestDynamicNavigatorPlot():
         data3 = s._plot.navigator_plot._current_data
         assert np.array_equal(data2, data3)
 
-    def test_plot_5d_1dSignal(self):
+    def test_plot_4d_1dSignal(self):
         import hyperspy.api as hs
         import numpy as np
-        s = hs.signals.Signal1D(np.arange((10 * 10 * 10 * 10)).reshape((10, 10, 10, 10,)))
+        s = self.signal4d1d
         nav = hs.signals.BaseSignal(np.arange((10 * 10 * 10)).reshape(10, 10, 10))
         s.plot(navigator=nav)
         data1 = s._plot.navigator_plot._current_data
@@ -875,10 +885,10 @@ class TestDynamicNavigatorPlot():
         data3 = s._plot.navigator_plot._current_data
         assert np.array_equal(data2, data3)
 
-    def test_plot_6d_1dsignal(self):
+    def test_plot_5d_1dsignal(self):
         import hyperspy.api as hs
         import numpy as np
-        s = hs.signals.Signal1D(np.arange((10 * 10 * 10 * 10 * 10)).reshape((10, 10, 10, 10, 10)))
+        s = self.signal5d1d
         nav = hs.signals.BaseSignal(np.arange((10 * 10 * 10 *10 )).reshape(10, 10, 10, 10))
         s.plot(navigator=nav)
         data1 = s._plot.navigator_plot._current_data

--- a/upcoming_changes/3199.enhancements.rst
+++ b/upcoming_changes/3199.enhancements.rst
@@ -1,0 +1,1 @@
+Add an dynamic navigator which updates when the number of navigation dimensions is greater than 3


### PR DESCRIPTION
### Description of the change
This allows navigators with dimension >2 to be plot in a more reasonable (and interactive) way.

- Navigators will update when they have dimensions>2 
- Lazy signals will plot an image navigator when dimensions >2

### Progress of the PR
- [x] Change implemented (can be split into several points),
- [x] update docstring (if appropriate),
- [x] update user guide (if appropriate),
- [x] add an changelog entry in the `upcoming_changes` folder (see [`upcoming_changes/README.rst`](https://github.com/hyperspy/hyperspy/blob/RELEASE_next_minor/upcoming_changes/README.rst)),
- [x] Check formatting changelog entry in the `readthedocs` doc build of this PR (link in github checks)
- [x] add tests,
- [x] ready for review.

### Minimal example of the bug fix or the new feature
```python
%matplotlib ipympl
import hyperspy.api as hs
import numpy as np
s = hs.signals.Signal2D(np.random.rand(10,10,10,10,10,10)).as_lazy()
s.plot()
```

https://github.com/hyperspy/hyperspy/assets/41125831/e07e1046-8a87-44b8-8bbe-1b2f999215e7



