### PR TITLE
numpy 2.0 removal

### DIFF
--- a/hyperspy/misc/utils.py
+++ b/hyperspy/misc/utils.py
@@ -845,7 +845,7 @@ def strlist2enumeration(lst):
 
 
 def ensure_unicode(stuff, encoding="utf8", encoding2="latin-1"):
-    if not isinstance(stuff, (bytes, np.string_)):
+    if not isinstance(stuff, (bytes, np.bytes_)):
         return stuff
     else:
         string = stuff
@@ -858,7 +858,7 @@ def ensure_unicode(stuff, encoding="utf8", encoding2="latin-1"):
 
 def check_long_string(value, max_len):
     "Checks whether string is too long for printing in html metadata"
-    if not isinstance(value, (str, np.string_)):
+    if not isinstance(value, (str, np.bytes_)):
         value = repr(value)
     value = ensure_unicode(value)
     strvalue = str(value)

--- a/hyperspy/model.py
+++ b/hyperspy/model.py
@@ -2546,9 +2546,9 @@ class BaseModel(list):
                     for vv in v:
                         if isinstance(vv, dict):
                             remove_empty_numpy_strings(vv)
-                        elif isinstance(vv, np.string_) and len(vv) == 0:
+                        elif isinstance(vv, np.bytes_) and len(vv) == 0:
                             vv = ""
-                elif isinstance(v, np.string_) and len(v) == 0:
+                elif isinstance(v, np.bytes_) and len(v) == 0:
                     del dic[k]
                     dic[k] = ""
 

--- a/hyperspy/tests/model/test_model_as_dictionary.py
+++ b/hyperspy/tests/model/test_model_as_dictionary.py
@@ -33,9 +33,9 @@ def remove_empty_numpy_strings(dic):
             for vv in v:
                 if isinstance(vv, dict):
                     remove_empty_numpy_strings(vv)
-                elif isinstance(vv, np.string_) and len(vv) == 0:
+                elif isinstance(vv, np.bytes_) and len(vv) == 0:
                     vv = ""
-        elif isinstance(v, np.string_) and len(v) == 0:
+        elif isinstance(v, np.bytes_) and len(v) == 0:
             del dic[k]
             dic[k] = ""
 

--- a/upcoming_changes/3338.maintenance.rst
+++ b/upcoming_changes/3338.maintenance.rst
@@ -1,0 +1,1 @@
+Replace deprecated ``np.string_`` by ``np.bytes_``.


### PR DESCRIPTION
Use `ruff check . --select NPY201` to find these.

For reference: https://numpy.org/devdocs/release/2.0.0-notes.html#numpy-2-0-python-api-removals.

### Progress of the PR
- [x] Replace deprecated `np.string_` by `np.bytes_`,
- [n/a] update docstring (if appropriate),
- [n/a] update user guide (if appropriate),
- [x] add an changelog entry in the `upcoming_changes` folder (see [`upcoming_changes/README.rst`](https://github.com/hyperspy/hyperspy/blob/RELEASE_next_minor/upcoming_changes/README.rst)),
- [x] Check formatting changelog entry in the `readthedocs` doc build of this PR (link in github checks)
- [n/a] add tests,
- [x] ready for review.


