### PR TITLE
Enable ruff isort

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -11,12 +11,11 @@
 # All configuration values have a default; values that are commented out
 # serve to show the default.
 
+import sys
 from datetime import datetime
 from importlib.metadata import version as get_version
-import sys
 
 import hyperspy
-
 
 sys.path.append("../")
 

--- a/doc/gh-pages.py
+++ b/doc/gh-pages.py
@@ -19,8 +19,7 @@ import shutil
 import sys
 from os import chdir as cd
 from os.path import join as pjoin
-
-from subprocess import Popen, PIPE, CalledProcessError, check_call
+from subprocess import PIPE, CalledProcessError, Popen, check_call
 
 # -----------------------------------------------------------------------------
 # Globals

--- a/hyperspy/__init__.py
+++ b/hyperspy/__init__.py
@@ -17,9 +17,10 @@
 # along with HyperSpy. If not, see <https://www.gnu.org/licenses/#GPL>.
 
 import importlib
-from importlib.metadata import version
 import logging
+from importlib.metadata import version
 from pathlib import Path
+
 from hyperspy import docstrings
 
 _logger = logging.getLogger(__name__)

--- a/hyperspy/_components/doniach.py
+++ b/hyperspy/_components/doniach.py
@@ -17,11 +17,12 @@
 # along with HyperSpy. If not, see <https://www.gnu.org/licenses/#GPL>.
 
 import math
+
 import numpy as np
 
-from hyperspy.component import _get_scaling_factor
 from hyperspy._components.expression import Expression
 from hyperspy._components.gaussian import _estimate_gaussian_parameters
+from hyperspy.component import _get_scaling_factor
 
 sqrt2pi = math.sqrt(2 * math.pi)
 

--- a/hyperspy/_components/exponential.py
+++ b/hyperspy/_components/exponential.py
@@ -16,11 +16,11 @@
 # You should have received a copy of the GNU General Public License
 # along with HyperSpy. If not, see <https://www.gnu.org/licenses/#GPL>.
 
-import numpy as np
 import logging
 
-from hyperspy._components.expression import Expression
+import numpy as np
 
+from hyperspy._components.expression import Expression
 
 _logger = logging.getLogger(__name__)
 

--- a/hyperspy/_components/expression.py
+++ b/hyperspy/_components/expression.py
@@ -17,16 +17,15 @@
 # along with HyperSpy. If not, see <https://www.gnu.org/licenses/#GPL>.
 
 import importlib
-from functools import wraps
 import logging
+import warnings
+from functools import wraps
+
 import numpy as np
 import sympy
 
-import warnings
-
 from hyperspy.component import Component
 from hyperspy.docstrings.parameters import FUNCTION_ND_DOCSTRING
-
 
 _logger = logging.getLogger(__name__)
 

--- a/hyperspy/_components/gaussian.py
+++ b/hyperspy/_components/gaussian.py
@@ -18,12 +18,11 @@
 
 import math
 
-import numpy as np
 import dask.array as da
+import numpy as np
 
-from hyperspy.component import _get_scaling_factor
 from hyperspy._components.expression import Expression
-
+from hyperspy.component import _get_scaling_factor
 
 sqrt2pi = math.sqrt(2 * math.pi)
 sigma2fwhm = 2 * math.sqrt(2 * math.log(2))

--- a/hyperspy/_components/gaussian2d.py
+++ b/hyperspy/_components/gaussian2d.py
@@ -17,9 +17,10 @@
 # along with HyperSpy. If not, see <https://www.gnu.org/licenses/#GPL>.
 
 import math
-import numpy as np
-from hyperspy._components.expression import Expression
 
+import numpy as np
+
+from hyperspy._components.expression import Expression
 
 sigma2fwhm = 2 * np.sqrt(2 * np.log(2))
 

--- a/hyperspy/_components/gaussianhf.py
+++ b/hyperspy/_components/gaussianhf.py
@@ -22,7 +22,6 @@ from hyperspy._components.expression import Expression
 from hyperspy._components.gaussian import _estimate_gaussian_parameters
 from hyperspy.component import _get_scaling_factor
 
-
 sqrt2pi = math.sqrt(2 * math.pi)
 sigma2fwhm = 2 * math.sqrt(2 * math.log(2))
 

--- a/hyperspy/_components/lorentzian.py
+++ b/hyperspy/_components/lorentzian.py
@@ -16,11 +16,11 @@
 # You should have received a copy of the GNU General Public License
 # along with HyperSpy. If not, see <https://www.gnu.org/licenses/#GPL>.
 
-import numpy as np
 import dask.array as da
+import numpy as np
 
-from hyperspy.component import _get_scaling_factor
 from hyperspy._components.expression import Expression
+from hyperspy.component import _get_scaling_factor
 
 
 def _estimate_lorentzian_parameters(signal, x1, x2, only_current):

--- a/hyperspy/_components/polynomial.py
+++ b/hyperspy/_components/polynomial.py
@@ -16,12 +16,12 @@
 # You should have received a copy of the GNU General Public License
 # along with HyperSpy. If not, see <https://www.gnu.org/licenses/#GPL>.
 
-import numpy as np
 import logging
+
+import numpy as np
 
 from hyperspy._components.expression import Expression
 from hyperspy.misc.utils import ordinal
-
 
 _logger = logging.getLogger(__name__)
 

--- a/hyperspy/_components/scalable_fixed_pattern.py
+++ b/hyperspy/_components/scalable_fixed_pattern.py
@@ -20,8 +20,8 @@ import numpy as np
 from scipy.interpolate import make_interp_spline
 
 from hyperspy.component import Component
-from hyperspy.ui_registry import add_gui_method
 from hyperspy.docstrings.parameters import FUNCTION_ND_DOCSTRING
+from hyperspy.ui_registry import add_gui_method
 
 
 @add_gui_method(toolkey="hyperspy.ScalableFixedPattern_Component")

--- a/hyperspy/_components/skew_normal.py
+++ b/hyperspy/_components/skew_normal.py
@@ -19,9 +19,8 @@
 import dask.array as da
 import numpy as np
 
-from hyperspy.component import _get_scaling_factor
 from hyperspy._components.expression import Expression
-
+from hyperspy.component import _get_scaling_factor
 
 sqrt2pi = np.sqrt(2 * np.pi)
 

--- a/hyperspy/_components/split_voigt.py
+++ b/hyperspy/_components/split_voigt.py
@@ -18,10 +18,9 @@
 
 import numpy as np
 
-from hyperspy.component import Component, _get_scaling_factor
 from hyperspy._components.gaussian import _estimate_gaussian_parameters
+from hyperspy.component import Component, _get_scaling_factor
 from hyperspy.docstrings.parameters import FUNCTION_ND_DOCSTRING
-
 
 sqrt2pi = np.sqrt(2 * np.pi)
 

--- a/hyperspy/_components/voigt.py
+++ b/hyperspy/_components/voigt.py
@@ -18,10 +18,9 @@
 
 import math
 
-from hyperspy.component import _get_scaling_factor
 from hyperspy._components.expression import Expression
 from hyperspy._components.gaussian import _estimate_gaussian_parameters
-
+from hyperspy.component import _get_scaling_factor
 
 sqrt2pi = math.sqrt(2 * math.pi)
 sigma2fwhm = 2 * math.sqrt(2 * math.log(2))

--- a/hyperspy/_lazy_signals.py
+++ b/hyperspy/_lazy_signals.py
@@ -16,13 +16,12 @@
 # You should have received a copy of the GNU General Public License
 # along with HyperSpy. If not, see <https://www.gnu.org/licenses/#GPL>.
 
-from hyperspy._signals.lazy import LazySignal
-from hyperspy._signals.signal1d import LazySignal1D
-from hyperspy._signals.signal2d import LazySignal2D
 from hyperspy._signals.complex_signal import LazyComplexSignal
 from hyperspy._signals.complex_signal1d import LazyComplexSignal1D
 from hyperspy._signals.complex_signal2d import LazyComplexSignal2D
-
+from hyperspy._signals.lazy import LazySignal
+from hyperspy._signals.signal1d import LazySignal1D
+from hyperspy._signals.signal2d import LazySignal2D
 
 __all__ = [
     "LazyComplexSignal",

--- a/hyperspy/_signals/common_signal1d.py
+++ b/hyperspy/_signals/common_signal1d.py
@@ -17,8 +17,8 @@
 # along with HyperSpy. If not, see <https://www.gnu.org/licenses/#GPL>.
 
 
-from hyperspy.exceptions import DataDimensionError
 from hyperspy.docstrings.signal import OPTIMIZE_ARG
+from hyperspy.exceptions import DataDimensionError
 
 
 class CommonSignal1D:

--- a/hyperspy/_signals/complex_signal.py
+++ b/hyperspy/_signals/complex_signal.py
@@ -17,13 +17,12 @@
 # along with HyperSpy. If not, see <https://www.gnu.org/licenses/#GPL>.
 
 from functools import wraps
-from packaging.version import Version
 
 import numpy as np
+from packaging.version import Version
 
-from hyperspy.signal import BaseSignal
-from hyperspy._signals.signal2d import Signal2D
 from hyperspy._signals.lazy import LazySignal
+from hyperspy._signals.signal2d import Signal2D
 from hyperspy.docstrings.plot import (
     BASE_PLOT_DOCSTRING,
     BASE_PLOT_DOCSTRING_PARAMETERS,
@@ -31,12 +30,12 @@ from hyperspy.docstrings.plot import (
     PLOT2D_KWARGS_DOCSTRING,
 )
 from hyperspy.docstrings.signal import (
-    SHOW_PROGRESSBAR_ARG,
-    NUM_WORKERS_ARG,
     LAZYSIGNAL_DOC,
+    NUM_WORKERS_ARG,
+    SHOW_PROGRESSBAR_ARG,
 )
 from hyperspy.misc.utils import parse_quantity
-
+from hyperspy.signal import BaseSignal
 
 ERROR_MESSAGE_SETTER = (
     "Setting the {} with a complex signal is ambiguous, "

--- a/hyperspy/_signals/complex_signal2d.py
+++ b/hyperspy/_signals/complex_signal2d.py
@@ -22,8 +22,8 @@ from hyperspy._signals.complex_signal import ComplexSignal, LazyComplexSignal
 from hyperspy.docstrings.plot import (
     BASE_PLOT_DOCSTRING,
     BASE_PLOT_DOCSTRING_PARAMETERS,
-    PLOT2D_DOCSTRING,
     COMPLEX_DOCSTRING,
+    PLOT2D_DOCSTRING,
     PLOT2D_KWARGS_DOCSTRING,
 )
 from hyperspy.docstrings.signal import LAZYSIGNAL_DOC

--- a/hyperspy/_signals/lazy.py
+++ b/hyperspy/_signals/lazy.py
@@ -16,34 +16,33 @@
 # You should have received a copy of the GNU General Public License
 # along with HyperSpy. If not, see <https://www.gnu.org/licenses/#GPL>.
 
-from functools import partial
 import logging
 import os
+from functools import partial
+from itertools import product
 
-import numpy as np
 import dask
 import dask.array as da
-from itertools import product
-from rsciio.utils.tools import get_file_handle
+import numpy as np
 from rsciio.utils import rgb_tools
+from rsciio.utils.tools import get_file_handle
 
-from hyperspy.signal import BaseSignal
 from hyperspy.defaults_parser import preferences
 from hyperspy.docstrings.signal import (
-    SHOW_PROGRESSBAR_ARG,
-    MANY_AXIS_PARAMETER,
     LAZYSIGNAL_DOC,
+    MANY_AXIS_PARAMETER,
+    SHOW_PROGRESSBAR_ARG,
 )
 from hyperspy.external.progressbar import progressbar
 from hyperspy.misc.array_tools import (
+    _get_navigation_dimension_chunk_slice,
     _requires_linear_rebin,
     get_signal_chunk_slice,
-    _get_navigation_dimension_chunk_slice,
 )
 from hyperspy.misc.hist_tools import histogram_dask
 from hyperspy.misc.machine_learning import import_sklearn
-from hyperspy.misc.utils import multiply, dummy_context_manager, isiterable
-
+from hyperspy.misc.utils import dummy_context_manager, isiterable, multiply
+from hyperspy.signal import BaseSignal
 
 _logger = logging.getLogger(__name__)
 
@@ -139,8 +138,8 @@ class LazySignal(BaseSignal):
         try:
             from dask import config
             from dask.array.svg import svg
-            from dask.widgets import get_template
             from dask.utils import format_bytes
+            from dask.widgets import get_template
 
             nav_chunks = self.get_chunk_size(self.axes_manager.navigation_axes)
             sig_chunks = self.get_chunk_size(self.axes_manager.signal_axes)

--- a/hyperspy/_signals/signal1d.py
+++ b/hyperspy/_signals/signal1d.py
@@ -20,49 +20,50 @@ import logging
 import math
 import warnings
 
+import dask.array as da
 import numpy as np
 import numpy.ma as ma
-import dask.array as da
 from scipy import interpolate
-from scipy.signal import savgol_filter, medfilt
 from scipy.ndimage import gaussian_filter1d
+from scipy.signal import medfilt, savgol_filter
 
-from hyperspy.signal import BaseSignal
 from hyperspy._signals.common_signal1d import CommonSignal1D
-from hyperspy.signal_tools import SpikesRemoval, SpikesRemovalInteractive, SimpleMessage
-from hyperspy.models.model1d import Model1D
-from hyperspy.misc.lowess_smooth import lowess
-
-from hyperspy.defaults_parser import preferences
-from hyperspy.signal_tools import (
-    Signal1DCalibration,
-    SmoothingSavitzkyGolay,
-    SmoothingLowess,
-    SmoothingTV,
-    ButterworthFilter,
-)
-from hyperspy.ui_registry import DISPLAY_DT, TOOLKIT_DT
-from hyperspy.misc.tv_denoise import _tv_denoise_1d
-from hyperspy.signal_tools import BackgroundRemoval
-from hyperspy.decorators import interactive_range_selector
-from hyperspy.signal_tools import _get_background_estimator
 from hyperspy._signals.lazy import LazySignal
-from hyperspy.docstrings.signal1d import (
-    CROP_PARAMETER_DOC,
-    SPIKES_REMOVAL_TOOL_DOCSTRING,
-)
-from hyperspy.docstrings.signal import (
-    SHOW_PROGRESSBAR_ARG,
-    NUM_WORKERS_ARG,
-    SIGNAL_MASK_ARG,
-    NAVIGATION_MASK_ARG,
-    LAZYSIGNAL_DOC,
-)
+from hyperspy.decorators import interactive_range_selector
+from hyperspy.defaults_parser import preferences
 from hyperspy.docstrings.plot import (
     BASE_PLOT_DOCSTRING,
     BASE_PLOT_DOCSTRING_PARAMETERS,
     PLOT1D_DOCSTRING,
 )
+from hyperspy.docstrings.signal import (
+    LAZYSIGNAL_DOC,
+    NAVIGATION_MASK_ARG,
+    NUM_WORKERS_ARG,
+    SHOW_PROGRESSBAR_ARG,
+    SIGNAL_MASK_ARG,
+)
+from hyperspy.docstrings.signal1d import (
+    CROP_PARAMETER_DOC,
+    SPIKES_REMOVAL_TOOL_DOCSTRING,
+)
+from hyperspy.misc.lowess_smooth import lowess
+from hyperspy.misc.tv_denoise import _tv_denoise_1d
+from hyperspy.models.model1d import Model1D
+from hyperspy.signal import BaseSignal
+from hyperspy.signal_tools import (
+    BackgroundRemoval,
+    ButterworthFilter,
+    Signal1DCalibration,
+    SimpleMessage,
+    SmoothingLowess,
+    SmoothingSavitzkyGolay,
+    SmoothingTV,
+    SpikesRemoval,
+    SpikesRemovalInteractive,
+    _get_background_estimator,
+)
+from hyperspy.ui_registry import DISPLAY_DT, TOOLKIT_DT
 
 _logger = logging.getLogger(__name__)
 

--- a/hyperspy/_signals/signal2d.py
+++ b/hyperspy/_signals/signal2d.py
@@ -16,16 +16,15 @@
 # You should have received a copy of the GNU General Public License
 # along with HyperSpy. If not, see <https://www.gnu.org/licenses/#GPL>.
 
-import matplotlib.pyplot as plt
-import numpy as np
-import numpy.ma as ma
-import dask.array as da
 import logging
 import warnings
 from copy import deepcopy
-
 from functools import partial
 
+import dask.array as da
+import matplotlib.pyplot as plt
+import numpy as np
+import numpy.ma as ma
 from scipy import ndimage
 
 try:
@@ -34,14 +33,10 @@ try:
 except ModuleNotFoundError:
     from skimage.feature.register_translation import _upsampled_dft
 
-from hyperspy.defaults_parser import preferences
-from hyperspy.external.progressbar import progressbar
-from hyperspy.misc.math_tools import symmetrize, antisymmetrize, optimal_fft_size
-from hyperspy.signal import BaseSignal
-from hyperspy._signals.signal1d import Signal1D
-from hyperspy._signals.lazy import LazySignal
 from hyperspy._signals.common_signal2d import CommonSignal2D
-from hyperspy.signal_tools import PeaksFinder2D, Signal2DCalibration
+from hyperspy._signals.lazy import LazySignal
+from hyperspy._signals.signal1d import Signal1D
+from hyperspy.defaults_parser import preferences
 from hyperspy.docstrings.plot import (
     BASE_PLOT_DOCSTRING,
     BASE_PLOT_DOCSTRING_PARAMETERS,
@@ -49,23 +44,26 @@ from hyperspy.docstrings.plot import (
     PLOT2D_KWARGS_DOCSTRING,
 )
 from hyperspy.docstrings.signal import (
-    SHOW_PROGRESSBAR_ARG,
-    NUM_WORKERS_ARG,
     LAZYSIGNAL_DOC,
+    NUM_WORKERS_ARG,
+    SHOW_PROGRESSBAR_ARG,
 )
+from hyperspy.external.progressbar import progressbar
+from hyperspy.misc.math_tools import antisymmetrize, optimal_fft_size, symmetrize
+from hyperspy.signal import BaseSignal
+from hyperspy.signal_tools import PeaksFinder2D, Signal2DCalibration
 from hyperspy.ui_registry import DISPLAY_DT, TOOLKIT_DT
 from hyperspy.utils.peakfinders2D import (
+    _get_peak_position_and_intensity,
     find_local_max,
+    find_peaks_dog,
+    find_peaks_log,
     find_peaks_max,
     find_peaks_minmax,
-    find_peaks_zaefferer,
     find_peaks_stat,
-    find_peaks_log,
-    find_peaks_dog,
     find_peaks_xc,
-    _get_peak_position_and_intensity,
+    find_peaks_zaefferer,
 )
-
 
 _logger = logging.getLogger(__name__)
 

--- a/hyperspy/api.py
+++ b/hyperspy/api.py
@@ -24,8 +24,8 @@ import hyperspy.api_nogui
 from hyperspy.api_nogui import __doc__, get_configuration_directory_path  # noqa: F401
 from hyperspy.defaults_parser import preferences  # noqa: F401
 from hyperspy.logger import set_log_level  # noqa: F401
-from . import __version__  # noqa: F401
 
+from . import __version__  # noqa: F401
 
 _logger = logging.getLogger(__name__)
 

--- a/hyperspy/api_nogui.py
+++ b/hyperspy/api_nogui.py
@@ -19,21 +19,20 @@
 # Set the PyQt API to 2 to avoid incompatibilities between matplotlib
 # traitsui
 
-import logging
 import importlib
+import logging
 import sys
 
-
-from hyperspy.logger import set_log_level
 from hyperspy.defaults_parser import preferences
+from hyperspy.logger import set_log_level
 
 # Need to run before other import to use the logger during import
 _logger = logging.getLogger(__name__)
 set_log_level(preferences.General.logging_level)
 
 from hyperspy import docstrings  # noqa: E402
-from . import __version__  # noqa: E402
 
+from . import __version__  # noqa: E402
 
 __doc__ = (
     """

--- a/hyperspy/axes.py
+++ b/hyperspy/axes.py
@@ -16,37 +16,35 @@
 # You should have received a copy of the GNU General Public License
 # along with HyperSpy. If not, see <https://www.gnu.org/licenses/#GPL>.
 
-from contextlib import contextmanager
 import copy
-import math
+import inspect
 import logging
+import math
+import warnings
+from collections.abc import Iterable
+from contextlib import contextmanager
 
 import dask.array as da
 import numpy as np
 import pint
-from sympy.utilities.lambdify import lambdify
 import traits.api as t
+from sympy.utilities.lambdify import lambdify
 from traits.trait_errors import TraitError
 
-from hyperspy.api_nogui import _ureg
-from hyperspy.events import Events, Event
-from hyperspy.misc.array_tools import (
-    numba_closest_index_round,
-    numba_closest_index_floor,
-    numba_closest_index_ceil,
-    round_half_towards_zero,
-    round_half_away_from_zero,
-)
-from hyperspy.misc.utils import isiterable, ordinal
-from hyperspy.misc.math_tools import isfloat
-from hyperspy.ui_registry import add_gui_method, get_gui
-from hyperspy.defaults_parser import preferences
 from hyperspy._components.expression import _parse_substitutions
-
-
-import warnings
-import inspect
-from collections.abc import Iterable
+from hyperspy.api_nogui import _ureg
+from hyperspy.defaults_parser import preferences
+from hyperspy.events import Event, Events
+from hyperspy.misc.array_tools import (
+    numba_closest_index_ceil,
+    numba_closest_index_floor,
+    numba_closest_index_round,
+    round_half_away_from_zero,
+    round_half_towards_zero,
+)
+from hyperspy.misc.math_tools import isfloat
+from hyperspy.misc.utils import isiterable, ordinal
+from hyperspy.ui_registry import add_gui_method, get_gui
 
 _logger = logging.getLogger(__name__)
 

--- a/hyperspy/component.py
+++ b/hyperspy/component.py
@@ -16,26 +16,25 @@
 # You should have received a copy of the GNU General Public License
 # along with HyperSpy. If not, see <https://www.gnu.org/licenses/#GPL>.
 
-import numpy as np
-from dask.array import Array as dArray
-import traits.api as t
-from traits.trait_numeric import Array
-import sympy
-from sympy.utilities.lambdify import lambdify
+import logging
 from pathlib import Path
 
-from hyperspy.misc.utils import slugify
-from rsciio.utils.tools import incremental_filename, append2pathname
+import numpy as np
+import sympy
+import traits.api as t
+from dask.array import Array as dArray
+from rsciio.utils.tools import append2pathname, incremental_filename
+from sympy.utilities.lambdify import lambdify
+from traits.trait_numeric import Array
+
+from hyperspy.events import Event, Events
 from hyperspy.misc.export_dictionary import (
     export_to_dictionary,
     load_from_dictionary,
 )
-from hyperspy.events import Events, Event
-from hyperspy.ui_registry import add_gui_method
 from hyperspy.misc.model_tools import CurrentComponentValues
-from hyperspy.misc.utils import display, get_object_package_info
-
-import logging
+from hyperspy.misc.utils import display, get_object_package_info, slugify
+from hyperspy.ui_registry import add_gui_method
 
 _logger = logging.getLogger(__name__)
 
@@ -725,7 +724,7 @@ class Parameter(t.HasTraits):
         # gives a ValueError. We therefore implement default_traits_view so
         # that configure/edit_traits will still work straight out of the box.
         # A whitelist controls which traits to include in this view.
-        from traitsui.api import RangeEditor, View, Item
+        from traitsui.api import Item, RangeEditor, View
 
         whitelist = ["bmax", "bmin", "free", "name", "std", "units", "value"]
         editable_traits = [

--- a/hyperspy/components1d.py
+++ b/hyperspy/components1d.py
@@ -16,9 +16,9 @@
 # You should have received a copy of the GNU General Public License
 # along with HyperSpy. If not, see <https://www.gnu.org/licenses/#GPL>.
 
-from hyperspy.extensions import EXTENSIONS as _EXTENSIONS
 import importlib
 
+from hyperspy.extensions import EXTENSIONS as _EXTENSIONS
 
 __all__ = [component for component, specs_ in _EXTENSIONS["components1D"].items()]
 

--- a/hyperspy/components2d.py
+++ b/hyperspy/components2d.py
@@ -17,9 +17,9 @@
 # along with HyperSpy. If not, see <https://www.gnu.org/licenses/#GPL>.
 
 
-from hyperspy.extensions import EXTENSIONS as _EXTENSIONS
 import importlib
 
+from hyperspy.extensions import EXTENSIONS as _EXTENSIONS
 
 __all__ = [component for component, specs_ in _EXTENSIONS["components2D"].items()]
 

--- a/hyperspy/data/__init__.py
+++ b/hyperspy/data/__init__.py
@@ -27,7 +27,6 @@ from .artificial_data import (
 )
 from .two_gaussians import two_gaussians
 
-
 __all__ = [
     "atomic_resolution_image",
     "luminescence_signal",

--- a/hyperspy/data/artificial_data.py
+++ b/hyperspy/data/artificial_data.py
@@ -24,11 +24,9 @@ For use in things like docstrings or to test HyperSpy functionalities.
 
 import numpy as np
 
-from hyperspy import components1d, components2d
-from hyperspy import signals
-from hyperspy.misc.math_tools import check_random_state
+from hyperspy import components1d, components2d, signals
 from hyperspy.axes import UniformDataAxis
-
+from hyperspy.misc.math_tools import check_random_state
 
 ADD_NOISE_DOCSTRING = """add_noise : bool
         If True, add noise to the signal. See note to seed the noise to

--- a/hyperspy/data/two_gaussians.py
+++ b/hyperspy/data/two_gaussians.py
@@ -18,6 +18,7 @@
 
 
 import numpy as np
+
 import hyperspy.api as hs
 
 

--- a/hyperspy/decorators.py
+++ b/hyperspy/decorators.py
@@ -16,21 +16,20 @@
 # You should have received a copy of the GNU General Public License
 # along with HyperSpy. If not, see <https://www.gnu.org/licenses/#GPL>.
 
-from functools import wraps
 import inspect
 import logging
-from typing import Callable, Optional, Union
 import warnings
+from functools import wraps
+from typing import Callable, Optional, Union
 
 import numpy as np
-
 
 _logger = logging.getLogger(__name__)
 
 
 def lazify(func, **kwargs):
-    from hyperspy.signal import BaseSignal
     from hyperspy.model import BaseModel
+    from hyperspy.signal import BaseSignal
 
     @wraps(func)
     def lazified_func(self, *args, **kwds):
@@ -105,8 +104,8 @@ def simple_decorator(decorator):
 
 @simple_decorator
 def interactive_range_selector(cm):
-    from hyperspy.ui_registry import get_gui
     from hyperspy.signal_tools import Signal1DRangeSelector
+    from hyperspy.ui_registry import get_gui
 
     def wrapper(self, *args, **kwargs):
         if not args and not kwargs:

--- a/hyperspy/defaults_parser.py
+++ b/hyperspy/defaults_parser.py
@@ -24,9 +24,8 @@ from pathlib import Path
 
 import traits.api as t
 
-from hyperspy.misc.ipython_tools import turn_logging_on, turn_logging_off
+from hyperspy.misc.ipython_tools import turn_logging_off, turn_logging_on
 from hyperspy.ui_registry import add_gui_method
-
 
 config_path = Path("~/.hyperspy").expanduser()
 config_path.mkdir(parents=True, exist_ok=True)

--- a/hyperspy/docstrings/signal1d.py
+++ b/hyperspy/docstrings/signal1d.py
@@ -43,8 +43,8 @@ SPIKES_DIAGNOSIS_DOCSTRING = """Plots a histogram to help in choosing the thresh
 
         """
 
-SPIKES_REMOVAL_TOOL_DOCSTRING = """Graphical interface to remove spikes from EELS spectra or 
-        luminescence data. 
+SPIKES_REMOVAL_TOOL_DOCSTRING = """Graphical interface to remove spikes from EELS spectra or
+        luminescence data.
         If non-interactive, it removes all spikes.
 
         Parameters
@@ -59,10 +59,10 @@ SPIKES_REMOVAL_TOOL_DOCSTRING = """Graphical interface to remove spikes from EEL
             method.
         %s
         interactive : bool
-            If True, remove the spikes using the graphical user interface. 
+            If True, remove the spikes using the graphical user interface.
             If False, remove all the spikes automatically, which can
-            introduce artefacts if used with signal containing peak-like 
-            features. However, this can be mitigated by using the 
+            introduce artefacts if used with signal containing peak-like
+            features. However, this can be mitigated by using the
             ``signal_mask`` argument to mask the signal of interest.
         %s
         %s

--- a/hyperspy/docstrings/utils.py
+++ b/hyperspy/docstrings/utils.py
@@ -43,7 +43,7 @@ REBIN_ARGS = """new_shape : list (of float or int) or None
             Whether or not to crop the resulting rebinned data (default is
             ``True``). When binning by a non-integer number of
             pixels it is likely that the final row in each dimension will
-            contain fewer than the full quota to fill one pixel. For example, 
+            contain fewer than the full quota to fill one pixel. For example,
             a 5*5 array binned by 2.1 will produce two rows containing
             2.1 pixels and one row containing only 0.8 pixels. Selection of
             ``crop=True`` or ``crop=False`` determines whether or not this

--- a/hyperspy/drawing/_markers/arrows.py
+++ b/hyperspy/drawing/_markers/arrows.py
@@ -16,9 +16,9 @@
 # You should have received a copy of the GNU General Public License
 # along with HyperSpy. If not, see <https://www.gnu.org/licenses/#GPL>.
 
+from hyperspy.docstrings.markers import OFFSET_DOCSTRING
 from hyperspy.drawing.markers import Markers
 from hyperspy.external.matplotlib.quiver import Quiver
-from hyperspy.docstrings.markers import OFFSET_DOCSTRING
 
 
 class Arrows(Markers):

--- a/hyperspy/drawing/_markers/circles.py
+++ b/hyperspy/drawing/_markers/circles.py
@@ -16,8 +16,8 @@
 # You should have received a copy of the GNU General Public License
 # along with HyperSpy. If not, see <https://www.gnu.org/licenses/#GPL>.
 
-from hyperspy.drawing.markers import Markers
 from hyperspy.docstrings.markers import OFFSET_DOCSTRING, UNITS_DOCSTRING
+from hyperspy.drawing.markers import Markers
 from hyperspy.external.matplotlib.collections import CircleCollection
 
 

--- a/hyperspy/drawing/_markers/ellipses.py
+++ b/hyperspy/drawing/_markers/ellipses.py
@@ -17,13 +17,12 @@
 # along with HyperSpy. If not, see <https://www.gnu.org/licenses/#GPL>.
 
 from hyperspy.docstrings.markers import (
-    OFFSET_DOCSTRING,
-    HEIGHTS_DOCSTRING,
-    WIDTHS_DOCSTRING,
     ANGLES_DOCSTRING,
+    HEIGHTS_DOCSTRING,
+    OFFSET_DOCSTRING,
     UNITS_DOCSTRING,
+    WIDTHS_DOCSTRING,
 )
-
 from hyperspy.drawing.markers import Markers
 from hyperspy.external.matplotlib.collections import EllipseCollection
 

--- a/hyperspy/drawing/_markers/horizontal_lines.py
+++ b/hyperspy/drawing/_markers/horizontal_lines.py
@@ -19,9 +19,9 @@
 import copy
 
 import numpy as np
+from matplotlib.collections import LineCollection
 
 from hyperspy.drawing.markers import Markers
-from matplotlib.collections import LineCollection
 
 
 class HorizontalLines(Markers):

--- a/hyperspy/drawing/_markers/lines.py
+++ b/hyperspy/drawing/_markers/lines.py
@@ -16,8 +16,9 @@
 # You should have received a copy of the GNU General Public License
 # along with HyperSpy. If not, see <https://www.gnu.org/licenses/#GPL>.
 
-from hyperspy.drawing.markers import Markers
 from matplotlib.collections import LineCollection
+
+from hyperspy.drawing.markers import Markers
 
 
 class Lines(Markers):

--- a/hyperspy/drawing/_markers/points.py
+++ b/hyperspy/drawing/_markers/points.py
@@ -16,8 +16,8 @@
 # You should have received a copy of the GNU General Public License
 # along with HyperSpy. If not, see <https://www.gnu.org/licenses/#GPL>.
 
-from hyperspy.drawing.markers import Markers
 from hyperspy.docstrings.markers import OFFSET_DOCSTRING, UNITS_DOCSTRING
+from hyperspy.drawing.markers import Markers
 from hyperspy.external.matplotlib.collections import CircleCollection
 
 

--- a/hyperspy/drawing/_markers/polygons.py
+++ b/hyperspy/drawing/_markers/polygons.py
@@ -16,8 +16,9 @@
 # You should have received a copy of the GNU General Public License
 # along with HyperSpy. If not, see <https://www.gnu.org/licenses/#GPL>.
 
-from hyperspy.drawing.markers import Markers
 from matplotlib.collections import PolyCollection
+
+from hyperspy.drawing.markers import Markers
 
 
 class Polygons(Markers):

--- a/hyperspy/drawing/_markers/rectangles.py
+++ b/hyperspy/drawing/_markers/rectangles.py
@@ -16,16 +16,15 @@
 # You should have received a copy of the GNU General Public License
 # along with HyperSpy. If not, see <https://www.gnu.org/licenses/#GPL>.
 
+from hyperspy.docstrings.markers import (
+    ANGLES_DOCSTRING,
+    HEIGHTS_DOCSTRING,
+    OFFSET_DOCSTRING,
+    UNITS_DOCSTRING,
+    WIDTHS_DOCSTRING,
+)
 from hyperspy.drawing.markers import Markers
 from hyperspy.external.matplotlib.collections import RectangleCollection
-
-from hyperspy.docstrings.markers import (
-    OFFSET_DOCSTRING,
-    HEIGHTS_DOCSTRING,
-    WIDTHS_DOCSTRING,
-    ANGLES_DOCSTRING,
-    UNITS_DOCSTRING,
-)
 
 
 class Rectangles(Markers):

--- a/hyperspy/drawing/_markers/squares.py
+++ b/hyperspy/drawing/_markers/squares.py
@@ -17,10 +17,10 @@
 # along with HyperSpy. If not, see <https://www.gnu.org/licenses/#GPL>.
 
 from hyperspy.docstrings.markers import (
-    OFFSET_DOCSTRING,
-    WIDTHS_DOCSTRING,
     ANGLES_DOCSTRING,
+    OFFSET_DOCSTRING,
     UNITS_DOCSTRING,
+    WIDTHS_DOCSTRING,
 )
 from hyperspy.drawing.markers import Markers
 from hyperspy.external.matplotlib.collections import SquareCollection

--- a/hyperspy/drawing/_markers/vertical_lines.py
+++ b/hyperspy/drawing/_markers/vertical_lines.py
@@ -19,9 +19,9 @@
 import copy
 
 import numpy as np
+from matplotlib.collections import LineCollection
 
 from hyperspy.drawing.markers import Markers
-from matplotlib.collections import LineCollection
 
 
 class VerticalLines(Markers):

--- a/hyperspy/drawing/_widgets/circle.py
+++ b/hyperspy/drawing/_widgets/circle.py
@@ -17,10 +17,10 @@
 # along with HyperSpy. If not, see <https://www.gnu.org/licenses/#GPL>.
 
 
-import numpy as np
 import matplotlib.pyplot as plt
+import numpy as np
 
-from hyperspy.drawing.widget import Widget2DBase, ResizersMixin
+from hyperspy.drawing.widget import ResizersMixin, Widget2DBase
 
 
 class CircleWidget(Widget2DBase, ResizersMixin):

--- a/hyperspy/drawing/_widgets/horizontal_line.py
+++ b/hyperspy/drawing/_widgets/horizontal_line.py
@@ -16,9 +16,9 @@
 # You should have received a copy of the GNU General Public License
 # along with HyperSpy. If not, see <https://www.gnu.org/licenses/#GPL>.
 
-from hyperspy.drawing.widget import Widget1DBase
-from hyperspy.drawing.utils import picker_kwargs
 from hyperspy.defaults_parser import preferences
+from hyperspy.drawing.utils import picker_kwargs
+from hyperspy.drawing.widget import Widget1DBase
 
 
 class HorizontalLineWidget(Widget1DBase):

--- a/hyperspy/drawing/_widgets/label.py
+++ b/hyperspy/drawing/_widgets/label.py
@@ -16,8 +16,8 @@
 # You should have received a copy of the GNU General Public License
 # along with HyperSpy. If not, see <https://www.gnu.org/licenses/#GPL>.
 
-import numpy as np
 import matplotlib.transforms as transforms
+import numpy as np
 
 from hyperspy.drawing.widget import Widget1DBase
 

--- a/hyperspy/drawing/_widgets/line2d.py
+++ b/hyperspy/drawing/_widgets/line2d.py
@@ -18,12 +18,12 @@
 
 
 import logging
-import numpy as np
+
 import matplotlib.pyplot as plt
+import numpy as np
 
-from hyperspy.drawing.widget import ResizableDraggableWidgetBase
 from hyperspy.drawing.utils import picker_kwargs
-
+from hyperspy.drawing.widget import ResizableDraggableWidgetBase
 
 _logger = logging.getLogger(__name__)
 

--- a/hyperspy/drawing/_widgets/range.py
+++ b/hyperspy/drawing/_widgets/range.py
@@ -18,13 +18,13 @@
 
 import inspect
 import logging
-from packaging.version import Version
 
 import matplotlib
 import numpy as np
+from packaging.version import Version
 
-from hyperspy.drawing.widget import ResizableDraggableWidgetBase
 from hyperspy.defaults_parser import preferences
+from hyperspy.drawing.widget import ResizableDraggableWidgetBase
 
 if Version(matplotlib.__version__) >= Version("3.6.0"):
     from matplotlib.widgets import SpanSelector

--- a/hyperspy/drawing/_widgets/rectangles.py
+++ b/hyperspy/drawing/_widgets/rectangles.py
@@ -16,12 +16,12 @@
 # You should have received a copy of the GNU General Public License
 # along with HyperSpy. If not, see <https://www.gnu.org/licenses/#GPL>.
 
-import numpy as np
-import matplotlib.pyplot as plt
 import logging
 
-from hyperspy.drawing.widget import Widget2DBase, ResizersMixin
+import matplotlib.pyplot as plt
+import numpy as np
 
+from hyperspy.drawing.widget import ResizersMixin, Widget2DBase
 
 _logger = logging.getLogger(__name__)
 # Track if we have already warned when the widget is out of range

--- a/hyperspy/drawing/_widgets/scalebar.py
+++ b/hyperspy/drawing/_widgets/scalebar.py
@@ -17,8 +17,9 @@
 # along with HyperSpy. If not, see <https://www.gnu.org/licenses/#GPL>.
 
 
-from hyperspy.misc.math_tools import closest_nice_number
 import numpy as np
+
+from hyperspy.misc.math_tools import closest_nice_number
 
 
 class ScaleBar(object):

--- a/hyperspy/drawing/_widgets/vertical_line.py
+++ b/hyperspy/drawing/_widgets/vertical_line.py
@@ -16,9 +16,9 @@
 # You should have received a copy of the GNU General Public License
 # along with HyperSpy. If not, see <https://www.gnu.org/licenses/#GPL>.
 
-from hyperspy.drawing.widget import Widget1DBase
-from hyperspy.drawing.utils import picker_kwargs
 from hyperspy.defaults_parser import preferences
+from hyperspy.drawing.utils import picker_kwargs
+from hyperspy.drawing.widget import Widget1DBase
 
 
 class VerticalLineWidget(Widget1DBase):

--- a/hyperspy/drawing/figure.py
+++ b/hyperspy/drawing/figure.py
@@ -16,13 +16,13 @@
 # You should have received a copy of the GNU General Public License
 # along with HyperSpy. If not, see <https://www.gnu.org/licenses/#GPL>.
 
-import textwrap
-import matplotlib.pyplot as plt
 import logging
+import textwrap
 
-from hyperspy.events import Event, Events
+import matplotlib.pyplot as plt
+
 from hyperspy.drawing import utils
-
+from hyperspy.events import Event, Events
 
 _logger = logging.getLogger(__name__)
 

--- a/hyperspy/drawing/image.py
+++ b/hyperspy/drawing/image.py
@@ -16,28 +16,26 @@
 # You should have received a copy of the GNU General Public License
 # along with HyperSpy. If not, see <https://www.gnu.org/licenses/#GPL>.
 
+import copy
+import inspect
+import logging
 import math
-from packaging.version import Version
 
-import numpy as np
 import matplotlib
 import matplotlib.pyplot as plt
-from matplotlib.colors import Normalize, LogNorm, SymLogNorm, PowerNorm
-from traits.api import Undefined
-import logging
-import inspect
-import copy
+import numpy as np
+from matplotlib.colors import LogNorm, Normalize, PowerNorm, SymLogNorm
+from packaging.version import Version
 from rsciio.utils import rgb_tools
+from traits.api import Undefined
 
-from hyperspy.drawing import widgets
-from hyperspy.drawing import utils
-from hyperspy.signal_tools import ImageContrastEditor
-from hyperspy.misc import math_tools
-from hyperspy.drawing.figure import BlittedFigure
-from hyperspy.ui_registry import DISPLAY_DT, TOOLKIT_DT
 from hyperspy.docstrings.plot import PLOT2D_DOCSTRING
+from hyperspy.drawing import utils, widgets
+from hyperspy.drawing.figure import BlittedFigure
+from hyperspy.misc import math_tools
 from hyperspy.misc.test_utils import ignore_warning
-
+from hyperspy.signal_tools import ImageContrastEditor
+from hyperspy.ui_registry import DISPLAY_DT, TOOLKIT_DT
 
 _logger = logging.getLogger(__name__)
 

--- a/hyperspy/drawing/markers.py
+++ b/hyperspy/drawing/markers.py
@@ -16,20 +16,19 @@
 # You should have received a copy of the GNU General Public License
 # along with HyperSpy. If not, see <https://www.gnu.org/licenses/#GPL>.
 
-import numpy as np
-import dask.array as da
 import logging
 from copy import deepcopy
 
+import dask.array as da
 import matplotlib.collections as mpl_collections
-from matplotlib.transforms import IdentityTransform
+import numpy as np
 from matplotlib.patches import Patch
+from matplotlib.transforms import IdentityTransform
 
 import hyperspy
 from hyperspy.events import Event, Events
 from hyperspy.misc.array_tools import _get_navigation_dimension_chunk_slice
 from hyperspy.misc.utils import isiterable
-
 
 _logger = logging.getLogger(__name__)
 

--- a/hyperspy/drawing/mpl_he.py
+++ b/hyperspy/drawing/mpl_he.py
@@ -16,15 +16,15 @@
 # You should have received a copy of the GNU General Public License
 # along with HyperSpy. If not, see <https://www.gnu.org/licenses/#GPL>.
 
-from functools import partial
 import logging
-
-from traits.api import Undefined
-import matplotlib as mpl
-
-from hyperspy.drawing import widgets, signal1d, image
-from hyperspy.defaults_parser import preferences
 import warnings
+from functools import partial
+
+import matplotlib as mpl
+from traits.api import Undefined
+
+from hyperspy.defaults_parser import preferences
+from hyperspy.drawing import image, signal1d, widgets
 
 _logger = logging.getLogger(__name__)
 
@@ -213,8 +213,8 @@ class MPL_HyperExplorer(object):
                 if plot_style is None:
                     plot_style = preferences.Plot.widget_plot_style
                 # If widgets do not already exist, we will `display` them at the end
-                from ipywidgets.widgets import HBox, VBox
                 from IPython.display import display
+                from ipywidgets.widgets import HBox, VBox
 
                 if self.signal_plot is None and self.navigator_plot is not None:
                     # in case the signal is navigation only

--- a/hyperspy/drawing/mpl_hie.py
+++ b/hyperspy/drawing/mpl_hie.py
@@ -16,9 +16,9 @@
 # You should have received a copy of the GNU General Public License
 # along with HyperSpy. If not, see <https://www.gnu.org/licenses/#GPL>.
 
+from hyperspy.defaults_parser import preferences
 from hyperspy.drawing import image
 from hyperspy.drawing.mpl_he import MPL_HyperExplorer
-from hyperspy.defaults_parser import preferences
 
 
 class MPL_HyperImage_Explorer(MPL_HyperExplorer):

--- a/hyperspy/drawing/mpl_hse.py
+++ b/hyperspy/drawing/mpl_hse.py
@@ -22,8 +22,8 @@ import copy
 import numpy as np
 from traits.api import Undefined
 
-from hyperspy.drawing.mpl_he import MPL_HyperExplorer
 from hyperspy.drawing import signal1d
+from hyperspy.drawing.mpl_he import MPL_HyperExplorer
 
 
 class MPL_HyperSignal1D_Explorer(MPL_HyperExplorer):

--- a/hyperspy/drawing/signal.py
+++ b/hyperspy/drawing/signal.py
@@ -18,8 +18,8 @@
 
 # This file contains plotting code generic to the BaseSignal class.
 
-import numpy as np
 import matplotlib.pyplot as plt
+import numpy as np
 from mpl_toolkits.axes_grid1 import make_axes_locatable
 from traits.api import Undefined
 

--- a/hyperspy/drawing/signal1d.py
+++ b/hyperspy/drawing/signal1d.py
@@ -16,19 +16,19 @@
 # You should have received a copy of the GNU General Public License
 # along with HyperSpy. If not, see <https://www.gnu.org/licenses/#GPL>.
 
-import numpy as np
-import matplotlib.pyplot as plt
-import matplotlib as mpl
-from mpl_toolkits.axes_grid1 import make_axes_locatable
-import logging
 import inspect
+import logging
 from functools import partial
 
-from hyperspy.drawing.figure import BlittedFigure
+import matplotlib as mpl
+import matplotlib.pyplot as plt
+import numpy as np
+from mpl_toolkits.axes_grid1 import make_axes_locatable
+
 from hyperspy.drawing import utils
+from hyperspy.drawing.figure import BlittedFigure
 from hyperspy.events import Event, Events
 from hyperspy.misc.test_utils import ignore_warning
-
 
 _logger = logging.getLogger(__name__)
 

--- a/hyperspy/drawing/tiles.py
+++ b/hyperspy/drawing/tiles.py
@@ -19,8 +19,8 @@
 
 from __future__ import division
 
-import numpy as np
 import matplotlib.pyplot as plt
+import numpy as np
 
 from hyperspy.drawing.figure import BlittedFigure
 

--- a/hyperspy/drawing/utils.py
+++ b/hyperspy/drawing/utils.py
@@ -17,29 +17,26 @@
 # along with HyperSpy. If not, see <https://www.gnu.org/licenses/#GPL>.
 
 import copy
-from functools import partial
 import itertools
 import logging
-from packaging.version import Version
 import textwrap
 import warnings
+from functools import partial
 
 import dask.array as da
-import traits.api as t
-import numpy as np
-
 import matplotlib as mpl
-from mpl_toolkits.axes_grid1 import make_axes_locatable
-from matplotlib.backend_bases import key_press_handler
-from matplotlib.colors import LinearSegmentedColormap, BASE_COLORS, to_rgba
 import matplotlib.pyplot as plt
+import numpy as np
+import traits.api as t
+from matplotlib.backend_bases import key_press_handler
+from matplotlib.colors import BASE_COLORS, LinearSegmentedColormap, to_rgba
+from mpl_toolkits.axes_grid1 import make_axes_locatable
+from packaging.version import Version
 from rsciio.utils import rgb_tools
-
 
 import hyperspy.api as hs
 from hyperspy.defaults_parser import preferences
 from hyperspy.misc.utils import to_numpy
-
 
 _logger = logging.getLogger(__name__)
 

--- a/hyperspy/drawing/widget.py
+++ b/hyperspy/drawing/widget.py
@@ -19,12 +19,12 @@
 from __future__ import division
 
 import matplotlib.pyplot as plt
-from matplotlib.backend_bases import MouseEvent, PickEvent
 import numpy as np
+from matplotlib.backend_bases import MouseEvent, PickEvent
 
-from hyperspy.drawing.utils import on_figure_window_close
-from hyperspy.events import Events, Event
 from hyperspy.defaults_parser import preferences
+from hyperspy.drawing.utils import on_figure_window_close
+from hyperspy.events import Event, Events
 
 
 class WidgetBase(object):

--- a/hyperspy/drawing/widgets.py
+++ b/hyperspy/drawing/widgets.py
@@ -18,23 +18,22 @@
 
 """Interactive widgets that can be added to :class:`~.api.signals.BaseSignal` plots."""
 
+from hyperspy.drawing._widgets.circle import CircleWidget
+from hyperspy.drawing._widgets.horizontal_line import HorizontalLineWidget
+from hyperspy.drawing._widgets.label import LabelWidget
+from hyperspy.drawing._widgets.line2d import Line2DWidget
+from hyperspy.drawing._widgets.range import RangeWidget
+from hyperspy.drawing._widgets.rectangles import RectangleWidget, SquareWidget
+from hyperspy.drawing._widgets.scalebar import ScaleBar
+from hyperspy.drawing._widgets.vertical_line import VerticalLineWidget
 from hyperspy.drawing.widget import (
-    WidgetBase,
     DraggableWidgetBase,
     ResizableDraggableWidgetBase,
-    Widget2DBase,
-    Widget1DBase,
     ResizersMixin,
+    Widget1DBase,
+    Widget2DBase,
+    WidgetBase,
 )
-from hyperspy.drawing._widgets.horizontal_line import HorizontalLineWidget
-from hyperspy.drawing._widgets.vertical_line import VerticalLineWidget
-from hyperspy.drawing._widgets.label import LabelWidget
-from hyperspy.drawing._widgets.scalebar import ScaleBar
-from hyperspy.drawing._widgets.circle import CircleWidget
-from hyperspy.drawing._widgets.rectangles import RectangleWidget, SquareWidget
-from hyperspy.drawing._widgets.range import RangeWidget
-from hyperspy.drawing._widgets.line2d import Line2DWidget
-
 
 __all__ = [
     "WidgetBase",

--- a/hyperspy/events.py
+++ b/hyperspy/events.py
@@ -17,10 +17,10 @@
 # along with HyperSpy. If not, see <https://www.gnu.org/licenses/#GPL>.
 
 import inspect
+import re
 from collections.abc import Iterable
 from contextlib import contextmanager
 from functools import wraps  # noqa: F401 Used in exec statement
-import re
 
 
 class Events:

--- a/hyperspy/extensions.py
+++ b/hyperspy/extensions.py
@@ -16,16 +16,15 @@
 # You should have received a copy of the GNU General Public License
 # along with HyperSpy. If not, see <https://www.gnu.org/licenses/#GPL>.
 
-import logging
 import copy
-import yaml
 import json
+import logging
+from pathlib import Path
 from urllib.parse import urlparse
 from urllib.request import url2pathname
 
-from pathlib import Path
 import importlib_metadata as metadata
-
+import yaml
 
 _logger = logging.getLogger(__name__)
 

--- a/hyperspy/io.py
+++ b/hyperspy/io.py
@@ -16,32 +16,31 @@
 # You should have received a copy of the GNU General Public License
 # along with HyperSpy. If not, see <https://www.gnu.org/licenses/#GPL>.
 
-import os
 import glob
-import warnings
-import logging
 import importlib
+import logging
+import os
+import warnings
+from collections.abc import MutableMapping
+from datetime import datetime
+from inspect import isgenerator
+from pathlib import Path
 
 import numpy as np
 from natsort import natsorted
-from inspect import isgenerator
-from pathlib import Path
-from collections.abc import MutableMapping
-from datetime import datetime
+from rsciio import IO_PLUGINS
 from rsciio.utils.tools import ensure_directory
 from rsciio.utils.tools import overwrite as overwrite_method
-from rsciio import IO_PLUGINS
 
 from hyperspy.api import __version__ as hs_version
-from hyperspy.drawing.markers import markers_dict_to_markers
-from hyperspy.exceptions import VisibleDeprecationWarning
-from hyperspy.misc.utils import strlist2enumeration, get_object_package_info
-from hyperspy.misc.utils import stack as stack_method
-from hyperspy.ui_registry import get_gui
-from hyperspy.extensions import ALL_EXTENSIONS
 from hyperspy.docstrings.signal import SHOW_PROGRESSBAR_ARG
 from hyperspy.docstrings.utils import STACK_METADATA_ARG
-
+from hyperspy.drawing.markers import markers_dict_to_markers
+from hyperspy.exceptions import VisibleDeprecationWarning
+from hyperspy.extensions import ALL_EXTENSIONS
+from hyperspy.misc.utils import get_object_package_info, strlist2enumeration
+from hyperspy.misc.utils import stack as stack_method
+from hyperspy.ui_registry import get_gui
 
 _logger = logging.getLogger(__name__)
 

--- a/hyperspy/learn/mva.py
+++ b/hyperspy/learn/mva.py
@@ -24,9 +24,12 @@ import warnings
 import dask.array as da
 import matplotlib.pyplot as plt
 import numpy as np
-from matplotlib.ticker import FuncFormatter, MaxNLocator
 import rsciio.utils.tools as io_tools
+from matplotlib.ticker import FuncFormatter, MaxNLocator
 
+from hyperspy.defaults_parser import preferences
+from hyperspy.docstrings.signal import SHOW_PROGRESSBAR_ARG
+from hyperspy.external.progressbar import progressbar
 from hyperspy.learn.mlpca import mlpca
 from hyperspy.learn.ornmf import ornmf
 from hyperspy.learn.orthomax import orthomax
@@ -35,15 +38,11 @@ from hyperspy.learn.svd_pca import svd_pca
 from hyperspy.learn.whitening import whiten_data
 from hyperspy.misc.machine_learning import import_sklearn
 from hyperspy.misc.utils import (
+    is_cupy_array,
+    is_hyperspy_signal,
     ordinal,
     stack,
-    is_hyperspy_signal,
-    is_cupy_array,
 )
-from hyperspy.docstrings.signal import SHOW_PROGRESSBAR_ARG
-from hyperspy.external.progressbar import progressbar
-from hyperspy.defaults_parser import preferences
-
 
 try:
     import mdp

--- a/hyperspy/learn/orthomax.py
+++ b/hyperspy/learn/orthomax.py
@@ -17,7 +17,6 @@
 # along with HyperSpy. If not, see <https://www.gnu.org/licenses/#GPL>.
 
 import numpy as np
-
 from numpy.linalg import svd
 
 

--- a/hyperspy/learn/svd_pca.py
+++ b/hyperspy/learn/svd_pca.py
@@ -27,7 +27,6 @@ from hyperspy.misc.machine_learning.import_sklearn import (
 )
 from hyperspy.misc.utils import is_cupy_array
 
-
 _logger = logging.getLogger(__name__)
 
 

--- a/hyperspy/misc/array_tools.py
+++ b/hyperspy/misc/array_tools.py
@@ -16,16 +16,15 @@
 # along with HyperSpy. If not, see <https://www.gnu.org/licenses/#GPL>
 
 
-import math
 import logging
+import math
 
 import dask.array as da
 import numpy as np
 
 from hyperspy.decorators import jit_ifnumba
-from hyperspy.misc.math_tools import anyfloatin
 from hyperspy.docstrings.utils import REBIN_ARGS
-
+from hyperspy.misc.math_tools import anyfloatin
 
 _logger = logging.getLogger(__name__)
 

--- a/hyperspy/misc/axis_tools.py
+++ b/hyperspy/misc/axis_tools.py
@@ -17,6 +17,7 @@
 
 
 import numpy as np
+
 from hyperspy.api_nogui import _ureg
 
 

--- a/hyperspy/misc/export_dictionary.py
+++ b/hyperspy/misc/export_dictionary.py
@@ -16,11 +16,13 @@
 # You should have received a copy of the GNU General Public License
 # along with HyperSpy. If not, see <https://www.gnu.org/licenses/#GPL>.
 
-from operator import attrgetter
-from hyperspy.misc.utils import attrsetter
 from copy import deepcopy
+from operator import attrgetter
+
 import cloudpickle
 from dask.array import Array
+
+from hyperspy.misc.utils import attrsetter
 
 
 def check_that_flags_make_sense(flags):

--- a/hyperspy/misc/ipython_tools.py
+++ b/hyperspy/misc/ipython_tools.py
@@ -16,11 +16,12 @@
 # You should have received a copy of the GNU General Public License
 # along with HyperSpy. If not, see <https://www.gnu.org/licenses/#GPL>.
 
-import __main__
+from pathlib import Path
+from time import strftime
+
 from packaging.version import Version
 
-from time import strftime
-from pathlib import Path
+import __main__
 
 
 def get_ipython():

--- a/hyperspy/misc/machine_learning/import_sklearn.py
+++ b/hyperspy/misc/machine_learning/import_sklearn.py
@@ -32,10 +32,10 @@ else:
     with warnings.catch_warnings():
         warnings.simplefilter("ignore")
         import sklearn  # noqa: F401
-        import sklearn.decomposition  # noqa: F401
         import sklearn.cluster  # noqa: F401
-        import sklearn.preprocessing  # noqa: F401
+        import sklearn.decomposition  # noqa: F401
         import sklearn.metrics  # noqa: F401
+        import sklearn.preprocessing  # noqa: F401
         from sklearn.utils.extmath import randomized_svd  # noqa: F401
 
         sklearn_installed = True

--- a/hyperspy/misc/math_tools.py
+++ b/hyperspy/misc/math_tools.py
@@ -16,15 +16,15 @@
 # You should have received a copy of the GNU General Public License
 # along with HyperSpy. If not, see <https://www.gnu.org/licenses/#GPL>.
 
-from functools import reduce
 import math
 import numbers
-from packaging.version import Version
 import warnings
+from functools import reduce
 
-import numpy as np
 import dask
 import dask.array as da
+import numpy as np
+from packaging.version import Version
 
 
 def symmetrize(a):

--- a/hyperspy/misc/model_tools.py
+++ b/hyperspy/misc/model_tools.py
@@ -16,8 +16,8 @@
 # You should have received a copy of the GNU General Public License
 # along with HyperSpy. If not, see <https://www.gnu.org/licenses/#GPL>.
 
-import numpy as np
 import dask.array as da
+import numpy as np
 
 
 def _format_string(val):

--- a/hyperspy/misc/signal_tools.py
+++ b/hyperspy/misc/signal_tools.py
@@ -16,13 +16,13 @@
 # You should have received a copy of the GNU General Public License
 # along with HyperSpy. If not, see <https://www.gnu.org/licenses/#GPL>.
 
-from itertools import zip_longest
 import logging
+from itertools import zip_longest
 
 import numpy as np
 
-from hyperspy.misc.axis_tools import check_axes_calibration
 from hyperspy.misc.array_tools import are_aligned
+from hyperspy.misc.axis_tools import check_axes_calibration
 
 _logger = logging.getLogger(__name__)
 

--- a/hyperspy/misc/slicing.py
+++ b/hyperspy/misc/slicing.py
@@ -17,12 +17,13 @@
 # along with HyperSpy. If not, see <https://www.gnu.org/licenses/#GPL>.
 
 from operator import attrgetter
-import numpy as np
-import dask.array as da
 
-from hyperspy.misc.utils import attrsetter
-from hyperspy.misc.export_dictionary import parse_flag_string
+import dask.array as da
+import numpy as np
+
 from hyperspy import roi
+from hyperspy.misc.export_dictionary import parse_flag_string
+from hyperspy.misc.utils import attrsetter
 
 
 def _slice_target(target, dims, both_slices, slice_nav=None, issignal=False):

--- a/hyperspy/misc/test_utils.py
+++ b/hyperspy/misc/test_utils.py
@@ -17,11 +17,11 @@
 # along with HyperSpy. If not, see <https://www.gnu.org/licenses/#GPL>.
 
 import os
-from contextlib import contextmanager
 import warnings
+from contextlib import contextmanager
+from unittest import mock
 
 import numpy as np
-from unittest import mock
 
 
 @contextmanager

--- a/hyperspy/misc/utils.py
+++ b/hyperspy/misc/utils.py
@@ -16,24 +16,24 @@
 # You should have received a copy of the GNU General Public License
 # along with HyperSpy. If not, see <https://www.gnu.org/licenses/#GPL>.
 
-from operator import attrgetter
-import inspect
-import copy
-import types
-from io import StringIO
 import codecs
-from collections.abc import Iterable, Mapping
-import unicodedata
-from contextlib import contextmanager
+import copy
 import importlib
+import inspect
 import logging
+import types
+import unicodedata
+from collections.abc import Iterable, Mapping
+from contextlib import contextmanager
+from io import StringIO
+from operator import attrgetter
 
 import dask.array as da
 import numpy as np
 
-from hyperspy.misc.signal_tools import broadcast_signals
 from hyperspy.docstrings.signal import SHOW_PROGRESSBAR_ARG
 from hyperspy.docstrings.utils import STACK_METADATA_ARG
+from hyperspy.misc.signal_tools import broadcast_signals
 
 _logger = logging.getLogger(__name__)
 
@@ -507,8 +507,8 @@ class DictionaryTreeBrowser:
 
         par_dict = {}
 
-        from hyperspy.signal import BaseSignal
         from hyperspy.axes import AxesManager, BaseDataAxis
+        from hyperspy.signal import BaseSignal
 
         for key_, item_ in self.__dict__.items():
             if not isinstance(item_, types.MethodType):
@@ -1104,9 +1104,10 @@ def stack(
            [10, 11, 12, 13, 14, 15, 16, 17, 18, 19]])
 
     """
-    from hyperspy.signals import BaseSignal
-    from hyperspy.axes import FunctionalDataAxis, UniformDataAxis, DataAxis
     from numbers import Number
+
+    from hyperspy.axes import DataAxis, FunctionalDataAxis, UniformDataAxis
+    from hyperspy.signals import BaseSignal
 
     axis_input = copy.deepcopy(axis)
     signal_list = list(signal_list)
@@ -1469,8 +1470,8 @@ def iterable_not_string(thing):
 
 def add_scalar_axis(signal, lazy=None):
     am = signal.axes_manager
-    from hyperspy.signal import BaseSignal
     from hyperspy._signals.lazy import LazySignal
+    from hyperspy.signal import BaseSignal
 
     if lazy is None:
         lazy = signal._lazy

--- a/hyperspy/model.py
+++ b/hyperspy/model.py
@@ -26,18 +26,19 @@ from contextlib import contextmanager
 from functools import partial
 
 import cloudpickle
-import numpy as np
 import dask.array as da
-from dask.diagnostics import ProgressBar
+import numpy as np
 import scipy.odr as odr
+from dask.diagnostics import ProgressBar
 from scipy.linalg import svd
 from scipy.optimize import (
-    differential_evolution,
-    leastsq,
-    least_squares,
-    minimize,
     OptimizeResult,
+    differential_evolution,
+    least_squares,
+    leastsq,
+    minimize,
 )
+
 from hyperspy.component import Component
 from hyperspy.components1d import Expression
 from hyperspy.defaults_parser import preferences
@@ -53,6 +54,7 @@ from hyperspy.misc.export_dictionary import (
     parse_flag_string,
     reconstruct_object,
 )
+from hyperspy.misc.machine_learning import import_sklearn
 from hyperspy.misc.model_tools import CurrentModelValues, _calculate_covariance
 from hyperspy.misc.slicing import copy_slice_from_whitelist
 from hyperspy.misc.utils import (
@@ -64,8 +66,6 @@ from hyperspy.misc.utils import (
 )
 from hyperspy.signal import BaseSignal
 from hyperspy.ui_registry import add_gui_method
-from hyperspy.misc.machine_learning import import_sklearn
-
 
 _logger = logging.getLogger(__name__)
 

--- a/hyperspy/models/model1d.py
+++ b/hyperspy/models/model1d.py
@@ -896,7 +896,7 @@ class Model1D(BaseModel):
 
         Parameters
         ----------
-        component : :class:`~hyperspy.component.Component` 
+        component : :class:`~hyperspy.component.Component`
             The component must be in the model, otherwise an exception
             is raised. The component can be specified by name, index or itself.
         signal_range : str, tuple of None

--- a/hyperspy/models/model1d.py
+++ b/hyperspy/models/model1d.py
@@ -19,18 +19,18 @@
 import copy
 
 import numpy as np
-from scipy.special import huber
 import traits.api as t
+from scipy.special import huber
 
 import hyperspy.drawing.signal1d
-from hyperspy.exceptions import SignalDimensionError
 from hyperspy.decorators import interactive_range_selector
 from hyperspy.drawing.widgets import LabelWidget, VerticalLineWidget
 from hyperspy.events import EventSuppressor
+from hyperspy.exceptions import SignalDimensionError
+from hyperspy.misc.utils import dummy_context_manager
 from hyperspy.model import BaseModel, ModelComponents
 from hyperspy.signal_tools import SpanSelectorInSignal1D
 from hyperspy.ui_registry import DISPLAY_DT, TOOLKIT_DT, add_gui_method
-from hyperspy.misc.utils import dummy_context_manager
 
 
 @add_gui_method(toolkey="hyperspy.Model1D.fit_component")

--- a/hyperspy/models/model2d.py
+++ b/hyperspy/models/model2d.py
@@ -22,7 +22,6 @@ import numpy as np
 
 from hyperspy.model import BaseModel, ModelComponents
 
-
 _SIGNAL_RANGE_VALUES = """x1, x2 : None or float
             Start and end of the range in the first axis (horizontal)
             in units.

--- a/hyperspy/roi.py
+++ b/hyperspy/roi.py
@@ -47,16 +47,15 @@ The following 2D ROIs are available:
 
 from functools import partial
 
-import traits.api as t
 import numpy as np
+import traits.api as t
 
 from hyperspy.axes import UniformDataAxis
 from hyperspy.drawing import widgets
-from hyperspy.events import Events, Event
+from hyperspy.events import Event, Events
 from hyperspy.interactive import interactive
 from hyperspy.misc.utils import is_cupy_array
 from hyperspy.ui_registry import add_gui_method
-
 
 not_set_error_msg = (
     "Some ROI parameters have not yet been set. " "Set them before slicing a signal."

--- a/hyperspy/roi.py
+++ b/hyperspy/roi.py
@@ -71,7 +71,7 @@ PARSE_AXES_DOCSTRING = """axes : None, str, int or :class:`hyperspy.axes.DataAxi
 
               - :class:`hyperspy.axes.DataAxis`
               - anything that can index the provided ``axes_manager``
-    
+
             * ``None``, it will check whether the widget can be added to the
               navigator, i.e. if dimensionality matches, and use it if
               possible, otherwise it will try the signal space. If none of the

--- a/hyperspy/samfire.py
+++ b/hyperspy/samfire.py
@@ -22,15 +22,13 @@ from multiprocessing import cpu_count
 import cloudpickle
 import numpy as np
 
-from hyperspy.misc.utils import DictionaryTreeBrowser
-from hyperspy.misc.utils import slugify
-from hyperspy.misc.math_tools import check_random_state
 from hyperspy.external.progressbar import progressbar
-from hyperspy.signal import BaseSignal
-from hyperspy.samfire_utils.strategy import LocalStrategy, GlobalStrategy
-from hyperspy.samfire_utils.local_strategies import ReducedChiSquaredStrategy
+from hyperspy.misc.math_tools import check_random_state
+from hyperspy.misc.utils import DictionaryTreeBrowser, slugify
 from hyperspy.samfire_utils.global_strategies import HistogramStrategy
-
+from hyperspy.samfire_utils.local_strategies import ReducedChiSquaredStrategy
+from hyperspy.samfire_utils.strategy import GlobalStrategy, LocalStrategy
+from hyperspy.signal import BaseSignal
 
 _logger = logging.getLogger(__name__)
 
@@ -528,8 +526,8 @@ class Samfire:
             self.optional_components = new_list
 
     def _request_user_input(self):
-        from hyperspy.signals import Image
         from hyperspy.drawing.widgets import SquareWidget
+        from hyperspy.signals import Image
 
         mark = Image(
             self.metadata.marker,

--- a/hyperspy/samfire_utils/fit_tests.py
+++ b/hyperspy/samfire_utils/fit_tests.py
@@ -23,7 +23,6 @@ from hyperspy.samfire_utils.goodness_of_fit_tests.information_theory import (
 )
 from hyperspy.samfire_utils.goodness_of_fit_tests.red_chisq import red_chisq_test
 
-
 __all__ = [
     "AIC_test",
     "AICc_test",

--- a/hyperspy/samfire_utils/global_strategies.py
+++ b/hyperspy/samfire_utils/global_strategies.py
@@ -16,8 +16,8 @@
 # You should have received a copy of the GNU General Public License
 # along with HyperSpy. If not, see <https://www.gnu.org/licenses/#GPL>.
 
-from hyperspy.samfire_utils.strategy import GlobalStrategy
 from hyperspy.samfire_utils.segmenters.histogram import HistogramSegmenter
+from hyperspy.samfire_utils.strategy import GlobalStrategy
 
 
 class HistogramStrategy(GlobalStrategy):

--- a/hyperspy/samfire_utils/goodness_of_fit_tests/information_theory.py
+++ b/hyperspy/samfire_utils/goodness_of_fit_tests/information_theory.py
@@ -16,8 +16,9 @@
 # You should have received a copy of the GNU General Public License
 # along with HyperSpy. If not, see <https://www.gnu.org/licenses/#GPL>.
 
-from hyperspy.utils.model_selection import AIC, AICc, BIC
 import numpy as np
+
+from hyperspy.utils.model_selection import AIC, BIC, AICc
 
 
 def notexp_o(x):

--- a/hyperspy/samfire_utils/samfire_kernel.py
+++ b/hyperspy/samfire_utils/samfire_kernel.py
@@ -19,7 +19,9 @@
 
 def single_kernel(model, ind, values, optional_components, _args, test):
     from itertools import combinations, product
+
     import numpy as np
+
     from hyperspy.utils.model_selection import AICc
 
     def generate_values_iterator(compnames, vals, turned_on_component_inds):
@@ -115,15 +117,17 @@ def single_kernel(model, ind, values, optional_components, _args, test):
 
 
 def multi_kernel(ind, m_dic, values, optional_components, _args, result_q, test_dict):
-    from hyperspy.signal import Signal
-    from multiprocessing import current_process
+    import copy
     from itertools import combinations, product
+    from multiprocessing import current_process
+
+    import cloudpickle
 
     # from collections import Iterable
     import numpy as np
-    import copy
+
+    from hyperspy.signal import Signal
     from hyperspy.utils.model_selection import AICc
-    import cloudpickle
 
     def generate_values_iterator(compnames, vals, turned_on_component_inds):
         turned_on_names = [compnames[i] for i in turned_on_component_inds]

--- a/hyperspy/samfire_utils/samfire_pool.py
+++ b/hyperspy/samfire_utils/samfire_pool.py
@@ -17,14 +17,15 @@
 # along with HyperSpy. If not, see <https://www.gnu.org/licenses/#GPL>.
 
 
-import time
 import logging
+import time
 from multiprocessing import Manager
+
 import numpy as np
 from dask.array import Array as dar
 
-from hyperspy.utils.parallel_pool import ParallelPool
 from hyperspy.samfire_utils.samfire_worker import create_worker
+from hyperspy.utils.parallel_pool import ParallelPool
 
 _logger = logging.getLogger(__name__)
 

--- a/hyperspy/samfire_utils/samfire_worker.py
+++ b/hyperspy/samfire_utils/samfire_worker.py
@@ -18,8 +18,8 @@
 
 import logging
 import os
-import time
 import sys
+import time
 from itertools import combinations, product
 from queue import Empty
 

--- a/hyperspy/signal.py
+++ b/hyperspy/signal.py
@@ -2287,7 +2287,7 @@ class MVATools(object):
     ):
         """Plot the cluster labels and centers.
 
-        Unlike :meth:`~hyperspy.api.signals.BaseSignal.plot_cluster_labels` and 
+        Unlike :meth:`~hyperspy.api.signals.BaseSignal.plot_cluster_labels` and
         :meth:`~hyperspy.api.signals.BaseSignal.plot_cluster_signals`, this
         method displays one component at a time.
         Therefore it provides a more compact visualization than then other

--- a/hyperspy/signal.py
+++ b/hyperspy/signal.py
@@ -16,43 +16,77 @@
 # You should have received a copy of the GNU General Public License
 # along with HyperSpy. If not, see <https://www.gnu.org/licenses/#GPL>.
 
-from collections.abc import MutableMapping
-from contextlib import contextmanager
 import copy
-from datetime import datetime
-from functools import partial
 import inspect
-from itertools import product
 import logging
 import numbers
-from pathlib import Path
 import warnings
+from collections.abc import MutableMapping
+from contextlib import contextmanager
+from datetime import datetime
+from functools import partial
+from itertools import product
+from pathlib import Path
 
 import dask.array as da
+import numpy as np
+import traits.api as t
 from dask.diagnostics import ProgressBar
 from matplotlib import pyplot as plt
-import numpy as np
 from pint import UndefinedUnitError
-from scipy import integrate
-from scipy import signal as sp_signal
-import traits.api as t
-from tlz import concat
 from rsciio.utils import rgb_tools
 from rsciio.utils.tools import ensure_directory
+from scipy import integrate
+from scipy import signal as sp_signal
 from scipy.interpolate import make_interp_spline
+from tlz import concat
 
-from hyperspy.axes import AxesManager, create_axis
 from hyperspy.api_nogui import _ureg
-from hyperspy.misc.array_tools import rebin as array_rebin
-from hyperspy.drawing import mpl_hie, mpl_hse, mpl_he
-from hyperspy.learn.mva import MVA, LearningResults
+from hyperspy.axes import AxesManager, create_axis
+from hyperspy.docstrings.plot import (
+    BASE_PLOT_DOCSTRING,
+    BASE_PLOT_DOCSTRING_PARAMETERS,
+    PLOT1D_DOCSTRING,
+    PLOT2D_KWARGS_DOCSTRING,
+)
+from hyperspy.docstrings.signal import (
+    CLUSTER_SIGNALS_ARG,
+    HISTOGRAM_BIN_ARGS,
+    HISTOGRAM_MAX_BIN_ARGS,
+    LAZY_OUTPUT_ARG,
+    MANY_AXIS_PARAMETER,
+    NAN_FUNC,
+    NUM_WORKERS_ARG,
+    ONE_AXIS_PARAMETER,
+    OPTIMIZE_ARG,
+    OUT_ARG,
+    RECHUNK_ARG,
+    SHOW_PROGRESSBAR_ARG,
+)
+from hyperspy.docstrings.utils import REBIN_ARGS
+from hyperspy.drawing import mpl_he, mpl_hie, mpl_hse
+from hyperspy.drawing import signal as sigdraw
+from hyperspy.drawing.markers import markers_dict_to_markers
+from hyperspy.drawing.utils import animate_legend
+from hyperspy.events import Event, Events
+from hyperspy.exceptions import (
+    DataDimensionError,
+    LazyCupyConversion,
+    SignalDimensionError,
+)
+from hyperspy.interactive import interactive
 from hyperspy.io import assign_signal_subclass
 from hyperspy.io import save as io_save
-from hyperspy.drawing import signal as sigdraw
-from hyperspy.exceptions import SignalDimensionError, DataDimensionError
+from hyperspy.learn.mva import MVA, LearningResults
+from hyperspy.misc.array_tools import rebin as array_rebin
+from hyperspy.misc.hist_tools import histogram
+from hyperspy.misc.math_tools import check_random_state, hann_window_nth_order, outer_nd
+from hyperspy.misc.signal_tools import are_signals_aligned, broadcast_signals
+from hyperspy.misc.slicing import FancySlicing, SpecialSlicers
 from hyperspy.misc.utils import (
-    add_scalar_axis,
     DictionaryTreeBrowser,
+    _get_block_pattern,
+    add_scalar_axis,
     guess_output_signal_size,
     is_cupy_array,
     isiterable,
@@ -63,38 +97,6 @@ from hyperspy.misc.utils import (
     to_numpy,
     underline,
 )
-from hyperspy.misc.hist_tools import histogram
-from hyperspy.drawing.utils import animate_legend
-from hyperspy.drawing.markers import markers_dict_to_markers
-from hyperspy.misc.slicing import SpecialSlicers, FancySlicing
-from hyperspy.misc.utils import _get_block_pattern
-from hyperspy.docstrings.signal import (
-    ONE_AXIS_PARAMETER,
-    MANY_AXIS_PARAMETER,
-    OUT_ARG,
-    NAN_FUNC,
-    OPTIMIZE_ARG,
-    RECHUNK_ARG,
-    SHOW_PROGRESSBAR_ARG,
-    NUM_WORKERS_ARG,
-    CLUSTER_SIGNALS_ARG,
-    HISTOGRAM_BIN_ARGS,
-    HISTOGRAM_MAX_BIN_ARGS,
-    LAZY_OUTPUT_ARG,
-)
-from hyperspy.docstrings.plot import (
-    BASE_PLOT_DOCSTRING,
-    PLOT1D_DOCSTRING,
-    BASE_PLOT_DOCSTRING_PARAMETERS,
-    PLOT2D_KWARGS_DOCSTRING,
-)
-from hyperspy.docstrings.utils import REBIN_ARGS
-from hyperspy.events import Events, Event
-from hyperspy.interactive import interactive
-from hyperspy.misc.signal_tools import are_signals_aligned, broadcast_signals
-from hyperspy.misc.math_tools import outer_nd, hann_window_nth_order, check_random_state
-from hyperspy.exceptions import LazyCupyConversion
-
 
 _logger = logging.getLogger(__name__)
 
@@ -632,8 +634,8 @@ class MVATools(object):
         no_nans=True,
         per_row=3,
     ):
-        from hyperspy._signals.signal2d import Signal2D
         from hyperspy._signals.signal1d import Signal1D
+        from hyperspy._signals.signal2d import Signal2D
 
         if multiple_files is None:
             multiple_files = True
@@ -806,8 +808,8 @@ class MVATools(object):
         no_nans=True,
         per_row=3,
     ):
-        from hyperspy._signals.signal2d import Signal2D
         from hyperspy._signals.signal1d import Signal1D
+        from hyperspy._signals.signal2d import Signal2D
 
         if multiple_files is None:
             multiple_files = True

--- a/hyperspy/signal_tools.py
+++ b/hyperspy/signal_tools.py
@@ -24,25 +24,23 @@ import matplotlib
 import matplotlib.colors
 import matplotlib.text as mpl_text
 import numpy as np
+import traits.api as t
 from scipy import interpolate
 from scipy import signal as sp_signal
-import traits.api as t
 
-from hyperspy import drawing
-from hyperspy.docstrings.signal import HISTOGRAM_MAX_BIN_ARGS
-from hyperspy.exceptions import SignalDimensionError
+from hyperspy import components1d, drawing
 from hyperspy.axes import AxesManager, UniformDataAxis
-from hyperspy.drawing.widgets import Line2DWidget, VerticalLineWidget
-from hyperspy.drawing.markers import convert_positions
+from hyperspy.component import Component
+from hyperspy.docstrings.signal import HISTOGRAM_MAX_BIN_ARGS
 from hyperspy.drawing._markers.circles import Circles
 from hyperspy.drawing._widgets.range import SpanSelector
-from hyperspy import components1d
-from hyperspy.component import Component
-from hyperspy.ui_registry import add_gui_method
+from hyperspy.drawing.markers import convert_positions
 from hyperspy.drawing.signal1d import Signal1DFigure
+from hyperspy.drawing.widgets import Line2DWidget, VerticalLineWidget
+from hyperspy.exceptions import SignalDimensionError
 from hyperspy.misc.array_tools import numba_histogram
 from hyperspy.misc.math_tools import check_random_state
-
+from hyperspy.ui_registry import add_gui_method
 
 _logger = logging.getLogger(__name__)
 

--- a/hyperspy/signals.py
+++ b/hyperspy/signals.py
@@ -39,9 +39,9 @@ ComplexSignal2D
     data of n-dimensions. The signal is unbinned by default.
 """
 
-from hyperspy.extensions import EXTENSIONS as EXTENSIONS_
 import importlib
 
+from hyperspy.extensions import EXTENSIONS as EXTENSIONS_
 
 __all__ = [
     signal_ for signal_, specs_ in EXTENSIONS_["signals"].items() if not specs_["lazy"]

--- a/hyperspy/tests/axes/test_axes_manager.py
+++ b/hyperspy/tests/axes/test_axes_manager.py
@@ -19,18 +19,17 @@
 from unittest import mock
 
 import numpy as np
+import pytest
 
 from hyperspy.axes import (
     AxesManager,
-    _serpentine_iter,
-    _flyback_iter,
-    GeneratorLen,
     BaseDataAxis,
+    GeneratorLen,
+    _flyback_iter,
+    _serpentine_iter,
 )
 from hyperspy.defaults_parser import preferences
 from hyperspy.signals import BaseSignal, Signal1D, Signal2D
-
-import pytest
 
 
 def generator():

--- a/hyperspy/tests/axes/test_conversion_units.py
+++ b/hyperspy/tests/axes/test_conversion_units.py
@@ -21,7 +21,7 @@ import pytest
 import traits.api as t
 
 from hyperspy.api_nogui import _ureg
-from hyperspy.axes import DataAxis, UniformDataAxis, AxesManager, UnitConversion
+from hyperspy.axes import AxesManager, DataAxis, UniformDataAxis, UnitConversion
 from hyperspy.misc.test_utils import assert_deep_almost_equal
 
 

--- a/hyperspy/tests/axes/test_data_axis.py
+++ b/hyperspy/tests/axes/test_data_axis.py
@@ -22,9 +22,9 @@ import platform
 from unittest import mock
 
 import numpy as np
-from numpy.testing import assert_allclose
-import traits.api as t
 import pytest
+import traits.api as t
+from numpy.testing import assert_allclose
 
 from hyperspy.axes import (
     BaseDataAxis,
@@ -33,8 +33,8 @@ from hyperspy.axes import (
     UniformDataAxis,
     create_axis,
 )
-from hyperspy.signals import Signal1D
 from hyperspy.misc.test_utils import assert_deep_almost_equal
+from hyperspy.signals import Signal1D
 
 
 class TestBaseDataAxis:

--- a/hyperspy/tests/component/test_backcompatibility.py
+++ b/hyperspy/tests/component/test_backcompatibility.py
@@ -21,8 +21,8 @@ import pathlib
 
 import pytest
 
-from hyperspy.exceptions import VisibleDeprecationWarning
 import hyperspy.api as hs
+from hyperspy.exceptions import VisibleDeprecationWarning
 
 DIRPATH = pathlib.Path(__file__).parent / "data"
 EXSPY_SPEC = importlib.util.find_spec("exspy")

--- a/hyperspy/tests/component/test_bleasdale.py
+++ b/hyperspy/tests/component/test_bleasdale.py
@@ -16,9 +16,8 @@
 # You should have received a copy of the GNU General Public License
 # along with HyperSpy. If not, see <https://www.gnu.org/licenses/#GPL>.
 
-import pytest
-
 import numpy as np
+import pytest
 
 from hyperspy.components1d import Bleasdale
 

--- a/hyperspy/tests/component/test_component.py
+++ b/hyperspy/tests/component/test_component.py
@@ -16,17 +16,16 @@
 # You should have received a copy of the GNU General Public License
 # along with HyperSpy. If not, see <https://www.gnu.org/licenses/#GPL>.
 
-import pytest
-from unittest import mock
 import pathlib
+from unittest import mock
 
 import numpy as np
+import pytest
 
 import hyperspy.api as hs
+from hyperspy._signals.signal1d import Signal1D
 from hyperspy.axes import AxesManager
 from hyperspy.component import Component, Parameter, _get_scaling_factor
-from hyperspy._signals.signal1d import Signal1D
-
 
 DIRPATH = pathlib.Path(__file__).parent / "data"
 

--- a/hyperspy/tests/component/test_component_print_current.py
+++ b/hyperspy/tests/component/test_component_print_current.py
@@ -20,9 +20,9 @@ import pytest
 
 import hyperspy.api as hs
 from hyperspy.misc.model_tools import (
-    _format_string,
     CurrentComponentValues,
     CurrentModelValues,
+    _format_string,
 )
 
 

--- a/hyperspy/tests/component/test_doniach.py
+++ b/hyperspy/tests/component/test_doniach.py
@@ -19,8 +19,8 @@
 import numpy as np
 import pytest
 
-from hyperspy.components1d import Doniach
 from hyperspy._signals.signal1d import Signal1D
+from hyperspy.components1d import Doniach
 
 sqrt2pi = np.sqrt(2 * np.pi)
 sigma2fwhm = 2 * np.sqrt(2 * np.log(2))

--- a/hyperspy/tests/component/test_splitvoigt.py
+++ b/hyperspy/tests/component/test_splitvoigt.py
@@ -26,7 +26,6 @@ from hyperspy.components1d import SplitVoigt
 from hyperspy.signals import Signal1D
 from hyperspy.utils import stack
 
-
 TRUE_FALSE_2_TUPLE = [p for p in itertools.product((True, False), repeat=2)]
 
 

--- a/hyperspy/tests/drawing/test_figure.py
+++ b/hyperspy/tests/drawing/test_figure.py
@@ -17,12 +17,11 @@
 
 import numpy as np
 import pytest
-
 from matplotlib.backend_bases import CloseEvent
 
 from hyperspy._components.polynomial import Polynomial
-from hyperspy.drawing.figure import BlittedFigure
 from hyperspy.drawing._markers.points import Points
+from hyperspy.drawing.figure import BlittedFigure
 from hyperspy.misc.test_utils import check_closing_plot
 from hyperspy.signals import Signal1D, Signal2D
 

--- a/hyperspy/tests/drawing/test_horizontal_plotting.py
+++ b/hyperspy/tests/drawing/test_horizontal_plotting.py
@@ -14,11 +14,11 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with HyperSpy. If not, see <https://www.gnu.org/licenses/#GPL>.
+import matplotlib
+import numpy as np
 import pytest
 
 import hyperspy.api as hs
-import numpy as np
-import matplotlib
 
 ipympl = pytest.importorskip("ipympl")
 ipywidgets = pytest.importorskip("ipywidgets")

--- a/hyperspy/tests/drawing/test_markers.py
+++ b/hyperspy/tests/drawing/test_markers.py
@@ -14,28 +14,27 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with HyperSpy. If not, see <https://www.gnu.org/licenses/#GPL>.
-import pytest
 from copy import deepcopy
 from pathlib import Path
 
-import numpy as np
-from matplotlib.transforms import (
-    IdentityTransform,
-    CompositeGenericTransform,
-)
-import matplotlib.pyplot as plt
 import dask.array as da
-
-import hyperspy.api as hs
-from hyperspy.drawing.markers import markers_dict_to_markers
-from hyperspy._signals.signal2d import Signal2D, BaseSignal, Signal1D
-from hyperspy.axes import UniformDataAxis
-from hyperspy.misc.test_utils import update_close_figure
+import matplotlib.pyplot as plt
+import numpy as np
+import pytest
 from matplotlib.collections import (
     LineCollection,
     PolyCollection,
     StarPolygonCollection,
 )
+from matplotlib.transforms import (
+    CompositeGenericTransform,
+    IdentityTransform,
+)
+
+import hyperspy.api as hs
+from hyperspy._signals.signal2d import BaseSignal, Signal1D, Signal2D
+from hyperspy.axes import UniformDataAxis
+from hyperspy.drawing.markers import markers_dict_to_markers
 from hyperspy.external.matplotlib.collections import (
     CircleCollection,
     EllipseCollection,
@@ -44,21 +43,21 @@ from hyperspy.external.matplotlib.collections import (
     TextCollection,
 )
 from hyperspy.external.matplotlib.quiver import Quiver
+from hyperspy.misc.test_utils import update_close_figure
 from hyperspy.utils.markers import (
     Arrows,
     Circles,
     Ellipses,
     HorizontalLines,
+    Lines,
     Markers,
     Points,
     Polygons,
-    VerticalLines,
     Rectangles,
     Squares,
     Texts,
-    Lines,
+    VerticalLines,
 )
-
 
 BASELINE_DIR = "markers"
 DEFAULT_TOL = 2.0
@@ -239,6 +238,7 @@ class TestMarkers:
     def test_find_peaks(self):
         from skimage.draw import disk
         from skimage.morphology import disk as disk2
+
         import hyperspy.api as hs
 
         rr, cc = disk(

--- a/hyperspy/tests/drawing/test_plot_histograms.py
+++ b/hyperspy/tests/drawing/test_plot_histograms.py
@@ -15,8 +15,9 @@
 # You should have received a copy of the GNU General Public License
 # along with HyperSpy. If not, see <https://www.gnu.org/licenses/#GPL>.
 
-import hyperspy.api as hs
 import numpy as np
+
+import hyperspy.api as hs
 
 
 def test_plot_histograms():

--- a/hyperspy/tests/drawing/test_plot_model.py
+++ b/hyperspy/tests/drawing/test_plot_model.py
@@ -16,9 +16,10 @@
 # You should have received a copy of the GNU General Public License
 # along with HyperSpy. If not, see <https://www.gnu.org/licenses/#GPL>.
 
+from pathlib import Path
+
 import numpy as np
 import pytest
-from pathlib import Path
 
 import hyperspy.api as hs
 from hyperspy.components1d import Gaussian

--- a/hyperspy/tests/drawing/test_plot_mva.py
+++ b/hyperspy/tests/drawing/test_plot_mva.py
@@ -16,10 +16,9 @@
 # You should have received a copy of the GNU General Public License
 # along with HyperSpy. If not, see <https://www.gnu.org/licenses/#GPL>.
 
-from packaging.version import Version
-
 import numpy as np
 import pytest
+from packaging.version import Version
 
 from hyperspy import signals
 from hyperspy.misc.machine_learning.import_sklearn import sklearn_installed

--- a/hyperspy/tests/drawing/test_plot_roi_map.py
+++ b/hyperspy/tests/drawing/test_plot_roi_map.py
@@ -17,11 +17,10 @@
 # along with HyperSpy. If not, see <https://www.gnu.org/licenses/#GPL>.
 
 
-import pytest
 import numpy as np
+import pytest
 
 import hyperspy.api as hs
-
 from hyperspy.utils.plot import plot_roi_map
 
 

--- a/hyperspy/tests/drawing/test_plot_signal.py
+++ b/hyperspy/tests/drawing/test_plot_signal.py
@@ -21,10 +21,9 @@ import pytest
 import traits.api as t
 
 import hyperspy.api as hs
-from hyperspy.drawing.signal1d import Signal1DFigure, Signal1DLine
 from hyperspy.drawing.image import ImagePlot
-from hyperspy.misc.test_utils import update_close_figure, check_closing_plot
-
+from hyperspy.drawing.signal1d import Signal1DFigure, Signal1DLine
+from hyperspy.misc.test_utils import check_closing_plot, update_close_figure
 
 scalebar_color = "blue"
 default_tol = 2.0

--- a/hyperspy/tests/drawing/test_plot_signal1d.py
+++ b/hyperspy/tests/drawing/test_plot_signal1d.py
@@ -22,9 +22,9 @@ from pathlib import Path
 from shutil import copyfile
 
 import matplotlib.pyplot as plt
-from matplotlib.backend_bases import MouseEvent, PickEvent
 import numpy as np
 import pytest
+from matplotlib.backend_bases import MouseEvent, PickEvent
 
 try:
     # scipy >=1.10
@@ -34,9 +34,9 @@ except ImportError:
     from scipy.misc import ascent, face
 
 import hyperspy.api as hs
+from hyperspy.drawing.signal1d import Signal1DLine
 from hyperspy.misc.test_utils import update_close_figure
 from hyperspy.signals import Signal1D
-from hyperspy.drawing.signal1d import Signal1DLine
 from hyperspy.tests.drawing.test_plot_signal import _TestPlot
 
 scalebar_color = "blue"

--- a/hyperspy/tests/drawing/test_plot_signal2d.py
+++ b/hyperspy/tests/drawing/test_plot_signal2d.py
@@ -16,14 +16,14 @@
 # along with HyperSpy. If not, see <https://www.gnu.org/licenses/#GPL>.
 
 import logging
-from packaging.version import Version
 
 import matplotlib
 import matplotlib.pyplot as plt
-from matplotlib.backend_bases import MouseEvent, MouseButton
 import numpy as np
 import pytest
 import scipy.ndimage
+from matplotlib.backend_bases import MouseButton, MouseEvent
+from packaging.version import Version
 
 try:
     # scipy >=1.10

--- a/hyperspy/tests/drawing/test_plot_signal_tools.py
+++ b/hyperspy/tests/drawing/test_plot_signal_tools.py
@@ -20,14 +20,13 @@ import numpy as np
 import pytest
 
 import hyperspy.api as hs
-from hyperspy import signals, components1d
+from hyperspy import components1d, signals
 from hyperspy.signal_tools import (
-    ImageContrastEditor,
     BackgroundRemoval,
-    SpanSelectorInSignal1D,
+    ImageContrastEditor,
     Signal1DCalibration,
+    SpanSelectorInSignal1D,
 )
-
 
 BASELINE_DIR = "plot_signal_tools"
 DEFAULT_TOL = 2.0

--- a/hyperspy/tests/drawing/test_plot_widgets.py
+++ b/hyperspy/tests/drawing/test_plot_widgets.py
@@ -21,8 +21,8 @@ import numpy as np
 import pytest
 
 from hyperspy.drawing import widgets
-from hyperspy.signals import Signal1D, Signal2D
 from hyperspy.misc.test_utils import mock_event
+from hyperspy.signals import Signal1D, Signal2D
 
 baseline_dir = "plot_widgets"
 default_tol = 2.0

--- a/hyperspy/tests/drawing/test_texts.py
+++ b/hyperspy/tests/drawing/test_texts.py
@@ -20,10 +20,9 @@ import matplotlib.pyplot as plt
 import numpy as np
 import pytest
 
-from hyperspy.drawing._markers.texts import Texts
 from hyperspy._signals.signal2d import Signal2D
+from hyperspy.drawing._markers.texts import Texts
 from hyperspy.misc.test_utils import update_close_figure
-
 
 BASELINE_DIR = "markers"
 DEFAULT_TOL = 2.0

--- a/hyperspy/tests/drawing/test_utils.py
+++ b/hyperspy/tests/drawing/test_utils.py
@@ -17,11 +17,11 @@
 
 from unittest.mock import Mock
 
-import numpy as np
 import matplotlib
+import numpy as np
 import pytest
 
-from hyperspy.drawing.utils import create_figure, contrast_stretching
+from hyperspy.drawing.utils import contrast_stretching, create_figure
 
 
 def test_create_figure():

--- a/hyperspy/tests/drawing/test_widget.py
+++ b/hyperspy/tests/drawing/test_widget.py
@@ -17,8 +17,8 @@
 
 import numpy as np
 
+from hyperspy import roi, signals
 from hyperspy.drawing import widget, widgets
-from hyperspy import signals, roi
 from hyperspy.misc.test_utils import mock_event
 
 

--- a/hyperspy/tests/learn/test_bss.py
+++ b/hyperspy/tests/learn/test_bss.py
@@ -28,7 +28,6 @@ from hyperspy.misc.machine_learning.import_sklearn import sklearn_installed
 from hyperspy.misc.machine_learning.tools import amari
 from hyperspy.signals import BaseSignal
 
-
 skip_sklearn = pytest.mark.skipif(not sklearn_installed, reason="sklearn not installed")
 
 

--- a/hyperspy/tests/learn/test_decomposition.py
+++ b/hyperspy/tests/learn/test_decomposition.py
@@ -16,8 +16,8 @@
 # You should have received a copy of the GNU General Public License
 # along with HyperSpy. If not, see <https://www.gnu.org/licenses/#GPL>.
 
-from tempfile import TemporaryDirectory
 from pathlib import Path
+from tempfile import TemporaryDirectory
 
 import numpy as np
 import pytest
@@ -25,7 +25,6 @@ import pytest
 from hyperspy import signals
 from hyperspy.decorators import lazifyTestClass
 from hyperspy.misc.machine_learning.import_sklearn import sklearn_installed
-
 
 skip_sklearn = pytest.mark.skipif(not sklearn_installed, reason="sklearn not installed")
 

--- a/hyperspy/tests/misc/test_array_tools.py
+++ b/hyperspy/tests/misc/test_array_tools.py
@@ -24,10 +24,10 @@ import pytest
 from hyperspy.misc.array_tools import (
     get_array_memory_size_in_GiB,
     get_signal_chunk_slice,
-    numba_histogram,
-    round_half_towards_zero,
-    round_half_away_from_zero,
     get_value_at_index,
+    numba_histogram,
+    round_half_away_from_zero,
+    round_half_towards_zero,
 )
 
 dt = [("x", np.uint8), ("y", np.uint16), ("text", (bytes, 6))]

--- a/hyperspy/tests/misc/test_axis_tools.py
+++ b/hyperspy/tests/misc/test_axis_tools.py
@@ -17,9 +17,10 @@
 # along with HyperSpy. If not, see <https://www.gnu.org/licenses/#GPL>.
 
 
+from numpy import arange
+
 from hyperspy.axes import DataAxis, FunctionalDataAxis, UniformDataAxis
 from hyperspy.misc.axis_tools import check_axes_calibration
-from numpy import arange
 
 
 def test_check_axes_calibration():

--- a/hyperspy/tests/misc/test_dictionary_tree_browser.py
+++ b/hyperspy/tests/misc/test_dictionary_tree_browser.py
@@ -16,19 +16,20 @@
 # You should have received a copy of the GNU General Public License
 # along with HyperSpy. If not, see <https://www.gnu.org/licenses/#GPL>.
 
-import numpy as np
 import os.path
 import tempfile
+
+import numpy as np
 import pytest
 
+from hyperspy.axes import UniformDataAxis
 from hyperspy.misc.utils import (
     DictionaryTreeBrowser,
     check_long_string,
-    replace_html_symbols,
     nested_dictionary_merge,
+    replace_html_symbols,
 )
 from hyperspy.signal import BaseSignal
-from hyperspy.axes import UniformDataAxis
 
 
 @pytest.fixture(params=[True, False], ids=["lazy", "not_lazy"])

--- a/hyperspy/tests/misc/test_math_tools.py
+++ b/hyperspy/tests/misc/test_math_tools.py
@@ -16,12 +16,11 @@
 # You should have received a copy of the GNU General Public License
 # along with HyperSpy. If not, see <https://www.gnu.org/licenses/#GPL>.
 
-from packaging.version import Version
-
-import pytest
-import numpy as np
 import dask
 import dask.array as da
+import numpy as np
+import pytest
+from packaging.version import Version
 
 from hyperspy.misc import math_tools
 

--- a/hyperspy/tests/misc/test_utils.py
+++ b/hyperspy/tests/misc/test_utils.py
@@ -20,23 +20,21 @@ import dask.array as da
 import numpy as np
 import pytest
 
-
 from hyperspy import signals
 from hyperspy.misc.utils import (
+    closest_power_of_two,
+    fsdict,
+    get_array_module,
+    is_cupy_array,
     is_hyperspy_signal,
     parse_quantity,
-    slugify,
-    strlist2enumeration,
-    str2num,
-    swapelem,
-    fsdict,
-    closest_power_of_two,
     shorten_name,
-    is_cupy_array,
+    slugify,
+    str2num,
+    strlist2enumeration,
+    swapelem,
     to_numpy,
-    get_array_module,
 )
-
 
 try:
     import cupy as cp

--- a/hyperspy/tests/model/test_constant.py
+++ b/hyperspy/tests/model/test_constant.py
@@ -18,8 +18,8 @@
 
 import numpy as np
 
-from hyperspy.components1d import Expression
 from hyperspy._signals.signal1d import Signal1D
+from hyperspy.components1d import Expression
 
 
 class TestLinearFitting:

--- a/hyperspy/tests/model/test_fit_component.py
+++ b/hyperspy/tests/model/test_fit_component.py
@@ -23,9 +23,9 @@ import pytest
 from hyperspy._signals.signal1d import Signal1D
 from hyperspy._signals.signal2d import Signal2D
 from hyperspy.components1d import Gaussian, Offset
-from hyperspy.models.model1d import ComponentFit
-from hyperspy.exceptions import SignalDimensionError
 from hyperspy.decorators import lazifyTestClass
+from hyperspy.exceptions import SignalDimensionError
+from hyperspy.models.model1d import ComponentFit
 
 
 class TestFitOneComponent:

--- a/hyperspy/tests/model/test_fitting.py
+++ b/hyperspy/tests/model/test_fitting.py
@@ -19,15 +19,14 @@
 import logging
 
 import numpy as np
-from packaging.version import Version
 import pytest
 import scipy
+from packaging.version import Version
 from scipy.optimize import OptimizeResult
 
 import hyperspy.api as hs
 from hyperspy.axes import GeneratorLen
 from hyperspy.decorators import lazifyTestClass
-
 
 TOL = 1e-5
 

--- a/hyperspy/tests/model/test_linear_model.py
+++ b/hyperspy/tests/model/test_linear_model.py
@@ -23,7 +23,7 @@ import pytest
 
 import hyperspy.api as hs
 from hyperspy.component import Component
-from hyperspy.components1d import Gaussian, Expression, Offset
+from hyperspy.components1d import Expression, Gaussian, Offset
 from hyperspy.components2d import Gaussian2D
 from hyperspy.decorators import lazifyTestClass
 from hyperspy.misc.utils import dummy_context_manager

--- a/hyperspy/tests/model/test_linearity.py
+++ b/hyperspy/tests/model/test_linearity.py
@@ -19,9 +19,9 @@
 import numpy as np
 import pytest
 
-from hyperspy.components1d import Expression, Gaussian
-from hyperspy._signals.signal1d import Signal1D
 from hyperspy._components.expression import _check_parameter_linearity
+from hyperspy._signals.signal1d import Signal1D
+from hyperspy.components1d import Expression, Gaussian
 
 
 class TestModelLinearity:

--- a/hyperspy/tests/samfire/test_samfire.py
+++ b/hyperspy/tests/samfire/test_samfire.py
@@ -39,9 +39,10 @@ class Mock_queue(object):
 
 
 def generate_test_model():
-    from hyperspy.signals import Signal1D
-    from hyperspy.components1d import Gaussian, Lorentzian
     from scipy.ndimage import gaussian_filter
+
+    from hyperspy.components1d import Gaussian, Lorentzian
+    from hyperspy.signals import Signal1D
 
     total = None
     blurs = [1.5]
@@ -194,8 +195,8 @@ class TestSamfireEmpty:
     def test_samfire_init_strategies(self):
         m = self.model
         samf = m.create_samfire(workers=N_WORKERS, setup=False)
-        from hyperspy.samfire_utils.local_strategies import ReducedChiSquaredStrategy
         from hyperspy.samfire_utils.global_strategies import HistogramStrategy
+        from hyperspy.samfire_utils.local_strategies import ReducedChiSquaredStrategy
 
         assert isinstance(samf.strategies[0], ReducedChiSquaredStrategy)
         assert isinstance(samf.strategies[1], HistogramStrategy)
@@ -303,8 +304,8 @@ class TestSamfireEmpty:
     def test_change_strategy(self):
         m = self.model
         samf = m.create_samfire(workers=N_WORKERS, setup=False)
-        from hyperspy.samfire_utils.local_strategies import ReducedChiSquaredStrategy
         from hyperspy.samfire_utils.global_strategies import HistogramStrategy
+        from hyperspy.samfire_utils.local_strategies import ReducedChiSquaredStrategy
 
         ind = (0, 0)
         samf.metadata.marker[ind] = -2

--- a/hyperspy/tests/signals/test_1D.py
+++ b/hyperspy/tests/signals/test_1D.py
@@ -17,7 +17,6 @@
 # along with HyperSpy. If not, see <https://www.gnu.org/licenses/#GPL>.
 
 import numpy as np
-
 import pytest
 
 from hyperspy.components1d import Gaussian

--- a/hyperspy/tests/signals/test_1D_tools.py
+++ b/hyperspy/tests/signals/test_1D_tools.py
@@ -18,10 +18,10 @@
 
 from unittest import mock
 
+import dask.array as da
 import numpy as np
 import pytest
 from scipy.signal import savgol_filter
-import dask.array as da
 
 import hyperspy.api as hs
 from hyperspy.decorators import lazifyTestClass

--- a/hyperspy/tests/signals/test_2D.py
+++ b/hyperspy/tests/signals/test_2D.py
@@ -17,12 +17,12 @@
 # along with HyperSpy. If not, see <https://www.gnu.org/licenses/#GPL>.
 
 import logging
-from packaging.version import Version
 from unittest import mock
 
 import dask
 import numpy as np
 import pytest
+from packaging.version import Version
 
 from hyperspy.decorators import lazifyTestClass
 from hyperspy.signal import BaseSignal

--- a/hyperspy/tests/signals/test_3D.py
+++ b/hyperspy/tests/signals/test_3D.py
@@ -20,8 +20,8 @@ import numpy as np
 import pytest
 
 from hyperspy.decorators import lazifyTestClass
-from hyperspy.signals import Signal1D
 from hyperspy.misc.array_tools import rebin
+from hyperspy.signals import Signal1D
 
 
 def _test_default_navigation_signal_operations_over_many_axes(self, op):

--- a/hyperspy/tests/signals/test_fancy_indexing.py
+++ b/hyperspy/tests/signals/test_fancy_indexing.py
@@ -20,8 +20,8 @@ import numpy as np
 import pytest
 from numpy.testing import assert_array_equal
 
-from hyperspy.decorators import lazifyTestClass
 from hyperspy import roi, signals
+from hyperspy.decorators import lazifyTestClass
 
 
 @lazifyTestClass

--- a/hyperspy/tests/signals/test_find_peaks1D_ohaver.py
+++ b/hyperspy/tests/signals/test_find_peaks1D_ohaver.py
@@ -17,6 +17,7 @@
 # along with HyperSpy. If not, see <https://www.gnu.org/licenses/#GPL>.
 
 from pathlib import Path
+
 import pytest
 
 from hyperspy.api import load

--- a/hyperspy/tests/signals/test_find_peaks2D.py
+++ b/hyperspy/tests/signals/test_find_peaks2D.py
@@ -16,14 +16,14 @@
 # You should have received a copy of the GNU General Public License
 # along with HyperSpy. If not, see <https://www.gnu.org/licenses/#GPL>.
 
-import pytest
 import numpy as np
+import pytest
 from scipy.stats import norm
 
-from hyperspy.signals import Signal2D, BaseSignal, Signal1D
 from hyperspy._signals.lazy import LazySignal
 from hyperspy.decorators import lazifyTestClass
 from hyperspy.signal_tools import PeaksFinder2D
+from hyperspy.signals import BaseSignal, Signal1D, Signal2D
 from hyperspy.ui_registry import TOOLKIT_REGISTRY
 
 

--- a/hyperspy/tests/signals/test_interpolate_on_axis.py
+++ b/hyperspy/tests/signals/test_interpolate_on_axis.py
@@ -20,11 +20,11 @@
 import gc
 from copy import deepcopy
 
-import pytest
 import numpy as np
+import pytest
 
 from hyperspy import signals
-from hyperspy.axes import UniformDataAxis, DataAxis, FunctionalDataAxis
+from hyperspy.axes import DataAxis, FunctionalDataAxis, UniformDataAxis
 
 
 def _assert_equal_dimensions(s1, s2):

--- a/hyperspy/tests/signals/test_lazy.py
+++ b/hyperspy/tests/signals/test_lazy.py
@@ -24,9 +24,9 @@ from dask.threaded import get
 import hyperspy.api as hs
 from hyperspy import _lazy_signals
 from hyperspy._signals.lazy import (
+    _get_navigation_dimension_chunk_slice,
     _reshuffle_mixed_blocks,
     to_array,
-    _get_navigation_dimension_chunk_slice,
 )
 
 

--- a/hyperspy/tests/signals/test_map_method.py
+++ b/hyperspy/tests/signals/test_map_method.py
@@ -18,14 +18,14 @@
 
 from unittest import mock
 
+import dask.array as da
 import numpy as np
 import pytest
-import dask.array as da
 from scipy.ndimage import gaussian_filter, gaussian_filter1d, rotate
 
 import hyperspy.api as hs
-from hyperspy.decorators import lazifyTestClass
 from hyperspy._signals.lazy import LazySignal
+from hyperspy.decorators import lazifyTestClass
 from hyperspy.misc.utils import _get_block_pattern
 
 

--- a/hyperspy/tests/signals/test_obj_in_dict2hspy.py
+++ b/hyperspy/tests/signals/test_obj_in_dict2hspy.py
@@ -18,7 +18,7 @@
 import numpy as np
 
 from hyperspy.axes import AxesManager
-from hyperspy.signal import _obj_in_dict2hspy, BaseSignal
+from hyperspy.signal import BaseSignal, _obj_in_dict2hspy
 
 
 def test_obj_in_dict2hspy_signal():

--- a/hyperspy/tests/signals/test_ragged_signal.py
+++ b/hyperspy/tests/signals/test_ragged_signal.py
@@ -16,8 +16,8 @@
 # You should have received a copy of the GNU General Public License
 # along with HyperSpy. If not, see <https://www.gnu.org/licenses/#GPL>.
 
-import pytest
 import numpy as np
+import pytest
 
 import hyperspy.api as hs
 from hyperspy.decorators import lazifyTestClass

--- a/hyperspy/tests/signals/test_rgb.py
+++ b/hyperspy/tests/signals/test_rgb.py
@@ -18,9 +18,9 @@
 
 import numpy as np
 import pytest
+from rsciio.utils import rgb_tools
 
 import hyperspy.api as hs
-from rsciio.utils import rgb_tools
 
 
 class TestRGBA8:

--- a/hyperspy/tests/signals/test_spike_removal_tool.py
+++ b/hyperspy/tests/signals/test_spike_removal_tool.py
@@ -18,7 +18,8 @@
 
 import numpy as np
 import pytest
-from hyperspy.signal_tools import SpikesRemovalInteractive, SpikesRemoval
+
+from hyperspy.signal_tools import SpikesRemoval, SpikesRemovalInteractive
 from hyperspy.signals import Signal1D
 
 

--- a/hyperspy/tests/test_io.py
+++ b/hyperspy/tests/test_io.py
@@ -17,22 +17,21 @@
 # along with HyperSpy. If not, see <https://www.gnu.org/licenses/#GPL>.
 
 import hashlib
-import os
 import logging
+import os
 import tempfile
 from pathlib import Path
 from unittest.mock import patch
 
 import numpy as np
 import pytest
+from rsciio import IO_PLUGINS
 
 import hyperspy.api as hs
+from hyperspy import __version__ as hs_version
+from hyperspy.axes import DataAxis
 from hyperspy.exceptions import VisibleDeprecationWarning
 from hyperspy.signals import Signal1D
-from hyperspy.axes import DataAxis
-from rsciio import IO_PLUGINS
-from hyperspy import __version__ as hs_version
-
 
 PATH = Path(__file__).resolve()
 FULLFILENAME = PATH.parent.joinpath("test_io_overwriting.hspy")

--- a/hyperspy/tests/utils/test_stack_calibration.py
+++ b/hyperspy/tests/utils/test_stack_calibration.py
@@ -20,6 +20,7 @@ import logging
 
 import numpy as np
 import pytest
+
 from hyperspy import signals
 from hyperspy.decorators import lazifyTestClass
 from hyperspy.misc.utils import stack

--- a/hyperspy/ui_registry.py
+++ b/hyperspy/ui_registry.py
@@ -33,7 +33,6 @@ import importlib
 
 from hyperspy.extensions import ALL_EXTENSIONS, _external_extensions
 
-
 UI_REGISTRY = {toolkey: {} for toolkey in ALL_EXTENSIONS["GUI"]["toolkeys"]}
 _EXTENSION_NAMES = [e.name for e in _external_extensions]
 

--- a/hyperspy/utils/__init__.py
+++ b/hyperspy/utils/__init__.py
@@ -58,9 +58,10 @@ def print_known_signal_types():
     +--------------------+---------------------+--------------------+----------+
 
     """
-    from hyperspy.ui_registry import ALL_EXTENSIONS
     from prettytable import PrettyTable
+
     from hyperspy.misc.utils import display
+    from hyperspy.ui_registry import ALL_EXTENSIONS
 
     table = PrettyTable()
     table.field_names = ["signal_type", "aliases", "class name", "package"]

--- a/hyperspy/utils/markers.py
+++ b/hyperspy/utils/markers.py
@@ -34,19 +34,18 @@ Examples
 
 """
 
-from hyperspy.drawing.markers import Markers
-from hyperspy.drawing._markers.texts import Texts
-from hyperspy.drawing._markers.horizontal_lines import HorizontalLines
-from hyperspy.drawing._markers.vertical_lines import VerticalLines
+from hyperspy.drawing._markers.arrows import Arrows
 from hyperspy.drawing._markers.circles import Circles
 from hyperspy.drawing._markers.ellipses import Ellipses
-from hyperspy.drawing._markers.squares import Squares
-from hyperspy.drawing._markers.arrows import Arrows
-from hyperspy.drawing._markers.points import Points
+from hyperspy.drawing._markers.horizontal_lines import HorizontalLines
 from hyperspy.drawing._markers.lines import Lines
-from hyperspy.drawing._markers.rectangles import Rectangles
+from hyperspy.drawing._markers.points import Points
 from hyperspy.drawing._markers.polygons import Polygons
-
+from hyperspy.drawing._markers.rectangles import Rectangles
+from hyperspy.drawing._markers.squares import Squares
+from hyperspy.drawing._markers.texts import Texts
+from hyperspy.drawing._markers.vertical_lines import VerticalLines
+from hyperspy.drawing.markers import Markers
 
 __all__ = [
     "Arrows",

--- a/hyperspy/utils/model.py
+++ b/hyperspy/utils/model.py
@@ -32,7 +32,6 @@ The model module contains the following submodules:
 import hyperspy.components1d as components1D
 import hyperspy.components2d as components2D
 
-
 __all__ = [
     "components1D",
     "components2D",

--- a/hyperspy/utils/peakfinders2D.py
+++ b/hyperspy/utils/peakfinders2D.py
@@ -25,7 +25,6 @@ from skimage.feature import blob_dog, blob_log, match_template, peak_local_max
 from hyperspy.decorators import jit_ifnumba
 from hyperspy.misc.machine_learning import import_sklearn
 
-
 NO_PEAKS = np.array([[np.nan, np.nan]])
 
 

--- a/hyperspy/utils/plot.py
+++ b/hyperspy/utils/plot.py
@@ -41,12 +41,11 @@ The :mod:`hyperspy.api.plot` module contains the following submodules:
 from hyperspy.drawing.utils import (
     plot_histograms,
     plot_images,
+    plot_roi_map,
     plot_signals,
     plot_spectra,
-    plot_roi_map,
 )
 from hyperspy.utils import markers
-
 
 __all__ = [
     "markers",

--- a/hyperspy/utils/roi.py
+++ b/hyperspy/utils/roi.py
@@ -26,7 +26,6 @@ from hyperspy.roi import (
     SpanROI,
 )
 
-
 __doc__ = hyperspy.roi.__doc__
 
 

--- a/hyperspy/utils/samfire.py
+++ b/hyperspy/utils/samfire.py
@@ -42,7 +42,6 @@ from hyperspy.samfire_utils import (
 )
 from hyperspy.samfire_utils.samfire_pool import SamfirePool
 
-
 __all__ = ["fit_tests", "global_strategies", "local_strategies", "SamfirePool"]
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -192,6 +192,17 @@ exclude = [
     "conftest.py",
     ]
 
+[tool.ruff.lint]
+select = [
+    # isort
+    "I"
+]
+# Rely on the formatter to define line-length
+# and avoid conflicting lint rules
+# https://docs.astral.sh/ruff/formatter/#conflicting-lint-rules
+extend-ignore = ["E501"]
+
+
 [tool.setuptools.package-data]
 "*" = [
     "hyperspy_extension.yaml",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -187,6 +187,7 @@ doctest_optionflags = [
 
 [tool.ruff]
 exclude = [
+    "api_nogui.py",
     "hyperspy/external/*",
     "examples",
     "conftest.py",
@@ -194,6 +195,11 @@ exclude = [
 
 [tool.ruff.lint]
 select = [
+    # Pyflakes
+    "F",
+    # Pycodestyle
+    "E",
+    "W",
     # isort
     "I"
 ]

--- a/upcoming_changes/3348.maintenance.rst
+++ b/upcoming_changes/3348.maintenance.rst
@@ -1,0 +1,1 @@
+Enable ruff isort and all pyflakes/Pycodestyle rules, except E501 to avoid confict with black formatting.


### PR DESCRIPTION
### Progress of the PR
- [x] Enable ruff isort, pyflakes and Pycodestyle rules,
- [x] exclude E501 rule to avoid conflict with black formatting,
- [n/a] update docstring (if appropriate),
- [n/a] update user guide (if appropriate),
- [x] add an changelog entry in the `upcoming_changes` folder (see [`upcoming_changes/README.rst`](https://github.com/hyperspy/hyperspy/blob/RELEASE_next_minor/upcoming_changes/README.rst)),
- [x] Check formatting changelog entry in the `readthedocs` doc build of this PR (link in github checks)
- [n/a] add tests,
- [x] ready for review.


