### PR TITLE
Add support for `"sig"` and `"nav"` to index `axes_manager`

### DIFF
--- a/hyperspy/axes.py
+++ b/hyperspy/axes.py
@@ -1592,8 +1592,14 @@ class AxesManager(t.HasTraits):
     def __getitem__(self, y):
         """x.__getitem__(y) <==> x[y]"""
         if isinstance(y, str) or not np.iterable(y):
-            return self[(y,)][0]
-        axes = [self._axes_getter(ax) for ax in y]
+            if y == "nav":
+                axes = self.navigation_axes
+            elif y == "sig":
+                axes = self.signal_axes
+            else:
+                return self[(y,)][0]
+        else:
+            axes = [self._axes_getter(ax) for ax in y]
         _, indices = np.unique([_id for _id in map(id, axes)], return_index=True)
         ans = tuple(axes[i] for i in sorted(indices))
         return ans

--- a/hyperspy/docstrings/signal.py
+++ b/hyperspy/docstrings/signal.py
@@ -20,14 +20,16 @@
 
 ONE_AXIS_PARAMETER = """: :class:`int`, :class:`str`, or :class:`~hyperspy.axes.DataAxis`
             The axis can be passed directly, or specified using the index of
-            the axis in the Signal's `axes_manager` or the axis name."""
+            the axis in the Signal's `axes_manager` or the axis name. If ``"sig"`` or
+            ``"nav"``, the signal or navigation axis will be used, respectively."""
 
 MANY_AXIS_PARAMETER = """: :class:`int`, :class:`str`, :class:`~hyperspy.axes.DataAxis` or tuple
             Either one on its own, or many axes in a tuple can be passed. In
             both cases the axes can be passed directly, or specified using the
             index in `axes_manager` or the name of the axis. Any duplicates are
-            removed. If ``None``, the operation is performed over all navigation
-            axes (default)."""
+            removed. If ``"sig"`` or ``"nav"``, the signal or navigation axes
+            will be used, respectively. If ``None``, the operation is performed
+            over all navigation axes (default)."""
 
 OUT_ARG = """out : :class:`~hyperspy.api.signals.BaseSignal` (or subclass) or None
             If ``None``, a new Signal is created with the result of the

--- a/hyperspy/docstrings/signal.py
+++ b/hyperspy/docstrings/signal.py
@@ -20,13 +20,13 @@
 
 ONE_AXIS_PARAMETER = """: :class:`int`, :class:`str`, or :class:`~hyperspy.axes.DataAxis`
             The axis can be passed directly, or specified using the index of
-            the axis in the Signal's `axes_manager` or the axis name. If ``"sig"`` or
+            the axis in the Signal's ``axes_manager`` or the *axis name*. If ``"sig"`` or
             ``"nav"``, the signal or navigation axis will be used, respectively."""
 
 MANY_AXIS_PARAMETER = """: :class:`int`, :class:`str`, :class:`~hyperspy.axes.DataAxis` or tuple
-            Either one on its own, or many axes in a tuple can be passed. In
-            both cases the axes can be passed directly, or specified using the
-            index in `axes_manager` or the name of the axis. Any duplicates are
+            Either a single or multiple axes in a tuple can be passed. In
+            both cases, the axes can be passed directly, or specified using the
+            index in ``axes_manager`` or the *name of the axis*. Any duplicates are
             removed. If ``"sig"`` or ``"nav"``, the signal or navigation axes
             will be used, respectively. If ``None``, the operation is performed
             over all navigation axes (default)."""

--- a/hyperspy/roi.py
+++ b/hyperspy/roi.py
@@ -276,15 +276,16 @@ class BaseROI(t.HasTraits):
                 )
             else:
                 raise ValueError("Could not find valid axes configuration.")
-        elif isinstance(axes, (tuple, list)):
-            if len(axes) > nd:
+        else:
+            if isinstance(axes, (tuple, list)) and len(axes) > nd:
                 raise ValueError(
                     "The length of the provided `axes` is larger "
                     "than the dimensionality of the ROI."
                 )
             axes_out = axes_manager[axes]
-        else:
-            axes_out = (axes_manager[axes],)
+
+        if not isinstance(axes_out, tuple):
+            axes_out = (axes_out,)
 
         return axes_out
 

--- a/hyperspy/signal.py
+++ b/hyperspy/signal.py
@@ -4616,11 +4616,14 @@ class BaseSignal(
             del kwargs["rechunk"]
         n = order
         der_data = self.data
+        axis = self.axes_manager[axis]
+        if isinstance(axis, tuple):
+            axis = axis[0]
         while n:
             der_data = np.gradient(
                 der_data,
-                self.axes_manager[axis].axis,
-                axis=self.axes_manager[axis].index_in_array,
+                axis.axis,
+                axis=axis.index_in_array,
                 **kwargs,
             )
             n -= 1
@@ -4894,7 +4897,10 @@ class BaseSignal(
         <Signal2D, title: , dimensions: (|64, 64)>
 
         """
-        if self.axes_manager[axis].is_binned:
+        axis = self.axes_manager[axis]
+        if isinstance(axis, tuple):
+            axis = axis[0]
+        if axis.is_binned:
             return self.sum(axis=axis, out=out, rechunk=rechunk)
         else:
             return self.integrate_simpson(axis=axis, out=out, rechunk=rechunk)

--- a/hyperspy/signal.py
+++ b/hyperspy/signal.py
@@ -4613,6 +4613,12 @@ class BaseSignal(
         """
         # rechunk was a valid keyword up to HyperSpy 1.6
         if "rechunk" in kwargs:
+            # We miss the deprecation cycle for 2.0
+            warnings.warn(
+                "The `rechunk` parameter is not used since HyperSpy 1.7 and"
+                "will be removed in HyperSpy 3.0.",
+                DeprecationWarning,
+            )
             del kwargs["rechunk"]
         n = order
         der_data = self.data

--- a/hyperspy/signal.py
+++ b/hyperspy/signal.py
@@ -73,6 +73,7 @@ from hyperspy.exceptions import (
     DataDimensionError,
     LazyCupyConversion,
     SignalDimensionError,
+    VisibleDeprecationWarning,
 )
 from hyperspy.interactive import interactive
 from hyperspy.io import assign_signal_subclass
@@ -4617,7 +4618,7 @@ class BaseSignal(
             warnings.warn(
                 "The `rechunk` parameter is not used since HyperSpy 1.7 and"
                 "will be removed in HyperSpy 3.0.",
-                DeprecationWarning,
+                VisibleDeprecationWarning,
             )
             del kwargs["rechunk"]
         n = order
@@ -6585,7 +6586,7 @@ class BaseSignal(
         if not keep_dtype:
             warnings.warn(
                 "The `keep_dtype` parameter is deprecated and will be removed in HyperSpy 3.0.",
-                DeprecationWarning,
+                VisibleDeprecationWarning,
             )
 
         if self._lazy:

--- a/hyperspy/tests/axes/test_axes_manager.py
+++ b/hyperspy/tests/axes/test_axes_manager.py
@@ -130,6 +130,8 @@ class TestAxesManager:
         with pytest.raises(ValueError):
             axis = BaseDataAxis()
             am[axis]
+        assert am["nav"] == am.navigation_axes
+        assert am["sig"] == am.signal_axes
 
 
 class TestAxesManagerScaleOffset:

--- a/hyperspy/tests/signals/test_1D.py
+++ b/hyperspy/tests/signals/test_1D.py
@@ -42,6 +42,7 @@ class Test1D:
     def one_d_navigate(self):
         return Signal1D(np.repeat(np.arange(0, 100, 1)[np.newaxis, :], 3, axis=0))
 
-    def test_integrate1D(self):
-        integrated_signal = self.signal.integrate1D(axis=0)
+    @pytest.mark.parametrize("axis", (0, "sig"))
+    def test_integrate1D(self, axis):
+        integrated_signal = self.signal.integrate1D(axis=axis)
         np.testing.assert_allclose(integrated_signal.data, 20, rtol=1e-6)

--- a/hyperspy/tests/signals/test_2D.py
+++ b/hyperspy/tests/signals/test_2D.py
@@ -24,6 +24,7 @@ import pytest
 from packaging.version import Version
 
 from hyperspy.decorators import lazifyTestClass
+from hyperspy.exceptions import VisibleDeprecationWarning
 from hyperspy.signal import BaseSignal
 from hyperspy.signals import Signal1D, Signal2D
 
@@ -461,5 +462,5 @@ class Test2D:
     def test_add_poisson_noise_warning(self, caplog):
         s = self.signal
 
-        with pytest.warns(DeprecationWarning):
+        with pytest.warns(VisibleDeprecationWarning):
             s.add_poissonian_noise(keep_dtype=False)

--- a/hyperspy/tests/signals/test_tools.py
+++ b/hyperspy/tests/signals/test_tools.py
@@ -82,12 +82,13 @@ class TestDerivative:
         )
 
 
-def test_derivative():
+@pytest.mark.parametrize("axis", (0, "sig"))
+def test_derivative(axis):
     data = np.arange(10)
     scale = 0.1
     s = signals.Signal1D(data)
     s.axes_manager[0].scale = scale
-    der = s.derivative(axis=0)
+    der = s.derivative(axis=axis)
     np.testing.assert_allclose(der.data, (data[2] - data[1]) / scale)
 
 
@@ -375,3 +376,13 @@ def test_lazy_to_device():
     s = signals.BaseSignal(np.arange(10)).as_lazy()
     with pytest.raises(BaseException):
         s.to_device()
+
+
+@pytest.mark.parametrize("axis", ("nav", "sig"))
+def test_reduction_axes(axis):
+    s = signals.Signal2D(np.ones((2, 3, 4, 5)))
+    s2 = s.sum(axis)
+    if axis == "nav":
+        assert s2.data.shape == (4, 5)
+    if axis == "sig":
+        assert s2.data.shape == (2, 3)

--- a/hyperspy/tests/signals/test_tools.py
+++ b/hyperspy/tests/signals/test_tools.py
@@ -25,6 +25,7 @@ import pytest
 from hyperspy import signals
 from hyperspy.decorators import lazifyTestClass
 from hyperspy.drawing._markers.points import Points
+from hyperspy.exceptions import VisibleDeprecationWarning
 
 
 def _verify_test_sum_x_E(self, s):
@@ -98,6 +99,17 @@ def test_derivative_non_uniform_axis():
     s = signals.Signal1D(data, axes=[axis_dict])
     der = s.derivative(axis=0)
     np.testing.assert_allclose(der.data[:4], np.array([-2, -5, -10, -17]))
+
+
+def test_derivative_deprecation_warning():
+    # Remove in hyperspy 3
+    data = np.arange(10)
+    scale = 0.1
+    s = signals.Signal1D(data)
+    s.axes_manager[0].scale = scale
+    with pytest.warns(VisibleDeprecationWarning):
+        der = s.derivative(axis=0, rechunk=True)
+    np.testing.assert_allclose(der.data, (data[2] - data[1]) / scale)
 
 
 @lazifyTestClass

--- a/hyperspy/tests/utils/test_roi.py
+++ b/hyperspy/tests/utils/test_roi.py
@@ -756,6 +756,20 @@ class TestROIs:
             r._set_default_values(s, axes=s.axes_manager.signal_axes)
             r(s)
 
+    @pytest.mark.parametrize("axes", ("sig", (2, 3)))
+    def test_call_signal_axes(self, axes):
+        s = self.s_i
+        r = RectangularROI(1, 1, 3, 3)
+        s_roi = r(s, axes=axes)
+        assert s_roi.data.shape == (100, 100, 2, 2)
+
+    @pytest.mark.parametrize("axes", ("nav", (0, 1)))
+    def test_call_navigation_axes(self, axes):
+        s = self.s_i
+        r = RectangularROI(25, 25, 75, 75)
+        s_roi = r(s, axes=axes)
+        assert s_roi.data.shape == (50, 50, 4, 4)
+
     def test_get_central_half_limits(self):
         ax = self.s_s.axes_manager[0]
         assert _get_central_half_limits_of_axis(ax) == (73.75, 221.25)

--- a/upcoming_changes/3385.api.rst
+++ b/upcoming_changes/3385.api.rst
@@ -1,0 +1,1 @@
+Explicitely deprecate ``rechunk`` keyword argument in :meth:`~.api.signals.BaseSignal.derivative`, which isn't doing anything since HyperSpy 1.7.

--- a/upcoming_changes/3385.enhancements.rst
+++ b/upcoming_changes/3385.enhancements.rst
@@ -1,0 +1,1 @@
+Improvement of indexing of the :class:`~.axes.AxesManager`: ``"nav"`` and ``"sig"`` can be used to index the navigation and signal axes, respectively. This can also be used for the ``axes`` or ``axis`` keywords arguments, for example ``s.sum(axis="sig")`` will compute the sum over the signal axes.


### PR DESCRIPTION
This is a simple change but very convenient!

### Progress of the PR
- [x] Add support for `"sig"` and `"nav"` to index `axes_manager`,
- [x] update docstring (if appropriate),
- [ ] update user guide (I may have another to see where best to update),
- [x] add an changelog entry in the `upcoming_changes` folder (see [`upcoming_changes/README.rst`](https://github.com/hyperspy/hyperspy/blob/RELEASE_next_minor/upcoming_changes/README.rst)),
- [x] Check formatting changelog entry in the `readthedocs` doc build of this PR (link in github checks)
- [x] add tests,
- [x] ready for review.

### Minimal example of the bug fix or the new feature
```python
import hyperspy.api as hs
import numpy as np
s = hs.signals.Signal1D(np.ones((10, 10, 10)))

assert s.axes_manager["nav"] == s.axes_manager.navigation_axes
assert s.axes_manager["sig"] == s.axes_manager.signal_axes

# Sum over navigation axis
s_sum_nav = s.sum(axis="nav")

# Sum over signal axis
s_sum_sig = s.sum(axis="sig")
```


