### PR TITLE
Fix external link in the api reference 

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -48,6 +48,7 @@ linkcheck_ignore = [
     "https://anaconda.org",  # 403 Client Error: Forbidden for url
     "https://doi.org/10.1021/acs.nanolett.5b00449",  # 403 Client Error: Forbidden for url
     "https://onlinelibrary.wiley.com",  # 403 Client Error: Forbidden for url
+    "https://www.jstor.org/stable/24307705",  # 403 Client Error: Forbidden for url
 ]
 
 linkcheck_exclude_documents = []


### PR DESCRIPTION
which is now failing with 403 error.

See for example: https://github.com/hyperspy/hyperspy/actions/runs/6106861420/job/16572715621:

```
(reference/api.model/components1D: line   18) broken    https://www.jstor.org/stable/24307705 - 403 Client Error: Forbidden for url: https://www.jstor.org/stable/24307705
```