### PR TITLE
Scipy deprecation 

### DIFF
--- a/doc/user_guide/region_of_interest.rst
+++ b/doc/user_guide/region_of_interest.rst
@@ -36,7 +36,7 @@ added before calling :py:meth:`~.roi.BaseInteractiveROI.interactive`.
 
 .. code-block:: python
 
-    >>> import scipy.datasets
+    >>> import scipy
     >>> im = hs.signals.Signal2D(scipy.datasets.ascent())
     >>> rectangular_roi = hs.roi.RectangularROI(left=30, right=500,
     ...                                         top=200, bottom=400)
@@ -78,7 +78,7 @@ can be plotted on a different signal altogether.
 
 .. code-block:: python
 
-    >>> import scipy.datasets
+    >>> import scipy
     >>> im = hs.signals.Signal2D(scipy.datasets.ascent())
     >>> s = hs.signals.Signal1D(np.random.rand(512, 512, 512))
     >>> roi = hs.roi.RectangularROI(left=30, right=77, top=20, bottom=50)
@@ -110,7 +110,7 @@ order to increase responsiveness.
 
 .. code-block:: python
 
-   >>> import scipy.datasets
+   >>> import scipy
    >>> im = hs.signals.Signal2D(scipy.datasets.ascent())
    >>> im.plot()
    >>> roi = hs.roi.RectangularROI(left=30, right=500, top=200, bottom=400)
@@ -208,7 +208,7 @@ ROIs can be used in place of slices when indexing. For example:
 .. versionadded:: 1.6
     New :meth:`__getitem__` method for all ROIs.
 
-In addition the following all ROIs have a py:meth:`__getitem__` method that enables
+In addition, all ROIs have a py:meth:`__getitem__` method that enables
 using them in place of tuples.
 For example, the method :py:meth:`~._signals.Signal2D.align2D` takes a ``roi``
 argument with the left, right, top, bottom coordinates of the ROI.

--- a/doc/user_guide/region_of_interest.rst
+++ b/doc/user_guide/region_of_interest.rst
@@ -36,8 +36,8 @@ added before calling :py:meth:`~.roi.BaseInteractiveROI.interactive`.
 
 .. code-block:: python
 
-    >>> import scipy.misc
-    >>> im = hs.signals.Signal2D(scipy.misc.ascent())
+    >>> import scipy.datasets
+    >>> im = hs.signals.Signal2D(scipy.datasets.ascent())
     >>> rectangular_roi = hs.roi.RectangularROI(left=30, right=500,
     ...                                         top=200, bottom=400)
     >>> line_roi = hs.roi.Line2DROI(0, 0, 512, 512, 1)
@@ -78,8 +78,8 @@ can be plotted on a different signal altogether.
 
 .. code-block:: python
 
-    >>> import scipy.misc
-    >>> im = hs.signals.Signal2D(scipy.misc.ascent())
+    >>> import scipy.datasets
+    >>> im = hs.signals.Signal2D(scipy.datasets.ascent())
     >>> s = hs.signals.Signal1D(np.random.rand(512, 512, 512))
     >>> roi = hs.roi.RectangularROI(left=30, right=77, top=20, bottom=50)
     >>> s.plot() # plot signal to have where to display the widget
@@ -110,8 +110,8 @@ order to increase responsiveness.
 
 .. code-block:: python
 
-   >>> import scipy.misc
-   >>> im = hs.signals.Signal2D(scipy.misc.ascent())
+   >>> import scipy.datasets
+   >>> im = hs.signals.Signal2D(scipy.datasets.ascent())
    >>> im.plot()
    >>> roi = hs.roi.RectangularROI(left=30, right=500, top=200, bottom=400)
    >>> im_roi = roi.interactive(im, color="red")
@@ -195,7 +195,7 @@ ROIs can be used in place of slices when indexing. For example:
 
 .. code-block:: python
 
-    >>> s = hs.datasets.example_signals.EDS_TEM_Spectrum()
+    >>> s = hs.datasets.ascent.example_signals.EDS_TEM_Spectrum()
     >>> roi = hs.roi.SpanROI(left=5, right=15)
     >>> sc = s.isig[roi]
     >>> im = hs.signals.Signal2D(scipy.datasets.ascent())

--- a/doc/user_guide/signal/generic_tools.rst
+++ b/doc/user_guide/signal/generic_tools.rst
@@ -241,7 +241,7 @@ to make a horizontal "collage" of the image stack:
 .. code-block:: python
 
     >>> import scipy.ndimage
-    >>> image_stack = hs.signals.Signal2D(np.array([scipy.misc.ascent()]*5))
+    >>> image_stack = hs.signals.Signal2D(np.array([scipy.datasets.ascent()]*5))
     >>> image_stack.axes_manager[1].name = "x"
     >>> image_stack.axes_manager[2].name = "y"
     >>> for image, angle in zip(image_stack, (0, 45, 90, 135, 180)):
@@ -270,7 +270,7 @@ using an external function can be more easily accomplished using the
 .. code-block:: python
 
     >>> import scipy.ndimage
-    >>> image_stack = hs.signals.Signal2D(np.array([scipy.misc.ascent()]*4))
+    >>> image_stack = hs.signals.Signal2D(np.array([scipy.datasets.ascent()]*4))
     >>> image_stack.axes_manager[1].name = "x"
     >>> image_stack.axes_manager[2].name = "y"
     >>> image_stack.map(scipy.ndimage.rotate,
@@ -293,7 +293,7 @@ arguments as in the following example.
 .. code-block:: python
 
     >>> import scipy.ndimage
-    >>> image_stack = hs.signals.Signal2D(np.array([scipy.misc.ascent()]*4))
+    >>> image_stack = hs.signals.Signal2D(np.array([scipy.datasets.ascent()]*4))
     >>> image_stack.axes_manager[1].name = "x"
     >>> image_stack.axes_manager[2].name = "y"
     >>> angles = hs.signals.BaseSignal(np.array([0, 45, 90, 135]))
@@ -325,7 +325,7 @@ data (default, ``True``) or storing it to a new signal (``False``).
 .. code-block:: python
 
     >>> import scipy.ndimage
-    >>> image_stack = hs.signals.Signal2D(np.array([scipy.misc.ascent()]*4))
+    >>> image_stack = hs.signals.Signal2D(np.array([scipy.datasets.ascent()]*4))
     >>> angles = hs.signals.BaseSignal(np.array([0, 45, 90, 135]))
     >>> result = image_stack.map(scipy.ndimage.rotate,
     ...                            angle=angles.T,
@@ -589,7 +589,7 @@ with same dimension.
 
 .. code-block:: python
 
-    >>> image = hs.signals.Signal2D(scipy.misc.ascent())
+    >>> image = hs.signals.Signal2D(scipy.datasets.ascent())
     >>> image = hs.stack([hs.stack([image]*3,axis=0)]*3,axis=1)
     >>> image.plot()
 

--- a/doc/user_guide/visualisation.rst
+++ b/doc/user_guide/visualisation.rst
@@ -195,7 +195,7 @@ Colorbar, scalebar and contrast controls are HyperSpy-specific, however
 .. code-block:: python
 
     >>> import scipy
-    >>> img = hs.signals.Signal2D(scipy.misc.ascent())
+    >>> img = hs.signals.Signal2D(scipy.datasets.ascent())
     >>> img.plot(colorbar=True, scalebar=False,
     ... 	 axes_ticks=True, cmap='RdYlBu_r')
 
@@ -308,7 +308,7 @@ the section :ref:`plot.customize_images` can be passed as a dictionary to the
 
     >>> import numpy as np
     >>> import scipy
-    >>> im = hs.signals.Signal2D(scipy.misc.ascent())
+    >>> im = hs.signals.Signal2D(scipy.datasets.ascent())
     >>> ims = hs.signals.BaseSignal(np.random.rand(15,13)).T * im
     >>> ims.metadata.General.title = 'My Images'
     >>> ims.plot(colorbar=False,
@@ -521,7 +521,7 @@ different slices of a multidimensional image (a *hyperimage*):
 .. code-block:: python
 
     >>> import scipy
-    >>> image = hs.signals.Signal2D([scipy.misc.ascent()]*6)
+    >>> image = hs.signals.Signal2D([scipy.datasets.ascent()]*6)
     >>> angles = hs.signals.BaseSignal(range(10,70,10))
     >>> image.map(scipy.ndimage.rotate, angle=angles.T, reshape=False)
     >>> hs.plot.plot_images(image, tight_layout=True)
@@ -544,7 +544,7 @@ axes labels and the ticks are also disabled with `axes_decor`:
 .. code-block:: python
 
     >>> import scipy
-    >>> image = hs.signals.Signal2D([scipy.misc.ascent()]*6)
+    >>> image = hs.signals.Signal2D([scipy.datasets.ascent()]*6)
     >>> angles = hs.signals.BaseSignal(range(10,70,10))
     >>> image.map(scipy.ndimage.rotate, angle=angles.T, reshape=False)
     >>> hs.plot.plot_images(
@@ -571,22 +571,22 @@ multiple individual ones:
     >>> import numpy as np
     >>>
     >>> # load red channel of raccoon as an image
-    >>> image0 = hs.signals.Signal2D(scipy.misc.face()[:,:,0])
+    >>> image0 = hs.signals.Signal2D(scipy.datasets.face()[:,:,0])
     >>> image0.metadata.General.title = 'Rocky Raccoon - R'
     >>>
     >>> # load ascent into a length 6 hyper-image
-    >>> image1 = hs.signals.Signal2D([scipy.misc.ascent()]*6)
+    >>> image1 = hs.signals.Signal2D([scipy.datasets.ascent()]*6)
     >>> angles = hs.signals.BaseSignal(np.arange(10,70,10)).T
     >>> image1.map(scipy.ndimage.rotate, angle=angles,
     ...            show_progressbar=False, reshape=False)
     >>> image1.data = np.clip(image1.data, 0, 255)  # clip data to int range
     >>>
     >>> # load green channel of raccoon as an image
-    >>> image2 = hs.signals.Signal2D(scipy.misc.face()[:,:,1])
+    >>> image2 = hs.signals.Signal2D(scipy.datasets.face()[:,:,1])
     >>> image2.metadata.General.title = 'Rocky Raccoon - G'
     >>>
     >>> # load rgb image of the raccoon
-    >>> rgb = hs.signals.Signal1D(scipy.misc.face())
+    >>> rgb = hs.signals.Signal1D(scipy.datasets.face())
     >>> rgb.change_dtype("rgb8")
     >>> rgb.metadata.General.title = 'Raccoon - RGB'
     >>>
@@ -819,8 +819,8 @@ a file:
 
 .. code-block:: python
 
-    >>> import scipy.misc
-    >>> s = hs.signals.Signal1D(scipy.misc.ascent()[100:160:10])
+    >>> import scipy.datasets
+    >>> s = hs.signals.Signal1D(scipy.datasets.ascent()[100:160:10])
     >>> cascade_plot = hs.plot.plot_spectra(s, style='cascade')
     >>> cascade_plot.figure.savefig("cascade_plot.png")
 
@@ -841,8 +841,8 @@ and provide the legend labels:
 
 .. code-block:: python
 
-    >>> import scipy.misc
-    >>> s = hs.signals.Signal1D(scipy.misc.ascent()[100:160:10])
+    >>> import scipy.datasets
+    >>> s = hs.signals.Signal1D(scipy.datasets.ascent()[100:160:10])
     >>> color_list = ['red', 'red', 'blue', 'blue', 'red', 'red']
     >>> linestyle_list = ['-', '--', '-.', ':', '-']
     >>> hs.plot.plot_spectra(s, style='cascade', color=color_list,
@@ -861,10 +861,10 @@ generate a list of colors that follows a certain colormap:
 
 .. code-block:: python
 
-    >>> import scipy.misc
+    >>> import scipy.datasets
     >>> fig, axarr = plt.subplots(1,2)
-    >>> s1 = hs.signals.Signal1D(scipy.misc.ascent()[100:160:10])
-    >>> s2 = hs.signals.Signal1D(scipy.misc.ascent()[200:260:10])
+    >>> s1 = hs.signals.Signal1D(scipy.datasets.ascent()[100:160:10])
+    >>> s2 = hs.signals.Signal1D(scipy.datasets.ascent()[200:260:10])
     >>> hs.plot.plot_spectra(s1,
     ...                         style='cascade',
     ...                         color=[plt.cm.RdBu(i/float(len(s1)-1))
@@ -892,8 +892,8 @@ There are also two other styles, "heatmap" and "mosaic":
 
 .. code-block:: python
 
-    >>> import scipy.misc
-    >>> s = hs.signals.Signal1D(scipy.misc.ascent()[100:160:10])
+    >>> import scipy.datasets
+    >>> s = hs.signals.Signal1D(scipy.datasets.ascent()[100:160:10])
     >>> hs.plot.plot_spectra(s, style='heatmap')
 
 .. figure::  images/plot_spectra_heatmap.png
@@ -905,8 +905,8 @@ There are also two other styles, "heatmap" and "mosaic":
 
 .. code-block:: python
 
-    >>> import scipy.misc
-    >>> s = hs.signals.Signal1D(scipy.misc.ascent()[100:120:10])
+    >>> import scipy.datasets
+    >>> s = hs.signals.Signal1D(scipy.datasets.ascent()[100:120:10])
     >>> hs.plot.plot_spectra(s, style='mosaic')
 
 .. figure::  images/plot_spectra_mosaic.png
@@ -923,8 +923,8 @@ can be used:
 .. code-block:: python
 
     >>> import matplotlib.cm
-    >>> import scipy.misc
-    >>> s = hs.signals.Signal1D(scipy.misc.ascent()[100:120:10])
+    >>> import scipy.datasets
+    >>> s = hs.signals.Signal1D(scipy.datasets.ascent()[100:120:10])
     >>> ax = hs.plot.plot_spectra(s, style="heatmap")
     >>> ax.images[0].set_cmap(matplotlib.cm.plasma)
 
@@ -943,8 +943,8 @@ directly to matplotlib.pyplot.figure as keyword arguments:
 
 .. code-block:: python
 
-    >>> import scipy.misc
-    >>> s = hs.signals.Signal1D(scipy.misc.ascent()[100:160:10])
+    >>> import scipy.datasets
+    >>> s = hs.signals.Signal1D(scipy.datasets.ascent()[100:160:10])
     >>> legendtext = ['Plot 0', 'Plot 1', 'Plot 2', 'Plot 3',
     ...               'Plot 4', 'Plot 5']
     >>> cascade_plot = hs.plot.plot_spectra(
@@ -966,8 +966,8 @@ the figure:
 
 .. code-block:: python
 
-    >>> import scipy.misc
-    >>> s = hs.signals.Signal1D(scipy.misc.ascent()[100:160:10])
+    >>> import scipy.datasets
+    >>> s = hs.signals.Signal1D(scipy.datasets.ascent()[100:160:10])
     >>> cascade_plot = hs.plot.plot_spectra(s)
     >>> cascade_plot.set_xlabel("An axis")
     >>> cascade_plot.set_ylabel("Another axis")
@@ -986,10 +986,10 @@ and "overlap" styles:
 
 .. code-block:: python
 
-    >>> import scipy.misc
+    >>> import scipy.datasets
     >>> fig, axarr = plt.subplots(1,2)
-    >>> s1 = hs.signals.Signal1D(scipy.misc.ascent()[100:160:10])
-    >>> s2 = hs.signals.Signal1D(scipy.misc.ascent()[200:260:10])
+    >>> s1 = hs.signals.Signal1D(scipy.datasets.ascent()[100:160:10])
+    >>> s2 = hs.signals.Signal1D(scipy.datasets.ascent()[200:260:10])
     >>> hs.plot.plot_spectra(s1, style='cascade',
     ...                      color='blue', ax=axarr[0], fig=fig)
     >>> hs.plot.plot_spectra(s2, style='cascade',
@@ -1047,8 +1047,8 @@ same time:
 
 .. code-block:: python
 
-    >>> import scipy.misc
-    >>> s1 = hs.signals.Signal1D(scipy.misc.face()).as_signal1D(0).inav[:,:3]
+    >>> import scipy.datasets
+    >>> s1 = hs.signals.Signal1D(scipy.datasets.face()).as_signal1D(0).inav[:,:3]
     >>> s2 = s1.deepcopy()*-1
     >>> hs.plot.plot_signals([s1, s2])
 
@@ -1067,8 +1067,8 @@ To specify the navigator:
 
 .. code-block:: python
 
-    >>> import scipy.misc
-    >>> s1 = hs.signals.Signal1D(scipy.misc.face()).as_signal1D(0).inav[:,:3]
+    >>> import scipy.datasets
+    >>> s1 = hs.signals.Signal1D(scipy.datasets.face()).as_signal1D(0).inav[:,:3]
     >>> s2 = s1.deepcopy()*-1
     >>> hs.plot.plot_signals([s1, s2], navigator="slider")
 
@@ -1085,8 +1085,8 @@ For example:
 
 .. code-block:: python
 
-    >>> import scipy.misc
-    >>> s1 = hs.signals.Signal1D(scipy.misc.face()).as_signal1D(0).inav[:,:3]
+    >>> import scipy.datasets
+    >>> s1 = hs.signals.Signal1D(scipy.datasets.face()).as_signal1D(0).inav[:,:3]
     >>> s2 = s1.deepcopy()*-1
     >>> s3 = hs.signals.Signal1D(np.linspace(0,9,9).reshape([3,3]))
     >>> hs.plot.plot_signals([s1, s2], navigator_list=["slider", s3])
@@ -1104,8 +1104,8 @@ each plot:
 
 .. code-block:: python
 
-    >>> import scipy.misc
-    >>> s1 = hs.signals.Signal1D(scipy.misc.face()).as_signal1D(0)[:,:3]
+    >>> import scipy.datasets
+    >>> s1 = hs.signals.Signal1D(scipy.datasets.face()).as_signal1D(0)[:,:3]
     >>> s2 = s1.deepcopy()*-1
     >>> hs.plot.plot_signals([s1, s2], sync=False,
     ...                      navigator_list=["slider", "slider"])
@@ -1126,8 +1126,8 @@ can be used in a static way
 
 .. code-block:: python
 
-    >>> import scipy.misc
-    >>> im = hs.signals.Signal2D(scipy.misc.ascent())
+    >>> import scipy.datasets
+    >>> im = hs.signals.Signal2D(scipy.datasets.ascent())
     >>> m = hs.plot.markers.Rectangle(x1=150, y1=100, x2=400, y2=400, color='red')
     >>> im.add_marker(m)
 
@@ -1144,8 +1144,8 @@ for each R, G and B channel of a colour image.
 .. code-block:: python
 
     >>> from skimage.feature import peak_local_max
-    >>> import scipy.misc
-    >>> ims = hs.signals.BaseSignal(scipy.misc.face()).as_signal2D([1,2])
+    >>> import scipy.datasets
+    >>> ims = hs.signals.BaseSignal(scipy.datasets.face()).as_signal2D([1,2])
     >>> index = np.array([peak_local_max(im.data, min_distance=100,
     ...                                  num_peaks=4)
     ...                   for im in ims])

--- a/doc/user_guide/visualisation.rst
+++ b/doc/user_guide/visualisation.rst
@@ -819,7 +819,7 @@ a file:
 
 .. code-block:: python
 
-    >>> import scipy.datasets
+    >>> import scipy
     >>> s = hs.signals.Signal1D(scipy.datasets.ascent()[100:160:10])
     >>> cascade_plot = hs.plot.plot_spectra(s, style='cascade')
     >>> cascade_plot.figure.savefig("cascade_plot.png")
@@ -841,7 +841,7 @@ and provide the legend labels:
 
 .. code-block:: python
 
-    >>> import scipy.datasets
+    >>> import scipy
     >>> s = hs.signals.Signal1D(scipy.datasets.ascent()[100:160:10])
     >>> color_list = ['red', 'red', 'blue', 'blue', 'red', 'red']
     >>> linestyle_list = ['-', '--', '-.', ':', '-']
@@ -861,7 +861,7 @@ generate a list of colors that follows a certain colormap:
 
 .. code-block:: python
 
-    >>> import scipy.datasets
+    >>> import scipy
     >>> fig, axarr = plt.subplots(1,2)
     >>> s1 = hs.signals.Signal1D(scipy.datasets.ascent()[100:160:10])
     >>> s2 = hs.signals.Signal1D(scipy.datasets.ascent()[200:260:10])
@@ -892,7 +892,7 @@ There are also two other styles, "heatmap" and "mosaic":
 
 .. code-block:: python
 
-    >>> import scipy.datasets
+    >>> import scipy
     >>> s = hs.signals.Signal1D(scipy.datasets.ascent()[100:160:10])
     >>> hs.plot.plot_spectra(s, style='heatmap')
 
@@ -905,7 +905,7 @@ There are also two other styles, "heatmap" and "mosaic":
 
 .. code-block:: python
 
-    >>> import scipy.datasets
+    >>> import scipy
     >>> s = hs.signals.Signal1D(scipy.datasets.ascent()[100:120:10])
     >>> hs.plot.plot_spectra(s, style='mosaic')
 
@@ -923,7 +923,7 @@ can be used:
 .. code-block:: python
 
     >>> import matplotlib.cm
-    >>> import scipy.datasets
+    >>> import scipy
     >>> s = hs.signals.Signal1D(scipy.datasets.ascent()[100:120:10])
     >>> ax = hs.plot.plot_spectra(s, style="heatmap")
     >>> ax.images[0].set_cmap(matplotlib.cm.plasma)
@@ -943,7 +943,7 @@ directly to matplotlib.pyplot.figure as keyword arguments:
 
 .. code-block:: python
 
-    >>> import scipy.datasets
+    >>> import scipy
     >>> s = hs.signals.Signal1D(scipy.datasets.ascent()[100:160:10])
     >>> legendtext = ['Plot 0', 'Plot 1', 'Plot 2', 'Plot 3',
     ...               'Plot 4', 'Plot 5']
@@ -966,7 +966,7 @@ the figure:
 
 .. code-block:: python
 
-    >>> import scipy.datasets
+    >>> import scipy
     >>> s = hs.signals.Signal1D(scipy.datasets.ascent()[100:160:10])
     >>> cascade_plot = hs.plot.plot_spectra(s)
     >>> cascade_plot.set_xlabel("An axis")
@@ -986,7 +986,7 @@ and "overlap" styles:
 
 .. code-block:: python
 
-    >>> import scipy.datasets
+    >>> import scipy
     >>> fig, axarr = plt.subplots(1,2)
     >>> s1 = hs.signals.Signal1D(scipy.datasets.ascent()[100:160:10])
     >>> s2 = hs.signals.Signal1D(scipy.datasets.ascent()[200:260:10])
@@ -1047,7 +1047,7 @@ same time:
 
 .. code-block:: python
 
-    >>> import scipy.datasets
+    >>> import scipy
     >>> s1 = hs.signals.Signal1D(scipy.datasets.face()).as_signal1D(0).inav[:,:3]
     >>> s2 = s1.deepcopy()*-1
     >>> hs.plot.plot_signals([s1, s2])
@@ -1067,7 +1067,7 @@ To specify the navigator:
 
 .. code-block:: python
 
-    >>> import scipy.datasets
+    >>> import scipy
     >>> s1 = hs.signals.Signal1D(scipy.datasets.face()).as_signal1D(0).inav[:,:3]
     >>> s2 = s1.deepcopy()*-1
     >>> hs.plot.plot_signals([s1, s2], navigator="slider")
@@ -1085,7 +1085,7 @@ For example:
 
 .. code-block:: python
 
-    >>> import scipy.datasets
+    >>> import scipy
     >>> s1 = hs.signals.Signal1D(scipy.datasets.face()).as_signal1D(0).inav[:,:3]
     >>> s2 = s1.deepcopy()*-1
     >>> s3 = hs.signals.Signal1D(np.linspace(0,9,9).reshape([3,3]))
@@ -1104,7 +1104,7 @@ each plot:
 
 .. code-block:: python
 
-    >>> import scipy.datasets
+    >>> import scipy
     >>> s1 = hs.signals.Signal1D(scipy.datasets.face()).as_signal1D(0)[:,:3]
     >>> s2 = s1.deepcopy()*-1
     >>> hs.plot.plot_signals([s1, s2], sync=False,
@@ -1126,7 +1126,7 @@ can be used in a static way
 
 .. code-block:: python
 
-    >>> import scipy.datasets
+    >>> import scipy
     >>> im = hs.signals.Signal2D(scipy.datasets.ascent())
     >>> m = hs.plot.markers.Rectangle(x1=150, y1=100, x2=400, y2=400, color='red')
     >>> im.add_marker(m)
@@ -1144,7 +1144,7 @@ for each R, G and B channel of a colour image.
 .. code-block:: python
 
     >>> from skimage.feature import peak_local_max
-    >>> import scipy.datasets
+    >>> import scipy
     >>> ims = hs.signals.BaseSignal(scipy.datasets.face()).as_signal2D([1,2])
     >>> index = np.array([peak_local_max(im.data, min_distance=100,
     ...                                  num_peaks=4)

--- a/hyperspy/tests/doc_docstr_examples/doc_examples_Visualisation.ipynb
+++ b/hyperspy/tests/doc_docstr_examples/doc_examples_Visualisation.ipynb
@@ -356,8 +356,8 @@
     }
    ],
    "source": [
-    "import scipy.misc\n",
-    "s = hs.signals.Signal1D(scipy.misc.ascent()[100:160:10])\n",
+    "import scipy.datasets\n",
+    "s = hs.signals.Signal1D(scipy.datasets.ascent()[100:160:10])\n",
     "cascade_plot = hs.plot.plot_spectra(s, style='cascade')\n",
     "cascade_plot.figure.savefig(\"cascade_plot.png\")"
    ]
@@ -389,8 +389,8 @@
     }
    ],
    "source": [
-    "import scipy.misc\n",
-    "s = hs.signals.Signal1D(scipy.misc.ascent()[100:160:10])\n",
+    "import scipy.datasets\n",
+    "s = hs.signals.Signal1D(scipy.datasets.ascent()[100:160:10])\n",
     "color_list = ['red', 'red', 'blue', 'blue', 'red', 'red']\n",
     "linestyle_list = ['-', '--', '-.', ':', '-']\n",
     "hs.plot.plot_spectra(s, style='cascade', color=color_list,\n",
@@ -424,8 +424,8 @@
     }
    ],
    "source": [
-    "import scipy.misc\n",
-    "s = hs.signals.Signal1D(scipy.misc.ascent()[100:160:10])\n",
+    "import scipy.datasets\n",
+    "s = hs.signals.Signal1D(scipy.datasets.ascent()[100:160:10])\n",
     "hs.plot.plot_spectra(s, style='heatmap')"
    ]
   },
@@ -457,8 +457,8 @@
     }
    ],
    "source": [
-    "import scipy.misc\n",
-    "s = hs.signals.Signal1D(scipy.misc.ascent()[100:120:10])\n",
+    "import scipy.datasets\n",
+    "s = hs.signals.Signal1D(scipy.datasets.ascent()[100:120:10])\n",
     "hs.plot.plot_spectra(s, style='mosaic')"
    ]
   },
@@ -480,8 +480,8 @@
    ],
    "source": [
     "import matplotlib.cm\n",
-    "import scipy.misc\n",
-    "s = hs.signals.Signal1D(scipy.misc.ascent()[100:120:10])\n",
+    "import scipy.datasets\n",
+    "s = hs.signals.Signal1D(scipy.datasets.ascent()[100:120:10])\n",
     "ax = hs.plot.plot_spectra(s, style=\"heatmap\")\n",
     "ax.images[0].set_cmap(matplotlib.cm.jet)"
    ]
@@ -505,8 +505,8 @@
     }
    ],
    "source": [
-    "import scipy.misc\n",
-    "s = hs.signals.Signal1D(scipy.misc.ascent()[100:160:10])\n",
+    "import scipy.datasets\n",
+    "s = hs.signals.Signal1D(scipy.datasets.ascent()[100:160:10])\n",
     "legendtext = ['Plot 0', 'Plot 1', 'Plot 2', 'Plot 3', 'Plot 4', 'Plot 5']\n",
     "cascade_plot = hs.plot.plot_spectra(\n",
     "s, style='cascade', legend=legendtext, dpi=60,\n",
@@ -536,8 +536,8 @@
     }
    ],
    "source": [
-    "import scipy.misc\n",
-    "s = hs.signals.Signal1D(scipy.misc.ascent()[100:160:10])\n",
+    "import scipy.datasets\n",
+    "s = hs.signals.Signal1D(scipy.datasets.ascent()[100:160:10])\n",
     "cascade_plot = hs.plot.plot_spectra(s)\n",
     "cascade_plot.set_xlabel(\"An axis\")\n",
     "cascade_plot.set_ylabel(\"Another axis\")\n",
@@ -562,10 +562,10 @@
     }
    ],
    "source": [
-    "import scipy.misc\n",
+    "import scipy.datasets\n",
     "fig, axarr = plt.subplots(1,2)\n",
-    "s1 = hs.signals.Signal1D(scipy.misc.ascent()[100:160:10])\n",
-    "s2 = hs.signals.Signal1D(scipy.misc.ascent()[200:260:10])\n",
+    "s1 = hs.signals.Signal1D(scipy.datasets.ascent()[100:160:10])\n",
+    "s2 = hs.signals.Signal1D(scipy.datasets.ascent()[200:260:10])\n",
     "hs.plot.plot_spectra(s1, style='cascade',color='blue',ax=axarr[0],fig=fig)\n",
     "hs.plot.plot_spectra(s2, style='cascade',color='red',ax=axarr[1],fig=fig)\n",
     "fig.canvas.draw()"
@@ -605,8 +605,8 @@
     }
    ],
    "source": [
-    "import scipy.misc\n",
-    "s1 = hs.signals.Signal1D(scipy.misc.face()).as_signal1D(0)[:,:3]\n",
+    "import scipy.datasets\n",
+    "s1 = hs.signals.Signal1D(scipy.datasets.face()).as_signal1D(0)[:,:3]\n",
     "s2 = s1.deepcopy()*-1\n",
     "hs.plot.plot_signals([s1, s2])"
    ]
@@ -632,8 +632,8 @@
     }
    ],
    "source": [
-    "import scipy.misc\n",
-    "s1 = hs.signals.Signal1D(scipy.misc.face()).as_signal1D(0)[:,:3]\n",
+    "import scipy.datasets\n",
+    "s1 = hs.signals.Signal1D(scipy.datasets.face()).as_signal1D(0)[:,:3]\n",
     "s2 = s1.deepcopy()*-1\n",
     "hs.plot.plot_signals([s1, s2], navigator=\"slider\")"
    ]
@@ -659,8 +659,8 @@
     }
    ],
    "source": [
-    "import scipy.misc\n",
-    "s1 = hs.signals.Signal1D(scipy.misc.face()).as_signal1D(0)[:,:3]\n",
+    "import scipy.datasets\n",
+    "s1 = hs.signals.Signal1D(scipy.datasets.face()).as_signal1D(0)[:,:3]\n",
     "s2 = s1.deepcopy()*-1\n",
     "s3 = hs.signals.Signal1D(np.linspace(0,9,9).reshape([3,3]))\n",
     "hs.plot.plot_signals([s1, s2], navigator_list=[\"slider\", s3])"
@@ -687,8 +687,8 @@
     }
    ],
    "source": [
-    "import scipy.misc\n",
-    "s1 = hs.signals.Signal1D(scipy.misc.face()).as_signal1D(0)[:,:3]\n",
+    "import scipy.datasets\n",
+    "s1 = hs.signals.Signal1D(scipy.datasets.face()).as_signal1D(0)[:,:3]\n",
     "s2 = s1.deepcopy()*-1\n",
     "hs.plot.plot_signals([s1, s2], sync=False, navigator_list=[\"slider\", \"slider\"])"
    ]
@@ -786,7 +786,7 @@
    ],
    "source": [
     "import scipy\n",
-    "image = hs.signals.Signal2D([scipy.misc.ascent()]*6)\n",
+    "image = hs.signals.Signal2D([scipy.datasets.ascent()]*6)\n",
     "angles = hs.signals.BaseSignal(range(10, 70, 10)).T\n",
     "image.map(scipy.ndimage.rotate, angle=angles, reshape=False)\n",
     "hs.plot.plot_images(image, tight_layout=True)"
@@ -840,7 +840,7 @@
    ],
    "source": [
     "import scipy\n",
-    "image = hs.signals.Signal2D([scipy.misc.ascent()]*6)\n",
+    "image = hs.signals.Signal2D([scipy.datasets.ascent()]*6)\n",
     "angles = hs.signals.BaseSignal(range(10, 70, 10)).T\n",
     "image.map(scipy.ndimage.rotate, angle=angles, reshape=False)\n",
     "hs.plot.plot_images(\n",
@@ -913,23 +913,23 @@
     "\n",
     "\n",
     "# load red channel of raccoon as an image\n",
-    "image0 = hs.signals.Signal2D(scipy.misc.face()[:,:,0])\n",
+    "image0 = hs.signals.Signal2D(scipy.datasets.face()[:,:,0])\n",
     "image0.metadata.General.title = 'Rocky Raccoon - R'\n",
     "\n",
     "\n",
     "# load ascent into 6 hyperimage\n",
-    "image1 = hs.signals.Signal2D([scipy.misc.ascent()]*6)\n",
+    "image1 = hs.signals.Signal2D([scipy.datasets.ascent()]*6)\n",
     "angles = hs.signals.BaseSignal(range(10, 70, 10)).T\n",
     "image1.map(scipy.ndimage.rotate, angle=angles, reshape=False)\n",
     "\n",
     "\n",
     "# load green channel of raccoon as an image\n",
-    "image2 = hs.signals.Signal2D(scipy.misc.face()[:,:,1])\n",
+    "image2 = hs.signals.Signal2D(scipy.datasets.face()[:,:,1])\n",
     "image2.metadata.General.title = 'Rocky Raccoon - G'\n",
     "\n",
     "\n",
     "# load rgb image of the raccoon\n",
-    "rgb = hs.signals.Signal1D(scipy.misc.face())\n",
+    "rgb = hs.signals.Signal1D(scipy.datasets.face())\n",
     "rgb.change_dtype(\"rgb8\")\n",
     "rgb.metadata.General.title = 'Raccoon - RGB'\n",
     "    \n",

--- a/hyperspy/tests/doc_docstr_examples/doc_examples_Visualisation.ipynb
+++ b/hyperspy/tests/doc_docstr_examples/doc_examples_Visualisation.ipynb
@@ -356,7 +356,7 @@
     }
    ],
    "source": [
-    "import scipy.datasets\n",
+    "import scipy\n",
     "s = hs.signals.Signal1D(scipy.datasets.ascent()[100:160:10])\n",
     "cascade_plot = hs.plot.plot_spectra(s, style='cascade')\n",
     "cascade_plot.figure.savefig(\"cascade_plot.png\")"
@@ -389,7 +389,7 @@
     }
    ],
    "source": [
-    "import scipy.datasets\n",
+    "import scipy\n",
     "s = hs.signals.Signal1D(scipy.datasets.ascent()[100:160:10])\n",
     "color_list = ['red', 'red', 'blue', 'blue', 'red', 'red']\n",
     "linestyle_list = ['-', '--', '-.', ':', '-']\n",
@@ -424,7 +424,7 @@
     }
    ],
    "source": [
-    "import scipy.datasets\n",
+    "import scipy\n",
     "s = hs.signals.Signal1D(scipy.datasets.ascent()[100:160:10])\n",
     "hs.plot.plot_spectra(s, style='heatmap')"
    ]
@@ -457,7 +457,7 @@
     }
    ],
    "source": [
-    "import scipy.datasets\n",
+    "import scipy\n",
     "s = hs.signals.Signal1D(scipy.datasets.ascent()[100:120:10])\n",
     "hs.plot.plot_spectra(s, style='mosaic')"
    ]
@@ -480,7 +480,7 @@
    ],
    "source": [
     "import matplotlib.cm\n",
-    "import scipy.datasets\n",
+    "import scipy\n",
     "s = hs.signals.Signal1D(scipy.datasets.ascent()[100:120:10])\n",
     "ax = hs.plot.plot_spectra(s, style=\"heatmap\")\n",
     "ax.images[0].set_cmap(matplotlib.cm.jet)"
@@ -505,7 +505,7 @@
     }
    ],
    "source": [
-    "import scipy.datasets\n",
+    "import scipy\n",
     "s = hs.signals.Signal1D(scipy.datasets.ascent()[100:160:10])\n",
     "legendtext = ['Plot 0', 'Plot 1', 'Plot 2', 'Plot 3', 'Plot 4', 'Plot 5']\n",
     "cascade_plot = hs.plot.plot_spectra(\n",
@@ -536,7 +536,7 @@
     }
    ],
    "source": [
-    "import scipy.datasets\n",
+    "import scipy\n",
     "s = hs.signals.Signal1D(scipy.datasets.ascent()[100:160:10])\n",
     "cascade_plot = hs.plot.plot_spectra(s)\n",
     "cascade_plot.set_xlabel(\"An axis\")\n",
@@ -562,7 +562,7 @@
     }
    ],
    "source": [
-    "import scipy.datasets\n",
+    "import scipy\n",
     "fig, axarr = plt.subplots(1,2)\n",
     "s1 = hs.signals.Signal1D(scipy.datasets.ascent()[100:160:10])\n",
     "s2 = hs.signals.Signal1D(scipy.datasets.ascent()[200:260:10])\n",
@@ -605,7 +605,7 @@
     }
    ],
    "source": [
-    "import scipy.datasets\n",
+    "import scipy\n",
     "s1 = hs.signals.Signal1D(scipy.datasets.face()).as_signal1D(0)[:,:3]\n",
     "s2 = s1.deepcopy()*-1\n",
     "hs.plot.plot_signals([s1, s2])"
@@ -632,7 +632,7 @@
     }
    ],
    "source": [
-    "import scipy.datasets\n",
+    "import scipy\n",
     "s1 = hs.signals.Signal1D(scipy.datasets.face()).as_signal1D(0)[:,:3]\n",
     "s2 = s1.deepcopy()*-1\n",
     "hs.plot.plot_signals([s1, s2], navigator=\"slider\")"
@@ -659,7 +659,7 @@
     }
    ],
    "source": [
-    "import scipy.datasets\n",
+    "import scipy\n",
     "s1 = hs.signals.Signal1D(scipy.datasets.face()).as_signal1D(0)[:,:3]\n",
     "s2 = s1.deepcopy()*-1\n",
     "s3 = hs.signals.Signal1D(np.linspace(0,9,9).reshape([3,3]))\n",
@@ -687,7 +687,7 @@
     }
    ],
    "source": [
-    "import scipy.datasets\n",
+    "import scipy\n",
     "s1 = hs.signals.Signal1D(scipy.datasets.face()).as_signal1D(0)[:,:3]\n",
     "s2 = s1.deepcopy()*-1\n",
     "hs.plot.plot_signals([s1, s2], sync=False, navigator_list=[\"slider\", \"slider\"])"

--- a/upcoming_changes/3225.maintenance.rst
+++ b/upcoming_changes/3225.maintenance.rst
@@ -1,0 +1,1 @@
+Replace deprecated scipy.misc by scipy.datasets in documentation


### PR DESCRIPTION
### Description of the change
Replace the deprecated usage of `scipy.misc` by `scipy.datasets` in the documentation.
See https://docs.scipy.org/doc/scipy/reference/generated/scipy.misc.ascent.html

### Progress of the PR
- [x] Change implemented (can be split into several points),
- [x] add an changelog entry in the `upcoming_changes` folder (see [`upcoming_changes/README.rst`](https://github.com/hyperspy/hyperspy/blob/RELEASE_next_minor/upcoming_changes/README.rst)),
- [ ] Check formatting changelog entry in the `readthedocs` doc build of this PR (link in github checks)
- [x] ready for review.