### PR TITLE
Bugfix model2d

### DIFF
--- a/hyperspy/model.py
+++ b/hyperspy/model.py
@@ -319,7 +319,7 @@ class BaseModel(list):
             raise ValueError(
                 "`mask` argument must be an array with boolean dtype."
                 )
-        if mask.shape != self.axes_manager.signal_shape:
+        if mask.shape != self.axes_manager._signal_shape_in_array:
             raise ValueError(
                 "`mask` argument must have the same shape as `signal_shape`."
                 )

--- a/hyperspy/model.py
+++ b/hyperspy/model.py
@@ -307,13 +307,21 @@ class BaseModel(list):
         ----------
         mask : numpy.ndarray of bool
             A boolean array defining the signal range. Must be the same
-            shape as the ``signal_shape``. Where array values are ``True``,
-            signal will be fitted, otherwise not.
+            shape as the reversed ``signal_shape``, i.e. ``signal_shape[::-1]``.
+            Where array values are ``True``, signal will be fitted, otherwise not.
 
         See Also
         --------
         set_signal_range, add_signal_range,
         remove_signal_range, reset_signal_range
+
+        Examples
+        --------
+        >>> s = hs.signals.Signal2D(np.random.rand(10, 10, 20))
+        >>> mask = (s.sum() > 5)
+        >>> m = s.create_model()
+        >>> m.set_signal_range_from_mask(mask.data)
+
         """
         if mask.dtype != bool:
             raise ValueError(

--- a/hyperspy/models/model2d.py
+++ b/hyperspy/models/model2d.py
@@ -120,7 +120,7 @@ class Model2D(BaseModel):
         self.axes_manager.events.indices_changed.connect(
             self._on_navigating, [])
         self._channel_switches = np.ones(
-            self.axes_manager.signal_shape[::-1], dtype=bool
+            self.axes_manager._signal_shape_in_array, dtype=bool
             )
         self.chisq = signal2D._get_navigation_signal()
         self.chisq.change_dtype("float")

--- a/hyperspy/models/model2d.py
+++ b/hyperspy/models/model2d.py
@@ -120,7 +120,7 @@ class Model2D(BaseModel):
         self.axes_manager.events.indices_changed.connect(
             self._on_navigating, [])
         self._channel_switches = np.ones(
-            self.axes_manager.signal_shape, dtype=bool
+            self.axes_manager.signal_shape[::-1], dtype=bool
             )
         self.chisq = signal2D._get_navigation_signal()
         self.chisq.change_dtype("float")

--- a/hyperspy/tests/model/test_model2d.py
+++ b/hyperspy/tests/model/test_model2d.py
@@ -199,15 +199,15 @@ class TestModel2DSetSignalRange:
 
     def test_set_signal_range_from_mask(self):
         m = self.m
-        mask = np.ones((20, 10), dtype=bool)
-        mask[slice(1, 6),slice(15, 19)] = False
+        mask = np.ones((10, 20), dtype=bool)
+        mask[slice(1, 6), slice(15, 19)] = False
         m.set_signal_range_from_mask(mask)
         np.testing.assert_allclose(m._channel_switches, mask)
 
     def test_set_signal_range_from_mask_error(self):
         m = self.m
         shape = m.signal.axes_manager.signal_shape
-        mask = np.ones(shape[::-1], dtype=bool)
+        mask = np.ones(shape, dtype=bool)
         with pytest.raises(ValueError):
             m.set_signal_range_from_mask(mask)
 
@@ -217,7 +217,7 @@ class TestModel2DSetSignalRange:
 
     def test_set_signal_range(self):
         m = self.m
-        signal_shape = self.s.axes_manager.signal_shape
+        signal_shape = self.s.axes_manager._signal_shape_in_array
         ch = m._channel_switches
 
         m._set_signal_range_in_pixels(17, 19, 1, 3)
@@ -234,7 +234,7 @@ class TestModel2DSetSignalRange:
 
     def test_add_signal_range(self):
         m = self.m
-        signal_shape = self.s.axes_manager.signal_shape
+        signal_shape = self.s.axes_manager.signal_shape[::-1]
         ch = m._channel_switches
 
         # Set all channel to zeros
@@ -267,7 +267,7 @@ class TestModel2DSetSignalRange:
 
     def test_remove_signal_range(self):
         m = self.m
-        signal_shape = self.s.axes_manager.signal_shape
+        signal_shape = self.s.axes_manager.signal_shape[::-1]
         ch = m._channel_switches
 
         m._remove_signal_range_in_pixels(17, 19, 1, 3)

--- a/hyperspy/tests/model/test_model2d.py
+++ b/hyperspy/tests/model/test_model2d.py
@@ -292,3 +292,9 @@ class TestModel2DSetSignalRange:
         m.remove_signal_range(2.5, 3, 0.5, 1.5)
         mask[slice(5, 7), slice(1, 4)] = False
         np.testing.assert_allclose(ch, mask)
+
+    def test_initial_mask(self):
+        m = self.m
+        assert m._channel_switches.shape == (10, 20)
+
+


### PR DESCRIPTION
Based on #3265 

If you try the following code:

```python
s = hs.signals.Signal2D(np.random.rand(10, 10, 20))
s.axes_manager[-2].scale = 0.5
s.axes_manager[-1].scale = 0.5
m = s.create_model()
m.fit()
```

It will currently fail as the `m._channel_switches.shape` does not match the data shape. This appears to be a bug introduced in 2.0.0.  This fixes that bug and adds an additional check for the initial `_channel_switches` shape.