### PR TITLE
Add support for pep 660 editable installs in extension

### DIFF
--- a/upcoming_changes/3252.enhancements.rst
+++ b/upcoming_changes/3252.enhancements.rst
@@ -1,0 +1,1 @@
+Add support for pep 660 on editable installs for pyproject.toml based builds of extension


### PR DESCRIPTION
To allow using pyproject.toml based builds in extension and simplify packaging of the split extension.
Relevant documentation:
- https://peps.python.org/pep-0610/#example-pip-commands-and-their-effect-on-direct-url-json
- https://peps.python.org/pep-0660/#frontend-requirements

### Progress of the PR
- [x] Add support for pep660 on editable installs for pyproject.toml based builds of extension,
- [n/a] update docstring (if appropriate),
- [n/a] update user guide (if appropriate),
- [x] add an changelog entry in the `upcoming_changes` folder (see [`upcoming_changes/README.rst`](https://github.com/hyperspy/hyperspy/blob/RELEASE_next_minor/upcoming_changes/README.rst)),
- [x] Check formatting changelog entry in the `readthedocs` doc build of this PR (link in github checks)
- [n/a] add tests,
- [x] ready for review.
