### PR TITLE
New Feature: Add sub-figure plotting

### DIFF
--- a/examples/plotting/README.rst
+++ b/examples/plotting/README.rst
@@ -1,0 +1,4 @@
+Making Publication-Quality Plots
+================================
+
+Below is a gallery of examples on making publication-quality plots using matplotlib.

--- a/examples/plotting/README.rst
+++ b/examples/plotting/README.rst
@@ -1,4 +1,4 @@
-Making Publication-Quality Plots
-================================
+Making Custom Layouts for Plots
+===============================
 
-Below is a gallery of examples on making publication-quality plots using matplotlib.
+Below is a gallery of examples on making simple custom layouts for plotting data.

--- a/examples/plotting/README.rst
+++ b/examples/plotting/README.rst
@@ -1,4 +1,8 @@
 Making Custom Layouts for Plots
 ===============================
 
-Below is a gallery of examples on making simple custom layouts for plotting data.
+Below is a gallery of examples on making simple custom layouts for plotting data
+using :class:`matplotlib.figure.SubFigure`.
+
+.. Note::
+    Plotting data with subfigures is slower than using separates figures.

--- a/examples/plotting/README.rst
+++ b/examples/plotting/README.rst
@@ -1,3 +1,5 @@
+.. _subfigure_examples_label:
+
 Making Custom Layouts for Plots
 ===============================
 

--- a/examples/plotting/ROI_insets.py
+++ b/examples/plotting/ROI_insets.py
@@ -38,15 +38,14 @@ s2.plot(fig=sub2, colorbar=False, axes_off=True, title="", plot_indices=False)
 s3.plot(fig=sub3, colorbar=False, axes_off=True, title="", plot_indices=False)
 s4.plot(fig=sub4, colorbar=False, axes_off=True, title="", plot_indices=False)
 
-# %%
 # Add ROI's to the navigator
 
 r1.add_widget(navigator, color="r")
 r2.add_widget(navigator, color="g")
 r3.add_widget(navigator, color="y")
 
-# %%
 # Add Borders to the match the color of the ROI
+
 red_edge = hs.plot.markers.Squares(
     offset_transform="axes",
     offsets=(0.5, 0.5),
@@ -81,7 +80,6 @@ yellow_edge = hs.plot.markers.Squares(
 
 s4.add_marker(yellow_edge)
 
-# %%
 # Label the insets
 
 label = hs.plot.markers.Texts(

--- a/examples/plotting/ROI_insets.py
+++ b/examples/plotting/ROI_insets.py
@@ -9,6 +9,9 @@ we can create a custom layout to visualize and interact with the data.
 """
 import matplotlib.pyplot as plt
 import hyperspy.api as hs
+import numpy as np
+
+rng = np.random.default_rng()
 
 fig = plt.figure(figsize=(5, 3))
 gs = fig.add_gridspec(6, 10)

--- a/examples/plotting/ROI_insets.py
+++ b/examples/plotting/ROI_insets.py
@@ -1,0 +1,101 @@
+"""
+==========
+ROI Insets
+==========
+
+ROI's can be powerful tools to help visualize data.  In this case we will define ROI's in hyperspy, sum
+the data within the ROI, and then plot the sum as a signal. Using the `matplotlib.figure.SubFigure` class
+we can create a custom layout to visualize and interact with the data.
+"""
+import matplotlib.pyplot as plt
+import hyperspy.api as hs
+
+fig = plt.figure(figsize=(5, 3))
+gs = fig.add_gridspec(6, 10)
+sub1 = fig.add_subfigure(gs[0:6, 0:6])
+sub2 = fig.add_subfigure(gs[0:2, 6:8])
+sub3 = fig.add_subfigure(gs[2:4, 7:9])
+sub4 = fig.add_subfigure(gs[4:6, 6:8])
+
+
+s = hs.signals.Signal2D(rng.random((10, 10, 30, 30)))
+r1 = hs.roi.RectangularROI(1, 1, 3, 3)
+r2 = hs.roi.RectangularROI(4, 4, 6, 6)
+r3 = hs.roi.RectangularROI(3, 7, 5, 9)
+
+
+s2 = r1(s).sum()
+s3 = r2(s).sum()
+s4 = r3(s).sum()
+
+navigator = s.sum(axis=(2, 3)).T  # create a navigator signal
+
+navigator.plot(fig=sub1, colorbar=False, axes_off=True, title="", plot_indices=False)
+s2.plot(fig=sub2, colorbar=False, axes_off=True, title="", plot_indices=False)
+s3.plot(fig=sub3, colorbar=False, axes_off=True, title="", plot_indices=False)
+s4.plot(fig=sub4, colorbar=False, axes_off=True, title="", plot_indices=False)
+
+# %%
+# Add ROI's to the navigator
+
+r1.add_widget(navigator, color="r")
+r2.add_widget(navigator, color="g")
+r3.add_widget(navigator, color="y")
+
+# %%
+# Add Borders to the match the color of the ROI
+red_edge = hs.plot.markers.Squares(
+    offset_transform="axes",
+    offsets=(0.5, 0.5),
+    units="width",
+    widths=1,
+    color="r",
+    linewidth=5,
+    facecolor="none",
+)
+s2.add_marker(red_edge)
+
+green_edge = hs.plot.markers.Squares(
+    offset_transform="axes",
+    offsets=(0.5, 0.5),
+    units="width",
+    widths=1,
+    color="g",
+    linewidth=5,
+    facecolor="none",
+)
+s3.add_marker(green_edge)
+
+yellow_edge = hs.plot.markers.Squares(
+    offset_transform="axes",
+    offsets=(0.5, 0.5),
+    units="width",
+    widths=1,
+    color="y",
+    linewidth=5,
+    facecolor="none",
+)
+
+s4.add_marker(yellow_edge)
+
+# %%
+# Label the insets
+
+label = hs.plot.markers.Texts(
+    texts=("a.",), offsets=[[0.9, 0.9]], offset_transform="axes", sizes=10, color="w"
+)
+navigator.add_marker(label)
+label = hs.plot.markers.Texts(
+    texts=("b.",), offsets=[[0.8, 0.8]], offset_transform="axes", sizes=3, color="w"
+)
+s2.add_marker(label)
+label = hs.plot.markers.Texts(
+    texts=("c.",), offsets=[[0.8, 0.8]], offset_transform="axes", sizes=3, color="w"
+)
+s3.add_marker(label)
+label = hs.plot.markers.Texts(
+    texts=("d.",), offsets=[[0.8, 0.8]], offset_transform="axes", sizes=3, color="w"
+)
+s4.add_marker(label)
+
+# %%

--- a/examples/plotting/ROI_insets.py
+++ b/examples/plotting/ROI_insets.py
@@ -4,7 +4,7 @@ ROI Insets
 ==========
 
 ROI's can be powerful tools to help visualize data.  In this case we will define ROI's in hyperspy, sum
-the data within the ROI, and then plot the sum as a signal. Using the `matplotlib.figure.SubFigure` class
+the data within the ROI, and then plot the sum as a signal. Using the :class:`matplotlib.figure.SubFigure` class
 we can create a custom layout to visualize and interact with the data.
 
 We can connect these ROI's using the :func:`hyperspy.api.interactive` function which allows us to move the ROI's and see the sum of the underlying data.

--- a/examples/plotting/ROI_insets.py
+++ b/examples/plotting/ROI_insets.py
@@ -6,6 +6,8 @@ ROI Insets
 ROI's can be powerful tools to help visualize data.  In this case we will define ROI's in hyperspy, sum
 the data within the ROI, and then plot the sum as a signal. Using the `matplotlib.figure.SubFigure` class
 we can create a custom layout to visualize and interact with the data.
+
+We can connect these ROI's using the :func:`hyperspy.api.interactive` function which allows us to move the ROI's and see the sum of the underlying data.
 """
 import matplotlib.pyplot as plt
 import hyperspy.api as hs
@@ -26,77 +28,56 @@ r1 = hs.roi.RectangularROI(1, 1, 3, 3)
 r2 = hs.roi.RectangularROI(4, 4, 6, 6)
 r3 = hs.roi.RectangularROI(3, 7, 5, 9)
 
-
-s2 = r1(s).sum()
-s3 = r2(s).sum()
-s4 = r3(s).sum()
-
 navigator = s.sum(axis=(2, 3)).T  # create a navigator signal
-
 navigator.plot(fig=sub1, colorbar=False, axes_off=True, title="", plot_indices=False)
-s2.plot(fig=sub2, colorbar=False, axes_off=True, title="", plot_indices=False)
-s3.plot(fig=sub3, colorbar=False, axes_off=True, title="", plot_indices=False)
-s4.plot(fig=sub4, colorbar=False, axes_off=True, title="", plot_indices=False)
 
-# Add ROI's to the navigator
 
-r1.add_widget(navigator, color="r")
-r2.add_widget(navigator, color="g")
-r3.add_widget(navigator, color="y")
+s2 = r1.interactive(s, navigation_signal=navigator, color="red")
+s3 = r2.interactive(s, navigation_signal=navigator, color="g")
+s4 = r3.interactive(s, navigation_signal=navigator, color="y")
+
+s2_int = s2.sum()
+s3_int = s3.sum()
+s4_int = s4.sum()
+
+s2_int.plot(fig=sub2, colorbar=False, axes_off=True, title="", plot_indices=False)
+s3_int.plot(fig=sub3, colorbar=False, axes_off=True, title="", plot_indices=False)
+s4_int.plot(fig=sub4, colorbar=False, axes_off=True, title="", plot_indices=False)
+
+# Connect ROIS
+for s, s_int, roi in zip([s2, s3, s4], [s2_int, s3_int, s4_int],[r1,r2,r3]):
+    hs.interactive(
+        s.sum,
+        event=roi.events.changed,
+        recompute_out_event=None,
+        out=s_int,
+    )
 
 # Add Borders to the match the color of the ROI
 
-red_edge = hs.plot.markers.Squares(
+for signal,color, label  in zip([s2_int, s3_int, s4_int], ["r", "g", "y"], ["b.", "c.", "d."]):
+    edge =  hs.plot.markers.Squares(
     offset_transform="axes",
     offsets=(0.5, 0.5),
     units="width",
     widths=1,
-    color="r",
+    color=color,
     linewidth=5,
     facecolor="none",
-)
-s2.add_marker(red_edge)
+    )
 
-green_edge = hs.plot.markers.Squares(
-    offset_transform="axes",
-    offsets=(0.5, 0.5),
-    units="width",
-    widths=1,
-    color="g",
-    linewidth=5,
-    facecolor="none",
-)
-s3.add_marker(green_edge)
+    signal.add_marker(edge)
 
-yellow_edge = hs.plot.markers.Squares(
-    offset_transform="axes",
-    offsets=(0.5, 0.5),
-    units="width",
-    widths=1,
-    color="y",
-    linewidth=5,
-    facecolor="none",
-)
+    label = hs.plot.markers.Texts(
+    texts=(label,), offsets=[[0.85, 0.85]], offset_transform="axes", sizes=2, color="w"
+    )
+    signal.add_marker(label)
 
-s4.add_marker(yellow_edge)
-
-# Label the insets
+# Label the big plot
 
 label = hs.plot.markers.Texts(
     texts=("a.",), offsets=[[0.9, 0.9]], offset_transform="axes", sizes=10, color="w"
-)
+    )
 navigator.add_marker(label)
-label = hs.plot.markers.Texts(
-    texts=("b.",), offsets=[[0.8, 0.8]], offset_transform="axes", sizes=3, color="w"
-)
-s2.add_marker(label)
-label = hs.plot.markers.Texts(
-    texts=("c.",), offsets=[[0.8, 0.8]], offset_transform="axes", sizes=3, color="w"
-)
-s3.add_marker(label)
-label = hs.plot.markers.Texts(
-    texts=("d.",), offsets=[[0.8, 0.8]], offset_transform="axes", sizes=3, color="w"
-)
-s4.add_marker(label)
 
 # %%

--- a/examples/plotting/ROI_insets.py
+++ b/examples/plotting/ROI_insets.py
@@ -7,6 +7,9 @@ ROI's can be powerful tools to help visualize data.  In this case we will define
 the data within the ROI, and then plot the sum as a signal. Using the :class:`matplotlib.figure.SubFigure` class
 we can create a custom layout to visualize and interact with the data.
 
+.. Note::
+    Plotting data with subfigures is slower than using separates figures.
+
 We can connect these ROI's using the :func:`hyperspy.api.interactive` function which allows us to move the ROI's and see the sum of the underlying data.
 """
 import matplotlib.pyplot as plt

--- a/examples/plotting/custom_figure_layout.py
+++ b/examples/plotting/custom_figure_layout.py
@@ -1,0 +1,37 @@
+"""
+=======================
+Creating Custom Layouts
+=======================
+
+Custom layouts for hyperspy figures can be created using the `matplotlib.figure.SubFigure` class. Passing
+the `fig` argument to the `plot` method of a hyperspy signal object will target that figure instead of
+creating a new one. This is useful for creating custom layouts with multiple subplots.
+"""
+
+# Creating a simple layout with two subplots
+
+import matplotlib.pyplot as plt
+import hyperspy.api as hs
+import numpy as np
+
+rng = np.random.default_rng()
+s = hs.signals.Signal2D(rng.random((10,10,10,10)))
+fig = plt.figure(figsize=(10, 5))
+subfigs = fig.subfigures(1, 2, wspace=0.07)
+s.plot(navigator_kwds=dict(fig=subfigs[0]), fig=subfigs[1])
+
+#%%
+
+# Sharing a navigator between two hyperspy signals
+
+s = hs.signals.Signal2D(rng.random((10,10,10,10)))
+s2 = hs.signals.Signal2D(rng.random((10,10,50,50)))
+
+fig = plt.figure(figsize=(8, 7))
+head_figures = fig.subfigures(1, 2, wspace=0.07)
+signal_figures = head_figures[1].subfigures(2, 1, hspace=0.07)
+s.plot(navigator_kwds=dict(fig=head_figures[0], colorbar=None), fig=signal_figures[0])
+s2.plot(navigator=None, fig=signal_figures[1], axes_manager=s.axes_manager)
+
+#%%
+# sphinx_gallery_thumbnail_number = 2

--- a/examples/plotting/custom_figure_layout.py
+++ b/examples/plotting/custom_figure_layout.py
@@ -3,9 +3,9 @@
 Creating Custom Layouts
 =======================
 
-Custom layouts for hyperspy figures can be created using the `matplotlib.figure.SubFigure` class. Passing
-the `fig` argument to the `plot` method of a hyperspy signal object will target that figure instead of
-creating a new one. This is useful for creating custom layouts with multiple subplots.
+Custom layouts for hyperspy figures can be created using the :class:`matplotlib.figure.SubFigure` class. Passing
+the `fig` argument to the :func:`hyperspy.api.BaseSignal.plot` method of a hyperspy signal object will target
+that figure instead of creating a new one. This is useful for creating custom layouts with multiple subplots.
 """
 
 # Creating a simple layout with two subplots

--- a/examples/plotting/custom_figure_layout.py
+++ b/examples/plotting/custom_figure_layout.py
@@ -4,7 +4,7 @@ Creating Custom Layouts
 =======================
 
 Custom layouts for hyperspy figures can be created using the :class:`matplotlib.figure.SubFigure` class. Passing
-the `fig` argument to the :func:`hyperspy.api.BaseSignal.plot` method of a hyperspy signal object will target
+the ``fig`` argument to the :meth:`~.api.signals.BaseSignal.plot` method of a hyperspy signal object will target
 that figure instead of creating a new one. This is useful for creating custom layouts with multiple subplots.
 """
 
@@ -16,7 +16,7 @@ import numpy as np
 
 rng = np.random.default_rng()
 s = hs.signals.Signal2D(rng.random((10, 10, 10, 10)))
-fig = plt.figure(figsize=(10, 5))
+fig = plt.figure(figsize=(10, 5), layout="constrained")
 subfigs = fig.subfigures(1, 2, wspace=0.07)
 s.plot(navigator_kwds=dict(fig=subfigs[0]), fig=subfigs[1])
 
@@ -27,7 +27,7 @@ s.plot(navigator_kwds=dict(fig=subfigs[0]), fig=subfigs[1])
 s = hs.signals.Signal2D(rng.random((10, 10, 10, 10)))
 s2 = hs.signals.Signal2D(rng.random((10, 10, 50, 50)))
 
-fig = plt.figure(figsize=(8, 7))
+fig = plt.figure(figsize=(8, 7), layout="constrained")
 head_figures = fig.subfigures(1, 2, wspace=0.07)
 signal_figures = head_figures[1].subfigures(2, 1, hspace=0.07)
 s.plot(navigator_kwds=dict(fig=head_figures[0], colorbar=None), fig=signal_figures[0])

--- a/examples/plotting/custom_figure_layout.py
+++ b/examples/plotting/custom_figure_layout.py
@@ -15,17 +15,17 @@ import hyperspy.api as hs
 import numpy as np
 
 rng = np.random.default_rng()
-s = hs.signals.Signal2D(rng.random((10,10,10,10)))
+s = hs.signals.Signal2D(rng.random((10, 10, 10, 10)))
 fig = plt.figure(figsize=(10, 5))
 subfigs = fig.subfigures(1, 2, wspace=0.07)
 s.plot(navigator_kwds=dict(fig=subfigs[0]), fig=subfigs[1])
 
-#%%
+# %%
 
 # Sharing a navigator between two hyperspy signals
 
-s = hs.signals.Signal2D(rng.random((10,10,10,10)))
-s2 = hs.signals.Signal2D(rng.random((10,10,50,50)))
+s = hs.signals.Signal2D(rng.random((10, 10, 10, 10)))
+s2 = hs.signals.Signal2D(rng.random((10, 10, 50, 50)))
 
 fig = plt.figure(figsize=(8, 7))
 head_figures = fig.subfigures(1, 2, wspace=0.07)
@@ -33,5 +33,5 @@ signal_figures = head_figures[1].subfigures(2, 1, hspace=0.07)
 s.plot(navigator_kwds=dict(fig=head_figures[0], colorbar=None), fig=signal_figures[0])
 s2.plot(navigator=None, fig=signal_figures[1], axes_manager=s.axes_manager)
 
-#%%
+# %%
 # sphinx_gallery_thumbnail_number = 2

--- a/examples/plotting/custom_figure_layout.py
+++ b/examples/plotting/custom_figure_layout.py
@@ -6,6 +6,10 @@ Creating Custom Layouts
 Custom layouts for hyperspy figures can be created using the :class:`matplotlib.figure.SubFigure` class. Passing
 the ``fig`` argument to the :meth:`~.api.signals.BaseSignal.plot` method of a hyperspy signal object will target
 that figure instead of creating a new one. This is useful for creating custom layouts with multiple subplots.
+
+.. Note::
+    Plotting data with subfigures is slower than using separates figures.
+
 """
 
 # Creating a simple layout with two subplots

--- a/hyperspy/conftest.py
+++ b/hyperspy/conftest.py
@@ -54,6 +54,7 @@ matplotlib.rcParams["interactive"] = False
 hs.preferences.Plot.cmap_navigator = "viridis"
 hs.preferences.Plot.cmap_signal = "viridis"
 hs.preferences.Plot.pick_tolerance = 5.0
+hs.preferences.Plot.use_subfigure = False
 # Don't show progressbar since it contains the runtime which
 # will make the doctest fail
 hs.preferences.General.show_progressbar = False

--- a/hyperspy/defaults_parser.py
+++ b/hyperspy/defaults_parser.py
@@ -120,6 +120,12 @@ class PlotConfig(t.HasTraits):
     widget_plot_style = t.Enum(
         ["horizontal", "vertical"], label="Widget plot style: (only with ipympl)"
     )
+    use_subfigure = t.CBool(
+        False,
+        desc="EXPERIMENTAL. Plot navigator and signal on the same figure. "
+        "Note that this is slower than using separate figures "
+        "and it requires matplotlib >=3.9.",
+    )
     cmap_navigator = t.Str(
         "gray",
         label="Color map navigator",

--- a/hyperspy/drawing/figure.py
+++ b/hyperspy/drawing/figure.py
@@ -106,6 +106,7 @@ class BlittedFigure:
         if self.figure is None:
             return None
         else:
+            # See https://github.com/matplotlib/matplotlib/pull/28177
             figure = self.figure
             # matplotlib SubFigure can be nested and we don't support it
             if isinstance(figure, matplotlib.figure.SubFigure):

--- a/hyperspy/drawing/image.py
+++ b/hyperspy/drawing/image.py
@@ -332,7 +332,8 @@ class ImagePlot(BlittedFigure):
         self.configure()
         if self.figure is None:
             fig = kwargs.pop("fig", None)
-            self.create_figure(fig=fig)
+            _on_figure_window_close = kwargs.pop("_on_figure_window_close", None)
+            self.create_figure(fig=fig, _on_figure_window_close=_on_figure_window_close)
             self.create_axis()
 
         if not self.axes_manager or self.axes_manager.navigation_size == 0:

--- a/hyperspy/drawing/image.py
+++ b/hyperspy/drawing/image.py
@@ -572,7 +572,7 @@ class ImagePlot(BlittedFigure):
                 if Version(matplotlib.__version__) <= Version("3.6.0"):
                     self._colorbar.draw_all()
                 elif isinstance(self.figure, SubFigure):
-                    self.figure.canvas.draw()  # draw without rendering not supported for sub-figures
+                    self.figure.canvas.draw_idle()  # draw without rendering not supported for sub-figures
                 else:
                     self.figure.draw_without_rendering()
                 self._colorbar.solids.set_animated(self.figure.canvas.supports_blit)

--- a/hyperspy/drawing/image.py
+++ b/hyperspy/drawing/image.py
@@ -385,7 +385,7 @@ class ImagePlot(BlittedFigure):
         # Bug extend='min' or extend='both' and power law norm
         # Use it when it is fixed in matplotlib
         ims = self.ax.images if len(self.ax.images) else self.ax.collections
-        self._colorbar = plt.colorbar(ims[0], ax=self.ax)
+        self._colorbar = self.figure.colorbar(ims[0], ax=self.ax)
         self.set_quantity_label()
         self._colorbar.set_label(self.quantity_label, rotation=-90, va="bottom")
         self._colorbar.ax.yaxis.set_animated(self.figure.canvas.supports_blit)

--- a/hyperspy/drawing/image.py
+++ b/hyperspy/drawing/image.py
@@ -22,6 +22,7 @@ import logging
 import math
 
 import matplotlib
+from matplotlib.figure import SubFigure
 import matplotlib.pyplot as plt
 import numpy as np
 from matplotlib.colors import LogNorm, Normalize, PowerNorm, SymLogNorm
@@ -330,7 +331,8 @@ class ImagePlot(BlittedFigure):
         self.data_function_kwargs = data_function_kwargs
         self.configure()
         if self.figure is None:
-            self.create_figure()
+            fig = kwargs.pop("fig", None)
+            self.create_figure(fig=fig)
             self.create_axis()
 
         if not self.axes_manager or self.axes_manager.navigation_size == 0:
@@ -569,6 +571,8 @@ class ImagePlot(BlittedFigure):
                 # `draw_all` is deprecated in matplotlib 3.6.0
                 if Version(matplotlib.__version__) <= Version("3.6.0"):
                     self._colorbar.draw_all()
+                elif isinstance(self.figure, SubFigure):
+                    self.figure.canvas.draw()  # draw without rendering not supported for sub-figures
                 else:
                     self.figure.draw_without_rendering()
                 self._colorbar.solids.set_animated(self.figure.canvas.supports_blit)

--- a/hyperspy/drawing/image.py
+++ b/hyperspy/drawing/image.py
@@ -22,10 +22,10 @@ import logging
 import math
 
 import matplotlib
-from matplotlib.figure import SubFigure
 import matplotlib.pyplot as plt
 import numpy as np
 from matplotlib.colors import LogNorm, Normalize, PowerNorm, SymLogNorm
+from matplotlib.figure import SubFigure
 from packaging.version import Version
 from rsciio.utils import rgb_tools
 from traits.api import Undefined

--- a/hyperspy/drawing/mpl_he.py
+++ b/hyperspy/drawing/mpl_he.py
@@ -210,7 +210,7 @@ class MPL_HyperExplorer(object):
                         self.pointer.disconnect, []
                     )
             self.plot_signal(**kwargs)
-            if _is_widget_backend():
+            if _is_widget_backend() and "fig" not in kwargs:
                 if plot_style not in ["vertical", "horizontal", None]:
                     raise ValueError(
                         "plot_style must be one of ['vertical', 'horizontal', None]"
@@ -246,7 +246,7 @@ class MPL_HyperExplorer(object):
                         )
                     )
 
-        if _is_widget_backend():
+        if _is_widget_backend() and "fig" not in kwargs:
             with matplotlib.pyplot.ioff():
                 plot_sig_and_nav(plot_style)
         else:

--- a/hyperspy/drawing/mpl_he.py
+++ b/hyperspy/drawing/mpl_he.py
@@ -25,6 +25,7 @@ from traits.api import Undefined
 
 from hyperspy.defaults_parser import preferences
 from hyperspy.drawing import image, signal1d, widgets
+from hyperspy.events import Event, Events
 
 _logger = logging.getLogger(__name__)
 
@@ -35,7 +36,7 @@ def _is_widget_backend():
     return backend.lower() in ["ipympl", "widget", "module://ipympl.backend_nbagg"]
 
 
-class MPL_HyperExplorer(object):
+class MPL_HyperExplorer:
     """ """
 
     def __init__(self):
@@ -52,6 +53,19 @@ class MPL_HyperExplorer(object):
         self.axis = None
         self.pointer = None
         self._pointer_nav_dim = None
+
+        self.events = Events()
+        self.events.closed = Event(
+            """
+            Event that triggers when the figure window is closed.
+
+            Parameters
+            ----------
+            obj:  SpectrumFigure instances
+                The instance that triggered the event.
+            """,
+            arguments=["obj"],
+        )
 
     def plot_signal(self, **kwargs):
         # This method should be implemented by the subclasses.
@@ -87,7 +101,12 @@ class MPL_HyperExplorer(object):
         if len(self.navigator_data_function().shape) == 1:
             # Create the figure
             fig = kwargs.pop("fig", None)
-            sf = signal1d.Signal1DFigure(title=title, fig=fig)
+            sf = signal1d.Signal1DFigure(
+                title=title,
+                # Passed to figure creation
+                _on_figure_window_close=self.close,
+                fig=fig,
+            )
             axis = self.axes_manager.navigation_axes[0]
             sf.xlabel = "%s" % str(axis)
             if axis.units is not Undefined:
@@ -117,13 +136,15 @@ class MPL_HyperExplorer(object):
                 self._get_navigation_sliders()
                 for axis in self.axes_manager.navigation_axes[:-2]:
                     axis.events.index_changed.connect(sf.update, [])
-                    sf.events.closed.connect(
+                    self.events.closed.connect(
                         partial(axis.events.index_changed.disconnect, sf.update), []
                     )
             self.navigator_plot = sf
         elif len(self.navigator_data_function().shape) >= 2:
             # Create the figure
-            imf = image.ImagePlot(title=title)
+            imf = image.ImagePlot(
+                title=title,
+            )
             imf.data_function = self.navigator_data_function
 
             # Set all kwargs value to the image figure before passing the rest
@@ -143,21 +164,21 @@ class MPL_HyperExplorer(object):
                     self._get_navigation_sliders()
                     for axis in self.axes_manager.navigation_axes[2:]:
                         axis.events.index_changed.connect(imf.update, [])
-                        imf.events.closed.connect(
+                        self.events.closed.connect(
                             partial(axis.events.index_changed.disconnect, imf.update),
                             [],
                         )
 
             if "cmap" not in kwargs.keys() or kwargs["cmap"] is None:
                 kwargs["cmap"] = preferences.Plot.cmap_navigator
-            imf.plot(**kwargs)
+            imf.plot(
+                # Passed to figure creation
+                _on_figure_window_close=self.close,
+                # Other kwargs
+                **kwargs,
+            )
             self.pointer.set_mpl_ax(imf.ax)
             self.navigator_plot = imf
-
-        if self.navigator_plot is not None:
-            self.navigator_plot.events.closed.connect(
-                self._on_navigator_plot_closing, []
-            )
 
     def _get_navigation_sliders(self):
         try:
@@ -207,9 +228,7 @@ class MPL_HyperExplorer(object):
                     self.pointer.connect_navigate()
                 self.plot_navigator(**kwargs.pop("navigator_kwds", {}))
                 if pointer is not None:
-                    self.navigator_plot.events.closed.connect(
-                        self.pointer.disconnect, []
-                    )
+                    self.events.closed.connect(self.pointer.disconnect, [])
             self.plot_signal(**kwargs)
             if _is_widget_backend() and "fig" not in kwargs:
                 if plot_style not in ["vertical", "horizontal", None]:
@@ -273,19 +292,25 @@ class MPL_HyperExplorer(object):
         self._pointer_nav_dim = nav_dim
         return Pointer
 
-    def _on_navigator_plot_closing(self):
-        self.navigator_plot = None
-
-    def _on_signal_plot_closing(self):
-        self.signal_plot = None
-
     def close(self):
-        """When closing, we make sure:
-        - close the matplotlib figure
-        - drawing events are disconnected
-        - the attribute 'signal_plot' and 'navigation_plot' are set to None
         """
-        if self.is_active:
-            if self.signal_plot:
-                self.signal_plot.close()
-            self.close_navigator_plot()
+        Close the plot of the signals.
+
+        This function is called programmatically or on matplotlib close
+        callback.
+        When closing, it does the following:
+        1. trigger a closed event
+        2. disconnect the closed event
+        3. run the close method of the signal_plot and navigator_plot
+        4. reset the attribute
+        """
+        self.events.closed.trigger(obj=self)
+        for f in self.events.closed.connected:
+            self.events.closed.disconnect(f)
+
+        for p in [self.signal_plot, self.navigator_plot]:
+            if p is not None:
+                p.close()
+
+        self.navigator_plot = None
+        self.signal_plot = None

--- a/hyperspy/drawing/mpl_he.py
+++ b/hyperspy/drawing/mpl_he.py
@@ -86,7 +86,8 @@ class MPL_HyperExplorer(object):
 
         if len(self.navigator_data_function().shape) == 1:
             # Create the figure
-            sf = signal1d.Signal1DFigure(title=title)
+            fig = kwargs.pop("fig", None)
+            sf = signal1d.Signal1DFigure(title=title, fig=fig)
             axis = self.axes_manager.navigation_axes[0]
             sf.xlabel = "%s" % str(axis)
             if axis.units is not Undefined:

--- a/hyperspy/drawing/mpl_hie.py
+++ b/hyperspy/drawing/mpl_hie.py
@@ -48,7 +48,12 @@ class MPL_HyperImage_Explorer(MPL_HyperExplorer):
         kwargs["data_function_kwargs"] = self.signal_data_function_kwargs
         if "cmap" not in kwargs.keys() or kwargs["cmap"] is None:
             kwargs["cmap"] = preferences.Plot.cmap_signal
-        imf.plot(**kwargs)
+        imf.plot(
+            # Passed to figure creation
+            _on_figure_window_close=self.close,
+            # Other kwargs
+            **kwargs,
+        )
         self.signal_plot = imf
 
         if imf.figure is not None:
@@ -60,5 +65,3 @@ class MPL_HyperImage_Explorer(MPL_HyperExplorer):
                 self.navigator_plot.figure.canvas.mpl_connect(
                     "key_press_event", self.axes_manager.key_navigator
                 )
-                imf.events.closed.connect(self.close_navigator_plot, [])
-            imf.events.closed.connect(self._on_signal_plot_closing, [])

--- a/hyperspy/drawing/mpl_hse.py
+++ b/hyperspy/drawing/mpl_hse.py
@@ -75,7 +75,8 @@ class MPL_HyperSignal1D_Explorer(MPL_HyperExplorer):
         super().plot_signal()
         # Create the figure
         self.axis = self.axes_manager.signal_axes[0]
-        sf = signal1d.Signal1DFigure(title=self.signal_title + " Signal")
+        fig = kwargs.pop("fig", None)
+        sf = signal1d.Signal1DFigure(title=self.signal_title + " Signal", fig=fig)
         sf.axis = self.axis
         if sf.ax is None:
             sf.create_axis()

--- a/hyperspy/drawing/mpl_hse.py
+++ b/hyperspy/drawing/mpl_hse.py
@@ -76,7 +76,12 @@ class MPL_HyperSignal1D_Explorer(MPL_HyperExplorer):
         # Create the figure
         self.axis = self.axes_manager.signal_axes[0]
         fig = kwargs.pop("fig", None)
-        sf = signal1d.Signal1DFigure(title=self.signal_title + " Signal", fig=fig)
+        sf = signal1d.Signal1DFigure(
+            title=self.signal_title + " Signal",
+            # Passed to figure creation
+            _on_figure_window_close=self.close,
+            fig=fig,
+        )
         sf.axis = self.axis
         if sf.ax is None:
             sf.create_axis()
@@ -121,7 +126,6 @@ class MPL_HyperSignal1D_Explorer(MPL_HyperExplorer):
                     "key_press_event", self.axes_manager.key_navigator
                 )
             if self.navigator_plot is not None:
-                sf.events.closed.connect(self.close_navigator_plot, [])
                 self.signal_plot.figure.canvas.mpl_connect(
                     "key_press_event", self.key2switch_right_pointer
                 )
@@ -131,7 +135,6 @@ class MPL_HyperSignal1D_Explorer(MPL_HyperExplorer):
                 self.navigator_plot.figure.canvas.mpl_connect(
                     "key_press_event", self.axes_manager.key_navigator
                 )
-            sf.events.closed.connect(self._on_signal_plot_closing, [])
 
     def key2switch_right_pointer(self, event):
         if event.key == "e":

--- a/hyperspy/drawing/utils.py
+++ b/hyperspy/drawing/utils.py
@@ -140,6 +140,7 @@ def centre_colormap_values(vmin, vmax):
 
 
 def create_figure(
+    fig=None,
     window_title=None,
     _on_figure_window_close=None,
     disable_xyscale_keys=False,
@@ -166,7 +167,9 @@ def create_figure(
     fig : plt.figure
 
     """
-    fig = plt.figure(**kwargs)
+    if fig is None:
+        fig = plt.figure(**kwargs)
+
     if window_title is not None:
         # remove non-alphanumeric characters to prevent file saving problems
         # This is a workaround for:

--- a/hyperspy/drawing/utils.py
+++ b/hyperspy/drawing/utils.py
@@ -169,6 +169,11 @@ def create_figure(
     """
     if fig is None:
         fig = plt.figure(**kwargs)
+    else:
+        if isinstance(fig, mpl.figure.SubFigure) and Version(mpl.__version__) < Version(
+            "3.9.0"
+        ):
+            raise ValueError("Subfigure are only supported for matplotlib>=3.9")
 
     if window_title is not None:
         # remove non-alphanumeric characters to prevent file saving problems

--- a/hyperspy/signal.py
+++ b/hyperspy/signal.py
@@ -3041,6 +3041,21 @@ class BaseSignal(
                 navigator = None
             else:
                 navigator = "slider"
+
+        from hyperspy.defaults_parser import preferences
+
+        if (
+            "fig" not in kwargs.keys()
+            and preferences.Plot.use_subfigure
+            and axes_manager.navigation_dimension > 0
+            and axes_manager.signal_dimension in [1, 2]
+        ):
+            # Create default subfigure
+            fig = plt.figure(figsize=(15, 7), layout="constrained")
+            subfigs = fig.subfigures(1, 2)
+            kwargs["fig"] = subfigs[1]
+            kwargs["navigator_kwds"] = dict(fig=subfigs[0])
+
         if axes_manager.signal_dimension == 0:
             if axes_manager.navigation_dimension == 0:
                 # 0d signal without navigation axis: don't make a figure

--- a/hyperspy/tests/drawing/test_figure.py
+++ b/hyperspy/tests/drawing/test_figure.py
@@ -18,6 +18,7 @@
 import numpy as np
 import pytest
 from matplotlib.backend_bases import CloseEvent
+import matplotlib.pyplot as plt
 
 from hyperspy._components.polynomial import Polynomial
 from hyperspy.drawing._markers.points import Points
@@ -118,3 +119,31 @@ def test_remove_markers():
     s._plot.signal_plot.remove_markers()
     assert len(s._plot.signal_plot.ax_markers) == 0
     assert m._collection is None  # Check that the collection is set to None
+
+
+def test_close_figure_with_subfigure():
+    rng = np.random.default_rng()
+    s = Signal1D(rng.random((10, 10, 10)))
+
+    fig = plt.figure()
+    subfig_nav, subfig_sig = fig.subfigures(1, 2)
+
+    s.plot(navigator_kwds=dict(fig=subfig_nav), fig=subfig_sig)
+    s._plot.close()
+
+    # Currently fails
+    # s.plot(
+    #     navigator_kwds=dict(fig=subfig_nav),
+    #     fig=subfig_sig
+    #     )
+
+
+def test_close_figure_with_subfigure_matplotlib_event():
+    rng = np.random.default_rng()
+    s = Signal1D(rng.random((10, 10, 10)))
+
+    fig = plt.figure()
+    subfig_nav, subfig_sig = fig.subfigures(1, 2)
+
+    s.plot(navigator_kwds=dict(fig=subfig_nav), fig=subfig_sig)
+    plt.close(fig)

--- a/hyperspy/tests/drawing/test_figure.py
+++ b/hyperspy/tests/drawing/test_figure.py
@@ -15,10 +15,10 @@
 # You should have received a copy of the GNU General Public License
 # along with HyperSpy. If not, see <https://www.gnu.org/licenses/#GPL>.
 
+import matplotlib.pyplot as plt
 import numpy as np
 import pytest
 from matplotlib.backend_bases import CloseEvent
-import matplotlib.pyplot as plt
 
 from hyperspy._components.polynomial import Polynomial
 from hyperspy.drawing._markers.points import Points

--- a/hyperspy/tests/drawing/test_figure.py
+++ b/hyperspy/tests/drawing/test_figure.py
@@ -15,10 +15,12 @@
 # You should have received a copy of the GNU General Public License
 # along with HyperSpy. If not, see <https://www.gnu.org/licenses/#GPL>.
 
+import matplotlib
 import matplotlib.pyplot as plt
 import numpy as np
 import pytest
 from matplotlib.backend_bases import CloseEvent
+from packaging.version import Version
 
 from hyperspy._components.polynomial import Polynomial
 from hyperspy.drawing._markers.points import Points
@@ -121,6 +123,10 @@ def test_remove_markers():
     assert m._collection is None  # Check that the collection is set to None
 
 
+@pytest.mark.skipif(
+    Version(matplotlib.__version__) < Version("3.9.0"),
+    reason="Subfigures plotting requires matplotlib >= 3.9.0",
+)
 def test_close_figure_with_subfigure():
     rng = np.random.default_rng()
     s = Signal1D(rng.random((10, 10, 10)))
@@ -138,6 +144,10 @@ def test_close_figure_with_subfigure():
     #     )
 
 
+@pytest.mark.skipif(
+    Version(matplotlib.__version__) < Version("3.9.0"),
+    reason="Subfigures plotting requires matplotlib >= 3.9.0",
+)
 def test_close_figure_with_subfigure_matplotlib_event():
     rng = np.random.default_rng()
     s = Signal1D(rng.random((10, 10, 10)))

--- a/hyperspy/tests/drawing/test_figure.py
+++ b/hyperspy/tests/drawing/test_figure.py
@@ -22,6 +22,7 @@ import pytest
 from matplotlib.backend_bases import CloseEvent
 from packaging.version import Version
 
+import hyperspy.api as hs
 from hyperspy._components.polynomial import Polynomial
 from hyperspy.drawing._markers.points import Points
 from hyperspy.drawing.figure import BlittedFigure
@@ -137,11 +138,30 @@ def test_close_figure_with_subfigure():
     s.plot(navigator_kwds=dict(fig=subfig_nav), fig=subfig_sig)
     s._plot.close()
 
-    # Currently fails
+    # This shows an empty axis...
     # s.plot(
     #     navigator_kwds=dict(fig=subfig_nav),
     #     fig=subfig_sig
     #     )
+
+
+@pytest.mark.skipif(
+    Version(matplotlib.__version__) >= Version("3.9.0"),
+    reason="Error raised for matplotlib < 3.9.0",
+)
+def test_subfigure_preferences_setting():
+    rng = np.random.default_rng()
+    s = Signal1D(rng.random((10, 10, 10)))
+
+    hs.preferences.Plot.use_subfigure = True
+    if Version(matplotlib.__version__) < Version("3.9.0"):
+        with pytest.raises(ValueError):
+            s.plot()
+    else:
+        s.plot()
+    s._plot.close()
+    # Set default setting back
+    hs.preferences.Plot.use_subfigure = False
 
 
 @pytest.mark.skipif(
@@ -157,3 +177,30 @@ def test_close_figure_with_subfigure_matplotlib_event():
 
     s.plot(navigator_kwds=dict(fig=subfig_nav), fig=subfig_sig)
     plt.close(fig)
+
+
+@pytest.mark.skipif(
+    Version(matplotlib.__version__) < Version("3.9.0"),
+    reason="Subfigures plotting requires matplotlib >= 3.9.0",
+)
+def test_subfigure_get_mpl_figure():
+    rng = np.random.default_rng()
+    s = Signal1D(rng.random((10, 10, 10)))
+
+    hs.preferences.Plot.use_subfigure = True
+    s.plot()
+    assert isinstance(s._plot.signal_plot.get_mpl_figure(), matplotlib.figure.Figure)
+    assert isinstance(s._plot.signal_plot.figure, matplotlib.figure.SubFigure)
+    s._plot.signal_plot.close()
+    # Set default setting back
+    hs.preferences.Plot.use_subfigure = False
+
+
+def test_separate_figure_get_mpl_figure():
+    rng = np.random.default_rng()
+    s = Signal1D(rng.random((10, 10, 10)))
+
+    s.plot()
+    assert isinstance(s._plot.signal_plot.get_mpl_figure(), matplotlib.figure.Figure)
+    assert isinstance(s._plot.signal_plot.figure, matplotlib.figure.Figure)
+    s._plot.signal_plot.close()

--- a/hyperspy/tests/drawing/test_plot_signal1d.py
+++ b/hyperspy/tests/drawing/test_plot_signal1d.py
@@ -431,8 +431,9 @@ def test_plot_add_line_events(ax):
     assert len(line.events.closed.connected) == 0
     assert len(s.axes_manager.events.indices_changed.connected) == 1
 
-    plot.close()
+    s._plot.close()
     assert len(s.axes_manager.events.indices_changed.connected) == 0
+    assert len(s._plot.events.closed.connected) == 0
     assert s._plot.signal_plot is None
 
 

--- a/hyperspy/tests/drawing/test_plot_signal2d.py
+++ b/hyperspy/tests/drawing/test_plot_signal2d.py
@@ -842,6 +842,10 @@ def test_plot_scalebar_list():
     assert not hasattr(ax1, "scalebar")
 
 
+@pytest.mark.skipif(
+    Version(matplotlib.__version__) < Version("3.9.0"),
+    reason="Subfigures plotting requires matplotlib >= 3.9.0",
+)
 def test_plot_subfigures():
     rng = np.random.default_rng()
     s = hs.signals.Signal2D(rng.random((10, 10, 10, 10, 10)))

--- a/hyperspy/tests/drawing/test_plot_signal2d.py
+++ b/hyperspy/tests/drawing/test_plot_signal2d.py
@@ -842,6 +842,14 @@ def test_plot_scalebar_list():
     assert not hasattr(ax1, "scalebar")
 
 
+def test_plot_subfigures():
+    rng = np.random.default_rng()
+    s = hs.signals.Signal2D(rng.random((10, 10, 10, 10, 10)))
+    fig = plt.figure(figsize=(10, 10))
+    subfigs = fig.subfigures(1, 2, wspace=0.07)
+    s.plot(fig=subfigs[0])
+
+
 def test_plot_images_bool():
     data = np.arange(100).reshape((10, 10)) > 50
     s = hs.signals.Signal2D(data)

--- a/hyperspy/tests/drawing/test_plot_signal2d.py
+++ b/hyperspy/tests/drawing/test_plot_signal2d.py
@@ -854,6 +854,20 @@ def test_plot_subfigures():
     s.plot(fig=subfigs[0])
 
 
+@pytest.mark.skipif(
+    Version(matplotlib.__version__) < Version("3.9.0"),
+    reason="Subfigures plotting requires matplotlib >= 3.9.0",
+)
+def test_plot_subfigures_change_navigation_indices():
+    rng = np.random.default_rng()
+    s = hs.signals.Signal2D(rng.random((10, 10, 10, 10, 10)))
+    hs.preferences.Plot.use_subfigure = True
+    s.plot()
+    s.axes_manager.indices = (1, 2, 3)
+    # Set default setting back
+    hs.preferences.Plot.use_subfigure = False
+
+
 def test_plot_images_bool():
     data = np.arange(100).reshape((10, 10)) > 50
     s = hs.signals.Signal2D(data)

--- a/hyperspy/tests/drawing/test_plot_signal_tools.py
+++ b/hyperspy/tests/drawing/test_plot_signal_tools.py
@@ -92,11 +92,13 @@ def test_plot_BackgroundRemoval_close_figure():
     br = BackgroundRemoval(s, background_type="Gaussian")
     signal_plot = s._plot.signal_plot
 
-    assert len(signal_plot.events.closed.connected) == 5
+    assert len(signal_plot.events.closed.connected) == 3
+    assert len(s._plot.events.closed.connected) == 1
     assert len(s.axes_manager.events.indices_changed.connected) == 4
     s._plot.close()
     assert br._fit not in s.axes_manager.events.indices_changed.connected
-    assert br.disconnect not in signal_plot.events.closed.connected
+    assert len(s._plot.events.closed.connected) == 0
+    assert len(signal_plot.events.closed.connected) == 0
 
 
 def test_plot_BackgroundRemoval_close_tool():
@@ -106,12 +108,14 @@ def test_plot_BackgroundRemoval_close_tool():
     br.span_selector_changed()
     signal_plot = s._plot.signal_plot
 
-    assert len(signal_plot.events.closed.connected) == 5
+    assert len(signal_plot.events.closed.connected) == 3
+    assert len(s._plot.events.closed.connected) == 1
     assert len(s.axes_manager.events.indices_changed.connected) == 4
     br.on_disabling_span_selector()
     assert br._fit not in s.axes_manager.events.indices_changed.connected
     s._plot.close()
-    assert br.disconnect not in signal_plot.events.closed.connected
+    assert len(s._plot.events.closed.connected) == 0
+    assert len(signal_plot.events.closed.connected) == 0
 
 
 @pytest.mark.mpl_image_compare(

--- a/upcoming_changes/3343.new.rst
+++ b/upcoming_changes/3343.new.rst
@@ -1,0 +1,1 @@
+Add support for plotting navigator and signal plot on same figure using `matplotlib subfigures <https://matplotlib.org/stable/gallery/subplots_axes_and_figures/subfigures.html>`_. See examples in the :ref:`custom layout for plots <subfigure_examples_label>` section.


### PR DESCRIPTION
### Description of the change 

This is still a fairly new `matplotlib` feature and still [Provisional](https://matplotlib.org/devdocs/gallery/subplots_axes_and_figures/subfigures.html#sphx-glr-gallery-subplots-axes-and-figures-subfigures-py) but I think there is/ will be a fair bit of ongoing support for it as many people are interested in this.

Additionally picking and dragging the marker isn't supported until matplotlib 3.9 (https://github.com/matplotlib/matplotlib/pull/27343) and the `draw_without_rendering` function isn't supported which causes a small bug related to the color bar.  Replacing with `draw_idle` works fine though. 

I think this is ultimately (going to be) a better choice than the previous horizontal plotting option but there are still some bugs related to it. 

A few sentences and/or a bulleted list to describe and motivate the change:

- Add ability to pass `fig` when plotting to specify a figure output


### Progress of the PR
- [x] Change implemented (can be split into several points),
- [ ] Add/update examples for plotting,
- [x] Add option to preferences (with "experimental label") to use subfigure to opt in using it default,
- [x] Document that using subfigure is slower than separate figure,
- [x] add an changelog entry in the `upcoming_changes` folder (see [`upcoming_changes/README.rst`](https://github.com/hyperspy/hyperspy/blob/RELEASE_next_minor/upcoming_changes/README.rst)),
- [x] Check formatting changelog entry in the `readthedocs` doc build of this PR (link in github checks)
- [x] add tests,
- [x] ready for review.

### Minimal example of the bug fix or the new feature
```python
%matplotlib ipympl
import matplotlib.pyplot as plt

import hyperspy.api as hs
import numpy as np
rng = np.random.default_rng()
s = hs.signals.Signal2D(rng.random((10,10,10,10)))
fig = plt.figure(figsize=(10,5))
subfigs = fig.subfigures(1, 2, wspace=0.07)
s.plot(navigator_kwds=dict(fig=subfigs[0]), fig=subfigs[1])
```
