### PR TITLE
Fix keeping dtype in rebin when original dtype specify endianess

### DIFF
--- a/hyperspy/misc/array_tools.py
+++ b/hyperspy/misc/array_tools.py
@@ -84,7 +84,9 @@ def homogenize_ndim(*args):
 
 
 def _requires_linear_rebin(arr, scale):
-    """Returns True if linear_rebin is required.
+    """
+    Returns True if linear_rebin is required.
+
     Parameters
     ----------
     arr: array
@@ -97,7 +99,8 @@ def _requires_linear_rebin(arr, scale):
 
 
 def rebin(a, new_shape=None, scale=None, crop=True, dtype=None):
-    """Rebin data into a smaller or larger array based on a linear
+    """
+    Rebin data into a smaller or larger array based on a linear
     interpolation. Specify either a new_shape or a scale. Scale of 1 means no
     binning. Scale less than one results in up-sampling.
 
@@ -147,7 +150,7 @@ def rebin(a, new_shape=None, scale=None, crop=True, dtype=None):
         return _linear_bin(a, scale, crop, dtype=dtype)
     else:
         if dtype == 'same':
-            dtype = a.dtype
+            dtype = a.dtype.name
         _logger.debug("Using standard rebin with lazy support")
         # if interpolation is not needed run fast re_bin function.
         # Adapted from scipy cookbook.

--- a/hyperspy/tests/signals/test_3D.py
+++ b/hyperspy/tests/signals/test_3D.py
@@ -130,7 +130,6 @@ class Test3D:
         new_s = self.signal.rebin(new_shape=(4, 2, 6))
         assert new_s.data.shape == self.data.shape
 
-
     def test_rebin_no_variance(self):
         new_s = self.signal.rebin(scale=(2, 2, 1))
         with pytest.raises(AttributeError):
@@ -148,6 +147,19 @@ class Test3D:
             rebin(self.signal.data, scale=(3, 3, 1), new_shape=(1, 2, 6))
         with pytest.raises(ValueError):
             rebin(self.signal.data, scale=(2, 2, 2, 2))
+
+    @pytest.mark.parametrize("dtype", (int, float, ">u4", np.uint16, np.int32))
+    def test_rebin_dtype_same(self, dtype):
+        s = self.signal
+        s.data = s.data.astype(dtype)
+        new_s = s.rebin(scale=(2, 2, 1), dtype="same")
+        assert new_s.data.dtype.name == s.data.dtype.name
+
+    @pytest.mark.parametrize("dtype", (int, float, np.uint16, np.int32))
+    def test_rebin_dtype_specify(self, dtype):
+        s = self.signal
+        new_s = s.rebin(scale=(2, 2, 1), dtype=dtype)
+        assert new_s.data.dtype.name == np.dtype(dtype).name
 
     def test_swap_axes_simple(self):
         s = self.signal

--- a/upcoming_changes/3237.bugfix.rst
+++ b/upcoming_changes/3237.bugfix.rst
@@ -1,0 +1,1 @@
+Fix keeping dtype in :py:meth:`~.api.signals.BaseSignal.rebin` when the endianess is specified in the dtype


### PR DESCRIPTION
### Progress of the PR
- [x] Fix keeping dtype in rebin when original dtype specify endianess,
- [n/a] update docstring (if appropriate),
- [n/a] update user guide (if appropriate),
- [x] add an changelog entry in the `upcoming_changes` folder (see [`upcoming_changes/README.rst`](https://github.com/hyperspy/hyperspy/blob/RELEASE_next_minor/upcoming_changes/README.rst)),
- [x] Check formatting changelog entry in the `readthedocs` doc build of this PR (link in github checks)
- [x] add tests,
- [x] ready for review.

### Minimal example of the bug fix or the new feature
```python
import hyperspy.api as hs
import numpy as np

s = hs.signals.BaseSignal(np.ones((10, 10), dtype=np.dtype('>u4')))
s.rebin((2, 2), dtype="same")
```
which fails with:
```python
Traceback (most recent call last):

  File ~\mambaforge\lib\site-packages\spyder_kernels\py3compat.py:356 in compat_exec
    exec(code, globals, locals)

  File c:\users\m0041user\dev\hyperspy\untitled0.py:12
    s.rebin((2, 2), dtype="same")

  File ~\Dev\hyperspy\hyperspy\signal.py:3379 in rebin
    data = array_rebin(

  File ~\Dev\hyperspy\hyperspy\misc\array_tools.py:179 in rebin
    return a.reshape(rshape).sum(axis=tuple(

  File ~\mambaforge\lib\site-packages\numpy\core\_methods.py:49 in _sum
    return umr_sum(a, axis, dtype, out, keepdims, initial, where)

TypeError: The `dtype` and `signature` arguments to ufuncs only select the general DType and not details such as the byte order or time unit. You can avoid this error by using the scalar types `np.float64` or the dtype string notation.
```

