### PR TITLE
Add support for specifying axes for the navigator and "streak" navigator

### DIFF
--- a/examples/Visualization/README.rst
+++ b/examples/Visualization/README.rst
@@ -1,0 +1,8 @@
+Visualization
+=============
+
+Below is a gallery of examples on using regions of interest with HyperSpy signals.
+Visualization
+=============
+
+Below is a gallery of examples on how to visualize data using HyperSpy signals.

--- a/examples/Visualization/navigator_axes.py
+++ b/examples/Visualization/navigator_axes.py
@@ -15,6 +15,14 @@ shape = (3, 4, 5, 10, 10)
 data = np.arange(np.prod(shape)).reshape(shape) + np.random.default_rng().random(shape) * 100
 s = hs.signals.Signal2D(data)
 
+# Set the name of the navigation axis
+for axis, name in zip(s.axes_manager.navigation_axes, ["x", "y", "z"]):
+    axis.name = name
+
+# Set the name of the signal axis
+for axis, name in zip(s.axes_manager.signal_axes, ["a", "b"]):
+    axis.name = name
+
 #%%
 # The signal has 3 navigation axes and 2 signal dimension:
 s.axes_manager
@@ -25,5 +33,9 @@ s.plot()
 
 #%%
 # The axes of the navigation can be specified using the `navigator_axes` argument,
-# for example, to select the first (index 0) and third (index 2) axes:
-s.plot(navigator_axes=[0, 2])
+# for example, to select the "x" and "z" axes:
+s.plot(navigator_axes=["x", "z"])
+
+#%%
+# Or with a different order of the navigation axes:
+s.plot(navigator_axes=["z", "x"])

--- a/examples/Visualization/navigator_axes.py
+++ b/examples/Visualization/navigator_axes.py
@@ -1,0 +1,29 @@
+"""
+Specify Navigator Axes
+======================
+
+This example shows how to specify the axes of the navigation space for
+the navigator
+"""
+
+import hyperspy.api as hs
+import numpy as np
+
+#%%
+# Create a 5D signal with signal dimension of 2:
+shape = (3, 4, 5, 10, 10)
+data = np.arange(np.prod(shape)).reshape(shape) + np.random.default_rng().random(shape) * 100
+s = hs.signals.Signal2D(data)
+
+#%%
+# The signal has 3 navigation axes and 2 signal dimension:
+s.axes_manager
+
+#%%
+# By default, the first two navigation axes will be used:
+s.plot()
+
+#%%
+# The axes of the navigation can be specified using the `navigator_axes` argument,
+# for example, to select the first (index 0) and third (index 2) axes:
+s.plot(navigator_axes=[0, 2])

--- a/examples/Visualization/streak_navigator.py
+++ b/examples/Visualization/streak_navigator.py
@@ -1,0 +1,19 @@
+"""
+Streak Navigator
+================
+
+Use a `streak image <https://en.wikipedia.org/wiki/Streak_camera>`_ as a navigator:
+the navigator will have the signal axis for the horizontal axis and the last navigation
+dimension for the vertical axis.
+
+"""
+
+import hyperspy.api as hs
+
+#%%
+# Create a signal:
+s = hs.data.two_gaussians()
+
+#%%
+# Plot the navigator with a streak image:
+s.plot(navigator="streak")

--- a/hyperspy/_signals/lazy.py
+++ b/hyperspy/_signals/lazy.py
@@ -1303,7 +1303,7 @@ class LazySignal(BaseSignal):
         navigator.compute(show_progressbar=show_progressbar)
         navigator.original_metadata.set_item("sum_from", str(isig_slice))
 
-        self.navigator = navigator.T
+        self.navigator = navigator
 
     compute_navigator.__doc__ %= SHOW_PROGRESSBAR_ARG
 

--- a/hyperspy/docstrings/plot.py
+++ b/hyperspy/docstrings/plot.py
@@ -63,10 +63,8 @@ BASE_PLOT_DOCSTRING_PARAMETERS = """navigator : str, None, or :class:`~hyperspy.
             - If ``None``, no navigator will be provided.
 
             Alternatively a :class:`~hyperspy.api.signals.BaseSignal` (or subclass)
-            instance can be provided. The navigation or signal shape must
-            match the navigation shape of the signal to plot or the
-            ``navigation_shape`` + ``signal_shape`` must be equal to the
-            ``navigator_shape`` of the current object (for a dynamic navigator).
+            instance can be provided. The navigation must have navigation dimension
+            only and its shape must match the navigation shape of the signal.
             If the signal ``dtype`` is RGB or RGBA this parameter has no effect and
             the value is always set to ``'slider'``.
         axes_manager : None or :class:`~hyperspy.axes.AxesManager`

--- a/hyperspy/drawing/mpl_he.py
+++ b/hyperspy/drawing/mpl_he.py
@@ -58,10 +58,12 @@ class MPL_HyperExplorer(object):
             for axis in self.axes_manager.signal_axes:
                 axis.offset = -axis.high_value / 2.0
 
-    def plot_navigator(self, title=None, **kwargs):
+    def plot_navigator(self, axes, title=None, **kwargs):
         """
         Parameters
         ----------
+        axes : list of :class:`~hyperspy.axes.DataAxis`
+            Axes of the navigator.
         title : str, optional
             Title of the navigator. The default is None.
         **kwargs : dict
@@ -77,19 +79,25 @@ class MPL_HyperExplorer(object):
         if self.navigator_data_function == "slider":
             self._get_navigation_sliders()
             return
+        if len(axes) > 2:
+            raise ValueError(
+                "The length of the `axes` argument can't be larger than 2."
+            )
+
+        # Get the navigation axes used for the navigator
         title = title or self.signal_title + " Navigator" if self.signal_title else ""
 
         if len(self.navigator_data_function().shape) == 1:
             # Create the figure
-            sf = signal1d.Signal1DFigure(title=title)
-            axis = self.axes_manager.navigation_axes[0]
-            sf.xlabel = "%s" % str(axis)
+            nav_plot = signal1d.Signal1DFigure(title=title)
+            axis = axes[0]
+            nav_plot.xlabel = "%s" % str(axis)
             if axis.units is not Undefined:
-                sf.xlabel += " (%s)" % axis.units
-            sf.ylabel = r"$\Sigma\mathrm{data\,over\,all\,other\,axes}$"
-            sf.axis = axis
-            sf.axes_manager = self.axes_manager
-            self.navigator_plot = sf
+                nav_plot.xlabel += " (%s)" % axis.units
+            nav_plot.ylabel = r"$\Sigma\mathrm{data\,over\,all\,other\,axes}$"
+            nav_plot.axis = axis
+            nav_plot.axes_manager = self.axes_manager
+            self.navigator_plot = nav_plot
 
             # Create a line to the left axis with the default indices
             sl = signal1d.Signal1DLine()
@@ -104,49 +112,45 @@ class MPL_HyperExplorer(object):
                 color="blue", type="step" if axis.is_uniform else "line"
             )
             # Add the line to the figure
-            sf.add_line(sl)
-            sf.plot()
-            self.pointer.set_mpl_ax(sf.ax)
-            if self.axes_manager.navigation_dimension > 1:
-                self._get_navigation_sliders()
-                for axis in self.axes_manager.navigation_axes[:-2]:
-                    axis.events.index_changed.connect(sf.update, [])
-                    sf.events.closed.connect(
-                        partial(axis.events.index_changed.disconnect, sf.update), []
-                    )
-            self.navigator_plot = sf
+            nav_plot.add_line(sl)
+            nav_plot.plot()
+            self.pointer.set_mpl_ax(nav_plot.ax)
+
         elif len(self.navigator_data_function().shape) >= 2:
             # Create the figure
-            imf = image.ImagePlot(title=title)
-            imf.data_function = self.navigator_data_function
+            nav_plot = image.ImagePlot(title=title)
+            nav_plot.data_function = self.navigator_data_function
 
             # Set all kwargs value to the image figure before passing the rest
             # of the kwargs to plot method of the image figure
             for key, value in list(kwargs.items()):
-                if hasattr(imf, key):
-                    setattr(imf, key, kwargs.pop(key))
+                if hasattr(nav_plot, key):
+                    setattr(nav_plot, key, kwargs.pop(key))
 
-            # Navigator labels
-            if self.axes_manager.navigation_dimension == 1:
-                imf.yaxis = self.axes_manager.navigation_axes[0]
-                imf.xaxis = self.axes_manager.signal_axes[0]
-            elif self.axes_manager.navigation_dimension >= 2:
-                imf.yaxis = self.axes_manager.navigation_axes[1]
-                imf.xaxis = self.axes_manager.navigation_axes[0]
-                if self.axes_manager.navigation_dimension > 2:
-                    self._get_navigation_sliders()
-                    for axis in self.axes_manager.navigation_axes[2:]:
-                        axis.events.index_changed.connect(imf.update, [])
-                        imf.events.closed.connect(
-                            partial(axis.events.index_changed.disconnect, imf.update),
-                            [],
-                        )
+            nav_plot.xaxis = axes[0]
+            nav_plot.yaxis = axes[1]
 
             if "cmap" not in kwargs.keys() or kwargs["cmap"] is None:
                 kwargs["cmap"] = preferences.Plot.cmap_navigator
-            imf.plot(**kwargs)
-            self.pointer.set_mpl_ax(imf.ax)
-            self.navigator_plot = imf
+            nav_plot.plot(**kwargs)
+            self.pointer.set_mpl_ax(nav_plot.ax)
+            self.navigator_plot = nav_plot
+
+        self.navigator_plot = nav_plot
+
+        # Add sliders
+        dim = len(axes) - len([axis for axis in axes if not axis.navigate])
+        if self.axes_manager.navigation_dimension > dim:
+            self._get_navigation_sliders()
+            # Connect events for axes which are not used in the navigator
+            for axis in [
+                axis for axis in self.axes_manager.navigation_axes if axis not in axes
+            ]:
+                axis.events.index_changed.connect(nav_plot.update, [])
+                nav_plot.events.closed.connect(
+                    partial(axis.events.index_changed.disconnect, nav_plot.update),
+                    [],
+                )
 
         if self.navigator_plot is not None:
             self.navigator_plot.events.closed.connect(
@@ -190,17 +194,25 @@ class MPL_HyperExplorer(object):
                 "plotting backends are used."
             )
         plot_style = kwargs.pop("plot_style", None)
+        navigator_axes = kwargs.pop("navigator_axes", None)
 
         # matplotlib plotting backend
         def plot_sig_and_nav(plot_style):
             if self.pointer is None:
-                pointer = self.assign_pointer()
+                streak = (
+                    not navigator_axes[0].navigate if len(navigator_axes) else False
+                )
+                pointer = self.assign_pointer(streak=streak)
                 if pointer is not None:
                     self.pointer = pointer(self.axes_manager)
                     self.pointer.is_pointer = True
                     self.pointer.color = "red"
+                    # if steak, we need to pick the second axis
+                    self.pointer.axes = navigator_axes[1:] if streak else navigator_axes
                     self.pointer.connect_navigate()
-                self.plot_navigator(**kwargs.pop("navigator_kwds", {}))
+                self.plot_navigator(
+                    axes=navigator_axes, **kwargs.pop("navigator_kwds", {})
+                )
                 if pointer is not None:
                     self.navigator_plot.events.closed.connect(
                         self.pointer.disconnect, []
@@ -250,7 +262,7 @@ class MPL_HyperExplorer(object):
         else:
             plot_sig_and_nav(plot_style)
 
-    def assign_pointer(self):
+    def assign_pointer(self, streak=False):
         if self.navigator_data_function is None:
             nav_dim = 0
         elif self.navigator_data_function == "slider":
@@ -259,9 +271,9 @@ class MPL_HyperExplorer(object):
             nav_dim = len(self.navigator_data_function().shape)
 
         if nav_dim == 2:  # It is an image
-            if self.axes_manager.navigation_dimension > 1:
+            if not streak and self.axes_manager.navigation_dimension > 1:
                 Pointer = widgets.SquareWidget
-            else:  # It is the image of a "spectrum stack"
+            else:  # It is the image of a "spectrum stack" or "streak"
                 Pointer = widgets.HorizontalLineWidget
         elif nav_dim == 1:  # It is a spectrum
             Pointer = widgets.VerticalLineWidget

--- a/hyperspy/drawing/utils.py
+++ b/hyperspy/drawing/utils.py
@@ -1829,8 +1829,8 @@ def plot_roi_map(signal, rois=1):
     The ROIs can be moved interactively and the corresponding plots will
     update automatically.
 
-    Arguments
-    ---------
+    Parameters
+    ----------
     signal: :class:`~.api.signals.BaseSignal`
         The signal to inspect.
     rois: int, list of :class:`~.api.roi.SpanROI` or :class:`~.api.roi.RectangularROI`

--- a/hyperspy/drawing/widget.py
+++ b/hyperspy/drawing/widget.py
@@ -343,9 +343,9 @@ class DraggableWidgetBase(WidgetBase):
         # Set default axes
         if self.axes_manager is not None:
             if self.axes_manager.navigation_dimension > 0:
-                self.axes = self.axes_manager.navigation_axes[0:1]
+                self.axes = self.axes_manager.navigation_axes[:1]
             else:
-                self.axes = self.axes_manager.signal_axes[0:1]
+                self.axes = self.axes_manager.signal_axes[:1]
         else:
             self._pos = np.array([0.0])
 
@@ -779,9 +779,9 @@ class Widget2DBase(ResizableDraggableWidgetBase):
         # Set default axes
         if self.axes_manager is not None:
             if self.axes_manager.navigation_dimension > 1:
-                self.axes = self.axes_manager.navigation_axes[0:2]
+                self.axes = self.axes_manager.navigation_axes[:2]
             elif self.axes_manager.signal_dimension > 1:
-                self.axes = self.axes_manager.signal_axes[0:2]
+                self.axes = self.axes_manager.signal_axes[:2]
             elif len(self.axes_manager.shape) > 1:
                 self.axes = (
                     self.axes_manager.signal_axes + self.axes_manager.navigation_axes

--- a/hyperspy/signal.py
+++ b/hyperspy/signal.py
@@ -46,7 +46,6 @@ from hyperspy.axes import AxesManager
 from hyperspy.api_nogui import _ureg
 from hyperspy.misc.array_tools import rebin as array_rebin
 from hyperspy.drawing import mpl_hie, mpl_hse, mpl_he
-from hyperspy.exceptions import VisibleDeprecationWarning
 from hyperspy.learn.mva import MVA, LearningResults
 from hyperspy.io import assign_signal_subclass
 from hyperspy.io import save as io_save
@@ -3135,13 +3134,8 @@ class BaseSignal(
             # string
             if isinstance(navigator, BaseSignal):
                 if navigator.axes_manager.signal_dimension > 0:
-                    # Deprecated in 2.1, to be removed in 3.0
-                    warnings.warn(
-                        "Support for navigator with signal dimension is deprecated, "
-                        "it will be removed in hyperspy 3.0. "
-                        "The navigator must have navigation dimension only.",
-                        VisibleDeprecationWarning,
-                    )
+                    # In view of adding support for signal dimension to
+                    # navigator in the future, we don't deprecate
                     navigator = navigator.transpose(signal_axes=[])
 
                 if (
@@ -3174,13 +3168,13 @@ class BaseSignal(
                     self._plot.navigator_data_function = get_dynamic_image_explorer
                 elif navigator == "spectrum":
                     self._plot.navigator_data_function = get_1D_sum_explorer
+                else:
+                    raise ValueError(
+                        'navigator must be one of "spectrum", "streak", "auto", '
+                        '"slider", None or a signal instance.'
+                    )
             elif navigator is None:
                 self._plot.navigator_data_function = None
-            else:
-                raise ValueError(
-                    'navigator must be one of "spectrum", "streak", "auto", '
-                    '"slider", None, a Signal instance'
-                )
 
         self._plot.plot(navigator_axes=navigator_axes, **kwargs)
         self.events.data_changed.connect(self.update_plot, [])

--- a/hyperspy/signal.py
+++ b/hyperspy/signal.py
@@ -3084,11 +3084,18 @@ class BaseSignal(
             return np.nan_to_num(to_numpy(navigator.data))
 
         def get_dynamic_image_explorer(*args, **kwargs):
+            # Find the indices to slice the correct slice of the navigator
+            # for when navigation axes > 2
             slices = [
                 Ellipsis if axis in navigator_axes else axis.index
                 for axis in self.axes_manager.navigation_axes
             ]
+
             data = getitem(navigator.inav, slices).data
+            # transpose slice when axes are not in order
+            axes = [axis.index_in_array for axis in navigator_axes]
+            if axes[1] > axes[0]:
+                data = data.T
             if np.issubdtype(self.data.dtype, np.complexfloating):
                 data = abs(data)
             return np.nan_to_num(to_numpy(data))

--- a/hyperspy/tests/drawing/test_plot_lazy.py
+++ b/hyperspy/tests/drawing/test_plot_lazy.py
@@ -57,7 +57,7 @@ def test_compute_navigator():
     assert s.navigator.original_metadata.sum_from == "[slice(5, 10, None)]"
 
     # change the navigator and check it is used when plotting
-    s.navigator = s.navigator / s.navigator.mean()
+    s.navigator = s.navigator / s.navigator.data.mean()
     s.plot()
     np.testing.assert_allclose(s._plot.navigator_data_function(), s.navigator.data)
 
@@ -144,7 +144,7 @@ def test_plot_navigator_signal():
     N = 15
     dim = 4
     s = hs.signals.Signal2D(da.arange(N**dim).reshape([N] * dim)).as_lazy()
-    nav = s.inav[10, 10]
+    nav = s.isig[10, 10]
     nav.compute()
     nav *= -1
     s.plot(navigator=nav)

--- a/hyperspy/tests/drawing/test_plot_signal.py
+++ b/hyperspy/tests/drawing/test_plot_signal.py
@@ -395,8 +395,12 @@ def test_plot_navigator_axes():
     data = np.arange(np.prod(shape)).reshape(shape)
     s = hs.signals.Signal1D(data)
     s.plot(navigator_axes=[0, 2])
-    # the first on third navigation axis
+    # the first and third navigation axis
     s._plot.navigator_data_function().shape == (3, 5)
+
+    s.plot(navigator_axes=[2, 0])
+    # the third and first navigation axis
+    s._plot.navigator_data_function().shape == (5, 3)
 
     with pytest.raises(ValueError):
         s.plot(navigator_axes=[0, 1, 2])

--- a/hyperspy/tests/drawing/test_plot_signal.py
+++ b/hyperspy/tests/drawing/test_plot_signal.py
@@ -23,6 +23,7 @@ import traits.api as t
 import hyperspy.api as hs
 from hyperspy.drawing.signal1d import Signal1DFigure, Signal1DLine
 from hyperspy.drawing.image import ImagePlot
+from hyperspy.exceptions import VisibleDeprecationWarning
 from hyperspy.misc.test_utils import update_close_figure, check_closing_plot
 
 
@@ -291,14 +292,11 @@ def test_plot_slider(ndim, sdim):
         check_closing_plot(s, check_data_changed_close=False)
 
 
-@pytest.mark.parametrize("tranpose", [True, False])
 @pytest.mark.parametrize("ndim", [1, 2])
-def test_plot_navigator_plot_signal(ndim, tranpose):
+def test_plot_navigator_plot_signal(ndim):
     test_plot_nav1d = _TestPlot(ndim=ndim, sdim=1, data_type="real")
     s = test_plot_nav1d.signal
     navigator = -s.sum(-1)
-    if tranpose:
-        navigator = navigator.T
     s.plot(navigator=navigator)
     if ndim == 1:
         navigator_data = s._plot.navigator_plot.ax_lines[0]._get_data()
@@ -356,3 +354,12 @@ def test_plot_ragged_array(lazy):
         s = s.as_lazy()
     with pytest.raises(RuntimeError):
         s.plot()
+
+
+def test_plot_navigator_deprecation():
+    s = hs.signals.Signal1D(np.arange(1000).reshape((10, 10, 10)))
+    nav = s.sum(axis=-1).T
+
+    with pytest.warns(VisibleDeprecationWarning):
+        s.plot(navigator=nav)
+        s = s.plot(navigator=nav)

--- a/hyperspy/tests/drawing/test_plot_signal2d.py
+++ b/hyperspy/tests/drawing/test_plot_signal2d.py
@@ -859,8 +859,7 @@ class TestDynamicNavigatorPlot:
 
     def test_plot_5d(self):
         s = self.signal5d2d
-        nav = hs.signals.BaseSignal(np.arange((10 * 10 * 10)).reshape(10, 10, 10)).T
-        s.plot(navigator=nav)
+        s.plot()
         data1 = s._plot.navigator_plot._current_data
         s.axes_manager.indices = (0, 0, 1)
         data2 = s._plot.navigator_plot._current_data
@@ -871,10 +870,7 @@ class TestDynamicNavigatorPlot:
 
     def test_plot_6d(self):
         s = self.signal6d2d
-        nav = hs.signals.BaseSignal(
-            np.arange((10 * 10 * 10 * 10)).reshape(10, 10, 10, 10)
-        ).T
-        s.plot(navigator=nav)
+        s.plot()
         data1 = s._plot.navigator_plot._current_data
         s.axes_manager.indices = (0, 0, 0, 1)
         data2 = s._plot.navigator_plot._current_data
@@ -885,8 +881,7 @@ class TestDynamicNavigatorPlot:
 
     def test_plot_4d_1dSignal(self):
         s = self.signal4d1d
-        nav = hs.signals.BaseSignal(np.arange((10 * 10 * 10)).reshape(10, 10, 10)).T
-        s.plot(navigator=nav)
+        s.plot()
         data1 = s._plot.navigator_plot._current_data
         s.axes_manager.indices = (0, 0, 1)
         data2 = s._plot.navigator_plot._current_data
@@ -897,10 +892,7 @@ class TestDynamicNavigatorPlot:
 
     def test_plot_5d_1dsignal(self):
         s = self.signal5d1d
-        nav = hs.signals.BaseSignal(
-            np.arange((10 * 10 * 10 * 10)).reshape(10, 10, 10, 10)
-        ).T
-        s.plot(navigator=nav)
+        s.plot()
         data1 = s._plot.navigator_plot._current_data
         s.axes_manager.indices = (0, 0, 0, 1)
         data2 = s._plot.navigator_plot._current_data

--- a/hyperspy/tests/drawing/test_plot_signal2d.py
+++ b/hyperspy/tests/drawing/test_plot_signal2d.py
@@ -837,7 +837,7 @@ def test_plot_images_bool():
 
 def test_plot_static_signal_nav():
     s = hs.signals.Signal2D(np.ones((20, 20, 10, 10)))
-    nav = hs.signals.Signal2D(np.ones((20, 20)))
+    nav = hs.signals.BaseSignal(np.ones((20, 20))).T
     s.plot(navigator=nav)
 
 
@@ -845,15 +845,7 @@ def test_plot_static_signal_nav():
 class TestDynamicNavigatorPlot:
     def setup_method(self, method):
         self.signal5d2d = hs.signals.Signal2D(
-            np.arange((10**5)).reshape(
-                (
-                    10,
-                    10,
-                    10,
-                    10,
-                    10,
-                )
-            )
+            np.arange((10**5)).reshape((10, 10, 10, 10, 10))
         )
         self.signal6d2d = hs.signals.Signal2D(
             np.arange((10**6)).reshape((10, 10, 10, 10, 10, 10))
@@ -862,38 +854,12 @@ class TestDynamicNavigatorPlot:
             np.arange((10**4)).reshape((10, 10, 10, 10))
         )
         self.signal5d1d = hs.signals.Signal1D(
-            np.arange((10**5)).reshape(
-                (
-                    10,
-                    10,
-                    10,
-                    10,
-                    10,
-                )
-            )
+            np.arange((10**5)).reshape((10, 10, 10, 10, 10))
         )
 
     def test_plot_5d(self):
-        import hyperspy.api as hs
-        import numpy as np
-
         s = self.signal5d2d
-        nav = hs.signals.BaseSignal(np.arange((10 * 10 * 10)).reshape(10, 10, 10))
-        s.plot(navigator=nav)
-        data1 = s._plot.navigator_plot._current_data
-        s.axes_manager.indices = (0, 0, 1)
-        data2 = s._plot.navigator_plot._current_data
-        assert not np.array_equal(data1, data2)
-        s.axes_manager.indices = (0, 2, 1)
-        data3 = s._plot.navigator_plot._current_data
-        assert np.array_equal(data2, data3)
-
-    def test_plot_5d_2(self):
-        import hyperspy.api as hs
-        import numpy as np
-
-        s = self.signal5d2d
-        nav = hs.signals.Signal2D(np.arange((10 * 10 * 10)).reshape(10, 10, 10))
+        nav = hs.signals.BaseSignal(np.arange((10 * 10 * 10)).reshape(10, 10, 10)).T
         s.plot(navigator=nav)
         data1 = s._plot.navigator_plot._current_data
         s.axes_manager.indices = (0, 0, 1)
@@ -904,13 +870,10 @@ class TestDynamicNavigatorPlot:
         assert np.array_equal(data2, data3)
 
     def test_plot_6d(self):
-        import hyperspy.api as hs
-        import numpy as np
-
         s = self.signal6d2d
         nav = hs.signals.BaseSignal(
             np.arange((10 * 10 * 10 * 10)).reshape(10, 10, 10, 10)
-        )
+        ).T
         s.plot(navigator=nav)
         data1 = s._plot.navigator_plot._current_data
         s.axes_manager.indices = (0, 0, 0, 1)
@@ -921,11 +884,8 @@ class TestDynamicNavigatorPlot:
         assert np.array_equal(data2, data3)
 
     def test_plot_4d_1dSignal(self):
-        import hyperspy.api as hs
-        import numpy as np
-
         s = self.signal4d1d
-        nav = hs.signals.BaseSignal(np.arange((10 * 10 * 10)).reshape(10, 10, 10))
+        nav = hs.signals.BaseSignal(np.arange((10 * 10 * 10)).reshape(10, 10, 10)).T
         s.plot(navigator=nav)
         data1 = s._plot.navigator_plot._current_data
         s.axes_manager.indices = (0, 0, 1)
@@ -936,13 +896,10 @@ class TestDynamicNavigatorPlot:
         assert np.array_equal(data2, data3)
 
     def test_plot_5d_1dsignal(self):
-        import hyperspy.api as hs
-        import numpy as np
-
         s = self.signal5d1d
         nav = hs.signals.BaseSignal(
             np.arange((10 * 10 * 10 * 10)).reshape(10, 10, 10, 10)
-        )
+        ).T
         s.plot(navigator=nav)
         data1 = s._plot.navigator_plot._current_data
         s.axes_manager.indices = (0, 0, 0, 1)

--- a/upcoming_changes/3209.enhancements.rst
+++ b/upcoming_changes/3209.enhancements.rst
@@ -1,0 +1,1 @@
+Add support for specifying the axes of the navigator and "streak" navigator


### PR DESCRIPTION
@jlaehne, as mentioned in https://github.com/LumiSpy/lumispy/issues/204#issuecomment-1925327502, this PR allow plotting streak images with additional navigation dimension.

### Progress of the PR
- [x] Simplify setting navigator,
- [x] make navigation dimensions consistent between lazy and non-lazy signal,
- [x] add support for "streak image"  navigator,
- [x] add support for specifying axes of the navigator, 
- [x] update docstring (if appropriate),
- [x] update user guide (if appropriate),
- [x] add an changelog entry in the `upcoming_changes` folder (see [`upcoming_changes/README.rst`](https://github.com/hyperspy/hyperspy/blob/RELEASE_next_minor/upcoming_changes/README.rst)),
- [x] Check formatting changelog entry in the `readthedocs` doc build of this PR (link in github checks)
- [x] add tests,
- [x] ready for review.

### Minimal example of the bug fix or the new feature
```python
import hyperspy.api as hs
import numpy as np

shape = (3, 4, 5, 10)
data = np.arange(np.prod(shape)).reshape(shape) + np.random.default_rng().random(shape) * 100
s = hs.signals.Signal1D(data)

s.plot(navigator="streak")

s.plot(navigator_axes=[0, 2])
```

