### PR TITLE
Fix0D ragged Map

### DIFF
--- a/hyperspy/_signals/lazy.py
+++ b/hyperspy/_signals/lazy.py
@@ -286,7 +286,10 @@ class LazySignal(BaseSignal):
         if not isinstance(sig_chunks, tuple):
             sig_chunks = (sig_chunks,) * len(self.axes_manager.signal_shape)
         if not isinstance(nav_chunks, tuple):
-            nav_chunks = (nav_chunks,) * len(self.axes_manager.navigation_shape)
+            if self.ragged and len(self.axes_manager.navigation_shape) == 0:
+                nav_chunks = (nav_chunks,) * 1
+            else:
+                nav_chunks = (nav_chunks,) * len(self.axes_manager.navigation_shape)
         new_chunks = nav_chunks + sig_chunks
         if inplace:
             self.data = self.data.rechunk(new_chunks, **kwargs)

--- a/hyperspy/tests/signals/test_ragged_signal.py
+++ b/hyperspy/tests/signals/test_ragged_signal.py
@@ -89,6 +89,19 @@ class TestRaggedArray:
         with pytest.raises(RuntimeError):
             s.isig[0]
 
+    def test_ragged_0D_map(self):
+        def return_value(val):
+            return val
+
+        zeroDragged = self.s.inav[0, 0]
+
+        new_signal = zeroDragged.map(return_value, inplace=False)
+        if self.s._lazy:
+            new_signal.compute()
+            assert self.s.data[0, 0].compute().shape == new_signal.data[0].shape
+        else:
+            self.s.data[0, 0].shape == new_signal.data[0].shape
+
 
 def test_create_ragged_array():
     data = np.array([[0, 1], [2, 3, 4]], dtype=object)


### PR DESCRIPTION
This is a small bugfix for #3375. 


### Description of the change
In pyxem many of the functions for working on vectors don't work well with 0D Vectors  (or at all) because the 0D Ragged behavior is non-deal.


### Progress of the PR
- [x] Fix 0D Behavior Non-Lazy
- [ ] Fix 0D Behavior Lazy
- [ ] add an changelog entry in the `upcoming_changes` folder (see [`upcoming_changes/README.rst`](https://github.com/hyperspy/hyperspy/blob/RELEASE_next_minor/upcoming_changes/README.rst)),
- [ ] Check formatting changelog entry in the `readthedocs` doc build of this PR (link in github checks)
- [x] add tests,
- [ ] ready for review.
