### PR TITLE
Tweak navigation bar documentation

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -183,7 +183,7 @@ html_theme_options = {
             "name": "Tutorial",
         },
     ],
-    "header_links_before_dropdown": 8,
+    "header_links_before_dropdown": 7,
     "switcher": {
         # Update when merged and released
         "json_url": "https://hyperspy.org/hyperspy-doc/dev/_static/switcher.json",

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -2,12 +2,11 @@
   :maxdepth: 1
   :hidden:
 
-  Introduction <intro>
   User Guide <user_guide/index>
   Examples <auto_examples/index>
   Reference <reference/index>
   Get Help <help>
-  Contribute <dev_guide/index>
   Release Notes <changes>
+  Contribute <dev_guide/index>
 
 .. include:: intro.rst


### PR DESCRIPTION
With recent version of `pydata-sphinx-theme`, some of the entries in the navigation bar are displayed on two lines because there isn't enough horizontal space. This PR removes the "introduction" entry from the navigation bar in the documentation because other items are more important, the introduction page can be accessed by clicking on the HyperSpy logo located top left and this is the landing of the documentation.


