### PR TITLE
plot_spectra heatmap should take kwarg as well

### DIFF
--- a/hyperspy/drawing/utils.py
+++ b/hyperspy/drawing/utils.py
@@ -1392,7 +1392,6 @@ def plot_spectra(
     **kwargs, optional
         Keywords arguments passed to :py:func:`matplotlib.pyplot.figure` or
         :py:func:`matplotlib.pyplot.subplots` if style='mosaic'.
-        Has no effect on 'heatmap' style.
 
     Example
     -------

--- a/hyperspy/drawing/utils.py
+++ b/hyperspy/drawing/utils.py
@@ -1519,7 +1519,7 @@ def plot_spectra(
                        spectra]
             spectra = hyperspy.utils.stack(spectra)
         with spectra.unfolded():
-            ax = _make_heatmap_subplot(spectra)
+            ax = _make_heatmap_subplot(spectra, **kwargs)
             ax.set_ylabel('Spectra')
     ax = ax if style != "mosaic" else subplots
 

--- a/hyperspy/drawing/utils.py
+++ b/hyperspy/drawing/utils.py
@@ -1389,9 +1389,12 @@ def plot_spectra(
         If True, the plot will update when the data are changed. Only supported
         with style='overlap' and a list of signal with navigation dimension 0.
         If None (default), update the plot only for style='overlap'.
-    **kwargs, optional
-        Keywords arguments passed to :py:func:`matplotlib.pyplot.figure` or
-        :py:func:`matplotlib.pyplot.subplots` if style='mosaic'.
+    **kwargs : dict, optional
+        Depending on the style used, the keyword arguments are passed to different functions
+
+        - ``"overlap"`` or ``"cascade"``: arguments passed to :py:func:`matplotlib.pyplot.figure`
+        - ``"mosiac"``: arguments passed to :py:func:`matplotlib.pyplot.subplots`
+        - ``"heatmap"``: arguments  passed to :py:meth:`~.api.signals.Signal2D.plot`.
 
     Example
     -------

--- a/upcoming_changes/3219.enhancements.rst
+++ b/upcoming_changes/3219.enhancements.rst
@@ -1,1 +1,1 @@
-Adding **kwargs to _make_heatmap_subplot in plot_spectra for more plotting options in heatmap style.
+Adding support for passing ``**kwargs`` to :py:meth:`~.api.signals.Signal2D.plot` when using heatmap style in :py:func:`~.api.plot.plot_spectra` .

--- a/upcoming_changes/3219.enhancements.rst
+++ b/upcoming_changes/3219.enhancements.rst
@@ -1,0 +1,1 @@
+Adding **kwargs to _make_heatmap_subplot in plot_spectra for more plotting options in heatmap style.


### PR DESCRIPTION
As title, currently plot_spectra heatmap does not take kwarg for .plot().