### PR TITLE
Fix `add_poissonian_noise` and `add_gaussian_noise` changing data object

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -25,7 +25,7 @@ jobs:
             PYTHON_VERSION: '3.8'
             PIP_SELECTOR: '[all, tests, coverage]'
             OLDEST_SUPPORTED_VERSION: true
-            DEPENDENCIES: dask[array]==2021.3.1 matplotlib==3.1.3 numba==0.52 numpy==1.20.0 scipy==1.6 scikit-image==0.18 scikit-learn==1.0.1
+            DEPENDENCIES: dask[array]==2021.5.1 matplotlib==3.1.3 numba==0.52 numpy==1.20.0 scipy==1.6 scikit-image==0.18 scikit-learn==1.0.1
             LABEL: -oldest
           # test minimum requirement
           - os: ubuntu

--- a/3379.bugfix.rst
+++ b/3379.bugfix.rst
@@ -1,1 +1,0 @@
-Avoid changing `data` object when using :meth:`~.api.signals.Signal1D.add_gaussian_noise` and :meth:`~.api.signals.Signal1D.add_poissonian_noise`.

--- a/3379.bugfix.rst
+++ b/3379.bugfix.rst
@@ -1,0 +1,1 @@
+Avoid changing `data` object when using :meth:`~.api.signals.Signal1D.add_gaussian_noise` and :meth:`~.api.signals.Signal1D.add_poissonian_noise`.

--- a/hyperspy/signal.py
+++ b/hyperspy/signal.py
@@ -6555,14 +6555,9 @@ class BaseSignal(
         Parameters
         ----------
         keep_dtype : bool, default True
-            This parameter is used only for lazy signals. Non-lazy signals
-            always keep their original data type.
-            If ``True``, keep the original data type of the signal data. For
-            example, if the data type was initially ``'float64'``, the result of
-            the operation (usually ``'int64'``) will be converted to
-            ``'float64'``.
-            If ``False``, the resulting data type is ``int64``. If this is different
-            from the original data type then a warning is added to the log.
+            This parameter is deprecated and will be removed in HyperSpy 3.0.
+            Currently, it does not have any effect. This method always
+            keeps the original dtype of the signal.
         random_state : None, int or numpy.random.Generator, default None
             Seed for the random generator.
 
@@ -6575,30 +6570,19 @@ class BaseSignal(
         """
         kwargs = {}
         random_state = check_random_state(random_state, lazy=self._lazy)
+        if not keep_dtype:
+            warnings.warn(
+                "The `keep_dtype` parameter is deprecated and will be removed in HyperSpy 3.0.",
+                DeprecationWarning,
+            )
 
         if self._lazy:
             kwargs["chunks"] = self.data.chunks
 
-        original_dtype = self.data.dtype
         if self._lazy:
             self.data[:] = random_state.poisson(lam=self.data, **kwargs)
         else:
             self.data[:] = random_state.poisson(lam=self.data, **kwargs)
-
-        if self.data.dtype != original_dtype:
-            if keep_dtype:
-                _logger.warning(
-                    f"Changing data type from {self.data.dtype} "
-                    f"to the original {original_dtype}"
-                )
-                # Don't change the object if possible
-                self.data = self.data.astype(original_dtype, copy=False)
-            else:
-                _logger.warning(
-                    f"The data type changed from {original_dtype} "
-                    f"to {self.data.dtype}"
-                )
-
         self.events.data_changed.trigger(obj=self)
 
     def add_gaussian_noise(self, std, random_state=None):

--- a/hyperspy/signal.py
+++ b/hyperspy/signal.py
@@ -6622,6 +6622,7 @@ class BaseSignal(
         noise = random_state.normal(loc=0, scale=std, size=self.data.shape, **kwargs)
 
         self.data += noise
+        self.events.data_changed.trigger(obj=self)
 
         self.events.data_changed.trigger(obj=self)
 

--- a/hyperspy/signal.py
+++ b/hyperspy/signal.py
@@ -6550,7 +6550,7 @@ class BaseSignal(
     def add_poissonian_noise(self, keep_dtype=True, random_state=None):
         """Add Poissonian noise to the data.
 
-        This method works in-place. 
+        This method works in-place.
 
         Parameters
         ----------

--- a/hyperspy/signal.py
+++ b/hyperspy/signal.py
@@ -6550,17 +6550,19 @@ class BaseSignal(
     def add_poissonian_noise(self, keep_dtype=True, random_state=None):
         """Add Poissonian noise to the data.
 
-        This method works in-place. The resulting data type is ``int64``.
-        If this is different from the original data type then a warning
-        is added to the log.
+        This method works in-place. 
 
         Parameters
         ----------
         keep_dtype : bool, default True
+            This parameter is used only for lazy signals. Non-lazy signals
+            always keep their original data type.
             If ``True``, keep the original data type of the signal data. For
             example, if the data type was initially ``'float64'``, the result of
             the operation (usually ``'int64'``) will be converted to
             ``'float64'``.
+            If ``False``, the resulting data type is ``int64``. If this is different
+            from the original data type then a warning is added to the log.
         random_state : None, int or numpy.random.Generator, default None
             Seed for the random generator.
 

--- a/hyperspy/signal.py
+++ b/hyperspy/signal.py
@@ -6623,12 +6623,7 @@ class BaseSignal(
 
         noise = random_state.normal(loc=0, scale=std, size=self.data.shape, **kwargs)
 
-        if self._lazy:
-            # With lazy data we can't keep the same array object
-            self.data = self.data + noise
-        else:
-            # Don't change the object
-            self.data += noise
+        self.data += noise
 
         self.events.data_changed.trigger(obj=self)
 

--- a/hyperspy/signal.py
+++ b/hyperspy/signal.py
@@ -6578,8 +6578,10 @@ class BaseSignal(
             kwargs["chunks"] = self.data.chunks
 
         original_dtype = self.data.dtype
-
-        self.data = random_state.poisson(lam=self.data, **kwargs)
+        if self._lazy:
+            self.data = random_state.poisson(lam=self.data, **kwargs)
+        else:
+            self.data[:] = random_state.poisson(lam=self.data, **kwargs)
 
         if self.data.dtype != original_dtype:
             if keep_dtype:

--- a/hyperspy/signal.py
+++ b/hyperspy/signal.py
@@ -6581,7 +6581,7 @@ class BaseSignal(
 
         original_dtype = self.data.dtype
         if self._lazy:
-            self.data = random_state.poisson(lam=self.data, **kwargs)
+            self.data[:] = random_state.poisson(lam=self.data, **kwargs)
         else:
             self.data[:] = random_state.poisson(lam=self.data, **kwargs)
 

--- a/hyperspy/signal.py
+++ b/hyperspy/signal.py
@@ -6579,10 +6579,8 @@ class BaseSignal(
         if self._lazy:
             kwargs["chunks"] = self.data.chunks
 
-        if self._lazy:
-            self.data[:] = random_state.poisson(lam=self.data, **kwargs)
-        else:
-            self.data[:] = random_state.poisson(lam=self.data, **kwargs)
+        self.data[:] = random_state.poisson(lam=self.data, **kwargs)
+        self.events.data_changed.trigger(obj=self)
         self.events.data_changed.trigger(obj=self)
 
     def add_gaussian_noise(self, std, random_state=None):

--- a/hyperspy/tests/signals/test_2D.py
+++ b/hyperspy/tests/signals/test_2D.py
@@ -447,8 +447,7 @@ class Test2D:
 
         if s._lazy:
             s.compute()
-        else:
-            assert s.data is original_data
+        assert s.data is original_data
 
         np.testing.assert_array_almost_equal(s.data, rng2.poisson(lam=data, **kwargs))
         s.change_dtype("float64")

--- a/hyperspy/tests/signals/test_2D.py
+++ b/hyperspy/tests/signals/test_2D.py
@@ -439,6 +439,7 @@ class Test2D:
             rng2 = default_rng(123)
         else:
             data = s.data.copy()
+            original_data = s.data
             rng1 = np.random.default_rng(123)
             rng2 = np.random.default_rng(123)
 
@@ -446,19 +447,24 @@ class Test2D:
 
         if s._lazy:
             s.compute()
+        else:
+            assert s.data is original_data
 
         np.testing.assert_array_almost_equal(s.data, rng2.poisson(lam=data, **kwargs))
         s.change_dtype("float64")
-
+        original_data = s.data
         s.add_poissonian_noise(keep_dtype=True, random_state=rng1)
         if s._lazy:
             s.compute()
+        else:
+            assert s.data is original_data
 
         assert s.data.dtype == np.dtype("float64")
 
     def test_add_poisson_noise_warning(self, caplog):
         s = self.signal
         s.change_dtype("float64")
+        s = s.as_lazy()
 
         with caplog.at_level(logging.WARNING):
             s.add_poissonian_noise(keep_dtype=True)

--- a/hyperspy/tests/signals/test_2D.py
+++ b/hyperspy/tests/signals/test_2D.py
@@ -16,7 +16,6 @@
 # You should have received a copy of the GNU General Public License
 # along with HyperSpy. If not, see <https://www.gnu.org/licenses/#GPL>.
 
-import logging
 from unittest import mock
 
 import dask
@@ -439,15 +438,15 @@ class Test2D:
             rng2 = default_rng(123)
         else:
             data = s.data.copy()
-            original_data = s.data
             rng1 = np.random.default_rng(123)
             rng2 = np.random.default_rng(123)
 
+        original_data = s.data
         s.add_poissonian_noise(random_state=rng1)
+        assert s.data is original_data
 
         if s._lazy:
             s.compute()
-        assert s.data is original_data
 
         np.testing.assert_array_almost_equal(s.data, rng2.poisson(lam=data, **kwargs))
         s.change_dtype("float64")

--- a/hyperspy/tests/signals/test_2D.py
+++ b/hyperspy/tests/signals/test_2D.py
@@ -463,7 +463,6 @@ class Test2D:
 
     def test_add_poisson_noise_warning(self, caplog):
         s = self.signal
-        s.change_dtype("float64")
 
         with pytest.warns(DeprecationWarning):
             s.add_poissonian_noise(keep_dtype=False)

--- a/hyperspy/tests/signals/test_2D.py
+++ b/hyperspy/tests/signals/test_2D.py
@@ -443,7 +443,7 @@ class Test2D:
             rng1 = np.random.default_rng(123)
             rng2 = np.random.default_rng(123)
 
-        s.add_poissonian_noise(keep_dtype=False, random_state=rng1)
+        s.add_poissonian_noise(random_state=rng1)
 
         if s._lazy:
             s.compute()
@@ -453,7 +453,7 @@ class Test2D:
         np.testing.assert_array_almost_equal(s.data, rng2.poisson(lam=data, **kwargs))
         s.change_dtype("float64")
         original_data = s.data
-        s.add_poissonian_noise(keep_dtype=True, random_state=rng1)
+        s.add_poissonian_noise(random_state=rng1)
         if s._lazy:
             s.compute()
         else:

--- a/hyperspy/tests/signals/test_2D.py
+++ b/hyperspy/tests/signals/test_2D.py
@@ -464,14 +464,6 @@ class Test2D:
     def test_add_poisson_noise_warning(self, caplog):
         s = self.signal
         s.change_dtype("float64")
-        s = s.as_lazy()
 
-        with caplog.at_level(logging.WARNING):
-            s.add_poissonian_noise(keep_dtype=True)
-
-        assert "Changing data type from" in caplog.text
-
-        with caplog.at_level(logging.WARNING):
+        with pytest.warns(DeprecationWarning):
             s.add_poissonian_noise(keep_dtype=False)
-
-        assert "The data type changed from" in caplog.text

--- a/hyperspy/tests/signals/test_2D.py
+++ b/hyperspy/tests/signals/test_2D.py
@@ -455,8 +455,7 @@ class Test2D:
         s.add_poissonian_noise(random_state=rng1)
         if s._lazy:
             s.compute()
-        else:
-            assert s.data is original_data
+        assert s.data is original_data
 
         assert s.data.dtype == np.dtype("float64")
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ classifiers = [
 ]
 dependencies = [
     "cloudpickle",
-    "dask[array]>=2021.3.1",
+    "dask[array]>=2021.5.1",
     "importlib-metadata>=3.6",
     "jinja2",
     "matplotlib>=3.1.3",

--- a/upcoming_changes/3379.bugfix.rst
+++ b/upcoming_changes/3379.bugfix.rst
@@ -1,0 +1,1 @@
+Avoid changing ``data`` object when using :meth:`~.api.signals.BaseSignal.add_gaussian_noise` and :meth:`~.api.signals.BaseSignal.add_poissonian_noise`.


### PR DESCRIPTION
### Description of the change

`Signal.add_poissonian_noise` was replacing the `data` object for all sort signals. 
`Signal.add_gaussian_noise` only for lazy signals. This fixes both issues.

### Progress of the PR
- [x] Change implemented (can be split into several points),
- [x] update docstring (if appropriate),
- [x] update user guide (if appropriate),
- [x] add an changelog entry in the `upcoming_changes` folder (see [`upcoming_changes/README.rst`](https://github.com/hyperspy/hyperspy/blob/RELEASE_next_minor/upcoming_changes/README.rst)),
- [x] Check formatting changelog entry in the `readthedocs` doc build of this PR (link in github checks)
- [x] add tests,
- [x] ready for review.

### Minimal example of the bug fix or the new feature

```python
import hyperspy.api as hs
import numpy as np
s = hs.signals.Signal1D(np.arange(10))
data = s.data
s.add_poissonian_noise()
assert s.data is data
```


