### PR TITLE
Update residual line when model line is changed. 

### DIFF
--- a/hyperspy/model.py
+++ b/hyperspy/model.py
@@ -708,26 +708,16 @@ class BaseModel(list):
     def _connect_parameters2update_plot(self, components):
         if self._plot_active is False:
             return
-
-        if update_residual: #update both model and its residual lines
-            for i, component in enumerate(components):
+        lines = [line for line in (self._model_line, self._residual_line) if line is not None]
+        for i, component in enumerate(components):
+            for line in lines:
                 component.events.active_changed.connect(
-                    self._model_line._auto_update_line, [])
-                component.events.active_changed.connect(
-                    self._residual_line.update, [])
+                    line ._auto_update_line, []
+                )
                 for parameter in component.parameters:
                     parameter.events.value_changed.connect(
-                        self._model_line._auto_update_line, [])
-                    parameter.events.value_changed.connect(
-                        self._residual_line.update, [])
-
-        else: #update only model line
-            for i, component in enumerate(components):
-                component.events.active_changed.connect(
-                    self._model_line._auto_update_line, [])
-                for parameter in component.parameters:
-                    parameter.events.value_changed.connect(
-                        self._model_line._auto_update_line, [])
+                        line ._auto_update_line, []
+                    )
 
     def _disconnect_parameters2update_plot(self, components):
         if self._model_line is None:

--- a/hyperspy/model.py
+++ b/hyperspy/model.py
@@ -705,17 +705,29 @@ class BaseModel(list):
         else:
             return False
 
-    def _connect_parameters2update_plot(self, components):
+    def _connect_parameters2update_plot(self, components, update_residual=False):
         if self._plot_active is False:
             return
-        for i, component in enumerate(components):
-            component.events.active_changed.connect(
-                self._model_line._auto_update_line, []
-            )
-            for parameter in component.parameters:
-                parameter.events.value_changed.connect(
-                    self._model_line._auto_update_line, []
-                )
+
+        if update_residual: #update both model and its residual lines
+            for i, component in enumerate(components):
+                component.events.active_changed.connect(
+                    self._model_line._auto_update_line, [])
+                component.events.active_changed.connect(
+                    self._residual_line.update, [])
+                for parameter in component.parameters:
+                    parameter.events.value_changed.connect(
+                        self._model_line._auto_update_line, [])
+                    parameter.events.value_changed.connect(
+                        self._residual_line.update, [])
+
+        else: #update only model line
+            for i, component in enumerate(components):
+                component.events.active_changed.connect(
+                    self._model_line._auto_update_line, [])
+                for parameter in component.parameters:
+                    parameter.events.value_changed.connect(
+                        self._model_line._auto_update_line, [])
 
     def _disconnect_parameters2update_plot(self, components):
         if self._model_line is None:

--- a/hyperspy/model.py
+++ b/hyperspy/model.py
@@ -709,7 +709,6 @@ class BaseModel(list):
         if self._plot_active is False:
             return
         lines = [line for line in (self._model_line, self._residual_line) if line is not None]
-        print(lines)
         for i, component in enumerate(components):
             for line in lines:
                 component.events.active_changed.connect(
@@ -723,14 +722,16 @@ class BaseModel(list):
     def _disconnect_parameters2update_plot(self, components):
         if self._model_line is None:
             return
+        lines = [line for line in (self._model_line, self._residual_line) if line is not None]
         for component in components:
-            component.events.active_changed.disconnect(
-                self._model_line._auto_update_line
-            )
-            for parameter in component.parameters:
-                parameter.events.value_changed.disconnect(
-                    self._model_line._auto_update_line
+            for line in lines:
+                component.events.active_changed.disconnect(
+                    line._auto_update_line
                 )
+                for parameter in component.parameters:
+                    parameter.events.value_changed.disconnect(
+                        line._auto_update_line
+                    )
 
     def update_plot(self, render_figure=False, update_ylimits=False, **kwargs):
         """Update model plot.
@@ -800,6 +801,8 @@ class BaseModel(list):
         if self._plot_components is True:
             self.disable_plot_components()
         self._disconnect_parameters2update_plot(components=self)
+        if self._residual_line is not None:
+            self._residual_line = None
         self._model_line = None
 
     def enable_plot_components(self):

--- a/hyperspy/model.py
+++ b/hyperspy/model.py
@@ -708,30 +708,26 @@ class BaseModel(list):
     def _connect_parameters2update_plot(self, components):
         if self._plot_active is False:
             return
-        lines = [line for line in (self._model_line, self._residual_line) if line is not None]
+        lines = [
+            line for line in (self._model_line, self._residual_line) if line is not None
+        ]
         for i, component in enumerate(components):
             for line in lines:
-                component.events.active_changed.connect(
-                    line._auto_update_line, []
-                )
+                component.events.active_changed.connect(line._auto_update_line, [])
                 for parameter in component.parameters:
-                    parameter.events.value_changed.connect(
-                        line._auto_update_line, []
-                    )
+                    parameter.events.value_changed.connect(line._auto_update_line, [])
 
     def _disconnect_parameters2update_plot(self, components):
         if self._model_line is None:
             return
-        lines = [line for line in (self._model_line, self._residual_line) if line is not None]
+        lines = [
+            line for line in (self._model_line, self._residual_line) if line is not None
+        ]
         for component in components:
             for line in lines:
-                component.events.active_changed.disconnect(
-                    line._auto_update_line
-                )
+                component.events.active_changed.disconnect(line._auto_update_line)
                 for parameter in component.parameters:
-                    parameter.events.value_changed.disconnect(
-                        line._auto_update_line
-                    )
+                    parameter.events.value_changed.disconnect(line._auto_update_line)
 
     def update_plot(self, render_figure=False, update_ylimits=False, **kwargs):
         """Update model plot.

--- a/hyperspy/model.py
+++ b/hyperspy/model.py
@@ -709,14 +709,15 @@ class BaseModel(list):
         if self._plot_active is False:
             return
         lines = [line for line in (self._model_line, self._residual_line) if line is not None]
+        print(lines)
         for i, component in enumerate(components):
             for line in lines:
                 component.events.active_changed.connect(
-                    line ._auto_update_line, []
+                    line._auto_update_line, []
                 )
                 for parameter in component.parameters:
                     parameter.events.value_changed.connect(
-                        line ._auto_update_line, []
+                        line._auto_update_line, []
                     )
 
     def _disconnect_parameters2update_plot(self, components):

--- a/hyperspy/model.py
+++ b/hyperspy/model.py
@@ -705,7 +705,7 @@ class BaseModel(list):
         else:
             return False
 
-    def _connect_parameters2update_plot(self, components, update_residual=False):
+    def _connect_parameters2update_plot(self, components):
         if self._plot_active is False:
             return
 

--- a/hyperspy/models/model1d.py
+++ b/hyperspy/models/model1d.py
@@ -672,7 +672,7 @@ class Model1D(BaseModel):
 
         self._model_line = l2
         self._plot = self.signal._plot
-
+        self._connect_parameters2update_plot(self)
 
         # Optional to plot the residual of (Signal - Model)
         if plot_residual:
@@ -685,11 +685,6 @@ class Model1D(BaseModel):
             l3.plot()
             # Quick access to _residual_line if needed
             self._residual_line = l3
-            #Update residual line when model line is updated
-            self._connect_parameters2update_plot(self, update_residual=True) 
-        else:
-            #Update only the model line
-            self._connect_parameters2update_plot(self, update_residual=False)
 
         if plot_components is True:
             self.enable_plot_components()

--- a/hyperspy/models/model1d.py
+++ b/hyperspy/models/model1d.py
@@ -672,7 +672,6 @@ class Model1D(BaseModel):
 
         self._model_line = l2
         self._plot = self.signal._plot
-        
 
         # Optional to plot the residual of (Signal - Model)
         if plot_residual:
@@ -687,7 +686,7 @@ class Model1D(BaseModel):
             self._residual_line = l3
 
         self._connect_parameters2update_plot(self)
-        
+
         if plot_components is True:
             self.enable_plot_components()
         else:

--- a/hyperspy/models/model1d.py
+++ b/hyperspy/models/model1d.py
@@ -672,7 +672,7 @@ class Model1D(BaseModel):
 
         self._model_line = l2
         self._plot = self.signal._plot
-        self._connect_parameters2update_plot(self)
+
 
         # Optional to plot the residual of (Signal - Model)
         if plot_residual:
@@ -685,6 +685,11 @@ class Model1D(BaseModel):
             l3.plot()
             # Quick access to _residual_line if needed
             self._residual_line = l3
+            #Update residual line when model line is updated
+            self._connect_parameters2update_plot(self, update_residual=True) 
+        else:
+            #Update only the model line
+            self._connect_parameters2update_plot(self, update_residual=False)
 
         if plot_components is True:
             self.enable_plot_components()

--- a/hyperspy/models/model1d.py
+++ b/hyperspy/models/model1d.py
@@ -672,7 +672,7 @@ class Model1D(BaseModel):
 
         self._model_line = l2
         self._plot = self.signal._plot
-        self._connect_parameters2update_plot(self)
+        
 
         # Optional to plot the residual of (Signal - Model)
         if plot_residual:
@@ -686,6 +686,8 @@ class Model1D(BaseModel):
             # Quick access to _residual_line if needed
             self._residual_line = l3
 
+        self._connect_parameters2update_plot(self)
+        
         if plot_components is True:
             self.enable_plot_components()
         else:

--- a/upcoming_changes/3355.bugfix.rst
+++ b/upcoming_changes/3355.bugfix.rst
@@ -1,0 +1,1 @@
+Fix updating residual line in model plot when changing components.


### PR DESCRIPTION
As suggested in #3352, I rebase to RELEASE_next_patch, as well as cleaning up the commits history.

Currently, the plotted residual is not being updated whenever the model line changes.
So I added update for model._residual_line whenever mode._model_line is being updated.
```python
import numpy as np
import hyperspy.api as hs

# Random Signal1D signal
s = hs.signals.Signal1D(data=np.random.random((2, 2, 1024)), 
                        axes=[{'name': 'x', 'size': 2}, 
                              {'name': 'y', 'size': 2}, 
                              {'name': 'sig', 'size': 1024}])
# Model object with Polynomial component
m = s.create_model()
# Polynomial=hs.model.components1D.Polynomial()
# m.append(Polynomial)
m.append(hs.model.components1D.PowerLaw())
m.plot(plot_residual=True)
```