### PR TITLE
Fix ROI slicing of non-uniform axis

### DIFF
--- a/examples/create_signal/README.rst
+++ b/examples/create_signal/README.rst
@@ -1,4 +1,4 @@
-Signal Creation and plotting
-============================
+Signal Creation
+===============
 
 Below is a gallery of examples on creating a signal and plotting.

--- a/examples/region_of_interest/ROI_navigator.py
+++ b/examples/region_of_interest/ROI_navigator.py
@@ -1,0 +1,39 @@
+"""
+Navigator ROI
+=============
+
+Use a RectangularROI to take the sum of an area of the navigation space.
+
+"""
+
+import hyperspy.api as hs
+
+#%%
+# Create a signal:
+s = hs.data.two_gaussians()
+
+#%%
+# Create the roi, here a :py:class:`~.api.roi.RectangularROI` for the two dimension navigation space:
+roi = hs.roi.RectangularROI()
+
+#%%
+# Slice signal with roi with the ROI. By using the `interactive` function, the
+# output signal ``s_roi`` will update automatically.
+# The ROI will be added automatically on the signal figure.
+#
+# By default, the ROI will be added to the navigation or signal. We specify
+# ``recompute_out_event=None`` to avoid redundant computation when changing the ROI
+
+s.plot()
+s_roi = roi.interactive(s, recompute_out_event=None, color='C1')
+
+# We use :py:class:`~.interactive` function to compute the sum over the ROI interactively:
+
+roi_sum = hs.interactive(s_roi.sum, recompute_out_event=None)
+
+# Choose the second figure as gallery thumbnail:
+# sphinx_gallery_thumbnail_number = 1
+
+#%%
+# Plot the signal sliced by the ROI:
+roi_sum.plot()

--- a/hyperspy/axes.py
+++ b/hyperspy/axes.py
@@ -722,7 +722,9 @@ class BaseDataAxis(t.HasTraits):
         any_changes = False
         changed = {}
         for f in attributes:
-            if getattr(self, f) != getattr(axis, f):
+            a, b = getattr(self, f), getattr(axis, f)
+            cond = np.allclose(a, b) if isinstance(a, np.ndarray) else a == b
+            if not cond:
                 changed[f] = getattr(axis, f)
         if len(changed) > 0:
             self.trait_set(**changed)
@@ -874,7 +876,7 @@ class DataAxis(BaseDataAxis):
 
         """
         if attributes is None:
-            attributes = ["units"]
+            attributes = ["axis"]
         return super().update_from(axis, attributes)
 
     def crop(self, start=None, end=None):
@@ -1029,7 +1031,7 @@ class FunctionalDataAxis(BaseDataAxis):
 
         """
         if attributes is None:
-            attributes = self.parameters_list
+            attributes = self.parameters_list + ["_expression", "x"]
         return super().update_from(axis, attributes)
 
     def calibrate(self, *args, **kwargs):
@@ -1307,7 +1309,7 @@ class UniformDataAxis(BaseDataAxis, UnitConversion):
 
         """
         if attributes is None:
-            attributes = ["scale", "offset", "units"]
+            attributes = ["scale", "offset", "size"]
         return super().update_from(axis, attributes)
 
     def crop(self, start=None, end=None):

--- a/hyperspy/misc/slicing.py
+++ b/hyperspy/misc/slicing.py
@@ -309,9 +309,7 @@ class FancySlicing(object):
                     axis_src._slice_me(slice_)
                     axis_dst = out.axes_manager._axes[i]
                     i += 1
-                    axis_dst.update_from(
-                        axis_src, attributes=("scale", "offset", "size")
-                    )
+                    axis_dst.update_from(axis_src)
 
         if hasattr(self, "_additional_slicing_targets"):
             for ta in self._additional_slicing_targets:

--- a/upcoming_changes/3328.bugfix.rst
+++ b/upcoming_changes/3328.bugfix.rst
@@ -1,0 +1,1 @@
+Fix ROI slicing of non-uniform axis


### PR DESCRIPTION
### Progress of the PR
- [x] Change implemented (can be split into several points),
- [n/a] update docstring (if appropriate),
- [x] Add example on interactive ROI,
- [x] add an changelog entry in the `upcoming_changes` folder (see [`upcoming_changes/README.rst`](https://github.com/hyperspy/hyperspy/blob/RELEASE_next_minor/upcoming_changes/README.rst)),
- [x] Check formatting changelog entry in the `readthedocs` doc build of this PR (link in github checks)
- [x] add tests,
- [x] ready for review.

### Minimal example of the bug fix or the new feature
```python
import hyperspy.api as hs
import numpy as np

s = hs.data.luminescence_signal(navigation_dimension=2, add_noise=False)
roi = hs.roi.RectangularROI()

s.plot()
_ = roi.interactive(s, recompute_out_event=None)
# change position to trigger events
roi.x = 4

```
Give the following error:

```python
Traceback (most recent call last):

  File ~\Dev\hyperspy\untitled0.py:17
    roi.x = 4

  File ~\Dev\hyperspy\hyperspy\roi.py:946 in x
    self.update()

  File ~\Dev\hyperspy\hyperspy\roi.py:339 in update
    self.events.changed.trigger(self)

  File <string>:4 in trigger

  File ~\Dev\hyperspy\hyperspy\events.py:423 in trigger
    function(**{kw: kwargs.get(kw, None) for kw in kwsl})

  File ~\Dev\hyperspy\hyperspy\interactive.py:125 in update
    self.f(*self.args, out=self.out, **self.kwargs)

  File ~\Dev\hyperspy\hyperspy\roi.py:231 in __call__
    roi = slicer(slices, out=out)

  File ~\Dev\hyperspy\hyperspy\misc\slicing.py:186 in __getitem__
    return self.obj._slicer(slices, self.isNavigation, out=out)

  File ~\Dev\hyperspy\hyperspy\misc\slicing.py:312 in _slicer
    axis_dst.update_from(

  File ~\Dev\hyperspy\hyperspy\axes.py:1033 in update_from
    return super().update_from(axis, attributes)

  File ~\Dev\hyperspy\hyperspy\axes.py:725 in update_from
    if getattr(self, f) != getattr(axis, f):

AttributeError: 'FunctionalDataAxis' object has no attribute 'scale'
```
