### PR TITLE
Update version switcher

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,7 @@ Changelog
 *********
 
 Changelog entries for the development version are available at
-https://hyperspy.readthedocs.io/en/latest/user_guide/changes.html
+https://hyperspy.readthedocs.io/en/latest/changes.html
 
 .. towncrier-draft-entries:: |release| [UNRELEASED]
 

--- a/doc/_static/switcher.json
+++ b/doc/_static/switcher.json
@@ -1,7 +1,7 @@
 [
     {
         "name": "dev",
-        "version": "2.0",
+        "version": "dev",
         "url": "https://hyperspy.org/hyperspy-doc/dev/"
     },
     {

--- a/doc/_static/switcher.json
+++ b/doc/_static/switcher.json
@@ -1,12 +1,16 @@
 [
     {
-        "name": "v2.0 (dev)",
+        "name": "dev",
         "version": "2.0",
         "url": "https://hyperspy.org/hyperspy-doc/dev/"
     },
     {
-        "version": "1.7",
+        "version": "2.0",
         "url": "https://hyperspy.org/hyperspy-doc/current/"
+    },
+    {
+        "version": "1.7",
+        "url": "https://hyperspy.org/hyperspy-doc/v1.7/"
     },
     {
         "version": "1.6",

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -161,6 +161,15 @@ html_static_path = ["_static"]
 
 favicons = ["hyperspy.ico", ]
 
+# For version switcher:
+# For development, we match to the dev version in `switcher.json`
+# for release version, we match to the minor increment
+import hyperspy
+_version = hyperspy.__version__
+version_match = "dev" if "dev" in _version else ".".join(_version.split(".")[:2])
+
+print("version_match:", version_match)
+
 html_theme_options = {
     "show_toc_level": 2,
     "github_url": "https://github.com/hyperspy/hyperspy",
@@ -190,7 +199,7 @@ html_theme_options = {
     "switcher": {
         # Update when merged and released
         "json_url": "https://hyperspy.org/hyperspy-doc/dev/_static/switcher.json",
-        "version_match": version,
+        "version_match": version_match,
     },
     "navbar_start": ["navbar-logo", "version-switcher"],
     "announcement": "HyperSpy API is changing in version 2.0, see the <a href='https://hyperspy.org/hyperspy-doc/current/changes.html'>release notes!</a>",

--- a/upcoming_changes/3291.maintenance.rst
+++ b/upcoming_changes/3291.maintenance.rst
@@ -1,0 +1,1 @@
+Update version switcher.


### PR DESCRIPTION
Fix documentation version switcher.
- For release version, use the major and minor increment 
- For dev version, set the version to dev
- in both case, the version, it is matched against the documentation available in [hyperspy/hyperspy-doc](https://github.com/hyperspy/hyperspy-doc)

The json file providing the link is in the dev version and will need to updated after a minor or major release - the content of this json file could automated too with a python script generating its content when building the doc but for now, this should do!

### Progress of the PR
- [x] Fix documentation version switcher,
- [n/a] update docstring (if appropriate),
- [x] update user guide (if appropriate),
- [x] add an changelog entry in the `upcoming_changes` folder (see [`upcoming_changes/README.rst`](https://github.com/hyperspy/hyperspy/blob/RELEASE_next_minor/upcoming_changes/README.rst)),
- [x] Check formatting changelog entry in the `readthedocs` doc build of this PR (link in github checks)
- [x] add tests,
- [x] ready for review.


