### PR TITLE
Fixing 3358 circle roi

### DIFF
--- a/hyperspy/drawing/utils.py
+++ b/hyperspy/drawing/utils.py
@@ -1939,7 +1939,6 @@ def plot_roi_map(signal, rois=1):
         hs.interactive(
             roi_signal.nansum,
             event=roi_signal.events.data_changed,
-            #event=roi_signal.axes_manager.events.any_axis_changed,
             axis=roi_signal.axes_manager.signal_axes,
             out=roi_sum,
             recompute_out_event=None,

--- a/hyperspy/drawing/utils.py
+++ b/hyperspy/drawing/utils.py
@@ -1938,7 +1938,8 @@ def plot_roi_map(signal, rois=1):
         # connect the span signal changing range to the value of span_sum
         hs.interactive(
             roi_signal.nansum,
-            event=roi_signal.axes_manager.events.any_axis_changed,
+            event=roi_signal.events.data_changed,
+            #event=roi_signal.axes_manager.events.any_axis_changed,
             axis=roi_signal.axes_manager.signal_axes,
             out=roi_sum,
             recompute_out_event=None,

--- a/hyperspy/tests/drawing/test_plot_roi_map.py
+++ b/hyperspy/tests/drawing/test_plot_roi_map.py
@@ -207,13 +207,13 @@ def test_circle_roi():
     data[-1, -1, 0, 0] = 10000
     s = hs.signals.Signal2D(data)
     roi = hs.roi.CircleROI(cx=3, cy=3, r=4, r_inner=0)
-    
+
     all_sum, rois, roi_signals, roi_sums = hs.plot.plot_roi_map(s, rois=[roi])
-    roi_signal, = roi_signals
-    roi_sum, = roi_sums
+    (roi_signal,) = roi_signals
+    (roi_sum,) = roi_sums
 
     assert not np.any(np.isin(10000, roi_signal.data[0, 0]))
-    
+
     assert not np.any(np.isin(10000, roi_sum))
     assert np.allclose(roi_sum, np.zeros((2, 2)))
 
@@ -234,4 +234,3 @@ def test_circle_roi():
 
     # check can actually find 10000
     assert np.any(np.isin(10000, roi_sum))
-

--- a/hyperspy/tests/drawing/test_plot_roi_map.py
+++ b/hyperspy/tests/drawing/test_plot_roi_map.py
@@ -200,3 +200,38 @@ def test_interaction(test_signal, which_plot):
         return all_sums._plot.signal_plot.figure
     elif which_plot == "roi_sums":
         return roi_sums[0]._plot.signal_plot.figure
+
+
+def test_circle_roi():
+    data = np.zeros((2, 2, 7, 7))
+    data[-1, -1, 0, 0] = 10000
+    s = hs.signals.Signal2D(data)
+    roi = hs.roi.CircleROI(cx=3, cy=3, r=4, r_inner=0)
+    
+    all_sum, rois, roi_signals, roi_sums = hs.plot.plot_roi_map(s, rois=[roi])
+    roi_signal, = roi_signals
+    roi_sum, = roi_sums
+
+    assert not np.any(np.isin(10000, roi_signal.data[0, 0]))
+    
+    assert not np.any(np.isin(10000, roi_sum))
+    assert np.allclose(roi_sum, np.zeros((2, 2)))
+
+    before = roi_signal.data.copy()
+
+    roi.cx = 4  # force update
+    roi.cx = 3
+
+    after = roi_signal.data.copy()
+
+    # no change expected
+    assert np.allclose(before, after, equal_nan=True)  # sorry maths
+    assert not np.any(np.isin(10000, roi_sum))
+    assert np.allclose(roi_sum, np.zeros((2, 2)))
+
+    roi.cx = 0
+    roi.cy = 0
+
+    # check can actually find 10000
+    assert np.any(np.isin(10000, roi_sum))
+

--- a/upcoming_changes/3358.bugfix.rst
+++ b/upcoming_changes/3358.bugfix.rst
@@ -1,0 +1,1 @@
+fixed issue with `plot_roi_map` interaction to allow using `CircleROI`.

--- a/upcoming_changes/3358.bugfix.rst
+++ b/upcoming_changes/3358.bugfix.rst
@@ -1,1 +1,1 @@
-fixed issue with `plot_roi_map` interaction to allow using `CircleROI`.
+fixed issue with ``plot_roi_map`` interaction to allow using ``CircleROI``.


### PR DESCRIPTION
### Description of the change
A few sentences and/or a bulleted list to describe and motivate the change:

Fixed bug (see #3358) where using `CircleROI` with `plot_roi_map` doesn't update correctly due to using an axis update signal rather than data update signal.

### Progress of the PR
- [x] Change implemented (can be split into several points),
- [x] update docstring (if appropriate), - N/A
- [x] update user guide (if appropriate), - N/A
- [x] add an changelog entry in the `upcoming_changes` folder (see [`upcoming_changes/README.rst`](https://github.com/hyperspy/hyperspy/blob/RELEASE_next_minor/upcoming_changes/README.rst)),
- [x] Check formatting changelog entry in the `readthedocs` doc build of this PR (link in github checks)
- [x] add tests,
- [x] ready for review.

### Minimal example of the bug fix or the new feature
```python

data = np.zeros((2, 2, 7, 7))
data[-1, -1, 0, 0] = 10000
s = hs.signals.Signal2D(data)
roi = hs.roi.CircleROI(cx=3, cy=3, r=4, r_inner=0)

all_sum, rois, roi_signals, roi_sums = hs.plot.plot_roi_map(s, rois=[roi])

assert np.allclose(roi_sum.data, np.zeros((2, 2)))   # 10,000 not included inside circle

roi.cx = 4  # force an update
roi.cx = 3

# fails because roi_sum evaluated when axis changes, which is before mask applied, so 10,000 included
assert np.allclose(roi_sum.data, np.zeros((2, 2)))  # now passes with this PR
```
