### PR TITLE
Increase rtol to avoid random test failure with mkl

### DIFF
--- a/hyperspy/tests/model/test_linear_model.py
+++ b/hyperspy/tests/model/test_linear_model.py
@@ -621,7 +621,6 @@ class TestTwinnedComponents:
     #     B = m.as_signal()
     #     np.testing.assert_allclose(A.data, B.data, rtol=5E-5)
 
-    @pytest.mark.flaky(reruns=1)
     def test_fit_fixed_twinned_components_and_std(self):
         m = self.m
         m[1].A.free = False
@@ -634,7 +633,7 @@ class TestTwinnedComponents:
         nonlinear_fit = m.as_signal()
         nonlinear_std = [para.std for para in nonlinear_parameters if para.std]
 
-        np.testing.assert_allclose(nonlinear_fit.data, lstsq_fit.data, rtol=1e-5)
+        np.testing.assert_allclose(nonlinear_fit.data, lstsq_fit.data, rtol=5e-5)
         np.testing.assert_allclose(nonlinear_std, linear_std)
 
 


### PR DESCRIPTION
The following failure happened a few times in the bundle workflow (for example: https://github.com/hyperspy/hyperspy-bundle/actions/runs/7952201114/job/21707262180):

```python
================================== FAILURES ===================================
_______ TestTwinnedComponents.test_fit_fixed_twinned_components_and_std _______
[gw1] win32 -- Python 3.11.8 D:\a\hyperspy-bundle\hyperspy-bundle\nd\python.exe

self = <hyperspy.tests.model.test_linear_model.TestTwinnedComponents object at 0x0000028C5A6726D0>

    @pytest.mark.flaky(reruns=1)
    def test_fit_fixed_twinned_components_and_std(self):
        m = self.m
        m[1].A.free = False
        m.fit(optimizer='lstsq')
        lstsq_fit = m.as_signal()
        nonlinear_parameters = [p for c in m for p in c.parameters
                                if not p._linear]
        linear_std = [para.std for para in nonlinear_parameters if para.std]
    
        m.fit()
        nonlinear_fit = m.as_signal()
        nonlinear_std = [para.std for para in nonlinear_parameters if para.std]
    
>       np.testing.assert_allclose(nonlinear_fit.data, lstsq_fit.data, rtol=1E-5)

nd\Lib\site-packages\hyperspy\tests\model\test_linear_model.py:618: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

args = (<function assert_allclose.<locals>.compare at 0x0000028C6ABE0F40>, array([ 2441.57813029,  2728.25969563,  3020.41715...1588.33838835, 11637.48949917, 11653.03613074,
       11630.41660594, 11564.80705562, 11451.10377116, 11283.9104389 ]))
kwds = {'equal_nan': True, 'err_msg': '', 'header': 'Not equal to tolerance rtol=1e-05, atol=0', 'verbose': True}

    @wraps(func)
    def inner(*args, **kwds):
        with self._recreate_cm():
>           return func(*args, **kwds)
E           AssertionError: 
E           Not equal to tolerance rtol=1e-05, atol=0
E           
E           Mismatched elements: 1 / 100 (1%)
E           Max absolute difference: 0.0258379
E           Max relative difference: 1.05[82](https://github.com/hyperspy/hyperspy-bundle/actions/runs/7952201114/job/21707262180#step:22:83)5714e-05
E            x: array([ 2441.57813 ,  2728.259696,  3020.41716 ,  3316.558068,
E                   3615.244732,  3915.094456,  4214.779796,  4513.028913,
E                   4808.626107,  5100.412591,  5387.287541,  5668.209465,...
E            y: array([ 2441.552292,  2728.234574,  3020.392596,  3316.533927,
E                   3615.2209  ,  3915.070[84](https://github.com/hyperspy/hyperspy-bundle/actions/runs/7952201114/job/21707262180#step:22:85) ,  4214.756321,  4513.005519,
E                   4808.602751,  5100.389241,  5387.264176,  5668.1[86](https://github.com/hyperspy/hyperspy-bundle/actions/runs/7952201114/job/21707262180#step:22:87)075,...

nd\Lib\contextlib.py:81: AssertionError
============================== warnings summary ===============================
``` 

### Progress of the PR
- [ ] Change implemented (can be split into several points),
- [ ] update docstring (if appropriate),
- [ ] update user guide (if appropriate),
- [ ] add an changelog entry in the `upcoming_changes` folder (see [`upcoming_changes/README.rst`](https://github.com/hyperspy/hyperspy/blob/RELEASE_next_minor/upcoming_changes/README.rst)),
- [ ] Check formatting changelog entry in the `readthedocs` doc build of this PR (link in github checks)
- [ ] add tests,
- [ ] ready for review.

