### PR TITLE
Fix API changes in scipy and scikit-image

### DIFF
--- a/hyperspy/signal.py
+++ b/hyperspy/signal.py
@@ -6841,7 +6841,7 @@ class BaseSignal(
         elif window == "tukey":
 
             def window_function(m):
-                return sp_signal.tukey(m, tukey_alpha)
+                return sp_signal.windows.tukey(m, tukey_alpha)
         else:
             raise ValueError("Wrong type parameter value.")
 

--- a/hyperspy/tests/signals/test_apodization.py
+++ b/hyperspy/tests/signals/test_apodization.py
@@ -18,7 +18,7 @@
 
 import numpy as np
 import pytest
-from scipy.signal import tukey
+from scipy.signal.windows import tukey
 
 from hyperspy.misc.math_tools import hann_window_nth_order, outer_nd
 from hyperspy.signals import BaseSignal, Signal1D, Signal2D

--- a/upcoming_changes/3306.maintenance.rst
+++ b/upcoming_changes/3306.maintenance.rst
@@ -1,0 +1,1 @@
+Fix API changes in scipy (:func:`scipy.signal.windows.tukey`) and scikit-image (:func:`skimage.restoration.unwrap_phase`).


### PR DESCRIPTION
xref https://github.com/hyperspy/hyperspy-extensions-list/pull/49

### Progress of the PR
- [x] Fix API changes for scipy, has changed since a long time: https://docs.scipy.org/doc/scipy-1.5.0/reference/generated/scipy.signal.windows.tukey.html?highlight=tukey#scipy.signal.windows.tukey
- [x] Fix API changes for scikit-image, deprecated since 0.21: https://scikit-image.org/docs/0.21.x/api/skimage.restoration.html#skimage.restoration.unwrap_phase,
- [n/a] update docstring (if appropriate),
- [n/a] update user guide (if appropriate),
- [x] add an changelog entry in the `upcoming_changes` folder (see [`upcoming_changes/README.rst`](https://github.com/hyperspy/hyperspy/blob/RELEASE_next_minor/upcoming_changes/README.rst)),
- [x] Check formatting changelog entry in the `readthedocs` doc build of this PR (link in github checks)
- [n/a] add tests,
- [x] ready for review.

