### PR TITLE
Allow hiding signals provided by extensions

### DIFF
--- a/doc/dev_guide/writing_extensions.rst
+++ b/doc/dev_guide/writing_extensions.rst
@@ -187,6 +187,12 @@ the signal subclass with ``Electron Energy Loss Spectroscopy`` signal type.
 It is good practice to choose a very explicit ``signal_type`` while leaving
 acronyms for ``signal_type_aliases``.
 
+Additionally, the optional key ``hidden: True`` can be defined if a signal should
+be registered with HyperSpy, but not listed by :meth:`hyperspy.api.print_known_signal_types`.
+This option can be used if a signal subclass is needed for certain functionalities,
+such as casting to a different signal subclass, but should usually not be set
+directly by the user.
+
 Creating new HyperSpy model components
 --------------------------------------
 

--- a/hyperspy/utils/__init__.py
+++ b/hyperspy/utils/__init__.py
@@ -74,7 +74,7 @@ def print_known_signal_types(style=None):
         table.set_style(style)
     for sclass, sdict in ALL_EXTENSIONS["signals"].items():
         # skip lazy signals and non-data-type specific signals
-        if sdict["lazy"] or not sdict["signal_type"]:
+        if sdict["lazy"] or sdict.get("hidden", False) or not sdict["signal_type"]:
             continue
         aliases = (
             ", ".join(sdict["signal_type_aliases"])

--- a/upcoming_changes/3302.enhancements.rst
+++ b/upcoming_changes/3302.enhancements.rst
@@ -1,0 +1,1 @@
+Allow setting optional ``hidden`` key in definition of signals extending hyperspy, which prevents them from being shown by ``print_known_signal_types()``.


### PR DESCRIPTION
Allow setting optional `"hidden"` key in definition of signals extending hyperspy, which prevents them from being shown by `print_known_signal_types()`.

### Progress of the PR
- [x] Change implemented (can be split into several points),
- [x] update user guide (if appropriate),
- [x] add an changelog entry in the `upcoming_changes` folder (see [`upcoming_changes/README.rst`](https://github.com/hyperspy/hyperspy/blob/RELEASE_next_minor/upcoming_changes/README.rst)),
- [x] Check formatting changelog entry in the `readthedocs` doc build of this PR (link in github checks)
- [n/a] add tests,
- [x] ready for review.


