### PR TITLE
Install the rsciio hdf5 extra

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -53,7 +53,7 @@ install_req = [
     'scikit-image>=0.18',
     'scipy>=1.5.0',
     'sympy>=1.6',
-    'rosettasciio',
+    'rosettasciio[hdf5]',
     'tqdm>=4.9.0',
     'traits>=4.5.0',
     ]


### PR DESCRIPTION
Following https://github.com/hyperspy/rosettasciio/pull/180, `rsciio` does not install `h5py` by default. Since `hspy` is the default writing format of HyperSpy, this PR adds the `hdf5` extra `rsciio` requirement.

