### PR TITLE
s.find_peaks docstring: fix reference to wrong function

### DIFF
--- a/hyperspy/_signals/signal2d.py
+++ b/hyperspy/_signals/signal2d.py
@@ -964,7 +964,7 @@ class Signal2D(BaseSignal, CommonSignal2D):
                function.
              * 'difference_of_gaussian' - a blob finder using the difference
                of Gaussian matrices approach. See the
-               :py:func:`~hyperspy.utils.peakfinders2D.find_peaks_log`
+               :py:func:`~hyperspy.utils.peakfinders2D.find_peaks_dog`
                function.
              * 'template_matching' - A cross correlation peakfinder. This
                method requires providing a template with the ``template``


### PR DESCRIPTION
The docstring for the parameter `difference_of_gaussian` wrongly references the `:py:func:~hyperspy.utils.peakfinders2D.find_peaks_log`, this pull request changes it to `find_peaks_dog`.
               