### PR TITLE
Add Google Analytics ID to documentation

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -175,6 +175,9 @@ version_match = "dev" if "dev" in _version else ".".join(_version.split(".")[:2]
 print("version_match:", version_match)
 
 html_theme_options = {
+    "analytics": {
+        "google_analytics_id": "G-B0XD0GTW1M",
+    },
     "show_toc_level": 2,
     "github_url": "https://github.com/hyperspy/hyperspy",
     "icon_links": [

--- a/upcoming_changes/3322.maintenance.rst
+++ b/upcoming_changes/3322.maintenance.rst
@@ -1,0 +1,1 @@
+Add Google Analytics ID to learn more about documentation usage.


### PR DESCRIPTION
The is the same tag as for the https://github.com/hyperspy/hyperspy-website/pull/59 and it will give us an idea of documentation usage: what pages are read most, number of views, etc.

### Progress of the PR
- [x] Add Google Analytics tag to documentation,
- [n/a] update docstring (if appropriate),
- [n/a] update user guide (if appropriate),
- [x] add an changelog entry in the `upcoming_changes` folder (see [`upcoming_changes/README.rst`](https://github.com/hyperspy/hyperspy/blob/RELEASE_next_minor/upcoming_changes/README.rst)),
- [x] Check formatting changelog entry in the `readthedocs` doc build of this PR (link in github checks)
- [n/a] add tests,
- [x] ready for review.


