### PR TITLE
Fix bug with side by side plotting of signal containing navigation dimension only

### DIFF
--- a/hyperspy/drawing/mpl_he.py
+++ b/hyperspy/drawing/mpl_he.py
@@ -217,7 +217,11 @@ class MPL_HyperExplorer(object):
                 from ipywidgets.widgets import HBox, VBox
                 from IPython.display import display
 
-                if not self.navigator_plot:
+                if self.signal_plot is None and self.navigator_plot is not None:
+                    # in case the signal is navigation only
+                    display(self.navigator_plot.figure.canvas)
+                elif self.navigator_plot is None:
+                    # in case the signal is signal  only
                     display(self.signal_plot.figure.canvas)
                 elif plot_style == "horizontal":
                     display(

--- a/hyperspy/tests/drawing/test_horizontal_plotting.py
+++ b/hyperspy/tests/drawing/test_horizontal_plotting.py
@@ -47,6 +47,13 @@ class TestIPYMPL:
         captured = capsys.readouterr()
         assert "Canvas(toolbar=Toolbar(" in captured.out
 
+    def test_only_navigation(self, capsys):
+        matplotlib.use("module://ipympl.backend_nbagg")
+        s = hs.signals.Signal2D(np.random.random((2, 2))).T
+        s.plot()
+        captured = capsys.readouterr()
+        assert "Canvas(toolbar=Toolbar(" in captured.out
+
     def test_warnings(
         self,
     ):

--- a/upcoming_changes/3304.bugfix.rst
+++ b/upcoming_changes/3304.bugfix.rst
@@ -1,0 +1,1 @@
+Fix bug with side by side plotting of signal containing navigation dimension only.


### PR DESCRIPTION
### Progress of the PR
- [x] Fix bug described in title,
- [n/a] update docstring (if appropriate),
- [n/a] update user guide (if appropriate),
- [x] add an changelog entry in the `upcoming_changes` folder (see [`upcoming_changes/README.rst`](https://github.com/hyperspy/hyperspy/blob/RELEASE_next_minor/upcoming_changes/README.rst)),
- [x] Check formatting changelog entry in the `readthedocs` doc build of this PR (link in github checks)
- [x] add tests,
- [x] ready for review.

### Minimal example of the bug fix or the new feature
```python
import hyperspy.api as hs
import matplotlib
import numpy as np

matplotlib.use("module://ipympl.backend_nbagg")
s = hs.signals.Signal2D(np.random.random((2, 2))).T
s.plot()
```

Give the following error:
```python

---------------------------------------------------------------------------
AttributeError                            Traceback (most recent call last)
Cell In[5], line 2
      1 s = hs.signals.Signal2D(np.random.random((2, 2))).T
----> 2 s.plot()

File ~\Dev\hyperspy\hyperspy\signal.py:2954, in BaseSignal.plot(self, navigator, axes_manager, plot_markers, **kwargs)
   2949     else:
   2950         raise ValueError(
   2951             'navigator must be one of "spectrum","auto", '
   2952             '"slider", None, a Signal instance')
-> 2954 self._plot.plot(**kwargs)
   2955 self.events.data_changed.connect(self.update_plot, [])
   2957 p = self._plot.signal_plot if self._plot.signal_plot else self._plot.navigator_plot

File ~\Dev\hyperspy\hyperspy\drawing\mpl_he.py:220, in MPL_HyperExplorer.plot(self, **kwargs)
    218     import matplotlib.pyplot as plt
    219     with plt.ioff():
--> 220         plot_sig_and_nav(plot_style)
    221 else:
    222     plot_sig_and_nav(plot_style)

File ~\Dev\hyperspy\hyperspy\drawing\mpl_he.py:214, in MPL_HyperExplorer.plot.<locals>.plot_sig_and_nav(plot_style)
    212     display(self.signal_plot.figure.canvas)
    213 elif plot_style == "horizontal":
--> 214     display(HBox([self.navigator_plot.figure.canvas,self.signal_plot.figure.canvas]))
    215 else: # plot_style == "vertical":
    216     display(VBox([self.navigator_plot.figure.canvas, self.signal_plot.figure.canvas]))

AttributeError: 'NoneType' object has no attribute 'figure'
```


