### PR TITLE
Fix checking matplotlib backend following changes in matplotlib dev (3.10.dev)

### DIFF
--- a/hyperspy/tests/drawing/test_mpl_testing_setup.py
+++ b/hyperspy/tests/drawing/test_mpl_testing_setup.py
@@ -24,7 +24,7 @@ from hyperspy.misc.test_utils import check_running_tests_in_CI
 
 def test_mlp_agg_for_CI_testing():
     if check_running_tests_in_CI():
-        assert matplotlib.get_backend() == "agg"
+        assert matplotlib.get_backend().lower() == "agg"
 
 
 @pytest.fixture

--- a/hyperspy/tests/drawing/test_utils.py
+++ b/hyperspy/tests/drawing/test_utils.py
@@ -25,12 +25,10 @@ from hyperspy.drawing.utils import contrast_stretching, create_figure
 
 
 def test_create_figure():
-    if matplotlib.get_backend() == "agg":
-        pytest.xfail(
-            "{} backend does not support on_close event.".format(
-                matplotlib.get_backend()
-            )
-        )
+    # needs to run inside the function to make sure the correct backend is used
+    # not possible to pytest.mark.skipif decorator
+    if matplotlib.get_backend().lower() == "agg":
+        pytest.skip("'agg' backend does not support on_close event.")
 
     dummy_function = Mock()
     fig = create_figure(

--- a/upcoming_changes/3367.maintenance.rst
+++ b/upcoming_changes/3367.maintenance.rst
@@ -1,0 +1,1 @@
+Use lower case when checking matplotlib backend in the test suite.


### PR DESCRIPTION
Necessary after https://github.com/matplotlib/matplotlib/pull/27948.

Example of test suite failure at https://github.com/hyperspy/hyperspy-extensions-list/actions/runs/8962764900

```python
=================================== FAILURES ===================================
_________________________ test_mlp_agg_for_CI_testing __________________________
[gw1] linux -- Python 3.11.9 /home/runner/miniconda3/envs/test/bin/python

    def test_mlp_agg_for_CI_testing():
        if check_running_tests_in_CI():
>           assert matplotlib.get_backend() == "agg"
E           AssertionError: assert 'Agg' == 'agg'
E             - agg
E             + Agg

../../../miniconda3/envs/test/lib/python3.11/site-packages/hyperspy/tests/drawing/test_mpl_testing_setup.py:27: AssertionError
______________________________ test_create_figure ______________________________
[gw0] linux -- Python 3.11.9 /home/runner/miniconda3/envs/test/bin/python

    def test_create_figure():
        if matplotlib.get_backend() == "agg":
            pytest.xfail(
                "{} backend does not support on_close event.".format(
                    matplotlib.get_backend()
                )
            )
    
        dummy_function = Mock()
        fig = create_figure(
            window_title="test title", _on_figure_window_close=dummy_function
        )
        assert isinstance(fig, matplotlib.figure.Figure) is True
        matplotlib.pyplot.close(fig)
>       dummy_function.assert_called_once_with()

../../../miniconda3/envs/test/lib/python3.11/site-packages/hyperspy/tests/drawing/test_utils.py:41: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

self = <Mock id='139[85](https://github.com/hyperspy/hyperspy-extensions-list/actions/runs/8962764900/job/24612091763#step:20:86)374[86](https://github.com/hyperspy/hyperspy-extensions-list/actions/runs/8962764900/job/24612091763#step:20:87)32464'>, args = (), kwargs = {}
msg = "Expected 'mock' to be called once. Called 0 times."

    def assert_called_once_with(self, /, *args, **kwargs):
        """assert that the mock was called exactly once and that that call was
        with the specified arguments."""
        if not self.call_count == 1:
            msg = ("Expected '%s' to be called once. Called %s times.%s"
                   % (self._mock_name or 'mock',
                      self.call_count,
                      self._calls_repr()))
>           raise AssertionError(msg)
E           AssertionError: Expected 'mock' to be called once. Called 0 times.

../../../miniconda3/envs/test/lib/python3.11/unittest/mock.py:[95](https://github.com/hyperspy/hyperspy-extensions-list/actions/runs/8962764900/job/24612091763#step:20:96)0: AssertionError
```

### Progress of the PR
- [x] Use lower case when checking for matplotlib backend,
- [n/a] update docstring (if appropriate),
- [n/a] update user guide (if appropriate),
- [ ] add an changelog entry in the `upcoming_changes` folder (see [`upcoming_changes/README.rst`](https://github.com/hyperspy/hyperspy/blob/RELEASE_next_minor/upcoming_changes/README.rst)),
- [ ] Check formatting changelog entry in the `readthedocs` doc build of this PR (link in github checks)
- [x] update tests,
- [ ] ready for review.


