### PR TITLE
Pin pytest-xdist to <3.5

### DIFF
--- a/conda_environment_dev.yml
+++ b/conda_environment_dev.yml
@@ -7,7 +7,8 @@ dependencies:
 - matplotlib-base=3.5.1
 - pytest
 - pytest-mpl
-- pytest-xdist
+# Regression introduced in https://github.com/pytest-dev/pytest-xdist/pull/778
+- pytest-xdist <3.5
 - pytest-rerunfailures
 - pytest-instafail
 - pooch

--- a/setup.py
+++ b/setup.py
@@ -72,7 +72,7 @@ extras_require = {
     "tests": [
         "pytest>=3.6",
         "pytest-mpl",
-        "pytest-xdist",
+        "pytest-xdist<3.5",
         "pytest-rerunfailures",
         "pytest-instafail",
         ],

--- a/upcoming_changes/3274.maintenance.rst
+++ b/upcoming_changes/3274.maintenance.rst
@@ -1,0 +1,1 @@
+Pin pytest-xdist to 3.5 as a workaround for test suite failure on Azure Pipeline


### PR DESCRIPTION
Pin pytest-xdist to <3.5 - issue seem to have introduced in https://github.com/pytest-dev/pytest-xdist/pull/778, even if at first this appear to be unrelated (we use `loadfile` and not `loadscope`)


