### PR TITLE
Replace deprecated `scipy.interpolate.interp1d`

### DIFF
--- a/hyperspy/_components/scalable_fixed_pattern.py
+++ b/hyperspy/_components/scalable_fixed_pattern.py
@@ -17,7 +17,7 @@
 # along with HyperSpy. If not, see <https://www.gnu.org/licenses/#GPL>.
 
 import numpy as np
-from scipy.interpolate import interp1d
+from scipy.interpolate import make_interp_spline
 
 from hyperspy.component import Component
 from hyperspy.ui_registry import add_gui_method
@@ -97,37 +97,23 @@ class ScalableFixedPattern(Component):
         self.xscale.free = value
         self.shift.free = value
 
-    def prepare_interpolator(self, kind='linear', fill_value=0, **kwargs):
+    def prepare_interpolator(self, **kwargs):
         """Prepare interpolation.
 
         Parameters
         ----------
         x : array
             The spectral axis of the fixed pattern
-        kind : str or int, optional
-            Specifies the kind of interpolation as a string
-            ('linear', 'nearest', 'zero', 'slinear', 'quadratic, 'cubic')
-            or as an integer specifying the order of the spline interpolator
-            to use. Default is 'linear'.
-
-        fill_value : float, optional
-            If provided, then this value will be used to fill in for requested
-            points outside of the data range. If not provided, then the default
-            is NaN.
-
-        Notes
-        -----
-        Any extra keyword argument is passed to `scipy.interpolate.interp1d`
-
+        **kwargs : dict
+            Keywords argument are passed to
+            :py:func:`scipy.interpolate.make_interp_spline`
         """
 
-        self.f = interp1d(
+        self.f = make_interp_spline(
             self.signal.axes_manager.signal_axes[0].axis,
             self.signal.data.squeeze(),
-            kind=kind,
-            bounds_error=False,
-            fill_value=fill_value,
-            **kwargs)
+            **kwargs
+            )
 
     def _function(self, x, xscale, yscale, shift):
         if self.interpolate is True:

--- a/hyperspy/misc/eels/base_gos.py
+++ b/hyperspy/misc/eels/base_gos.py
@@ -153,4 +153,4 @@ class TabulatedGOS(BaseGOS):
         qint *= (4.0 * np.pi * a0 ** 2.0 * R ** 2 / E / T *
                  self.subshell_factor) * 1e28
         self.qint = qint
-        return interpolate.interp1d(E, qint, kind=3)
+        return interpolate.make_interp_spline(E, qint, k=3)

--- a/hyperspy/misc/eels/hydrogenic_gos.py
+++ b/hyperspy/misc/eels/hydrogenic_gos.py
@@ -144,7 +144,9 @@ class HydrogenicGOS(BaseGOS):
                     lambda x: self.gosfunc(E, np.exp(x)),
                     math.log(qa0sqmin), math.log(qa0sqmax))[0])
         self.qint = qint
-        return interpolate.interp1d(self.energy_axis + energy_shift, qint)
+        return interpolate.make_interp_spline(
+            self.energy_axis + energy_shift, qint, k=1,
+            )
 
     def gosfuncK(self, E, qa02):
         # gosfunc calculates (=DF/DE) which IS PER EV AND PER ATOM

--- a/hyperspy/signal.py
+++ b/hyperspy/signal.py
@@ -3112,32 +3112,30 @@ class BaseSignal(FancySlicing,
                             axis=0,
                             inplace=False,
                             degree=1):
-        """Replaces the given `axis` with the provided `new_axis`
-        and interpolates data accordingly using :py:func:`scipy.interpolate.make_interp_spline`.
+        """Replaces the given ``axis`` with the provided ``new_axis``
+        and interpolates data accordingly using
+        :py:func:`scipy.interpolate.make_interp_spline`.
 
         Parameters
         ----------
         new_axis : UniformDataAxis, DataAxis or FunctionalDataAxis
-            Axis which replaces the one specified by the `axis` argument.
+            Axis which replaces the one specified by the ``axis`` argument.
             If this new axis exceeds the range of the old axis,
             a warning is raised that the data will be extrapolated.
-
         axis : int or str, default=0
             Specifies the axis which will be replaced using the index of the
             axis in the `axes_manager`. The axis can be specified using the index of the
             axis in `axes_manager` or the axis name.
-
         inplace : bool, default=False
             If ``True`` the data of `self` is replaced by the result and
             the axis is changed inplace. Otherwise `self` is not changed
             and a new signal with the changes incorporated is returned.
-
         degree: int, default=1
             Specifies the B-Spline degree of the used interpolator.
 
         Returns
         -------
-        s : :py:class:`~hyperspy.signal.BaseSignal` (or subclass)
+        s : :py:class:`~.api.signals.BaseSignal` (or subclass)
             A copy of the object with the axis exchanged and the data interpolated.
             This only occurs when inplace is set to ``False``, otherwise nothing is returned.
         """

--- a/hyperspy/tests/component/test_components.py
+++ b/hyperspy/tests/component/test_components.py
@@ -366,10 +366,10 @@ class TestScalableFixedPattern:
         m = s.create_model()
         fp = hs.model.components1D.ScalableFixedPattern(s1)
         m.append(fp)
-        with ignore_warning(message="invalid value encountered in sqrt",
-                            category=RuntimeWarning):
-            m.fit()
-        assert abs(fp.yscale.value - 100) <= 0.1
+        fp.xscale.free = False
+        fp.shift.free = False
+        m.fit()
+        np.testing.assert_allclose(fp.yscale.value, 100)
 
     @pytest.mark.parametrize(("uniform"), (True, False))
     def test_both_binned(self, uniform):
@@ -383,10 +383,10 @@ class TestScalableFixedPattern:
         m = s.create_model()
         fp = hs.model.components1D.ScalableFixedPattern(s1)
         m.append(fp)
-        with ignore_warning(message="invalid value encountered in sqrt",
-                            category=RuntimeWarning):
-            m.fit()
-        assert abs(fp.yscale.value - 100) <= 0.1
+        fp.xscale.free = False
+        fp.shift.free = False
+        m.fit()
+        np.testing.assert_allclose(fp.yscale.value, 100)
 
     def test_pattern_unbinned_signal_binned(self):
         s = self.s
@@ -396,10 +396,10 @@ class TestScalableFixedPattern:
         m = s.create_model()
         fp = hs.model.components1D.ScalableFixedPattern(s1)
         m.append(fp)
-        with ignore_warning(message="invalid value encountered in sqrt",
-                            category=RuntimeWarning):
-            m.fit()
-        assert abs(fp.yscale.value - 1000) <= 1
+        fp.xscale.free = False
+        fp.shift.free = False
+        m.fit()
+        np.testing.assert_allclose(fp.yscale.value, 1000)
 
     def test_pattern_binned_signal_unbinned(self):
         s = self.s
@@ -409,10 +409,10 @@ class TestScalableFixedPattern:
         m = s.create_model()
         fp = hs.model.components1D.ScalableFixedPattern(s1)
         m.append(fp)
-        with ignore_warning(message="invalid value encountered in sqrt",
-                            category=RuntimeWarning):
-            m.fit()
-        assert abs(fp.yscale.value - 10) <= .1
+        fp.xscale.free = False
+        fp.shift.free = False
+        m.fit()
+        np.testing.assert_allclose(fp.yscale.value, 10)
 
     def test_function(self):
         s = self.s

--- a/hyperspy/tests/signals/test_1D_tools.py
+++ b/hyperspy/tests/signals/test_1D_tools.py
@@ -68,8 +68,8 @@ class TestAlignTools:
         # Check that at the edges of the spectrum the value == to the
         # background value. If it wasn't it'll mean that the cropping
         # code is buggy
-        assert (s.data[:, -1] == 2).all()
-        assert (s.data[:, 0] == 2).all()
+        np.testing.assert_allclose(s.data[:, -1], 2)
+        np.testing.assert_allclose(s.data[:, 0], 2)
         # Check that the calibration is correct
         assert s.axes_manager._axes[1].offset == self.new_offset
         assert s.axes_manager._axes[1].scale == self.scale
@@ -82,8 +82,8 @@ class TestAlignTools:
         # Check that at the edges of the spectrum the value == to the
         # background value. If it wasn't it'll mean that the cropping
         # code is buggy
-        assert (s.data[:, -1] == 2).all()
-        assert (s.data[:, 0] == 2).all()
+        np.testing.assert_allclose(s.data[:, -1], 2)
+        np.testing.assert_allclose(s.data[:, 0], 2)
         # Check that the calibration is correct
         assert (
             s.axes_manager._axes[1].offset == self.new_offset)

--- a/upcoming_changes/3233.maintenance.rst
+++ b/upcoming_changes/3233.maintenance.rst
@@ -1,0 +1,1 @@
+Replace deprecated :py:class:`scipy.interpolate.interp1d` with :py:func:`scipy.interpolate.make_interp_spline`


### PR DESCRIPTION
Fix #3223. This uses [`scipy.interpolate.make_interp_spline`](https://docs.scipy.org/doc/scipy/reference/generated/scipy.interpolate.make_interp_spline.html) and masked array to deal with `np.nan`.

### Progress of the PR
- [x] Replace `scipy.interpolate.interp1d` with `scipy.interpolate.make_interp_spline`
- [n/a] update docstring (if appropriate),
- [n/a] update user guide (if appropriate),
- [x] add an changelog entry in the `upcoming_changes` folder (see [`upcoming_changes/README.rst`](https://github.com/hyperspy/hyperspy/blob/RELEASE_next_minor/upcoming_changes/README.rst)),
- [x] Check formatting changelog entry in the `readthedocs` doc build of this PR (link in github checks)
- [x] add tests,
- [x] ready for review.

