### PR TITLE
Fix Saving Axes in Metadata

### DIFF
--- a/hyperspy/misc/utils.py
+++ b/hyperspy/misc/utils.py
@@ -509,7 +509,7 @@ class DictionaryTreeBrowser:
         par_dict = {}
 
         from hyperspy.signal import BaseSignal
-        from hyperspy.axes import AxesManager
+        from hyperspy.axes import AxesManager, BaseDataAxis
 
         for key_, item_ in self.__dict__.items():
             if not isinstance(item_, types.MethodType):
@@ -526,6 +526,9 @@ class DictionaryTreeBrowser:
                 elif isinstance(item_["_dtb_value_"], AxesManager):
                     item = item_["_dtb_value_"]._get_axes_dicts()
                     key = "_hspy_AxesManager_" + key
+                elif isinstance(item_["_dtb_value_"], BaseDataAxis):
+                    item = item_["_dtb_value_"].get_axis_dictionary()
+                    key = "_hspy_Axis_" + key
                 elif type(item_["_dtb_value_"]) in (list, tuple):
                     signals = []
                     container = item_["_dtb_value_"]

--- a/hyperspy/tests/misc/test_dictionary_tree_browser.py
+++ b/hyperspy/tests/misc/test_dictionary_tree_browser.py
@@ -28,6 +28,7 @@ from hyperspy.misc.utils import (
     nested_dictionary_merge,
 )
 from hyperspy.signal import BaseSignal
+from hyperspy.axes import UniformDataAxis
 
 
 @pytest.fixture(params=[True, False], ids=["lazy", "not_lazy"])
@@ -123,6 +124,19 @@ class TestDictionaryBrowser:
             tree.signal_name.axes_manager._get_axes_dicts()
             == s.axes_manager._get_axes_dicts()
         )
+
+    def test_add_axes(self, tree):
+        axis = UniformDataAxis(name="x", units="ly", size=10)
+        tree.set_item("axis", axis)
+        tree.set_item("axis2", axis)
+        tree_dict = tree.as_dictionary()
+        assert tree_dict["_hspy_Axis_axis"]["name"] == "x"
+        assert tree_dict["_hspy_Axis_axis"]["units"] == "ly"
+        assert tree_dict["_hspy_Axis_axis2"]["units"] == "ly"
+        assert tree_dict["_hspy_Axis_axis2"]["name"] == "x"
+        new_signal = BaseSignal([1, 2, 3, 4], metadata=tree_dict)
+        assert isinstance(new_signal.metadata.axis, UniformDataAxis)
+        assert isinstance(new_signal.metadata.axis2, UniformDataAxis)
 
     def test_export(self, tree):
         with tempfile.TemporaryDirectory() as tmpdir:

--- a/upcoming_changes/3342.bugfix.rst
+++ b/upcoming_changes/3342.bugfix.rst
@@ -1,0 +1,1 @@
+Adds the ability to save and load `BaseDataAxis` objects to a hyperspy file.


### PR DESCRIPTION
### Description of the change
This support saving and loading axes in metadata.  Currently this occurs when you `find_peaks` and it would be good to retain this information.

### Progress of the PR
- [x] Change implemented (can be split into several points),
- [x] add an changelog entry in the `upcoming_changes` folder (see [`upcoming_changes/README.rst`](https://github.com/hyperspy/hyperspy/blob/RELEASE_next_minor/upcoming_changes/README.rst)),
- [x] Check formatting changelog entry in the `readthedocs` doc build of this PR (link in github checks)
- [x] add tests,
- [x] ready for review.

### Minimal example of the bug fix or the new feature
```python
import hyperspy.api as hs
import numpy as np
s = hs.signals.Signal1D(np.arange(10))
axis = UniformDataAxis(name="x", units="ly", size=10)
s.metadata.set_item("axis", axis)
s.save("temp.hspy")
hs.load("temp.hspy").metadata
```

