### PR TITLE
s.save docstring: for write_dataset parameter add zspy

### DIFF
--- a/hyperspy/signal.py
+++ b/hyperspy/signal.py
@@ -3011,9 +3011,10 @@ class BaseSignal(FancySlicing,
             If set to True the signal or first signal in the list of signals
             will be defined as the default (following Nexus v3 data rules).
         write_dataset : bool, optional
-            Only for hspy files. If True, write the dataset, otherwise, don't
+            Only for hspy and zspy files. If True, write the dataset, otherwise, don't
             write it. Useful to save attributes without having to write the
-            whole dataset. Default is True.
+            whole dataset. Default is True. Note: for zspy files, only the default
+            file writer (``DirectoryStore``) is supported.
         close_file : bool, optional
             Only for hdf5-based files and some zarr store. Close the file after
             writing. Default is True.


### PR DESCRIPTION
When working with really large datasets, it is nice to change the metadata without having to rewrite the whole dataset.

Currently, the docstring only mentions `.hspy` but it seems to work for (at least) the default `.zspy` (in other words, the folder structure one).

However, I'm not sure if this will work for different zarr readers/writers.

### Description of the change

- Add `.zspy` to `s.save(write_dataset)` parameter.

@CSSFrancis 
