### PR TITLE
Only import gui widget when the toolkit is enabled

### DIFF
--- a/hyperspy/ui_registry.py
+++ b/hyperspy/ui_registry.py
@@ -127,8 +127,8 @@ def get_gui(self, toolkey, display=True, toolkit=None, **kwargs):
     available_toolkits = set()
     used_toolkits = set()
     for toolkit, specs in UI_REGISTRY[toolkey].items():
-        f = getattr(importlib.import_module(specs["module"]), specs["function"])
         if toolkit in toolkits:
+            f = getattr(importlib.import_module(specs["module"]), specs["function"])
             used_toolkits.add(toolkit)
             try:
                 thisw = f(obj=self, display=display, **kwargs)

--- a/upcoming_changes/3366.enhancements.rst
+++ b/upcoming_changes/3366.enhancements.rst
@@ -1,0 +1,1 @@
+Only import gui widget when the toolkit is enabled.


### PR DESCRIPTION
### Progress of the PR
- [x] Only import gui widget when the toolkit is enabled to avoid unnecessary import of gui library,
- [n/a] update docstring (if appropriate),
- [n/a] update user guide (if appropriate),
- [x] add an changelog entry in the `upcoming_changes` folder (see [`upcoming_changes/README.rst`](https://github.com/hyperspy/hyperspy/blob/RELEASE_next_minor/upcoming_changes/README.rst)),
- [x] Check formatting changelog entry in the `readthedocs` doc build of this PR (link in github checks)
- [n/a] add tests,
- [x] ready for review.


