### PR TITLE
Interpolate on axis

### DIFF
--- a/doc/user_guide/signal/generic_tools.rst
+++ b/doc/user_guide/signal/generic_tools.rst
@@ -535,6 +535,32 @@ signal:
     uint64
 
 
+Interpolate to a different axis
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The :py:meth:`~.api.signals.BaseSignal.interpolate_on_axis` method makes it possible to
+exchange any existing axis of a signal with a new axis,
+regardless of the signals dimension or the axes types.
+This is achieved by interpolating the data using :py:meth:`scipy.interpolate.interp1d`
+from the old axis to the new axis. Replacing multiple axes can be done iteratively.
+
+.. code-block:: python
+
+    >>> from hyperspy.axes import UniformDataAxis, DataAxis
+    >>> x = {"offset": 0, "scale": 1, "size": 10, "name": "X", "navigate": True}
+    >>> e = {"offset": 0, "scale": 1, "size": 50, "name": "E", "navigate": False}
+    >>> s = hs.signals.Signal1D(np.random.random((10, 50)), axes=[x, e])
+    >>> s
+    <Signal1D, title: , dimensions: (10|50)>
+    >>> x_new = UniformDataAxis(offset=1.5, scale=0.8, size=7, name="X_NEW")
+    >>> e_new = DataAxis(axis=np.arange(23)**2, name="E_NEW")
+    >>> s2 = s.interpolate_on_axis(x_new, 0, inplace=False)
+    >>> s2
+    <Signal1D, title: , dimensions: (7|50)>
+    >>> s2.interpolate_on_axis(e_new, 1, inplace=True)
+    <Signal1D, title: , dimensions: (7|23)>
+
+
 .. _squeeze-label:
 
 Squeezing
@@ -929,28 +955,3 @@ is preserved. If alpha is one, the Tukey window is equivalent to a Hann window.
 
 Apodization can be applied in place by setting keyword argument ``inplace`` to ``True``.
 In this case method will not return anything.
-
-Interpolate to a different axis
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-The :py:meth:`~.api.signals.BaseSignal.interpolate_on_axis` method makes it possible to
-exchange any existing axis of a signal with a new axis,
-regardless of the signals dimension or the axes types.
-This is achieved by interpolating the data using :py:meth:`scipy.interpolate.interp1d`
-from the old axis to the new axis. Replacing multiple axes can be done iteratively.
-
-.. code-block:: python
-
-    >>> from hyperspy.axes import UniformDataAxis, DataAxis
-    >>> x = {"offset": 0, "scale": 1, "size": 10, "name": "X", "navigate": True}
-    >>> e = {"offset": 0, "scale": 1, "size": 50, "name": "E", "navigate": False}
-    >>> s = hs.signals.Signal1D(np.random.random((10, 50), axes=[x, e])
-    >>> s
-    <Signal1D, title: , dimensions: (10|50)>
-    >>> x_new = UniformDataAxis(offset=1.5, scale=0.8, size=7, name="X_NEW")
-    >>> e_new = DataAxis(axis=np.arange(23)**2, name="E_NEW")
-    >>> s2 = s.interpolate_on_axis(x_new, 0, inplace=False)
-    >>> s2
-    <Signal1D, title: , dimensions: (7|50)>
-    >>> s2.interpolate_on_axis(e_new, 1, inplace=True)
-    <Signal1D, title: , dimensions: (7|23)>

--- a/doc/user_guide/signal/generic_tools.rst
+++ b/doc/user_guide/signal/generic_tools.rst
@@ -553,12 +553,12 @@ from the old axis to the new axis. Replacing multiple axes can be done iterative
     >>> s
     <Signal1D, title: , dimensions: (10|50)>
     >>> x_new = UniformDataAxis(offset=1.5, scale=0.8, size=7, name="X_NEW")
-    >>> e_new = DataAxis(axis=np.arange(23)**2, name="E_NEW")
+    >>> e_new = DataAxis(axis=np.arange(8))**2, name="E_NEW")
     >>> s2 = s.interpolate_on_axis(x_new, 0, inplace=False)
     >>> s2
     <Signal1D, title: , dimensions: (7|50)>
     >>> s2.interpolate_on_axis(e_new, 1, inplace=True)
-    <Signal1D, title: , dimensions: (7|23)>
+    <Signal1D, title: , dimensions: (7|8)>
 
 
 .. _squeeze-label:

--- a/doc/user_guide/signal/generic_tools.rst
+++ b/doc/user_guide/signal/generic_tools.rst
@@ -929,3 +929,28 @@ is preserved. If alpha is one, the Tukey window is equivalent to a Hann window.
 
 Apodization can be applied in place by setting keyword argument ``inplace`` to ``True``.
 In this case method will not return anything.
+
+Interpolate to a different axis
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The :py:meth:`~.api.signals.BaseSignal.interpolate_on_axis` method makes it possible to
+exchange any existing axis of a signal with a new axis,
+regardless of the signals dimension or the axes types.
+This is achieved by interpolating the data using :py:meth:`scipy.interpolate.interp1d`
+from the old axis to the new axis. Replacing multiple axes can be done iteratively.
+
+.. code-block:: python
+
+    >>> from hyperspy.axes import UniformDataAxis, DataAxis
+    >>> x = {"offset": 0, "scale": 1, "size": 10, "name": "X", "navigate": True}
+    >>> e = {"offset": 0, "scale": 1, "size": 50, "name": "E", "navigate": False}
+    >>> s = hs.signals.Signal1D(np.random.random((10, 50), axes=[x, e])
+    >>> s
+    <Signal1D, title: , dimensions: (10|50)>
+    >>> x_new = UniformDataAxis(offset=1.5, scale=0.8, size=7, name="X_NEW")
+    >>> e_new = DataAxis(axis=np.arange(23)**2, name="E_NEW")
+    >>> s2 = s.interpolate_on_axis(x_new, 0, inplace=False)
+    >>> s2
+    <Signal1D, title: , dimensions: (7|50)>
+    >>> s2.interpolate_on_axis(e_new, 1, inplace=True)
+    <Signal1D, title: , dimensions: (7|23)>

--- a/doc/user_guide/signal/generic_tools.rst
+++ b/doc/user_guide/signal/generic_tools.rst
@@ -541,7 +541,7 @@ Interpolate to a different axis
 The :py:meth:`~.api.signals.BaseSignal.interpolate_on_axis` method makes it possible to
 exchange any existing axis of a signal with a new axis,
 regardless of the signals dimension or the axes types.
-This is achieved by interpolating the data using :py:meth:`scipy.interpolate.interp1d`
+This is achieved by interpolating the data using :py:meth:`scipy.interpolate.make_interp_spline`
 from the old axis to the new axis. Replacing multiple axes can be done iteratively.
 
 .. code-block:: python

--- a/doc/user_guide/signal/generic_tools.rst
+++ b/doc/user_guide/signal/generic_tools.rst
@@ -552,12 +552,12 @@ from the old axis to the new axis. Replacing multiple axes can be done iterative
     >>> s = hs.signals.Signal1D(np.random.random((10, 50)), axes=[x, e])
     >>> s
     <Signal1D, title: , dimensions: (10|50)>
-    >>> x_new = UniformDataAxis(offset=1.5, scale=0.8, size=7, name="X_NEW")
-    >>> e_new = DataAxis(axis=np.arange(8))**2, name="E_NEW")
+    >>> x_new = UniformDataAxis(offset=1.5, scale=0.8, size=7, name="X_NEW", navigate=True)
+    >>> e_new = DataAxis(axis=np.arange(8)**2, name="E_NEW", navigate=False)
     >>> s2 = s.interpolate_on_axis(x_new, 0, inplace=False)
     >>> s2
     <Signal1D, title: , dimensions: (7|50)>
-    >>> s2.interpolate_on_axis(e_new, 1, inplace=True)
+    >>> s2.interpolate_on_axis(e_new, "E", inplace=True)
     <Signal1D, title: , dimensions: (7|8)>
 
 

--- a/hyperspy/signal.py
+++ b/hyperspy/signal.py
@@ -3123,20 +3123,34 @@ class BaseSignal(FancySlicing,
 
         Parameters
         ----------
-        axis: UniformAxis, DataAxis or FunctionalAxis
-            axis which replaces the axis specified with replace_index
+        new_axis : UniformDataAxis, DataAxis or FunctionalDataAxis
+            Axis which replaces the axis specified with replace_index.
+            If this new axis exceeds the range of the old axis,
+            a warning is raised that the data will be extrapolated.
 
-        replace_index: int
-            index of the to be replaced axis
+        replace_axis_index : int
+            Specifies the axis which will be replaced using the index of the
+            axis in `axes_manager`.
 
-        inplace: bool, default=False
+        inplace : bool, default=False
+            If ``True`` the data of `self` is replaced by the result and
+            the axis is changed inplace. Otherwise `self` is not changed
+            and a new signal with the changes incorporated is returned.
+
+        set_navigate : bool, default=True
+            If ``True``, sets the `navigate` attribute of `new_axis` to the value given
+            by the old axis.
 
         **kwargs: dict
-            extra keywords passed to :py:func:`scipy.interpolate.interp1d`
+            Extra keywords passed to :py:func:`scipy.interpolate.interp1d`.
+            Extracted are: `kind` (default: linear), `bounds_error` (default: False)
+            and `fill_value` (default: extrapolate).
 
         Returns
         -------
-        When inplace is set to False, a new signal with the replaced axis is returned.
+        s : :py:class:`~hyperspy.signal.BaseSignal` (or subclass)
+            A copy of the object with the axis exchanged and the data interpolated.
+            This only occurs when inplace is set to ``False``, otherwise nothing is returned.
         """
         kind = kwargs.get("kind", "linear")
         bounds_error = kwargs.get("bounds_error", False)

--- a/hyperspy/signal.py
+++ b/hyperspy/signal.py
@@ -3173,12 +3173,16 @@ class BaseSignal(FancySlicing,
             axis=set_axis_idx,
             k=degree,
         )
+        new_data = interpolator(new_axis.axis)
+
         if inplace:
-            self.data = interpolator(new_axis.axis)
-            self.axes_manager.set_axis(new_axis, set_axis_idx)
+            self.data = new_data
+            s = self
         else:
-            s = self._deepcopy_with_new_data(interpolator(new_axis.axis))
-            s.axes_manager.set_axis(new_axis, set_axis_idx)
+            s = self._deepcopy_with_new_data(new_data)
+
+        s.axes_manager.set_axis(new_axis, set_axis_idx)
+        if not inplace:
             return s
 
     def swap_axes(self, axis1, axis2, optimize=False):

--- a/hyperspy/signal.py
+++ b/hyperspy/signal.py
@@ -3147,18 +3147,15 @@ class BaseSignal(FancySlicing,
             This only occurs when inplace is set to ``False``, otherwise nothing is returned.
         """
         old_axis = self.axes_manager[axis]
+        if old_axis.navigate != new_axis.navigate:
+            raise ValueError(
+                "The navigate attribute of new_axis differs from the to be replaced axis."
+            )
         axis_idx = old_axis.index_in_array
         if old_axis.low_value > new_axis.low_value or old_axis.high_value < new_axis.high_value:
             _logger.warning(
                 "The specified new axis exceeds the range of the to be replaced old axis. "
                 "The data will be extrapolated if not specified otherwise via fill_value/bounds_error"
-            )
-
-        if old_axis.navigate != new_axis.navigate:
-            _logger.warning(
-                f"The navigate attribute of new_axis differs from the to be replaced axis. "
-                f"new_axis has priority, thus navigate will be set to {new_axis.navigate}. "
-                f"If that is not intended, please specify navigate for new_axis."
             )
 
         interpolator = make_interp_spline(

--- a/hyperspy/signal.py
+++ b/hyperspy/signal.py
@@ -3149,7 +3149,6 @@ class BaseSignal(FancySlicing,
         else:
             axes_manager_idx = (2 * nav_dim + sig_dim - 1) - replace_index
 
-        # TODO: test if multidimensional data interpolation works as intended
         interpolator = interp1d(
             self.axes_manager[axes_manager_idx].axis,
             self.data,

--- a/hyperspy/signal.py
+++ b/hyperspy/signal.py
@@ -3140,13 +3140,17 @@ class BaseSignal(FancySlicing,
         """
         kind = kwargs.get("kind", "linear")
         bounds_error = kwargs.get("bounds_error", False)
-        fill_value = kwargs.get("fill_value", np.nan)
-        # TODO: how to handle bounds_error (custom error msg, or leave it from scipy?)
-        # I think atleast a warning would be good in any case
+        fill_value = kwargs.get("fill_value", "extrapolate")
+
+        old_axis = self.axes_manager[replace_axis_index]
+        if old_axis.low_value > new_axis.low_value or old_axis.high_value < new_axis.high_value:
+            _logger.warning(
+                "The specified new axis exceeds the range of the to be replaced old axis. "
+                "The data will be extrapolated if not specified otherwise via fill_value/bounds_error"
+            )
 
         nav_dim = self.axes_manager.navigation_dimension
         sig_dim = self.axes_manager.signal_dimension
-        old_axis = self.axes_manager[replace_axis_index]
         if old_axis.navigate:
             set_axis_idx = (nav_dim - 1) - replace_axis_index
         else:

--- a/hyperspy/signal.py
+++ b/hyperspy/signal.py
@@ -3114,7 +3114,7 @@ class BaseSignal(FancySlicing,
 
     def interpolate_on_axis(self,
                             new_axis,
-                            replace_axis_index,
+                            index_in_axes_manager=0,
                             inplace=False,
                             set_navigate=True,
                             **kwargs):
@@ -3128,9 +3128,9 @@ class BaseSignal(FancySlicing,
             If this new axis exceeds the range of the old axis,
             a warning is raised that the data will be extrapolated.
 
-        replace_axis_index : int
+        index_in_axes_manager : int, default=0
             Specifies the axis which will be replaced using the index of the
-            axis in `axes_manager`.
+            axis in the `axes_manager`.
 
         inplace : bool, default=False
             If ``True`` the data of `self` is replaced by the result and
@@ -3156,7 +3156,7 @@ class BaseSignal(FancySlicing,
         bounds_error = kwargs.get("bounds_error", False)
         fill_value = kwargs.get("fill_value", "extrapolate")
 
-        old_axis = self.axes_manager[replace_axis_index]
+        old_axis = self.axes_manager[index_in_axes_manager]
         if old_axis.low_value > new_axis.low_value or old_axis.high_value < new_axis.high_value:
             _logger.warning(
                 "The specified new axis exceeds the range of the to be replaced old axis. "
@@ -3166,9 +3166,9 @@ class BaseSignal(FancySlicing,
         nav_dim = self.axes_manager.navigation_dimension
         sig_dim = self.axes_manager.signal_dimension
         if old_axis.navigate:
-            set_axis_idx = (nav_dim - 1) - replace_axis_index
+            set_axis_idx = (nav_dim - 1) - index_in_axes_manager
         else:
-            set_axis_idx = (2*nav_dim + sig_dim - 1) - replace_axis_index
+            set_axis_idx = (2*nav_dim + sig_dim - 1) - index_in_axes_manager
 
         if set_navigate:
             new_axis.navigate = old_axis.navigate

--- a/hyperspy/signal.py
+++ b/hyperspy/signal.py
@@ -3154,6 +3154,13 @@ class BaseSignal(FancySlicing,
                 "The data will be extrapolated if not specified otherwise via fill_value/bounds_error"
             )
 
+        if old_axis.navigate != new_axis.navigate:
+            _logger.warning(
+                f"The navigate attribute of new_axis differs from the to be replaced axis. "
+                f"new_axis has priority, thus navigate will be set to {new_axis.navigate}. "
+                f"If that is not intended, please specify navigate for new_axis."
+            )
+
         interpolator = make_interp_spline(
             old_axis.axis,
             self.data,

--- a/hyperspy/tests/signals/test_interpolate_on_axis.py
+++ b/hyperspy/tests/signals/test_interpolate_on_axis.py
@@ -82,6 +82,12 @@ class TestInterpolateAxis1D:
         _assert_axes_equality(s2.axes_manager[0], x_uniform, "uniform")
         np.testing.assert_almost_equal(s2.data, s1.data)
 
+        # test index by string
+        s3 = self.s0.interpolate_on_axis(x_uniform, "X", inplace=False)
+        _assert_equal_dimensions(s3, self.s0)
+        _assert_axes_equality(s3.axes_manager[0], x_uniform, "uniform")
+        np.testing.assert_almost_equal(s3.data, np.arange(10, 60, 5))
+
     def test_interpolate_functional_axis(self):
         x_functional = FunctionalDataAxis(
             expression="x^2", size=10, navigate=False, name="XF"
@@ -99,11 +105,12 @@ class TestInterpolateAxis1D:
         np.testing.assert_almost_equal(s2.data, np.arange(0, 10) ** 2)
 
     def test_extrapolation(self):
-        x_new = UniformDataAxis(offset=30, scale=30, size=10, name="X1", units="µm")
+        x_new = UniformDataAxis(
+            offset=30, scale=30, size=10, navigate=False, name="X1", units="µm"
+        )
         s2 = self.s0.interpolate_on_axis(x_new, inplace=False)
         _assert_equal_dimensions(s2, self.s0)
         _assert_axes_equality(s2.axes_manager[0], x_new, "uniform")
-        assert s2.axes_manager[0].navigate == False  # test if set_navigate works
         np.testing.assert_almost_equal(s2.data, np.arange(30, 330, 30))
 
 
@@ -233,11 +240,10 @@ def test_interpolate_on_axis_random_switch(dim):
     s = signals.BaseSignal(data, axes=axes_list)
     switch_idx = rng.integers(0, dim)
     navigate = s.axes_manager[switch_idx].navigate
-    new_ax = UniformDataAxis(offset=1, scale=2, size=2, name="NEW")
+    new_ax = UniformDataAxis(offset=1, scale=2, size=2, navigate=navigate, name="NEW")
     try:
         s.interpolate_on_axis(new_ax, switch_idx, inplace=True)
         _assert_axes_equality(s.axes_manager[switch_idx], new_ax, "uniform")
-        assert s.axes_manager[switch_idx].navigate == navigate
     except Exception as e:
         print(
             f"{e}\n\n seed: {seed}, nav_dim: {nav_dim}, dim: {dim}, switch_idx: {switch_idx}"

--- a/hyperspy/tests/signals/test_interpolate_on_axis.py
+++ b/hyperspy/tests/signals/test_interpolate_on_axis.py
@@ -234,3 +234,15 @@ def test_interpolate_on_axis_random_switch(dim):
         print(
             f"{e}\n\n seed: {seed}, nav_dim: {nav_dim}, dim: {dim}, switch_idx: {switch_idx}"
         )
+
+
+def test_extrapolation():
+    x_initial = {"offset": 0, "scale": 1, "size": 10, "name": "X", "units": "µm"}
+    x_new = UniformDataAxis(offset=3, scale=3, size=30, name="X1", units="µm")
+    d = np.arange(0, 10)
+    s = signals.Signal1D(d, axes=[x_initial])
+    s2 = s.interpolate_on_axis(x_new, 0, inplace=False)
+    _assert_equal_dimensions(s, s2)
+    _assert_axes_equality(s2.axes_manager[0], x_new, "uniform")
+    assert s2.axes_manager[0].navigate == False
+    np.testing.assert_almost_equal(s2.data, np.arange(3, 93, 3))

--- a/hyperspy/tests/signals/test_interpolate_on_axis.py
+++ b/hyperspy/tests/signals/test_interpolate_on_axis.py
@@ -113,6 +113,13 @@ class TestInterpolateAxis1D:
         _assert_axes_equality(s2.axes_manager[0], x_new, "uniform")
         np.testing.assert_almost_equal(s2.data, np.arange(30, 330, 30))
 
+    def test_interpolate_error_navigate(self):
+        x_uniform = UniformDataAxis(
+            offset=10, scale=5, size=10, navigate=True, name="XU"
+        )
+        with pytest.raises(ValueError):
+            self.s0.interpolate_on_axis(x_uniform, 0)
+
 
 def test_interpolate_on_axis_2D():
     d = np.arange(0, 140).reshape(7, 20)

--- a/hyperspy/tests/signals/test_interpolate_on_axis.py
+++ b/hyperspy/tests/signals/test_interpolate_on_axis.py
@@ -1,0 +1,239 @@
+# -*- coding: utf-8 -*-
+# Copyright 2007-2023 The HyperSpy developers
+#
+# This file is part of HyperSpy.
+#
+# HyperSpy is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# HyperSpy is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with HyperSpy. If not, see <https://www.gnu.org/licenses/#GPL>.
+
+
+import gc
+from copy import deepcopy
+
+import pytest
+import numpy as np
+
+from hyperspy import signals
+from hyperspy.axes import UniformDataAxis, DataAxis, FunctionalDataAxis
+
+
+def _assert_equal_dimensions(s1, s2):
+    assert s1.axes_manager.navigation_dimension == s2.axes_manager.navigation_dimension
+    assert s1.axes_manager.signal_dimension == s2.axes_manager.signal_dimension
+
+
+def _assert_axes_equality(ax1, ax2, type):
+    _type = type.lower().strip()
+    assert _type in ["data", "uniform", "functional"]
+    assert ax1.name == ax2.name
+    if _type == "uniform":
+        np.testing.assert_almost_equal(ax1.offset, ax2.offset)
+        np.testing.assert_almost_equal(ax1.scale, ax2.scale)
+        assert ax1.size == ax2.size
+    elif _type == "data":
+        np.testing.assert_almost_equal(ax1.axis, ax2.axis)
+    elif _type == "functional":
+        assert ax1.x.size == ax2.x.size
+        assert ax1.x.offset == ax2.x.offset
+        assert ax1.x.scale == ax2.x.scale
+        assert ax1.size == ax2.size
+        np.testing.assert_almost_equal(ax1.axis, ax2.axis)
+    else:
+        raise ValueError(
+            f"Invalid argument {type}, only data, functional and uniform are accepted"
+        )
+
+
+class TestInterpolateAxis1D:
+    @classmethod
+    def setup_class(cls):
+        d = np.arange(0, 100)
+        x_initial = {"offset": 0, "scale": 1, "size": 100, "name": "X"}
+        cls.s0 = signals.Signal1D(d, axes=[x_initial])
+
+    @classmethod
+    def teardown_class(cls):
+        del cls.s0
+        gc.collect()
+
+    def test_interpolate_uniform(self):
+        x_uniform = UniformDataAxis(
+            offset=10, scale=5, size=10, navigate=False, name="XU"
+        )
+        s1 = self.s0.interpolate_on_axis(x_uniform, 0, inplace=False)
+        _assert_equal_dimensions(s1, self.s0)
+        _assert_axes_equality(s1.axes_manager[0], x_uniform, "uniform")
+        np.testing.assert_almost_equal(s1.data, np.arange(10, 60, 5))
+
+        # test inplace=True
+        s2 = self.s0.deepcopy()
+        s2.interpolate_on_axis(x_uniform, 0, inplace=True)
+        _assert_equal_dimensions(s2, self.s0)
+        _assert_axes_equality(s2.axes_manager[0], x_uniform, "uniform")
+        np.testing.assert_almost_equal(s2.data, s1.data)
+
+    def test_interpolate_functional(self):
+        x_functional = FunctionalDataAxis(
+            expression="x^2", size=10, navigate=False, name="XF"
+        )
+        s3 = self.s0.interpolate_on_axis(x_functional, 0, inplace=False)
+        _assert_equal_dimensions(s3, self.s0)
+        _assert_axes_equality(s3.axes_manager[0], x_functional, "functional")
+        np.testing.assert_almost_equal(s3.data, np.arange(0, 10) ** 2)
+
+    def test_interpolate_data(self):
+        x_data = DataAxis(axis=(np.arange(0, 10) ** 2), navigate=False, name="XD")
+        s2 = self.s0.interpolate_on_axis(x_data, 0, inplace=False)
+        _assert_equal_dimensions(s2, self.s0)
+        _assert_axes_equality(s2.axes_manager[0], x_data, "data")
+        np.testing.assert_almost_equal(s2.data, np.arange(0, 10) ** 2)
+
+
+def test_interpolate_on_axis_2D():
+    d = np.arange(0, 140).reshape(7, 20)
+    x_initial = {"offset": 0, "scale": 1, "size": 20, "name": "X"}
+    y_initial = {"offset": 5, "scale": 0.5, "size": 7, "name": "Y"}
+    s0 = signals.Signal1D(d, axes=[y_initial, x_initial])
+
+    y_new = UniformDataAxis(offset=5.5, scale=1, size=3, navigate=True, name="Y1")
+    x_new = UniformDataAxis(offset=11, scale=2, size=3, navigate=False, name="X1")
+
+    # switch y-axis
+    s1 = s0.interpolate_on_axis(y_new, 0, inplace=False)
+    _assert_equal_dimensions(s1, s0)
+    _assert_axes_equality(s1.axes_manager[0], y_new, "uniform")
+    _assert_axes_equality(s1.axes_manager[1], s0.axes_manager[1], "uniform")
+    np.testing.assert_almost_equal(
+        s1.data,
+        np.stack((np.arange(20, 40), np.arange(60, 80), np.arange(100, 120))),
+    )
+
+    # switch also x-axis inplace for s1, such that both axes are now replaced
+    s1.interpolate_on_axis(x_new, 1, inplace=True)
+    _assert_equal_dimensions(s1, s0)
+    _assert_axes_equality(s1.axes_manager[0], y_new, "uniform")
+    _assert_axes_equality(s1.axes_manager[1], x_new, "uniform")
+    np.testing.assert_almost_equal(
+        s1.data,
+        np.stack((np.arange(31, 37, 2), np.arange(71, 77, 2), np.arange(111, 117, 2))),
+    )
+
+    # switch both axes inplace in different order and compare with previous result
+    s0.interpolate_on_axis(x_new, 1, inplace=True)
+    s0.interpolate_on_axis(y_new, 0, inplace=True)
+    _assert_equal_dimensions(s1, s0)
+    _assert_axes_equality(s0.axes_manager[0], y_new, "uniform")
+    _assert_axes_equality(s0.axes_manager[1], x_new, "uniform")
+    np.testing.assert_almost_equal(s0.data, s1.data)
+
+
+class TestInterpolateAxis3D:
+    @classmethod
+    def setup_class(cls):
+        x_initial = {"offset": 0, "scale": 1, "size": 10, "name": "X"}
+        y_initial = {"offset": 0, "scale": 1, "size": 10, "name": "Y"}
+        e_initial = {"offset": 400, "scale": 1, "size": 100, "name": "E"}
+        d = np.arange(0, 10000).reshape(10, 10, 100)
+        cls.s0 = signals.Signal1D(d, axes=[y_initial, x_initial, e_initial])
+
+        cls.y_new = UniformDataAxis(offset=3, scale=1, size=3, navigate=True, name="Y1")
+        cls.x_new = UniformDataAxis(offset=3, scale=1, size=3, navigate=True, name="X1")
+        cls.e_new = UniformDataAxis(
+            offset=420, scale=1, size=50, navigate=False, name="E1"
+        )
+
+    @classmethod
+    def teardown_class(cls):
+        del cls.s0
+        gc.collect()
+
+    def test_interpolate_1s2n(self):
+        s1 = self.s0.interpolate_on_axis(self.y_new, 0, inplace=False)
+        _assert_equal_dimensions(s1, self.s0)
+        _assert_axes_equality(s1.axes_manager[1], self.y_new, "uniform")
+        _assert_axes_equality(s1.axes_manager[0], self.s0.axes_manager[0], "uniform")
+        _assert_axes_equality(s1.axes_manager[2], self.s0.axes_manager[2], "uniform")
+        s1.interpolate_on_axis(self.x_new, 1, inplace=True)
+        _assert_equal_dimensions(s1, self.s0)
+        _assert_axes_equality(s1.axes_manager[0], self.x_new, "uniform")
+        _assert_axes_equality(s1.axes_manager[1], self.y_new, "uniform")
+        _assert_axes_equality(s1.axes_manager[2], self.s0.axes_manager[2], "uniform")
+        s1.interpolate_on_axis(self.e_new, 2, inplace=True)
+        _assert_equal_dimensions(s1, self.s0)
+        _assert_axes_equality(s1.axes_manager[2], self.e_new, "uniform")
+        _assert_axes_equality(s1.axes_manager[1], self.y_new, "uniform")
+        _assert_axes_equality(s1.axes_manager[0], self.x_new, "uniform")
+        np.testing.assert_almost_equal(s1.inav[0, 0].data, np.arange(3320, 3370, 1))
+        np.testing.assert_almost_equal(s1.inav[1, 0].data, np.arange(3420, 3470, 1))
+        np.testing.assert_almost_equal(s1.inav[0, 1].data, np.arange(4320, 4370, 1))
+
+    def test_interpolate_2s1n(self):
+        s2 = self.s0.T
+        e_new = deepcopy(self.e_new)
+        x_new = deepcopy(self.x_new)
+        y_new = deepcopy(self.y_new)
+        e_new.navigate = True
+        x_new.navigate = False
+        y_new.navigate = False
+        s3 = s2.interpolate_on_axis(e_new, 0, inplace=False)
+        _assert_equal_dimensions(s3, s2)
+        _assert_axes_equality(s3.axes_manager[0], e_new, "uniform")
+        _assert_axes_equality(s3.axes_manager[1], s2.axes_manager[1], "uniform")
+        _assert_axes_equality(s3.axes_manager[2], s2.axes_manager[2], "uniform")
+        s3.interpolate_on_axis(x_new, 2, inplace=True)
+        _assert_equal_dimensions(s3, s2)
+        _assert_axes_equality(s3.axes_manager[1], x_new, "uniform")
+        _assert_axes_equality(s3.axes_manager[0], e_new, "uniform")
+        _assert_axes_equality(s3.axes_manager[2], s2.axes_manager[2], "uniform")
+        s3.interpolate_on_axis(y_new, 1, inplace=True)
+        _assert_equal_dimensions(s3, s2)
+        _assert_axes_equality(s3.axes_manager[2], y_new, "uniform")
+        _assert_axes_equality(s3.axes_manager[1], x_new, "uniform")
+        _assert_axes_equality(s3.axes_manager[0], e_new, "uniform")
+        np.testing.assert_almost_equal(s3.isig[0, 0].data, np.arange(3320, 3370, 1))
+        np.testing.assert_almost_equal(s3.isig[1, 0].data, np.arange(3420, 3470, 1))
+        np.testing.assert_almost_equal(s3.isig[0, 1].data, np.arange(4320, 4370, 1))
+
+
+@pytest.mark.parametrize("dim", [1, 2, 3, 4, 5])
+def test_interpolate_on_axis_random_switch(dim):
+    seed = np.random.randint(0, 1000000)
+    rng = np.random.default_rng(seed)
+    nav_dim = rng.integers(0, dim + 1)
+    axes_list = []
+    data_sizes = np.ones(dim, dtype="int")
+    for i in range(dim):
+        size = 3 + i
+        data_sizes[i] = size
+        ax_dict = {"name": f"{i}", "size": size, "offset": 0, "scale": 1}
+        if i < nav_dim:
+            ax_dict["navigate"] = True
+        else:
+            ax_dict["navigate"] = False
+        axes_list.append(ax_dict)
+    data = rng.random(int(data_sizes.prod())).reshape(data_sizes)
+    s = signals.BaseSignal(data, axes=axes_list)
+    switch_idx = rng.integers(0, dim)
+    if switch_idx < nav_dim:
+        navigate = True
+    else:
+        navigate = False
+    new_ax = UniformDataAxis(offset=1, scale=2, size=2, name="NEW", navigate=navigate)
+    s.interpolate_on_axis(new_ax, switch_idx, inplace=True)
+    if navigate:
+        axes_manager_idx = (nav_dim - 1) - switch_idx
+    else:
+        axes_manager_idx = (nav_dim + dim - 1) - switch_idx
+    assert (
+        s.axes_manager[axes_manager_idx] == new_ax
+    ), f"seed: {seed}, nav_dim: {nav_dim}, dim: {dim}, switch_idx: {switch_idx}"

--- a/hyperspy/tests/signals/test_interpolate_on_axis.py
+++ b/hyperspy/tests/signals/test_interpolate_on_axis.py
@@ -158,12 +158,12 @@ class TestInterpolateAxis3D:
         gc.collect()
 
     def test_interpolate_1s2n(self):
-        s1 = self.s0.interpolate_on_axis(self.y_new, 0, inplace=False)
+        s1 = self.s0.interpolate_on_axis(self.y_new, 1, inplace=False)
         _assert_equal_dimensions(s1, self.s0)
         _assert_axes_equality(s1.axes_manager[1], self.y_new, "uniform")
         _assert_axes_equality(s1.axes_manager[0], self.s0.axes_manager[0], "uniform")
         _assert_axes_equality(s1.axes_manager[2], self.s0.axes_manager[2], "uniform")
-        s1.interpolate_on_axis(self.x_new, 1, inplace=True)
+        s1.interpolate_on_axis(self.x_new, 0, inplace=True)
         _assert_equal_dimensions(s1, self.s0)
         _assert_axes_equality(s1.axes_manager[0], self.x_new, "uniform")
         _assert_axes_equality(s1.axes_manager[1], self.y_new, "uniform")
@@ -190,12 +190,12 @@ class TestInterpolateAxis3D:
         _assert_axes_equality(s3.axes_manager[0], e_new, "uniform")
         _assert_axes_equality(s3.axes_manager[1], s2.axes_manager[1], "uniform")
         _assert_axes_equality(s3.axes_manager[2], s2.axes_manager[2], "uniform")
-        s3.interpolate_on_axis(x_new, 2, inplace=True)
+        s3.interpolate_on_axis(x_new, 1, inplace=True)
         _assert_equal_dimensions(s3, s2)
         _assert_axes_equality(s3.axes_manager[1], x_new, "uniform")
         _assert_axes_equality(s3.axes_manager[0], e_new, "uniform")
         _assert_axes_equality(s3.axes_manager[2], s2.axes_manager[2], "uniform")
-        s3.interpolate_on_axis(y_new, 1, inplace=True)
+        s3.interpolate_on_axis(y_new, 2, inplace=True)
         _assert_equal_dimensions(s3, s2)
         _assert_axes_equality(s3.axes_manager[2], y_new, "uniform")
         _assert_axes_equality(s3.axes_manager[1], x_new, "uniform")
@@ -224,16 +224,13 @@ def test_interpolate_on_axis_random_switch(dim):
     data = rng.random(int(data_sizes.prod())).reshape(data_sizes)
     s = signals.BaseSignal(data, axes=axes_list)
     switch_idx = rng.integers(0, dim)
-    if switch_idx < nav_dim:
-        navigate = True
-    else:
-        navigate = False
-    new_ax = UniformDataAxis(offset=1, scale=2, size=2, name="NEW", navigate=navigate)
-    s.interpolate_on_axis(new_ax, switch_idx, inplace=True)
-    if navigate:
-        axes_manager_idx = (nav_dim - 1) - switch_idx
-    else:
-        axes_manager_idx = (nav_dim + dim - 1) - switch_idx
-    assert (
-        s.axes_manager[axes_manager_idx] == new_ax
-    ), f"seed: {seed}, nav_dim: {nav_dim}, dim: {dim}, switch_idx: {switch_idx}"
+    navigate = s.axes_manager[switch_idx].navigate
+    new_ax = UniformDataAxis(offset=1, scale=2, size=2, name="NEW")
+    try:
+        s.interpolate_on_axis(new_ax, switch_idx, inplace=True)
+        _assert_axes_equality(s.axes_manager[switch_idx], new_ax, "uniform")
+        assert s.axes_manager[switch_idx].navigate == navigate
+    except Exception as e:
+        print(
+            f"{e}\n\n seed: {seed}, nav_dim: {nav_dim}, dim: {dim}, switch_idx: {switch_idx}"
+        )

--- a/upcoming_changes/3214.new.rst
+++ b/upcoming_changes/3214.new.rst
@@ -1,0 +1,2 @@
+Adds the method `interpolate_on_axis`, which can be used to switch one axis of a signal.
+The data is interpolated in the process.


### PR DESCRIPTION
### Description of the change
The idea for this feature came from the wish to create the functionality to remove the background from a signal ([`remove_background_signal`](https://github.com/LumiSpy/lumispy/issues/124#issue-1221181993)). For this problem the signal dimension is usually 1 and the background signal is loaded from a seperate file. The axis of the background signal `b` doesn't necessarily match the axis of the measured signal `s`. Thus for the subtraction of the background it would be nice to simply interpolate the `b` onto the axis of `s` and then subtract `s-b`.

This PR aims to solve the interpolation part, which may be more generally useful. The function `interpolate_on_axis()` takes an axis (`UniformDataAxis`, `FunctionalDataAxis` or `DataAxis`) as input and replaces an axis (specified by an index). The data is interpolated using `scipy.interpolate.interp1d` in the process. This feature works both on signal and navigation axes and replaces one axes for a signal with arbitrary dimensions. Moreover, it can be used to switch between different axis types.

### Progress of the PR
- [x] Change implemented
- [x] handle extrapolation (custom error msg or use scipy `bounds_error`?)
- [x] which index to use (from `set_axis` or from `axes_manager`?)
- [x] update docstring (if appropriate),
- [x] update user guide (if appropriate),
- [x] add an changelog entry in the `upcoming_changes` folder (see [`upcoming_changes/README.rst`](https://github.com/hyperspy/hyperspy/blob/RELEASE_next_minor/upcoming_changes/README.rst)),
- [x] Check formatting changelog entry in the `readthedocs` doc build of this PR (link in github checks)
- [x] add tests,
- [x] ready for review.

### Minimal example of the bug fix or the new feature
```python
import hyperspy.api as hs
import numpy as np

x = {"offset": 0, "scale": 1, "size": 10, "name": "X", "units": "µm", "navigate": True}
s = {"offset": 0, "scale": 1, "size": 50, "name": "S", "units": "eV", "navigate": False}

x_new = UniformDataAxis(offset=1.5, scale=0.8, size=7, navigate=True, name="X", units="nm")
s_new = DataAxis(axis=np.arange(23)**2, navigate=False, name="S", units="eV")

d = np.random.random((10, 50))
s = hs.signals.Signal1D(d, axes=[x, s])

s2 = s.interpolate_on_axis(x_new, 0, inplace=False)
s2.interpolate_on_axis(s_new, 1, inplace=True)
```