### PR TITLE
Fix setting bounds for trf, dogbox optimizer

### DIFF
--- a/hyperspy/model.py
+++ b/hyperspy/model.py
@@ -793,7 +793,7 @@ class BaseModel(list):
     def _bounds_as_tuple(self, transpose):
         """
         Converts parameter bounds to tuples for scipy optimizer. For scipy
-        least_squares, transpose=True needs to be used, as the order of the
+        ``least_squares``, ``transpose=True`` needs to be used, as the order of the
         bounds are different.
         """
         if self.free_parameters_boundaries is None:

--- a/hyperspy/tests/model/test_fitting.py
+++ b/hyperspy/tests/model/test_fitting.py
@@ -100,12 +100,27 @@ class TestModelFitBinnedLeastSquares:
         assert len(self.m.p_std) == 3
         assert np.all(~np.isnan(self.m.p_std))
 
+    @pytest.mark.parametrize("bounded", (True, None))
     @pytest.mark.parametrize(
         "grad, expected",
         [("fd", (250.66282746, 50.0, 5.0)), ("analytical", (250.66282746, 50.0, 5.0))],
     )
-    def test_fit_trf(self, grad, expected):
-        self.m.fit(optimizer="trf", grad=grad)
+    def test_fit_trf(self, grad, expected, bounded):
+        self.m.fit(optimizer="trf", grad=grad, bounded=bounded)
+        self._check_model_values(self.m[0], expected, rtol=TOL)
+
+        assert isinstance(self.m.fit_output, OptimizeResult)
+        assert self.m.p_std is not None
+        assert len(self.m.p_std) == 3
+        assert np.all(~np.isnan(self.m.p_std))
+
+    @pytest.mark.parametrize("bounded", (True, None))
+    @pytest.mark.parametrize(
+        "grad, expected",
+        [("fd", (250.66282746, 50.0, 5.0)), ("analytical", (250.66282746, 50.0, 5.0))],
+    )
+    def test_fit_dogbox(self, grad, expected, bounded):
+        self.m.fit(optimizer="dogbox", grad=grad, bounded=bounded)
         self._check_model_values(self.m[0], expected, rtol=TOL)
 
         assert isinstance(self.m.fit_output, OptimizeResult)
@@ -239,6 +254,25 @@ class TestModelFitBinnedScipyMinimize:
         assert "Maximum number of iterations has been exceeded" in caplog.text
         assert not self.m.fit_output.success
         assert self.m.fit_output.nit == 1
+
+
+def test_bounds_as_tuple():
+    m = _create_toy_1d_gaussian_model()
+    m[0].A.bmin = 200.0
+    m[0].A.bmax = 300.0
+    m[0].centre.bmin = 40.0
+    m[0].centre.bmax = 60.0
+    m[0].sigma.bmin = 4.5
+    m[0].sigma.bmax = 5.5
+    m._set_boundaries()
+
+    assert m._bounds_as_tuple(transpose=False) == (
+        (200.0, 300.0), (40.0, 60.0), (4.5, 5.5)
+        )
+
+    assert m._bounds_as_tuple(transpose=True) == (
+        (200.0, 40.0, 4.5), (300.0, 60.0, 5.5)
+        )
 
 
 class TestModelFitBinnedGlobal:

--- a/upcoming_changes/3244.bugfix.rst
+++ b/upcoming_changes/3244.bugfix.rst
@@ -1,0 +1,2 @@
+Fix setting bounds for ``"trf"``, ``"dogbox"`` optimizer
+


### PR DESCRIPTION
Fix setting bounds for optimizer using `trf` or `dogbox`

### Progress of the PR
- [x] Fix setting bounds: the one using [scipy.optimize.least_squares](https://docs.scipy.org/doc/scipy/reference/generated/scipy.optimize.least_squares.html) needs to be transposed while other optimizer from https://docs.scipy.org/doc/scipy/reference/optimize.html doesn't need to be transposed,
- [n/a] update docstring (if appropriate),
- [n.a] update user guide (if appropriate),
- [x] add an changelog entry in the `upcoming_changes` folder (see [`upcoming_changes/README.rst`](https://github.com/hyperspy/hyperspy/blob/RELEASE_next_minor/upcoming_changes/README.rst)),
- [x] Check formatting changelog entry in the `readthedocs` doc build of this PR (link in github checks)
- [x] add tests,
- [x] ready for review.

