### PR TITLE
Add ruff linter

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,14 @@
+repos:
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    # Ruff version.
+    rev: v0.1.13
+    hooks:
+      # Run the linter.
+      - id: ruff
+        args: [ --fix ]
+      # Run the formatter.
+      #- id: ruff-format
+ci:
+    # Don't run automatically on PRs, instead add the comment
+    # "pre-commit.ci autofix" on a pull request to manually trigger auto-fixing 
+    autofix_prs: false

--- a/README.rst
+++ b/README.rst
@@ -1,6 +1,6 @@
 .. -*- mode: rst -*-
 
-|Azure|_ |Github|_ |rtd|_ |Codecov|_
+|Azure|_ |Github|_ |pre-commit|_ |rtd|_ |Codecov|_
 
 |python_version|_ |pypi_version|_ |anaconda_cloud|_
 
@@ -11,6 +11,9 @@
 
 .. |Github| image:: https://github.com/hyperspy/hyperspy/actions/workflows/tests.yml/badge.svg
 .. _Github: https://github.com/hyperspy/hyperspy/actions/workflows/tests.yml
+
+.. |pre-commit| image:: https://results.pre-commit.ci/badge/github/hyperspy/hyperspy/RELEASE_next_minor.svg
+.. _pre-commit: https://results.pre-commit.ci/latest/github/hyperspy/hyperspy/RELEASE_next_minor
 
 .. |Codecov| image:: https://codecov.io/gh/hyperspy/hyperspy/branch/RELEASE_next_minor/graph/badge.svg
 .. _Codecov: https://codecov.io/gh/hyperspy/hyperspy

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -15,6 +15,8 @@ from datetime import datetime
 from importlib.metadata import version as get_version
 import sys
 
+import hyperspy
+
 
 sys.path.append('../')
 
@@ -63,7 +65,7 @@ linkcheck_exclude_documents = []
 user_agent = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/108.0.0.0 Safari/537.36 Edg/108.0.1462.54"
 
 try:
-    import sphinxcontrib.spelling
+    import sphinxcontrib.spelling # noqa: F401
     extensions.append('sphinxcontrib.spelling')
 except BaseException:
     pass
@@ -164,7 +166,6 @@ favicons = ["hyperspy.ico", ]
 # For version switcher:
 # For development, we match to the dev version in `switcher.json`
 # for release version, we match to the minor increment
-import hyperspy
 _version = hyperspy.__version__
 version_match = "dev" if "dev" in _version else ".".join(_version.split(".")[:2])
 

--- a/doc/dev_guide/coding_style.rst
+++ b/doc/dev_guide/coding_style.rst
@@ -1,5 +1,4 @@
-
-
+.. _ruff: https://docs.astral.sh/ruff
 .. _coding_style-label:
 
 Coding style
@@ -8,33 +7,19 @@ Coding style
 HyperSpy follows the Style Guide for Python Code - these are rules
 for code consistency that you can read all about in the `Python Style Guide
 <https://www.python.org/dev/peps/pep-0008/>`_. You can use the
-`black <https://github.com/psf/black>`_ code formatter to automatically
-fix the style of your code. You can install and run ``black`` by:
+`black <https://github.com/psf/black>`_ or `ruff`_ code formatter to automatically
+fix the style of your code using pre-commit hooks.
 
-.. code:: bash
+Linting error can be suppressed in the code using the ``# noqa`` marker,
+more information in the `ruff documentation <https://docs.astral.sh/ruff/linter/#error-suppression>`_.
 
-   pip install black
-   black /path/to/your/file.py
+Pre-commit hooks
+================
+Code linting and formatting is checked continuously using `ruff`_ pre-commit hooks.
 
-In Linux and MacOS you can run ``black`` automatically after each commit by
-adding a ``post-commit`` file to ``.git/hook/`` with the following content:
-
-.. code-block:: bash
-
-    #!/bin/sh
-    # From https://gist.github.com/temoto/6183235
-    FILES=$(git diff HEAD^ HEAD --name-only --diff-filter=ACM | grep -e '\.py$')
-    if [ -n "$FILES" ]; then
-        for f in $FILES
-        do
-            # black correction
-            black -v $f
-            git add $f
-        done
-    #git commit -m "Automatic style corrections courtesy of black"
-    GIT_COMMITTER_NAME="black" GIT_COMMITTER_EMAIL="black@email.com" git
-    commit --author="black <black@email.com>" -m "Automatic style
-    corrections courtesy of black"
+These can be run locally by using `pre-commit <https://pre-commit.com>`__.
+Alternatively, the comment ``pre-commit.ci autofix`` can be added to a PR to fix the formatting
+using `pre-commit.ci <https://pre-commit.ci>`_.
 
 Deprecations
 ============
@@ -64,4 +49,4 @@ A deprecation decorator should be placed right above the object signature to be 
 This will update the docstring, and print a visible deprecation warning telling
 the user to use the alternative function or argument.
 
-These deprecation wrappers are inspired by those in ``kikuchipy``
+These deprecation wrappers are inspired by those in ``kikuchipy``.

--- a/hyperspy/_components/expression.py
+++ b/hyperspy/_components/expression.py
@@ -16,6 +16,7 @@
 # You should have received a copy of the GNU General Public License
 # along with HyperSpy. If not, see <https://www.gnu.org/licenses/#GPL>.
 
+import importlib
 from functools import wraps
 import logging
 import numpy as np
@@ -170,15 +171,15 @@ class Expression(Component):
                  **kwargs):
 
         if module is None:
-            try:
-                import numexpr
-                module = "numexpr"
-            except ImportError:
+            numexpr_spec = importlib.util.find_spec("numexpr")
+            if numexpr_spec is None:
                 module = "numpy"
                 _logger.warning(
                     "Numexpr is not installed, falling back to numpy, "
                     "which is slower to calculate model."
-                )
+                )                
+            else:
+                module = "numexpr"
 
         if linear_parameter_list is None:
             linear_parameter_list = []

--- a/hyperspy/_signals/lazy.py
+++ b/hyperspy/_signals/lazy.py
@@ -24,7 +24,6 @@ import numpy as np
 import dask
 import dask.array as da
 from itertools import product
-from packaging.version import Version
 from rsciio.utils.tools import get_file_handle
 from rsciio.utils import rgb_tools
 
@@ -131,7 +130,7 @@ class LazySignal(BaseSignal):
         # the NumPy array originates from.
         self._cache_dask_chunk = None
         self._cache_dask_chunk_slice = None
-        if not self._clear_cache_dask_data in self.events.data_changed.connected:
+        if self._clear_cache_dask_data not in self.events.data_changed.connected:
             self.events.data_changed.connect(self._clear_cache_dask_data)
 
     __init__.__doc__ = BaseSignal.__init__.__doc__.replace(

--- a/hyperspy/_signals/signal1d.py
+++ b/hyperspy/_signals/signal1d.py
@@ -18,7 +18,6 @@
 
 import logging
 import math
-import os
 import warnings
 
 import numpy as np
@@ -45,7 +44,6 @@ from hyperspy.signal_tools import (
 from hyperspy.ui_registry import DISPLAY_DT, TOOLKIT_DT
 from hyperspy.misc.tv_denoise import _tv_denoise_1d
 from hyperspy.signal_tools import BackgroundRemoval
-from hyperspy.misc.array_tools import get_value_at_index
 from hyperspy.decorators import interactive_range_selector
 from hyperspy.signal_tools import _get_background_estimator
 from hyperspy._signals.lazy import LazySignal
@@ -256,8 +254,6 @@ def _shift1D(data, **kwargs):
     be passed as a kwarg. """
     shift = kwargs.get('shift', 0.)
     original_axis = kwargs.get('original_axis', None)
-    fill_value = kwargs.get('fill_value', np.nan)
-    kind = kwargs.get('kind', 'linear')
 
     if np.isnan(shift) or shift == 0:
         return data

--- a/hyperspy/api.py
+++ b/hyperspy/api.py
@@ -21,10 +21,10 @@ import importlib
 import logging
 
 import hyperspy.api_nogui
-from hyperspy.api_nogui import __doc__, get_configuration_directory_path
-from hyperspy.defaults_parser import preferences
-from hyperspy.logger import set_log_level
-from . import __version__
+from hyperspy.api_nogui import __doc__, get_configuration_directory_path # noqa: F401
+from hyperspy.defaults_parser import preferences # noqa: F401
+from hyperspy.logger import set_log_level # noqa: F401
+from . import __version__ # noqa: F401
 
 
 _logger = logging.getLogger(__name__)

--- a/hyperspy/api_nogui.py
+++ b/hyperspy/api_nogui.py
@@ -23,13 +23,16 @@ import logging
 import importlib
 import sys
 
-_logger = logging.getLogger(__name__)
+
 from hyperspy.logger import set_log_level
 from hyperspy.defaults_parser import preferences
+
+# Need to run before other import to use the logger during import
+_logger = logging.getLogger(__name__)
 set_log_level(preferences.General.logging_level)
 
-from hyperspy import docstrings
-from . import __version__
+from hyperspy import docstrings # noqa: E402
+from . import __version__ # noqa: E402
 
 
 __doc__ = """
@@ -100,7 +103,7 @@ def get_configuration_directory_path():
     return hyperspy.misc.config_dir.config_path
 
 
-__all__ = [
+__all__ = [ # noqa: F822
     'data',
     'get_configuration_directory_path',
     'interactive',

--- a/hyperspy/axes.py
+++ b/hyperspy/axes.py
@@ -1616,7 +1616,7 @@ class AxesManager(t.HasTraits):
 
     @property
     def all_uniform(self):
-        if any([axis.is_uniform == False for axis in self._axes]):
+        if any([axis.is_uniform is False for axis in self._axes]):
             return False
         else:
             return True

--- a/hyperspy/component.py
+++ b/hyperspy/component.py
@@ -552,8 +552,8 @@ class Parameter(t.HasTraits):
         """
         if mask is None:
             mask = np.zeros(self.map.shape, dtype='bool')
-        self.map['values'][mask == False] = self.value
-        self.map['is_set'][mask == False] = True
+        self.map['values'][mask == 0] = self.value
+        self.map['is_set'][mask == 0] = True
 
     def _create_array(self):
         """Create the map array to store the information in

--- a/hyperspy/data/artificial_data.py
+++ b/hyperspy/data/artificial_data.py
@@ -21,7 +21,6 @@
 For use in things like docstrings or to test HyperSpy functionalities.
 
 """
-import functools
 
 import numpy as np
 

--- a/hyperspy/data/two_gaussians.py
+++ b/hyperspy/data/two_gaussians.py
@@ -16,7 +16,6 @@
 # You should have received a copy of the GNU General Public License
 # along with HyperSpy. If not, see <https://www.gnu.org/licenses/#GPL>.
 
-import functools
 
 import numpy as np
 import hyperspy.api as hs

--- a/hyperspy/defaults_parser.py
+++ b/hyperspy/defaults_parser.py
@@ -235,7 +235,7 @@ if preferences.General.logger_on:
 
 def file_version(fname):
     with open(fname, 'r') as f:
-        for l in f.readlines():
-            if '__version__' in l:
-                return l[l.find('=') + 1:].strip()
+        for line in f.readlines():
+            if '__version__' in line:
+                return line[line.find('=') + 1:].strip()
     return '0'

--- a/hyperspy/drawing/_markers/circles.py
+++ b/hyperspy/drawing/_markers/circles.py
@@ -55,7 +55,7 @@ class Circles(Markers):
 
         if kwargs.setdefault("transform", "display") != "display":
             raise ValueError(
-                f"The `transform` argument is not supported for Circles Markers. Instead, "
+                "The `transform` argument is not supported for Circles Markers. Instead, "
                 "use the `offset_transform` argument to specify the transform of the "
                 "`offsets` and use the `units` argument to specify transform of the "
                 "`sizes` argument."

--- a/hyperspy/drawing/_markers/ellipses.py
+++ b/hyperspy/drawing/_markers/ellipses.py
@@ -56,7 +56,7 @@ class Ellipses(Markers):
         """
         if kwargs.setdefault("transform", "display") != "display":
             raise ValueError(
-                f"The transform argument is not supported for Squares Markers. Instead, "
+                "The transform argument is not supported for Squares Markers. Instead, "
                 "use the offset_transform argument to specify the transform of the "
                 "offsets and use the ``units`` argument to specify transform of the "
                 "sizes.")

--- a/hyperspy/drawing/_markers/points.py
+++ b/hyperspy/drawing/_markers/points.py
@@ -48,7 +48,7 @@ class Points(Markers):
         """
         if kwargs.setdefault("transform", "display") != "display":
             raise ValueError(
-                f"The transform argument is not supported for Squares Markers. Instead, "
+                "The transform argument is not supported for Squares Markers. Instead, "
                 "use the offset_transform argument to specify the transform of the "
                 "offsets and use the ``units`` argument to specify transform of the "
                 "sizes.")

--- a/hyperspy/drawing/_markers/rectangles.py
+++ b/hyperspy/drawing/_markers/rectangles.py
@@ -56,7 +56,7 @@ class Rectangles(Markers):
         """
         if kwargs.setdefault("transform", "display") != "display":
             raise ValueError(
-                f"The `transform` argument is not supported for Rectangle Markers. Instead, "
+                "The `transform` argument is not supported for Rectangle Markers. Instead, "
                 "use the `offset_transform` argument to specify the transform of the "
                 "`offsets` and use the `units` argument to specify transform of the "
                 "`sizes` argument."

--- a/hyperspy/drawing/_markers/squares.py
+++ b/hyperspy/drawing/_markers/squares.py
@@ -15,7 +15,6 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with HyperSpy. If not, see <https://www.gnu.org/licenses/#GPL>.
-import numpy as np
 
 from hyperspy.docstrings.markers import (OFFSET_DOCSTRING,
                                          WIDTHS_DOCSTRING,
@@ -57,7 +56,7 @@ class Squares(Markers):
         """
         if kwargs.setdefault("transform", "display") != "display":
             raise ValueError(
-                f"The transform argument is not supported for Squares Markers. Instead, "
+                "The transform argument is not supported for Squares Markers. Instead, "
                 "use the offset_transform argument to specify the transform of the "
                 "offsets and use the ``units`` argument to specify transform of the "
                 "sizes.")

--- a/hyperspy/drawing/image.py
+++ b/hyperspy/drawing/image.py
@@ -37,7 +37,6 @@ from hyperspy.drawing.figure import BlittedFigure
 from hyperspy.ui_registry import DISPLAY_DT, TOOLKIT_DT
 from hyperspy.docstrings.plot import PLOT2D_DOCSTRING
 from hyperspy.misc.test_utils import ignore_warning
-from hyperspy.defaults_parser import preferences
 
 
 _logger = logging.getLogger(__name__)

--- a/hyperspy/drawing/markers.py
+++ b/hyperspy/drawing/markers.py
@@ -22,7 +22,7 @@ import logging
 from copy import deepcopy
 
 import matplotlib.collections as mpl_collections
-from matplotlib.transforms import Affine2D, IdentityTransform
+from matplotlib.transforms import IdentityTransform
 from matplotlib.patches import Patch
 
 import hyperspy

--- a/hyperspy/drawing/mpl_he.py
+++ b/hyperspy/drawing/mpl_he.py
@@ -182,7 +182,7 @@ class MPL_HyperExplorer(object):
             if key in kwargs:
                 self.signal_data_function_kwargs[key] = kwargs.pop(key)
         backend = mpl.get_backend()
-        if not "ipympl" in backend and "plot_style" in kwargs:
+        if "ipympl" not in backend and "plot_style" in kwargs:
             warnings.warn("The `plot_style` keyword is only used when the `ipympl` or `widget`"
                           "plotting backends are used.")
         plot_style = kwargs.pop("plot_style", None)

--- a/hyperspy/drawing/utils.py
+++ b/hyperspy/drawing/utils.py
@@ -1431,14 +1431,14 @@ def plot_spectra(
             This parameter controls where the legend is placed on the
             figure; see the pyplot.legend docstring for valid values.
         """
-        l = ax_.get_legend()
-        labels = [lb.get_text() for lb in list(l.get_texts())]
+        line = ax_.get_legend()
+        labels = [lb.get_text() for lb in list(line.get_texts())]
         # "legendHandles" is deprecated in matplotlib 3.7.0 in favour of
         # "legend_handles".
         if Version(mpl.__version__) >= Version("3.7"):
-            handles = l.legend_handles
+            handles = line.legend_handles
         else:
-            handles = l.legendHandles
+            handles = line.legendHandles
         ax_.legend(reversed(handles), reversed(labels), loc=legend_loc_)
 
     # Before v1.3 default would read the value from prefereces.

--- a/hyperspy/drawing/widget.py
+++ b/hyperspy/drawing/widget.py
@@ -207,7 +207,7 @@ class WidgetBase(object):
                 # Introduced in matplotlib 3.6 and `pick_event` deprecated
                 event = PickEvent('pick_event', figure, mouseevent, self.patch[0])
                 figure.canvas.callbacks.process('pick_event', event)
-            except: # Deprecated in matplotlib 3.6
+            except Exception: # Deprecated in matplotlib 3.6
                 figure.canvas.pick_event(mouseevent, self.patch[0])
         self.picked = False
 

--- a/hyperspy/drawing/widgets.py
+++ b/hyperspy/drawing/widgets.py
@@ -21,8 +21,13 @@
 
 
 from hyperspy.drawing.widget import (
-    WidgetBase, DraggableWidgetBase, ResizableDraggableWidgetBase,
-    Widget2DBase, Widget1DBase, ResizersMixin)
+    WidgetBase,
+    DraggableWidgetBase,
+    ResizableDraggableWidgetBase,
+    Widget2DBase,
+    Widget1DBase,
+    ResizersMixin
+    )
 from hyperspy.drawing._widgets.horizontal_line import HorizontalLineWidget
 from hyperspy.drawing._widgets.vertical_line import VerticalLineWidget
 from hyperspy.drawing._widgets.label import LabelWidget
@@ -31,3 +36,22 @@ from hyperspy.drawing._widgets.circle import CircleWidget
 from hyperspy.drawing._widgets.rectangles import RectangleWidget, SquareWidget
 from hyperspy.drawing._widgets.range import RangeWidget
 from hyperspy.drawing._widgets.line2d import Line2DWidget
+
+
+__all__ = [
+    "WidgetBase",
+    "DraggableWidgetBase",
+    "ResizableDraggableWidgetBase",
+    "Widget2DBase",
+    "Widget1DBase",
+    "ResizersMixin",
+    "HorizontalLineWidget",
+    "VerticalLineWidget",
+    "LabelWidget",
+    "CircleWidget",
+    "ScaleBar",
+    "RectangleWidget",
+    "SquareWidget",
+    "RangeWidget",
+    "Line2DWidget",
+]

--- a/hyperspy/events.py
+++ b/hyperspy/events.py
@@ -19,7 +19,7 @@
 import inspect
 from collections.abc import Iterable
 from contextlib import contextmanager
-from functools import wraps   # Used in exec statement
+from functools import wraps   # noqa: F401 Used in exec statement
 import re
 
 

--- a/hyperspy/learn/mva.py
+++ b/hyperspy/learn/mva.py
@@ -1895,7 +1895,7 @@ class MVA:
 
         toreturn=None
         # Is it a signal - i.e. BaseSignal
-        if type(cluster_source) is str and cluster_source=="signal":
+        if isinstance(cluster_source, str) and cluster_source=="signal":
             cluster_source = self
 
         if is_hyperspy_signal(cluster_source):
@@ -1943,7 +1943,7 @@ class MVA:
             data = cluster_source.data \
                 if cluster_source.axes_manager[0].index_in_array == 0 else cluster_source.data.T
             toreturn = data[:,signal_mask][navigation_mask,:]
-        elif type(cluster_source) is str:
+        elif isinstance(cluster_source, str):
             if cluster_source == "bss":
                 loadings = self.learning_results.bss_loadings
             else:
@@ -2147,10 +2147,8 @@ class MVA:
             self.learning_results.__dict__.update(target.__dict__)
             # if the cluster_source or source_for_centers is a signal
             # fold it back, if required, when finished
-            if (type(cluster_source) is str and \
-                cluster_source == "signal") or   \
-                (type(source_for_centers) is str and \
-                source_for_centers == "signal"):
+            if (isinstance(cluster_source, str) and cluster_source == "signal") or \
+                (isinstance(source_for_centers, str) and source_for_centers == "signal"):
                 if hasattr(self,"unfolded4clustering"):
                     if self.unfolded4clustering:
                         self.fold()
@@ -2520,8 +2518,7 @@ class MVA:
             return best_k
         finally:
             # fold
-            if (type(cluster_source) is str and \
-                cluster_source == "signal"):
+            if isinstance(cluster_source, str) is str and cluster_source == "signal":
                 if hasattr(self,"unfolded4clustering"):
                     if self.unfolded4clustering:
                         self.fold()

--- a/hyperspy/learn/rpca.py
+++ b/hyperspy/learn/rpca.py
@@ -17,7 +17,6 @@
 # along with HyperSpy. If not, see <https://www.gnu.org/licenses/#GPL>.
 
 import logging
-import warnings
 from itertools import chain
 
 import numpy as np

--- a/hyperspy/learn/svd_pca.py
+++ b/hyperspy/learn/svd_pca.py
@@ -17,11 +17,9 @@
 # along with HyperSpy. If not, see <https://www.gnu.org/licenses/#GPL>.
 
 import logging
-from packaging.version import Version
 
 import numpy as np
 from numpy.linalg import svd
-import scipy
 
 from hyperspy.misc.machine_learning.import_sklearn import (
     randomized_svd,

--- a/hyperspy/misc/axis_tools.py
+++ b/hyperspy/misc/axis_tools.py
@@ -44,12 +44,12 @@ def check_axes_calibration(ax1, ax2, rtol=1e-7):
     if ax1.size == ax2.size:
         try:
             unit1 = _ureg.Unit(ax1.units)
-        except:
+        except Exception:
             unit1 = ax1.units
         try:
             unit2 = ax2.units
             unit2 = _ureg.Unit(ax2.units)
-        except:
+        except Exception:
             pass
         if np.allclose(ax1.axis, ax2.axis, atol=0, rtol=rtol) and unit1 == unit2:
             return True

--- a/hyperspy/misc/machine_learning/import_sklearn.py
+++ b/hyperspy/misc/machine_learning/import_sklearn.py
@@ -20,21 +20,22 @@
 Import sklearn.* and randomized_svd from scikit-learn
 """
 
+import importlib
 import warnings
 
+sklearn_spec = importlib.util.find_spec("sklearn")
 
-try:
-    with warnings.catch_warnings():
-        warnings.simplefilter("ignore")
-        import sklearn
-        import sklearn.decomposition
-        import sklearn.cluster
-        import sklearn.preprocessing
-        import sklearn.metrics
-        from sklearn.utils.extmath import randomized_svd
-
-        sklearn_installed = True
-
-except ImportError:  # pragma: no cover
+if sklearn_spec is None:  # pragma: no cover
     randomized_svd = None
     sklearn_installed = False
+else:
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        import sklearn # noqa: F401
+        import sklearn.decomposition # noqa: F401
+        import sklearn.cluster # noqa: F401
+        import sklearn.preprocessing # noqa: F401
+        import sklearn.metrics # noqa: F401
+        from sklearn.utils.extmath import randomized_svd # noqa: F401
+
+        sklearn_installed = True

--- a/hyperspy/misc/test_utils.py
+++ b/hyperspy/misc/test_utils.py
@@ -82,7 +82,7 @@ def assert_deep_almost_equal(actual, expected, *args, **kwargs):
         :func:`numpy.testing.assert_allclose` or
         :func:`assert_deep_almost_equal`.
     """
-    is_root = not "__trace" in kwargs
+    is_root = "__trace" not in kwargs
     trace = kwargs.pop("__trace", "ROOT")
     try:
         if isinstance(expected, (int, float, complex)):

--- a/hyperspy/misc/utils.py
+++ b/hyperspy/misc/utils.py
@@ -17,7 +17,6 @@
 # along with HyperSpy. If not, see <https://www.gnu.org/licenses/#GPL>.
 
 from operator import attrgetter
-import warnings
 import inspect
 import copy
 import types
@@ -28,13 +27,11 @@ import unicodedata
 from contextlib import contextmanager
 import importlib
 import logging
-from packaging.version import Version
 
 import dask.array as da
 import numpy as np
 
 from hyperspy.misc.signal_tools import broadcast_signals
-from hyperspy.exceptions import VisibleDeprecationWarning
 from hyperspy.docstrings.signal import SHOW_PROGRESSBAR_ARG
 from hyperspy.docstrings.utils import STACK_METADATA_ARG
 

--- a/hyperspy/model.py
+++ b/hyperspy/model.py
@@ -114,7 +114,7 @@ def reconstruct_component(comp_dictionary, **init_args):
             _logger.info("Legacy Voigt component converted to PESVoigt during file reading.")
     if (comp_dictionary['_id_name'] == "Arctan" and 'minimum_at_zero' in comp_dictionary):
         # in HyperSpy 1.6 the old Arctan component was moved to EELSArctan
-        if comp_dictionary['minimum_at_zero'] == True:
+        if comp_dictionary['minimum_at_zero'] is True:
             comp_dictionary['_id_name'] = "EELSArctan"
             _logger.info("Legacy Arctan component converted to EELSArctan during file reading.")
     _id = comp_dictionary['_id_name']

--- a/hyperspy/models/model1d.py
+++ b/hyperspy/models/model1d.py
@@ -23,11 +23,11 @@ from scipy.special import huber
 import traits.api as t
 
 import hyperspy.drawing.signal1d
-from hyperspy.exceptions import WrongObjectError, SignalDimensionError
+from hyperspy.exceptions import SignalDimensionError
 from hyperspy.decorators import interactive_range_selector
 from hyperspy.drawing.widgets import LabelWidget, VerticalLineWidget
 from hyperspy.events import EventSuppressor
-from hyperspy.model import BaseModel, ModelComponents, ModelSpecialSlicers
+from hyperspy.model import BaseModel, ModelComponents
 from hyperspy.signal_tools import SpanSelectorInSignal1D
 from hyperspy.ui_registry import DISPLAY_DT, TOOLKIT_DT, add_gui_method
 from hyperspy.misc.utils import dummy_context_manager

--- a/hyperspy/models/model2d.py
+++ b/hyperspy/models/model2d.py
@@ -20,9 +20,7 @@ import copy
 
 import numpy as np
 
-from hyperspy._signals.signal2d import Signal2D
-from hyperspy.exceptions import WrongObjectError
-from hyperspy.model import BaseModel, ModelComponents, ModelSpecialSlicers
+from hyperspy.model import BaseModel, ModelComponents
 
 
 _SIGNAL_RANGE_VALUES = """x1, x2 : None or float

--- a/hyperspy/roi.py
+++ b/hyperspy/roi.py
@@ -866,7 +866,7 @@ class RectangularROI(BaseInteractiveROI):
         return {"left":self.left, "top":self.top, "right":self.right, "bottom":self.bottom}
 
     def is_valid(self):
-        return (not t.Undefined in tuple(self) and
+        return (t.Undefined not in tuple(self) and
                 self.right >= self.left and self.bottom >= self.top)
 
     def _top_changed(self, old, new):

--- a/hyperspy/samfire.py
+++ b/hyperspy/samfire.py
@@ -18,7 +18,6 @@
 
 import logging
 from multiprocessing import cpu_count
-import warnings
 
 import cloudpickle
 import numpy as np

--- a/hyperspy/samfire_utils/samfire_kernel.py
+++ b/hyperspy/samfire_utils/samfire_kernel.py
@@ -67,7 +67,7 @@ def single_kernel(model, ind, values, optional_components, _args, test):
             for (comp_n, par_n), val in zip(name_list, it):
                 try:
                     getattr(model[comp_n], par_n).value = val
-                except:
+                except Exception:
                     pass
             model.fit(**_args)
             # only perform iterations until we find a solution that we think is
@@ -108,7 +108,7 @@ def single_kernel(model, ind, values, optional_components, _args, test):
         for (comp_n, par_n), val in zip(best_names, best_values):
             try:
                 getattr(model[comp_n], par_n).value = val
-            except:
+            except Exception:
                 pass
         model.fit(**_args)
         return True
@@ -116,7 +116,6 @@ def single_kernel(model, ind, values, optional_components, _args, test):
 
 def multi_kernel(
         ind, m_dic, values, optional_components, _args, result_q, test_dict):
-    import hyperspy.api as hs
     from hyperspy.signal import Signal
     from multiprocessing import current_process
     from itertools import combinations, product
@@ -188,7 +187,7 @@ def multi_kernel(
             for (comp_n, par_n), val in zip(name_list, it):
                 try:
                     getattr(model[comp_n], par_n).value = val
-                except:
+                except Exception:
                     pass
             model.fit(**_args)
             # only perform iterations until we find a solution that we think is
@@ -231,7 +230,7 @@ def multi_kernel(
         for (comp_n, par_n), val in zip(best_names, best_values):
             try:
                 getattr(model[comp_n], par_n).value = val
-            except:
+            except Exception:
                 pass
         model.fit(**_args)
         send_good_results(model, previous_switching, cur_p, result_q, ind)

--- a/hyperspy/samfire_utils/samfire_worker.py
+++ b/hyperspy/samfire_utils/samfire_worker.py
@@ -22,11 +22,9 @@ import time
 import sys
 from itertools import combinations, product
 from queue import Empty
+
 import cloudpickle
 import numpy as np
-import matplotlib
-
-matplotlib.rcParams['backend'] = 'Agg'
 
 from hyperspy.signal import BaseSignal
 from hyperspy.utils.model_selection import AICc

--- a/hyperspy/signal.py
+++ b/hyperspy/signal.py
@@ -2555,7 +2555,7 @@ class BaseSignal(FancySlicing,
                     # As of numpy 1.20, it raises a VisibleDeprecationWarning
                     # and in the future, it will raise an error
                     data = np.array(self.data.tolist())
-            except:
+            except Exception:
                 raise ValueError(error)
 
             if data.dtype == object:
@@ -4419,7 +4419,7 @@ class BaseSignal(FancySlicing,
 
         if self.axes_manager.signal_dimension == 0:
             raise AttributeError("Signal dimension must be at least one.")
-        if apodization == True:
+        if apodization is True:
             apodization = 'hann'
 
         if apodization:

--- a/hyperspy/signal_tools.py
+++ b/hyperspy/signal_tools.py
@@ -1349,7 +1349,7 @@ class BackgroundRemoval(SpanSelectorInSignal1D):
         try:
             self._fit()
             self._update_line()
-        except:
+        except Exception:
             pass
 
     def _fit(self):

--- a/hyperspy/tests/axes/test_axes_manager.py
+++ b/hyperspy/tests/axes/test_axes_manager.py
@@ -110,9 +110,9 @@ class TestAxesManager:
         assert am[-2].scale == am[-1].scale
 
     def test_all_uniform(self):
-        assert self.am.all_uniform == True
+        assert self.am.all_uniform is True
         self.am[-1].convert_to_non_uniform_axis()
-        assert self.am.all_uniform == False
+        assert self.am.all_uniform is False
 
     def test_get_axis(self):
         am = self.am
@@ -474,8 +474,8 @@ class TestIterPathScanPattern:
 
     def test_get_iterpath_size2(self):
         self.am.iterpath = generator()
-        assert self.am._get_iterpath_size() == None
-        assert self.am._get_iterpath_size(masked_elements = 1) == None
+        assert self.am._get_iterpath_size() is None
+        assert self.am._get_iterpath_size(masked_elements = 1) is None
 
     def test_get_iterpath_size3(self):
         self.am.iterpath =[(0,0,0), (0,0,1)]

--- a/hyperspy/tests/axes/test_data_axis.py
+++ b/hyperspy/tests/axes/test_data_axis.py
@@ -356,7 +356,7 @@ class TestFunctionalDataAxis:
         # Returns integer
         assert isinstance(self.axis.value2index(45), (int, np.integer))
         #Input None --> output None
-        assert self.axis.value2index(None) == None
+        assert self.axis.value2index(None) is None
         #NaN in --> error out
         with pytest.raises(ValueError):
             self.axis.value2index(np.nan)
@@ -490,7 +490,7 @@ class TestUniformDataAxis:
         #Endpoint right
         assert self.axis.value2index(10.9) == 9
         #Input None --> output None
-        assert self.axis.value2index(None) == None
+        assert self.axis.value2index(None) is None
         #NaN in --> error out
         with pytest.raises(ValueError):
             self.axis.value2index(np.nan)
@@ -691,10 +691,10 @@ class TestUniformDataAxis:
         ax.units = 'nm'
         # slicing by index
         assert ax._parse_value(5) == 5
-        assert type(ax._parse_value(5)) is int
+        assert isinstance(ax._parse_value(5), int)
         # slicing by calibrated value
         assert ax._parse_value(10.5) == 10.5
-        assert type(ax._parse_value(10.5)) is float
+        assert isinstance(ax._parse_value(10.5), float)
         # slicing by unit
         assert ax._parse_value('10.5nm') == 10.5
         np.testing.assert_almost_equal(ax._parse_value('10500pm'), 10.5)
@@ -762,7 +762,7 @@ def test_rounding_consistency_axis_type():
 @pytest.mark.parametrize('shift', (0.05, 0.025))
 def test_rounding_consistency_axis_type_half(shift):
 
-    axis = UniformDataAxis(size=20, scale=0.1, offset=-1.0);
+    axis = UniformDataAxis(size=20, scale=0.1, offset=-1.0)
     test_vals = axis.axis[:-1] + shift
 
     uaxis_indices = axis.value2index(test_vals)

--- a/hyperspy/tests/component/test_arctan.py
+++ b/hyperspy/tests/component/test_arctan.py
@@ -16,11 +16,9 @@
 # You should have received a copy of the GNU General Public License
 # along with HyperSpy. If not, see <https://www.gnu.org/licenses/#GPL>.
 
-import pytest
 import numpy as np
 
 from hyperspy.components1d import Arctan
-from hyperspy.exceptions import VisibleDeprecationWarning
 
 
 def test_function():

--- a/hyperspy/tests/component/test_components2D.py
+++ b/hyperspy/tests/component/test_components2D.py
@@ -73,8 +73,8 @@ class TestExpression2D:
         g.sy.value = 1
         g.x0.value = 1
         g.y0.value = 1
-        l = np.linspace(-2, 2, 5)
-        x, y = np.meshgrid(l, l)
+        values = np.linspace(-2, 2, 5)
+        x, y = np.meshgrid(values, values)
         np.testing.assert_allclose(
             g.function(x, y),
             np.array([[6.68025544e-06, 8.55249949e-04, 6.49777231e-03,
@@ -112,8 +112,8 @@ class TestExpression2D:
         g.sy.value = .1
         g.x0.value = 0
         g.y0.value = 0
-        l = np.linspace(-2, 2, 5)
-        x, y = np.meshgrid(l, l)
+        values = np.linspace(-2, 2, 5)
+        x, y = np.meshgrid(values, values)
         np.testing.assert_allclose(
             g.function(x, y),
             np.array([[1.77220718e-208, 1.97005871e-181, 1.00498099e-181,
@@ -136,8 +136,8 @@ class TestExpression2D:
         g.sy.value = .1
         g.x0.value = 0
         g.y0.value = 0
-        l = np.linspace(-2, 2, 5)
-        x, y = np.meshgrid(l, l)
+        values = np.linspace(-2, 2, 5)
+        x, y = np.meshgrid(values, values)
         np.testing.assert_allclose(
             g.function(x, y),
             np.array([[9.64172248e-175, 5.46609733e-099, 5.03457536e-045,
@@ -156,8 +156,8 @@ class TestExpression2D:
         g = hs.model.components2D.Expression(
             GAUSSIAN2D_EXPR, "gaussian2d", add_rotation=True, module="numpy",
             sx=.5, sy=.1, x0=0, y0=0, rotation_angle=np.radians(45))
-        l = np.linspace(-2, 2, 5)
-        x, y = np.meshgrid(l, l)
+        values = np.linspace(-2, 2, 5)
+        x, y = np.meshgrid(values, values)
         np.testing.assert_allclose(
             g.function(x, y),
             np.array([[9.64172248e-175, 5.46609733e-099, 5.03457536e-045,
@@ -181,8 +181,8 @@ class TestExpression2D:
         g.sy.value = 1
         g.x0.value = 1
         g.y0.value = 1
-        l = np.linspace(-2, 2, 5)
-        x, y = np.meshgrid(l, l)
+        values = np.linspace(-2, 2, 5)
+        x, y = np.meshgrid(values, values)
         np.testing.assert_allclose(g.function(x, y), self.array0)
         np.testing.assert_allclose(
             g.grad_sx(x, y),
@@ -208,8 +208,8 @@ class TestExpression2D:
         g.sy.value = 1
         g.x0.value = 1
         g.y0.value = 1
-        l = np.linspace(-2, 2, 5)
-        x, y = np.meshgrid(l, l)
+        values = np.linspace(-2, 2, 5)
+        x, y = np.meshgrid(values, values)
         np.testing.assert_allclose(g.function_nd(x, y), self.array0)
 
     def test_no_function_nd_signal(self):
@@ -221,8 +221,8 @@ class TestExpression2D:
         g.sy.value = 1
         g.x0.value = 1
         g.y0.value = 1
-        l = np.arange(0, 3)
-        x, y = np.meshgrid(l, l)
+        values = np.arange(0, 3)
+        x, y = np.meshgrid(values, values)
         s = hs.signals.Signal2D(g.function(x, y))
         s2 = hs.stack([s]*2)
         m = s2.create_model()

--- a/hyperspy/tests/component/test_expression.py
+++ b/hyperspy/tests/component/test_expression.py
@@ -93,24 +93,24 @@ def test_separate_pseudocomponents():
 
 
 def test_separate_pseudocomponents_expression_rename_parameters():
-    l = hs.model.components1D.Lorentzian()
-    free, fixed = l._separate_pseudocomponents()
+    lorentzian = hs.model.components1D.Lorentzian()
+    free, fixed = lorentzian._separate_pseudocomponents()
     assert list(free.keys()) == ['A', 'centre', 'gamma']
     assert list(fixed.keys()) == ['function', 'parameters']
 
-    l.centre.free = False
-    l.gamma.free = False
+    lorentzian.centre.free = False
+    lorentzian.gamma.free = False
 
-    free, fixed = l._separate_pseudocomponents()
+    free, fixed = lorentzian._separate_pseudocomponents()
     assert list(free.keys()) == ['A']
     
 
 def test_linear_rename_parameters():
     # with the lorentzian component, the gamma component is rename
-    l = hs.model.components1D.Lorentzian()
-    assert l.A._linear
-    assert not l.gamma._linear
-    assert not l.centre._linear
+    lorentzian = hs.model.components1D.Lorentzian()
+    assert lorentzian.A._linear
+    assert not lorentzian.gamma._linear
+    assert not lorentzian.centre._linear
 
     g = hs.model.components1D.Expression(
             expression="height * exp(-(x - x0) ** 2 * 4 * log(2)/ fwhm ** 2)",

--- a/hyperspy/tests/drawing/test_figure.py
+++ b/hyperspy/tests/drawing/test_figure.py
@@ -32,7 +32,7 @@ def _close_figure_matplotlib_event(figure):
         # Introduced in matplotlib 3.6 and `clost_event` deprecated
         event = CloseEvent('close_event', figure)
         figure.canvas.callbacks.process('close_event', event)
-    except: # Deprecated in matplotlib 3.6
+    except Exception: # Deprecated in matplotlib 3.6
         figure.canvas.close_event()
 
 

--- a/hyperspy/tests/drawing/test_plot_lazy.py
+++ b/hyperspy/tests/drawing/test_plot_lazy.py
@@ -30,7 +30,7 @@ def test_plot_lazy(ndim):
     s.plot()
 
     if ndim == 0:
-        assert s._plot.navigator_data_function == None
+        assert s._plot.navigator_data_function is None
     elif ndim in [1, 2]:
         assert s.navigator.data.shape == tuple([N]*ndim)
         assert isinstance(s.navigator, hs.signals.BaseSignal)

--- a/hyperspy/tests/drawing/test_plot_model.py
+++ b/hyperspy/tests/drawing/test_plot_model.py
@@ -22,7 +22,6 @@ from pathlib import Path
 
 import hyperspy.api as hs
 from hyperspy.components1d import Gaussian
-from hyperspy.exceptions import VisibleDeprecationWarning
 from hyperspy.signals import Signal1D
 
 my_path = Path(__file__).resolve().parent

--- a/hyperspy/tests/drawing/test_plot_signal1d.py
+++ b/hyperspy/tests/drawing/test_plot_signal1d.py
@@ -16,9 +16,10 @@
 # along with HyperSpy. If not, see <https://www.gnu.org/licenses/#GPL>.
 
 import copy
+import importlib
 import os
-from shutil import copyfile
 from pathlib import Path
+from shutil import copyfile
 
 import matplotlib.pyplot as plt
 from matplotlib.backend_bases import MouseEvent, PickEvent
@@ -67,19 +68,20 @@ def _matplotlib_pick_event(figure, click, artist):
         # Introduced in matplotlib 3.6 and `pick_event` deprecated
         event = PickEvent('pick_event', figure, click, artist)
         figure.canvas.callbacks.process('pick_event', event)
-    except: # Deprecated in matplotlib 3.6
+    except Exception: # Deprecated in matplotlib 3.6
         figure.canvas.pick_event(figure.canvas, click, artist)
 
 
 @pytest.fixture
 def setup_teardown(request, scope="class"):
     plot_testing = request.config.getoption("--mpl")
-    try:
-        import pytest_mpl
+    pytest_mpl_spec = importlib.util.find_spec("pytest_mpl")
+
+    if pytest_mpl_spec is None:
+        mpl_generate_path_cmdopt = None
+    else:
         # This option is available only when pytest-mpl is installed
         mpl_generate_path_cmdopt = request.config.getoption("--mpl-generate-path")
-    except ImportError:
-        mpl_generate_path_cmdopt = None
 
     # SETUP
     # duplicate baseline images to match the test_name when the

--- a/hyperspy/tests/drawing/test_plot_signal_tools.py
+++ b/hyperspy/tests/drawing/test_plot_signal_tools.py
@@ -94,8 +94,8 @@ def test_plot_BackgroundRemoval_close_figure():
     assert len(signal_plot.events.closed.connected) == 5
     assert len(s.axes_manager.events.indices_changed.connected) == 4
     s._plot.close()
-    assert not br._fit in s.axes_manager.events.indices_changed.connected
-    assert not br.disconnect in signal_plot.events.closed.connected
+    assert br._fit not in s.axes_manager.events.indices_changed.connected
+    assert br.disconnect not in signal_plot.events.closed.connected
 
 
 def test_plot_BackgroundRemoval_close_tool():
@@ -108,9 +108,9 @@ def test_plot_BackgroundRemoval_close_tool():
     assert len(signal_plot.events.closed.connected) == 5
     assert len(s.axes_manager.events.indices_changed.connected) == 4
     br.on_disabling_span_selector()
-    assert not br._fit in s.axes_manager.events.indices_changed.connected
+    assert br._fit not in s.axes_manager.events.indices_changed.connected
     s._plot.close()
-    assert not br.disconnect in signal_plot.events.closed.connected
+    assert br.disconnect not in signal_plot.events.closed.connected
 
 
 @pytest.mark.mpl_image_compare(baseline_dir=BASELINE_DIR,

--- a/hyperspy/tests/drawing/test_plot_widgets.py
+++ b/hyperspy/tests/drawing/test_plot_widgets.py
@@ -127,7 +127,7 @@ class TestPlotLine2DWidget():
         assert self.line2d.axes[1].scale == 1.2
         self.line2d.snap_size = True
         # snapping size with the different axes scale is not supported
-        assert self.line2d.snap_size == False
+        assert self.line2d.snap_size is False
 
     @pytest.mark.mpl_image_compare(baseline_dir=baseline_dir,
                                    tolerance=default_tol, style=style_pytest_mpl)

--- a/hyperspy/tests/drawing/test_texts.py
+++ b/hyperspy/tests/drawing/test_texts.py
@@ -21,7 +21,7 @@ import numpy as np
 import pytest
 
 from hyperspy.drawing._markers.texts import Texts
-from hyperspy._signals.signal2d import Signal2D, Signal1D
+from hyperspy._signals.signal2d import Signal2D
 from hyperspy.misc.test_utils import update_close_figure
 
 

--- a/hyperspy/tests/drawing/test_utils.py
+++ b/hyperspy/tests/drawing/test_utils.py
@@ -32,7 +32,7 @@ def test_create_figure():
     dummy_function = Mock()
     fig = create_figure(window_title="test title",
                         _on_figure_window_close=dummy_function)
-    assert isinstance(fig, matplotlib.figure.Figure) == True
+    assert isinstance(fig, matplotlib.figure.Figure) is True
     matplotlib.pyplot.close(fig)
     dummy_function.assert_called_once_with()
 

--- a/hyperspy/tests/drawing/test_widget.py
+++ b/hyperspy/tests/drawing/test_widget.py
@@ -15,7 +15,6 @@
 # You should have received a copy of the GNU General Public License
 # along with HyperSpy. If not, see <https://www.gnu.org/licenses/#GPL>.
 
-from matplotlib.backend_bases import MouseEvent, PickEvent
 import numpy as np
 
 from hyperspy.drawing import widget, widgets

--- a/hyperspy/tests/learn/test_bss.py
+++ b/hyperspy/tests/learn/test_bss.py
@@ -16,7 +16,6 @@
 # You should have received a copy of the GNU General Public License
 # along with HyperSpy. If not, see <https://www.gnu.org/licenses/#GPL>.
 
-from packaging.version import Version
 
 import numpy as np
 import pytest

--- a/hyperspy/tests/learn/test_ornmf.py
+++ b/hyperspy/tests/learn/test_ornmf.py
@@ -77,7 +77,7 @@ class TestRNMF:
         compare_norms(W @ H, self.X)
 
     def test_no_method(self):
-        with pytest.raises(ValueError, match=f"'method' not recognised"):
+        with pytest.raises(ValueError, match="'method' not recognised"):
             _ = ornmf(self.X, self.rank, method="uniform")
 
     def test_subspace_tracking(self):
@@ -101,7 +101,7 @@ class TestRNMF:
         )
         compare_norms(W @ H, self.X)
 
-        with pytest.raises(ValueError, match=f"must be a float between 0 and 1"):
+        with pytest.raises(ValueError, match="must be a float between 0 and 1"):
             _ = ornmf(self.X, self.rank, method="MomentumSGD", subspace_momentum=1.9)
 
     @pytest.mark.parametrize("poisson", [True, False])

--- a/hyperspy/tests/misc/test_array_tools.py
+++ b/hyperspy/tests/misc/test_array_tools.py
@@ -168,11 +168,11 @@ def test_get_value_at_index(start, norm, factor):
 
 def test_get_value_at_index_fail():
     with pytest.raises(ValueError):
-        lines = get_value_at_index(np.arange(1, 11, 1),
-                                   indexes=[3, 4],
-                                   real_index=[2, 3],
-                                   factor=0.1,
-                                   start=0,
-                                   stop=1.0,
-                                   norm="log",
-                                   minimum_intensity=None)
+        _ = get_value_at_index(np.arange(1, 11, 1),
+                                indexes=[3, 4],
+                                real_index=[2, 3],
+                                factor=0.1,
+                                start=0,
+                                stop=1.0,
+                                norm="log",
+                                minimum_intensity=None)

--- a/hyperspy/tests/misc/test_axis_tools.py
+++ b/hyperspy/tests/misc/test_axis_tools.py
@@ -16,7 +16,6 @@
 # You should have received a copy of the GNU General Public License
 # along with HyperSpy. If not, see <https://www.gnu.org/licenses/#GPL>.
 
-import numpy as np
 
 from hyperspy.axes import DataAxis, FunctionalDataAxis, UniformDataAxis
 from hyperspy.misc.axis_tools import check_axes_calibration

--- a/hyperspy/tests/misc/test_dictionary_tree_browser.py
+++ b/hyperspy/tests/misc/test_dictionary_tree_browser.py
@@ -79,9 +79,9 @@ class TestDictionaryBrowser:
             "Node3": {"leaf31": 31},
         } == tree.as_dictionary()
         tree.add_dictionary({"_double_lines": ""}, double_lines=True)
-        assert tree._double_lines == True
+        assert tree._double_lines is True
         tree.add_dictionary({"_double_lines": ""}, double_lines=False)
-        assert tree._double_lines == False
+        assert tree._double_lines is False
 
     def test_setattr_dictionary(self, tree):
         d = {"leaf13": 13}
@@ -275,30 +275,30 @@ class TestDictionaryBrowser:
         assert tree.get_item(".Node1.Node21.leaf311", 44) == 44
 
     def test_has_nested_item(self, tree):
-        assert tree.has_item("leaf11", full_path=False) == True
-        assert tree.has_item("leaf111", full_path=False) == True
-        assert tree.has_item("leaf211", full_path=False) == True
-        assert tree.has_item("leaf333", full_path=False) == False
-        assert tree.has_item("211", full_path=False, wild=True) == True
-        assert tree.has_item("333", full_path=False, wild=True) == False
+        assert tree.has_item("leaf11", full_path=False) is True
+        assert tree.has_item("leaf111", full_path=False) is True
+        assert tree.has_item("leaf211", full_path=False) is True
+        assert tree.has_item("leaf333", full_path=False) is False
+        assert tree.has_item("211", full_path=False, wild=True) is True
+        assert tree.has_item("333", full_path=False, wild=True) is False
         tree.add_dictionary(
             {
                 "_double_lines": False,
             }
         )
-        assert tree.has_item("leaf211", full_path=False) == True
-        assert tree.has_item("Node11.leaf111", full_path=False) == True
-        assert tree.has_item("Node41.leaf111", full_path=False) == False
+        assert tree.has_item("leaf211", full_path=False) is True
+        assert tree.has_item("Node11.leaf111", full_path=False) is True
+        assert tree.has_item("Node41.leaf111", full_path=False) is False
 
     def test_has_nested_item_path(self, tree):
-        assert tree.has_item("leaf333", full_path=False, return_path=True) == None
-        assert tree.has_item("leaf", full_path=False, return_path=True) == None
+        assert tree.has_item("leaf333", full_path=False, return_path=True) is None
+        assert tree.has_item("leaf", full_path=False, return_path=True) is None
         assert (
             tree.has_item("leaf333", full_path=False, return_path=True, default=[])
             == []
         )
         assert (
-            tree.has_item("333", full_path=False, return_path=True, wild=True) == None
+            tree.has_item("333", full_path=False, return_path=True, wild=True) is None
         )
         assert (
             tree.has_item(
@@ -333,7 +333,7 @@ class TestDictionaryBrowser:
             == "Node1.Node11.leaf111"
         )
         assert (
-            tree.has_item("Node41.leaf111", full_path=False, return_path=True) == None
+            tree.has_item("Node41.leaf111", full_path=False, return_path=True) is None
         )
         assert (
             tree.has_item(
@@ -352,14 +352,14 @@ class TestDictionaryBrowser:
         ]
 
     def test_get_nested_item(self, tree):
-        assert tree.get_item("leaf333", full_path=False) == None
-        assert tree.get_item("leaf", full_path=False) == None
+        assert tree.get_item("leaf333", full_path=False) is None
+        assert tree.get_item("leaf", full_path=False) is None
         assert tree.get_item("leaf333", full_path=False, default=[]) == []
         assert tree.get_item("333", full_path=False, return_path=True, default=[]) == []
-        assert tree.get_item("333", full_path=False, wild=True) == None
+        assert tree.get_item("333", full_path=False, wild=True) is None
         assert tree.get_item("333", full_path=False, wild=True, default=[]) == []
         assert (
-            tree.get_item("333", full_path=False, wild=True, return_path=True) == None
+            tree.get_item("333", full_path=False, wild=True, return_path=True) is None
         )
         assert tree.get_item("333", full_path=False, return_path=True, default=[]) == []
         assert (
@@ -373,7 +373,7 @@ class TestDictionaryBrowser:
         assert tree.get_item("leaf211", full_path=False, default=[]) == 211
         assert tree.get_item("211", full_path=False, wild=True) == 211
         assert tree.get_item("Node11.leaf111", full_path=False) == 111
-        assert tree.get_item("Node41.leaf111", full_path=False) == None
+        assert tree.get_item("Node41.leaf111", full_path=False) is None
         assert tree.get_item("Node41.leaf111", full_path=False, default=[]) == []
         assert tree.get_item("leaf211", full_path=False, return_path=True) == (
             211,
@@ -387,7 +387,7 @@ class TestDictionaryBrowser:
             "Node1.Node11.leaf111",
         )
         assert (
-            tree.get_item("Node41.leaf111", full_path=False, return_path=True) == None
+            tree.get_item("Node41.leaf111", full_path=False, return_path=True) is None
         )
         assert (
             tree.get_item(
@@ -470,12 +470,12 @@ def test_check_long_string():
     max_len = 20
     value = "Hello everyone this is a long string"
     truth, shortened = check_long_string(value, max_len)
-    assert truth == False
+    assert truth is False
     assert shortened == "Hello everyone this is a long string"
 
     value = "No! It was not a long string! This is a long string!"
     truth, shortened = check_long_string(value, max_len)
-    assert truth == True
+    assert truth is True
     assert shortened == "No! It was not a lon ... is is a long string!"
 
 

--- a/hyperspy/tests/misc/test_utils.py
+++ b/hyperspy/tests/misc/test_utils.py
@@ -18,7 +18,6 @@
 
 import dask.array as da
 import numpy as np
-from prettytable import PrettyTable
 import pytest
 
 

--- a/hyperspy/tests/model/test_fancy_indexing.py
+++ b/hyperspy/tests/model/test_fancy_indexing.py
@@ -17,7 +17,6 @@
 # along with HyperSpy. If not, see <https://www.gnu.org/licenses/#GPL>.
 
 import numpy as np
-import pytest
 
 from hyperspy._signals.signal1d import Signal1D
 from hyperspy.components1d import Gaussian
@@ -107,7 +106,7 @@ class TestModelIndexingClass:
     def setup_method(self, method):
         s = Signal1D([list(range(10))] * 3)
         m = s.create_model()
-        self.m = s.create_model()
+        self.m = m
 
     def test_model_class(self):
         m = self.m

--- a/hyperspy/tests/model/test_linear_model.py
+++ b/hyperspy/tests/model/test_linear_model.py
@@ -779,16 +779,16 @@ def test_lorentzian():
     s = m_ref.as_signal()
 
     m = s.create_model()
-    l = hs.model.components1D.Lorentzian()
-    l.centre.value = l_ref.centre.value
-    m.append(l)
+    lorentzian = hs.model.components1D.Lorentzian()
+    lorentzian.centre.value = l_ref.centre.value
+    m.append(lorentzian)
     m.set_parameters_not_free(only_nonlinear=True)
     m.plot()
     m.fit(optimizer='lstsq')
 
-    np.testing.assert_allclose(l_ref.A.value, l.A.value)
-    np.testing.assert_allclose(l_ref.centre.value, l.centre.value)
-    np.testing.assert_allclose(l_ref.gamma.value, l.gamma.value)
+    np.testing.assert_allclose(l_ref.A.value, lorentzian.A.value)
+    np.testing.assert_allclose(l_ref.centre.value, lorentzian.centre.value)
+    np.testing.assert_allclose(l_ref.gamma.value, lorentzian.gamma.value)
     np.testing.assert_allclose(m.as_signal().data, s.data)
 
 

--- a/hyperspy/tests/model/test_linearity.py
+++ b/hyperspy/tests/model/test_linearity.py
@@ -52,24 +52,24 @@ class TestModelLinearity:
         nonlinear_parameters = [p for c in self.m for p in c.parameters
                                 if not p._linear]
         assert len(nonlinear_parameters) == 2
-        l = [p for p in nonlinear_parameters if p in self.m._free_parameters]
-        assert len(l) == 0
+        _list = [p for p in nonlinear_parameters if p in self.m._free_parameters]
+        assert len(_list) == 0
 
     def test_model_parameters_inactive(self):
         self.g.active = False
         nonlinear_parameters = [p for c in self.m for p in c.parameters
                                 if not p._linear]
         assert len(nonlinear_parameters) == 2
-        l = [p for p in nonlinear_parameters if p in self.m._free_parameters]
-        assert len(l) == 0
+        _list = [p for p in nonlinear_parameters if p in self.m._free_parameters]
+        assert len(_list) == 0
 
     def test_model_parameters_set_inactive(self):
         self.m.set_component_active_value(False, [self.g])
         nonlinear_parameters = [p for c in self.m for p in c.parameters
                                 if not p._linear]
         assert len(nonlinear_parameters) == 2
-        l = [p for p in nonlinear_parameters if p in self.m._free_parameters]
-        assert len(l) == 0
+        _list = [p for p in nonlinear_parameters if p in self.m._free_parameters]
+        assert len(_list) == 0
 
 
 def test_sympy_linear_expression():

--- a/hyperspy/tests/model/test_model_storing.py
+++ b/hyperspy/tests/model/test_model_storing.py
@@ -194,7 +194,7 @@ def test_EELSModel_saving(tmp_path):
     m.components.C_K.fine_structure_active = True
 
     m.save(tmp_path / 'tmp.hspy')
-    l = load(tmp_path / 'tmp.hspy')
-    assert hasattr(l.models, 'a')
-    n = l.models.restore('a')
+    s2 = load(tmp_path / 'tmp.hspy')
+    assert hasattr(s2.models, 'a')
+    n = s2.models.restore('a')
     assert n[0].fine_structure_width == 50

--- a/hyperspy/tests/samfire/test_samfire.py
+++ b/hyperspy/tests/samfire/test_samfire.py
@@ -397,16 +397,16 @@ class TestSamfireWorker:
         g.sigma.value = self.widths[0]
         g.A.value = self.areas[0]
 
-        l = hs.model.components1D.Lorentzian()
-        l.gamma.value = self.widths[1]
-        l.A.value = self.areas[1]
+        l0 = hs.model.components1D.Lorentzian()
+        l0.gamma.value = self.widths[1]
+        l0.A.value = self.areas[1]
 
         l1 = hs.model.components1D.Lorentzian()
         l1.gamma.value = self.widths[2]
         l1.A.value = self.areas[2]
 
         d = g.function(ax - self.centres[0]) + \
-            l.function(ax - self.centres[1]) + \
+            l0.function(ax - self.centres[1]) + \
             l1.function(ax - self.centres[2])
         s = hs.signals.Signal1D(np.array([d, d]))
         s.add_poissonian_noise()

--- a/hyperspy/tests/samfire/test_strategy_list.py
+++ b/hyperspy/tests/samfire/test_strategy_list.py
@@ -32,8 +32,8 @@ class TestStrategyList:
         self.sl = StrategyList(self.samf)
 
     def test_append(self):
-        assert not self.w1.samf is self.samf
-        assert not self.w1 in self.sl
+        assert self.w1.samf is not self.samf
+        assert self.w1 not in self.sl
         self.sl.append(self.w1)
         assert self.w1.samf is self.samf
         assert self.w1 in self.sl
@@ -48,11 +48,11 @@ class TestStrategyList:
     def test_remove_int(self):
         self.sl.append(self.w1)
         self.sl.remove(0)
-        assert not self.w1.samf is self.samf
-        assert not self.w1 in self.sl
+        assert self.w1.samf is not self.samf
+        assert self.w1 not in self.sl
 
     def test_remove_object(self):
         self.sl.append(self.w1)
         self.sl.remove(self.w1)
-        assert not self.w1.samf is self.samf
-        assert not self.w1 in self.sl
+        assert self.w1.samf is not self.samf
+        assert self.w1 not in self.sl

--- a/hyperspy/tests/signals/test_1D.py
+++ b/hyperspy/tests/signals/test_1D.py
@@ -23,9 +23,6 @@ import pytest
 from hyperspy.components1d import Gaussian
 from hyperspy.decorators import lazifyTestClass
 from hyperspy.signals import Signal1D
-from hyperspy.drawing.markers import Markers
-from hyperspy.drawing._markers.circles import Circles
-from matplotlib.collections import LineCollection
 
 
 @lazifyTestClass

--- a/hyperspy/tests/signals/test_1D_tools.py
+++ b/hyperspy/tests/signals/test_1D_tools.py
@@ -18,7 +18,6 @@
 
 from unittest import mock
 
-import logging
 import numpy as np
 import pytest
 from scipy.signal import savgol_filter

--- a/hyperspy/tests/signals/test_3D.py
+++ b/hyperspy/tests/signals/test_3D.py
@@ -177,9 +177,9 @@ class Test3D:
                 cks[0],
                 cks[2],
             )
-        assert s.swap_axes(0, 2).axes_manager[0].navigate == True
+        assert s.swap_axes(0, 2).axes_manager[0].navigate is True
         s.axes_manager[2].is_binned = True
-        assert s.swap_axes(0, 2).axes_manager[2].is_binned == True
+        assert s.swap_axes(0, 2).axes_manager[2].is_binned is True
 
     def test_swap_axes_iteration(self):
         s = self.signal
@@ -344,7 +344,7 @@ class TestRebinDtype:
         s = self.s
         s.change_dtype(np.uint8)
         s2 = s.rebin(scale=(5, 2, 1), dtype=dtype)
-        if dtype == None:
+        if dtype is None:
             # np.sum default uses platform (un)signed interger (input dependent)
             dtype = np.uint
         elif dtype == 'same':

--- a/hyperspy/tests/signals/test_assign_subclass.py
+++ b/hyperspy/tests/signals/test_assign_subclass.py
@@ -25,7 +25,6 @@ import pytest
 import hyperspy.api as hs
 from hyperspy import _lazy_signals
 from hyperspy.decorators import lazifyTestClass
-from hyperspy.exceptions import VisibleDeprecationWarning
 from hyperspy.io import assign_signal_subclass
 
 testcase = namedtuple('testcase', ['dtype', 'sig_dim', 'sig_type', 'cls'])

--- a/hyperspy/tests/signals/test_cuda.py
+++ b/hyperspy/tests/signals/test_cuda.py
@@ -16,7 +16,6 @@
 # You should have received a copy of the GNU General Public License
 # along with  HyperSpy.  If not, see <https://www.gnu.org/licenses/>.
 
-from packaging.version import Version
 
 import dask
 import numpy as np

--- a/hyperspy/tests/signals/test_lazy.py
+++ b/hyperspy/tests/signals/test_lazy.py
@@ -28,7 +28,6 @@ from hyperspy._signals.lazy import (
     to_array,
     _get_navigation_dimension_chunk_slice
     )
-from hyperspy.exceptions import VisibleDeprecationWarning
 
 
 def _signal():
@@ -141,8 +140,8 @@ def test_ma_lazify():
             data=[
                 1, 2, 3], mask=[
                 0, 1, 0]))
-    l = s.as_lazy()
-    assert np.isnan(l.data[1].compute())
+    s2 = s.as_lazy()
+    assert np.isnan(s2.data[1].compute())
     ss = hs.stack([s, s])
     assert np.isnan(ss.data[:, 1]).all()
 

--- a/hyperspy/tests/signals/test_signal_subclass_conversion.py
+++ b/hyperspy/tests/signals/test_signal_subclass_conversion.py
@@ -19,7 +19,7 @@
 import numpy as np
 import pytest
 
-from hyperspy import _lazy_signals, signals
+from hyperspy import signals
 from hyperspy.decorators import lazifyTestClass
 from hyperspy.exceptions import DataDimensionError
 from hyperspy.signals import BaseSignal

--- a/hyperspy/tests/test_extension_registry.py
+++ b/hyperspy/tests/test_extension_registry.py
@@ -16,52 +16,46 @@
 # You should have received a copy of the GNU General Public License
 # along with HyperSpy. If not, see <https://www.gnu.org/licenses/#GPL>.
 
+import importlib
+
 from hyperspy.extensions import ALL_EXTENSIONS
 
 
-signals = {key: value for key, value in ALL_EXTENSIONS["signals"].items()
-           if not value["lazy"]}
+def test_signal_registry():
+    signals = {key: value for key, value in ALL_EXTENSIONS["signals"].items()
+            if not value["lazy"]}
 
 
-hyperspy_signals = [
-    'BaseSignal',
-    'Signal1D',
-    'Signal2D',
-    'ComplexSignal',
-    'ComplexSignal1D',
-    'ComplexSignal2D',
-    ]
+    hyperspy_signals = [
+        'BaseSignal',
+        'Signal1D',
+        'Signal2D',
+        'ComplexSignal',
+        'ComplexSignal1D',
+        'ComplexSignal2D',
+        ]
 
 
-for signal in hyperspy_signals:
-    assert signal in signals.keys()
+    for signal in hyperspy_signals:
+        assert signal in signals.keys()
 
-try:
-    import exspy
-    assert 'EELSSpectrum' in signals.keys()
-    assert 'EDSTEMSpectrum' in signals.keys()
-    assert 'EDSSTEMSpectrum' in signals.keys()
-    assert 'DielectricFunction' in signals.keys()
-except:
-    pass
+    exspy_spec = importlib.util.find_spec("exspy")
+    if exspy_spec is not None:
+        assert 'EELSSpectrum' in signals.keys()
+        assert 'EDSTEMSpectrum' in signals.keys()
+        assert 'DielectricFunction' in signals.keys()
 
-try:
-    import holospy
-    assert 'HologramImage' in signals.keys()
-except:
-    pass
+    holospy_spec = importlib.util.find_spec("holospy")
+    if holospy_spec is not None:
+        assert 'HologramImage' in signals.keys()
 
-try:
-    import lumipsy
-    assert 'LumiSpectrum' in signals.keys()
-    assert 'CLSEMSpectrum' in signals.keys()
-except:
-    pass
+    lumispy_spec = importlib.util.find_spec("lumispy")
+    if lumispy_spec is not None:
+        assert 'LumiSpectrum' in signals.keys()
+        assert 'CLSEMSpectrum' in signals.keys()
 
-
-try:
-    import pyxem
-    assert 'Diffraction2D' in signals.keys()
-    assert 'ElectronDiffraction' in signals.keys()
-except:
-    pass
+    pyxem_spec = importlib.util.find_spec("pyxem")
+    if pyxem_spec is not None:
+        assert 'Diffraction2D' in signals.keys()
+        assert 'ElectronDiffraction2D' in signals.keys()
+            

--- a/hyperspy/tests/test_import.py
+++ b/hyperspy/tests/test_import.py
@@ -18,7 +18,7 @@
 
 
 def test_import_version():
-    from hyperspy import __version__
+    from hyperspy import __version__ # noqa: F401
 
 
 def test_import():

--- a/hyperspy/tests/test_io.py
+++ b/hyperspy/tests/test_io.py
@@ -104,19 +104,19 @@ class TestNonUniformAxisCheck:
         # make sure we start from a clean state
 
     def test_io_nonuniform(self):
-        assert(self.s.axes_manager[0].is_uniform == False)
+        assert(self.s.axes_manager[0].is_uniform is False)
         self.s.save('tmp.hspy', overwrite = True)
         with pytest.raises(TypeError, match = "not supported for non-uniform"):
             self.s.save('tmp.msa', overwrite = True)
 
     def test_nonuniform_writer_characteristic(self):
         for plugin in IO_PLUGINS:
-            if not "non_uniform_axis" in plugin:
+            if "non_uniform_axis" not in plugin:
                 print(plugin.name + ' IO-plugin is missing the '
                       'characteristic `non_uniform_axis`')
 
     def test_nonuniform_error(self):
-        assert(self.s.axes_manager[0].is_uniform == False)
+        assert(self.s.axes_manager[0].is_uniform is False)
         incompatible_writers = [
             plugin["file_extensions"][plugin["default_extension"]]
             for plugin in IO_PLUGINS if (plugin["writes"] is True or

--- a/hyperspy/tests/utils/test_parallel_pool.py
+++ b/hyperspy/tests/utils/test_parallel_pool.py
@@ -15,6 +15,8 @@
 # You should have received a copy of the GNU General Public License
 # along with HyperSpy. If not, see <https://www.gnu.org/licenses/#GPL>.
 
+import importlib
+
 import pytest
 
 from hyperspy.utils.parallel_pool import ParallelPool
@@ -28,10 +30,8 @@ def test_parallel_pool_multiprocessing():
 
 def test_parallel_pool_ipyparallel_not_installed():
     pool = ParallelPool()
-    try:
-        import ipyparallel
-        # ipyparallel is installed, use it as default
-    except ImportError:
+    ipyparallel_spec = importlib.util.find_spec("ipyparallel")
+    if ipyparallel_spec is None:
         # ipyparallel is installed, use multiprocessing instead
         assert pool.is_multiprocessing
         assert not pool.is_ipyparallel

--- a/hyperspy/ui_registry.py
+++ b/hyperspy/ui_registry.py
@@ -47,7 +47,7 @@ if "widgets" in ALL_EXTENSIONS["GUI"] and ALL_EXTENSIONS["GUI"]["widgets"]:
         for toolkey, specs in widgets.items():
             # Skip toolkey if extension is not installed
             if toolkey.split(".")[0] in _EXTENSION_NAMES + ["hyperspy"]:
-                if not toolkey in UI_REGISTRY:
+                if toolkey not in UI_REGISTRY:
                     raise NameError(f"{toolkey} is not a registered toolkey")
                 UI_REGISTRY[toolkey][toolkit] = specs
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -188,7 +188,6 @@ doctest_optionflags = [
 [tool.ruff]
 exclude = [
     "hyperspy/external/*",
-    "hyperspy/tests/*",
     ]
 
 [tool.setuptools.package-data]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -185,6 +185,12 @@ doctest_optionflags = [
     "ELLIPSIS",
 ]
 
+[tool.ruff]
+exclude = [
+    "hyperspy/external/*",
+    "hyperspy/tests/*",
+    ]
+
 [tool.setuptools.package-data]
 "*" = [
     "hyperspy_extension.yaml",

--- a/upcoming_changes/3299.maintenance.rst
+++ b/upcoming_changes/3299.maintenance.rst
@@ -1,0 +1,1 @@
+Use ruff to lint code.


### PR DESCRIPTION
Ruff can be used for linting and formatting. This PR update code to pass `ruff check` (https://docs.astral.sh/ruff/linter/) which does the same as `flake8`.

### Progress of the PR
- [x] Use ruff for linting code,
- [n/a] update docstring (if appropriate),
- [x] update contributor guide (if appropriate),
- [x] add an changelog entry in the `upcoming_changes` folder (see [`upcoming_changes/README.rst`](https://github.com/hyperspy/hyperspy/blob/RELEASE_next_minor/upcoming_changes/README.rst)),
- [x] Check formatting changelog entry in the `readthedocs` doc build of this PR (link in github checks)
- [n/a] add tests,
- [x] ready for review.

