### PR TITLE
Run test suite on osx arm64 on GitHub CI

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,7 +10,7 @@ jobs:
     env:
       MPLBACKEND: agg
       PIP_ARGS: --upgrade -e
-      PYTEST_ARGS: --pyargs hyperspy --reruns 3 -n 2 --instafail
+      PYTEST_ARGS: --pyargs hyperspy --reruns 3 --instafail
     strategy:
       fail-fast: false
       matrix:
@@ -21,6 +21,7 @@ jobs:
         include:
           # test oldest supported version of main dependencies on python 3.8
           - os: ubuntu
+            os_version: latest
             PYTHON_VERSION: '3.8'
             PIP_SELECTOR: '[all, tests, coverage]'
             OLDEST_SUPPORTED_VERSION: true
@@ -28,18 +29,21 @@ jobs:
             LABEL: -oldest
           # test minimum requirement
           - os: ubuntu
+            os_version: latest
             PYTHON_VERSION: '3.12'
             PIP_SELECTOR: '[tests, coverage]'
             LABEL: -minimum
             # Run coverage
           - os: ubuntu
+            os_version: latest
             PYTHON_VERSION: '3.8'
             PIP_SELECTOR: '[all, tests, coverage]'
           - os: ubuntu
+            os_version: latest
             PYTHON_VERSION: '3.11'
             PIP_SELECTOR: '[all, tests, coverage]'
           - os: macos
-            os_version: '13'
+            os_version: '14'
             PYTHON_VERSION: '3.11'
             PIP_SELECTOR: '[all, tests, coverage]'
 
@@ -62,6 +66,18 @@ jobs:
         with:
           python-version: ${{ matrix.PYTHON_VERSION }}
 
+      - name: Get the number of CPUs
+        id: cpus
+        run: |
+          import os, platform
+          num_cpus = os.cpu_count()
+          print(f"Number of CPU: {num_cpus}")
+          print(f"Architecture: {platform.machine()}")
+          output_file = os.environ["GITHUB_OUTPUT"]
+          with open(output_file, "a", encoding="utf-8") as output_stream:
+              output_stream.write(f"count={num_cpus}\n")
+        shell: python
+
       - name: Display version
         run: |
           python --version
@@ -83,7 +99,7 @@ jobs:
 
       - name: Run test suite
         run: |
-          pytest ${{ env.PYTEST_ARGS }} --cov=. --cov-report=xml
+          pytest ${{ env.PYTEST_ARGS }} -n ${{ steps.cpus.outputs.count }} --cov=. --cov-report=xml
 
       - name: Run doctest (Docstring)
         run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -4,8 +4,8 @@ on: [push, pull_request]
 
 jobs:
   run_test_site:
-    name: ${{ matrix.os }}-py${{ matrix.PYTHON_VERSION }}${{ matrix.LABEL }}
-    runs-on: ${{ matrix.os }}-latest
+    name: ${{ matrix.os }}-${{ matrix.os_version }}-py${{ matrix.PYTHON_VERSION }}${{ matrix.LABEL }}
+    runs-on: ${{ matrix.os }}-${{ matrix.os_version }}
     timeout-minutes: 30
     env:
       MPLBACKEND: agg
@@ -15,6 +15,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu, windows, macos]
+        os_version: [latest]
         PYTHON_VERSION: ['3.9', '3.10', ]
         PIP_SELECTOR: ['[all, tests, coverage]']
         include:
@@ -35,6 +36,10 @@ jobs:
             PYTHON_VERSION: '3.8'
             PIP_SELECTOR: '[all, tests, coverage]'
           - os: ubuntu
+            PYTHON_VERSION: '3.11'
+            PIP_SELECTOR: '[all, tests, coverage]'
+          - os: macos
+            os_version: '13'
             PYTHON_VERSION: '3.11'
             PIP_SELECTOR: '[all, tests, coverage]'
 

--- a/upcoming_changes/3305.maintenance.rst
+++ b/upcoming_changes/3305.maintenance.rst
@@ -1,0 +1,1 @@
+Run test suite on osx arm64 on GitHub CI and speed running test suite using all available CPUs (3 or 4) instead of only 2.


### PR DESCRIPTION
https://github.blog/changelog/2024-01-30-github-actions-introducing-the-new-m1-macos-runner-available-to-open-source/
https://github.blog/2024-01-17-github-hosted-runners-double-the-power-for-open-source/

### Progress of the PR
- [x] Add osx arm64 build to GitHub CI,
- [x] Speed running test suite using all available CPUs (3 or 4) instead of only 2,
- [n/a] update docstring (if appropriate),
- [n/a] update user guide (if appropriate),
- [x] add an changelog entry in the `upcoming_changes` folder (see [`upcoming_changes/README.rst`](https://github.com/hyperspy/hyperspy/blob/RELEASE_next_minor/upcoming_changes/README.rst)),
- [x] Check formatting changelog entry in the `readthedocs` doc build of this PR (link in github checks)
- [n/a] add tests,
- [x] ready for review.

