### PR TITLE
Fix `mask` being replaced by the `blind_source_separation` method

### DIFF
--- a/hyperspy/learn/mva.py
+++ b/hyperspy/learn/mva.py
@@ -793,7 +793,7 @@ class MVA:
                     )
             else:
                 raise ValueError("`mask` must be a HyperSpy signal.")
-            mask = mask.deepcopy() # Avoid changing the original mask
+            mask = mask.deepcopy()  # Avoid changing the original mask
             if hasattr(mask, "compute"):
                 # if the mask is lazy, we compute them, which should be fine
                 # since we already reduce the dimensionality of the data.

--- a/hyperspy/learn/mva.py
+++ b/hyperspy/learn/mva.py
@@ -897,6 +897,7 @@ class MVA:
                     if diff_axes is not None
                     else None
                 )
+                mask = mask.deepcopy() # Avoid changing the original mask
                 mask.change_dtype("float")
                 mask.data[mask.data == 1] = np.nan
                 mask = _get_derivative(

--- a/hyperspy/learn/mva.py
+++ b/hyperspy/learn/mva.py
@@ -793,7 +793,7 @@ class MVA:
                     )
             else:
                 raise ValueError("`mask` must be a HyperSpy signal.")
-
+            mask = mask.deepcopy() # Avoid changing the original mask
             if hasattr(mask, "compute"):
                 # if the mask is lazy, we compute them, which should be fine
                 # since we already reduce the dimensionality of the data.
@@ -897,7 +897,6 @@ class MVA:
                     if diff_axes is not None
                     else None
                 )
-                mask = mask.deepcopy() # Avoid changing the original mask
                 mask.change_dtype("float")
                 mask.data[mask.data == 1] = np.nan
                 mask = _get_derivative(

--- a/hyperspy/tests/learn/test_bss.py
+++ b/hyperspy/tests/learn/test_bss.py
@@ -330,10 +330,14 @@ class TestBSS1D:
         # we get "ConvergenceWarning: FastICA did not converge."
         # We test for convergence warnings separately
         n_components = 2 if diff_order == 1 and on_loadings else 3
-
+        mask_data = mask.data
         self.s.blind_source_separation(
             n_components, diff_order=diff_order, mask=mask, on_loadings=on_loadings
         )
+
+        # Verify that the mask is not changed
+        # See https://github.com/hyperspy/hyperspy/issues/3384
+        assert mask_data is mask.data
 
 
 @skip_sklearn

--- a/hyperspy/tests/learn/test_decomposition.py
+++ b/hyperspy/tests/learn/test_decomposition.py
@@ -134,7 +134,10 @@ class TestNdAxes:
         s1s = s1.isig[:, 1:]
         s1n = s1.inav[:, :, 1:]
         s1sn = s1n.isig[:, 1:]
+        sig_mask_data = sig_mask.data
+        nav_mask_data = nav_mask.data
         s1.decomposition(poisson, signal_mask=sig_mask)
+        assert sig_mask_data is sig_mask.data
         s1s.decomposition(poisson)
         np.testing.assert_array_almost_equal(
             s1s.learning_results.explained_variance,
@@ -142,6 +145,7 @@ class TestNdAxes:
         )
 
         s1.decomposition(poisson, navigation_mask=nav_mask)
+        assert nav_mask_data is nav_mask.data
         s1n.decomposition(poisson)
         np.testing.assert_array_almost_equal(
             s1n.learning_results.explained_variance,

--- a/upcoming_changes/3384.bugfix.rst
+++ b/upcoming_changes/3384.bugfix.rst
@@ -1,3 +1,3 @@
-Avoid replacing the original mask in `blind_source_separation`
+Avoid replacing the original mask in :meth:`~.api.signals.BaseSignal.blind_source_separation`
 
 

--- a/upcoming_changes/3384.bugfix.rst
+++ b/upcoming_changes/3384.bugfix.rst
@@ -1,0 +1,3 @@
+Avoid replacing the original mask in `blind_source_separation`
+
+


### PR DESCRIPTION
### Description of the change

Avoid replacing the original mask by deepcopying it.

### Progress of the PR
- [x] Change implemented (can be split into several points),
- [x] update docstring (if appropriate),
- [x] add an changelog entry in the `upcoming_changes` folder (see [`upcoming_changes/README.rst`](https://github.com/hyperspy/hyperspy/blob/RELEASE_next_minor/upcoming_changes/README.rst)),
- [x] Check formatting changelog entry in the `readthedocs` doc build of this PR (link in github checks)
- [x] add tests,
- [x] ready for review.


