### PR TITLE
align_zero_loss_peak should take left and right arguments for low loss spectra

### DIFF
--- a/hyperspy/_signals/eels.py
+++ b/hyperspy/_signals/eels.py
@@ -315,6 +315,8 @@ class EELSSpectrum(Signal1D):
             also_align=[],
             print_stats=True,
             subpixel=True,
+            left=-3.0,
+            right=3.0,
             mask=None,
             signal_range=None,
             show_progressbar=None,
@@ -323,7 +325,8 @@ class EELSSpectrum(Signal1D):
         """Align the zero-loss peak.
 
         This function first aligns the spectra using the result of
-        `estimate_zero_loss_peak_centre` and afterward, if subpixel is True,
+        `estimate_zero_loss_peak_centre` which finds the maximum in the 
+        given energy range, then if subpixel is True,
         proceeds to align with subpixel accuracy using `align1D`. The offset
         is automatically correct if `calibrate` is True.
 
@@ -343,6 +346,12 @@ class EELSSpectrum(Signal1D):
         subpixel : bool
             If True, perform the alignment with subpixel accuracy
             using cross-correlation.
+        left : float
+            When subpixel is True, left is the start of energy range used 
+            in cross-correlation in whichever unit the energy axis is in.
+        right : float
+            When subpixel is True, right is the end of energy range used 
+            in cross-correlation in whichever unit the energy axis is in.
         mask : Signal1D of bool data type or bool array.
             It must have signal_dimension = 0 and navigation_shape equal to
             the shape of the current signal. Where mask is True the shift is
@@ -435,7 +444,7 @@ class EELSSpectrum(Signal1D):
 
         if subpixel is False:
             return
-        left, right = -3., 3.
+        left, right = left, right
         if calibrate is False:
             left += mean_
             right += mean_


### PR DESCRIPTION
### Description of the change
Adding additional description for align_zero_loss_peak and added left and right arguments. 
When subpixel = True, align1D (with cross-correlation) is used. The range of align1D depends on variables "left" and "right."
Currently by default, left and right are set to be -3. and 3. I think these are in whichever unit the energy axis is in.
Thus, for low loss data that are in the units of meV being about to adjust them will be helpful. 

### Progress of the PR
- [x] Change implemented (can be split into several points),
- [ ] update docstring (if appropriate),
- [ ] update user guide (if appropriate),
- [ ] add an changelog entry in the `upcoming_changes` folder (see [`upcoming_changes/README.rst`](https://github.com/hyperspy/hyperspy/blob/RELEASE_next_minor/upcoming_changes/README.rst)),
- [ ] Check formatting changelog entry in the `readthedocs` doc build of this PR (link in github checks)
- [ ] add tests,
- [ ] ready for review.