### PR TITLE
Fix the "flyback" to "serpentine" deprecation

### DIFF
--- a/hyperspy/_signals/signal1d.py
+++ b/hyperspy/_signals/signal1d.py
@@ -710,7 +710,7 @@ class Signal1D(BaseSignal, CommonSignal1D):
                 also_align=None,
                 mask=None,
                 show_progressbar=None,
-                iterpath="flyback"):
+                iterpath="serpentine"):
         """Estimate the shifts in the signal axis using
         cross-correlation and use the estimation to align the data in place.
         This method can only estimate the shift by comparing

--- a/hyperspy/axes.py
+++ b/hyperspy/axes.py
@@ -1489,7 +1489,7 @@ class AxesManager(t.HasTraits):
 
         self._update_attributes()
         self._update_trait_handlers()
-        self.iterpath = 'flyback'
+        self.iterpath = 'serpentine'
         self._ragged = False
 
     @property

--- a/hyperspy/drawing/utils.py
+++ b/hyperspy/drawing/utils.py
@@ -924,8 +924,6 @@ def plot_images(images,
         colorbar = None
         warnings.warn("Sorry, colorbar is not implemented for RGB images.")
 
-
-
     def check_list_length(arg, arg_name):
         if isinstance(arg, (list, tuple)):
             if len(arg) != n:
@@ -1051,6 +1049,9 @@ def plot_images(images,
             axes_manager = ims.axes_manager
             if axes_manager.navigation_dimension > 0:
                 ims = ims._deepcopy_with_new_data(ims.data)
+                # Use flyback iterpath to get "natural",
+                # i.e. order the user would except
+                ims.axes_manager.iterpath = 'flyback'
             for j, im in enumerate(ims):
                 ax = f.add_subplot(rows, per_row, idx + 1)
                 axes_list.append(ax)

--- a/hyperspy/tests/component/test_gaussianhf.py
+++ b/hyperspy/tests/component/test_gaussianhf.py
@@ -39,11 +39,12 @@ def test_function():
     assert g.function(2) == 1.5
     assert g.function(1) == 3
 
+
 def test_integral_as_signal():
     s = Signal1D(np.zeros((2, 3, 100)))
     g1 = GaussianHF(fwhm=3.33, centre=20.)
     h_ref = np.linspace(0.1, 3.0, s.axes_manager.navigation_size)
-    for d, h in zip(s._iterate_signal(), h_ref):
+    for d, h in zip(s._iterate_signal("flyback"), h_ref):
         g1.height.value = h
         d[:] = g1.function(s.axes_manager.signal_axes[0].axis)
     m = s.create_model()
@@ -54,6 +55,7 @@ def test_integral_as_signal():
     s_out = g2.integral_as_signal()
     ref = (h_ref * 3.33 * sqrt2pi / sigma2fwhm).reshape(s_out.data.shape)
     np.testing.assert_allclose(s_out.data, ref)
+
 
 @pytest.mark.parametrize(("lazy"), (True, False))
 @pytest.mark.parametrize(("uniform"), (True, False))


### PR DESCRIPTION
`multifit` iterpath is expected to be changed to `serpentine` in hyperspy 2.0 but it is still using `flyback`. This PR fixes it by setting the changing the default "iterpath" to `serpentine` in the axes manager.