### PR TITLE
Fix dev version on `RELEASE_next_minor` branch and fix image contrast tool traitsui 

### DIFF
--- a/hyperspy/__init__.py
+++ b/hyperspy/__init__.py
@@ -44,7 +44,7 @@ if (_root / ".git").exists() and not (_root / ".git/shallow").exists():
         # setuptools_scm may not be installed
         from setuptools_scm import get_version
 
-        __version__ = get_version(_root)
+        __version__ = get_version(_root, version_scheme="release-branch-semver")
     except ImportError:  # pragma: no cover
         # setuptools_scm not install, we keep the existing __version__
         pass

--- a/hyperspy/signal_tools.py
+++ b/hyperspy/signal_tools.py
@@ -768,8 +768,9 @@ class ImageContrastEditor(t.HasTraits):
         enter_set=True,
     )
     gamma = t.Range(0.1, 3.0, 1.0)
-    vmin_percentile = t.Range(0.0, 100.0, 0)
-    vmax_percentile = t.Range(0.0, 100.0, 100)
+    percentile_range = t.Range(0.0, 100.0)
+    vmin_percentile = t.Float(0.0)
+    vmax_percentile = t.Float(100.0)
 
     norm = t.Enum("Linear", "Power", "Log", "Symlog", default="Linear")
     linthresh = t.Range(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -228,6 +228,7 @@ where = ["."]
 
 [tool.setuptools_scm]
 fallback_version = "2.1.0.dev0"
+version_scheme = "release-branch-semver"
 
 [tool.towncrier]
 directory = "upcoming_changes/"

--- a/upcoming_changes/3368.bugfix.rst
+++ b/upcoming_changes/3368.bugfix.rst
@@ -1,0 +1,1 @@
+Fix development version on ``RELEASE_next_minor`` branch.

--- a/upcoming_changes/3368.maintenance.rst
+++ b/upcoming_changes/3368.maintenance.rst
@@ -1,0 +1,1 @@
+Add ``percentile_range`` traitsui attribute to ``ImageContrastEditor`` necessary for `hyperspy/hyperspy_gui_traitsui#76 <https://github.com/hyperspy/hyperspy_gui_traitsui/pull/76>`_.


### PR DESCRIPTION
### Description of the change
On `RELEASE_next_minor` uses `"release-branch-semver"` version scheme to increment the minor segment - see https://setuptools-scm.readthedocs.io/en/latest/extending/#available-implementations.
On `RELEASE_next_patch`, it can stay as it is, as the default increase the micro segment.

### Progress of the PR
- [x] On `RELEASE_next_minor` uses `"release-branch-semver"` version scheme to increment the minor segment,
- [x] fix image contrast tool traitsui,
- [n/a] update docstring (if appropriate),
- [n/a] update user guide (if appropriate),
- [x] add an changelog entry in the `upcoming_changes` folder (see [`upcoming_changes/README.rst`](https://github.com/hyperspy/hyperspy/blob/RELEASE_next_minor/upcoming_changes/README.rst)),
- [x] Check formatting changelog entry in the `readthedocs` doc build of this PR (link in github checks)
- [n/a] add tests,
- [x] ready for review.


