### PR TITLE
Fix getting release on some linux system wide install

### DIFF
--- a/prepare_release.py
+++ b/prepare_release.py
@@ -1,0 +1,52 @@
+#!/usr/bin/env python3
+import argparse
+import re
+import subprocess
+
+
+def run_towncrier(tag):
+    cmd = ("towncrier", "build", "--version", tag.strip("v"))
+
+    return subprocess.call(cmd)
+
+
+def update_fallback_version_in_pyproject(tag, fname="pyproject.toml"):
+    version = tag.strip("v").split(".")
+    if len(version) < 3:
+        version += ["0"]
+
+    # Default to +1 on patch version
+    major, minor, patch = version[0], version[1], int(version[2]) + 1
+
+    with open(fname, "r") as file:
+        lines = file.readlines()
+
+    pattern = "fallback_version"
+    new_version = f"{major}.{minor}.{patch}.dev0"
+    # Iterate through the lines and find the pattern
+    for i, line in enumerate(lines):
+        if re.search(pattern, line):
+            lines[i] = f'{pattern} = "{new_version}"\n'
+            break
+
+    # Write the updated content back to the file
+    with open(fname, "w") as file:
+        file.writelines(lines)
+
+    print(
+        f"\nNew (fallback) dev version ({new_version}) written to `pyproject.toml`.\n"
+    )
+
+
+if __name__ == "__main__":
+    # Get tag argument
+    parser = argparse.ArgumentParser()
+    parser.add_argument("tag")
+    args = parser.parse_args()
+    tag = args.tag
+
+    # Update release notes
+    run_towncrier(tag)
+
+    # Update fallback version for setuptools_scm
+    update_fallback_version_in_pyproject(tag)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -163,7 +163,7 @@ omit = [
     "examples/*",
     "hyperspy/conftest.py",
     "hyperspy/tests/*",
-    "setup.py",
+    "prepare_release.py",
 ]
 source = ["hyperspy"]
 

--- a/releasing_guide.md
+++ b/releasing_guide.md
@@ -5,7 +5,10 @@ Cut a Release
 Create a PR to the `RELEASE_next_patch` branch and go through the following steps:
 
 **Preparation**
-- Update and check changelog in `CHANGES.rst`: run `towncrier build` (to preview, run `towncrier build --draft`)
+- Prepare the release by running the `prepare_release.py` python script (e.g. `python prepare_release.py 2.0.1`) , which will do the following:
+  - update the release notes in `CHANGES.rst` by running `towncrier`,
+  - update the `setuptools_scm` fallback version in `pyproject.toml`.
+- Check release notes
 - (optional) check conda-forge and wheels build. Pushing a tag to a fork will run the release workflow without uploading to pypi
 - Let that PR collect comments for a day to ensure that other maintainers are comfortable with releasing
 

--- a/upcoming_changes/3318.bugfix.rst
+++ b/upcoming_changes/3318.bugfix.rst
@@ -1,0 +1,1 @@
+Fix getting release on some linux system wide install, e.g. Debian or Google colab


### PR DESCRIPTION
Fix https://github.com/hyperspy/hyperspy/issues/3317.
Similar as https://github.com/hyperspy/rosettasciio/pull/187 with small adaptations. Some linux system wide install uses `dist-packages` instead of `site-packages`, which breaks getting the version.

### Progress of the PR
- [x] Use different approach to get version,
- [n/a] update docstring (if appropriate),
- [n/a] update user guide (if appropriate),
- [x] add an changelog entry in the `upcoming_changes` folder (see [`upcoming_changes/README.rst`](https://github.com/hyperspy/hyperspy/blob/RELEASE_next_minor/upcoming_changes/README.rst)),
- [x] Check formatting changelog entry in the `readthedocs` doc build of this PR (link in github checks)
- [n/a] add tests,
- [x] ready for review.


