### PR TITLE
Support numpy 2.0

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -48,7 +48,7 @@ jobs:
             PYTHON_VERSION: '3.11'
             PIP_SELECTOR: '[all, tests, coverage]'
           - os: macos
-            os_version: '14'
+            os_version: '13'
             PYTHON_VERSION: '3.11'
             PIP_SELECTOR: '[all, tests, coverage]'
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -33,7 +33,12 @@ jobs:
             PYTHON_VERSION: '3.12'
             PIP_SELECTOR: '[tests, coverage]'
             LABEL: -minimum
-            # Run coverage
+          - os: ubuntu
+            os_version: latest
+            PYTHON_VERSION: '3.12'
+            PIP_SELECTOR: '[tests, coverage]'
+            NUMPY20: true
+            LABEL: -npy20
           - os: ubuntu
             os_version: latest
             PYTHON_VERSION: '3.8'
@@ -87,6 +92,11 @@ jobs:
         if: ${{ matrix.OLDEST_SUPPORTED_VERSION }}
         run: |
           pip install ${{ matrix.DEPENDENCIES }} -v
+
+      - name: Install numpy 2.0
+        if: ${{ matrix.NUMPY20 }}
+        run: |
+          pip install --pre numpy
 
       - name: Install
         shell: bash

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -116,7 +116,7 @@ jobs:
           pytest ${{ env.PYTEST_ARGS }} --doctest-modules --ignore=hyperspy/tests
 
       - name: Upload coverage to Codecov
-        if: ${{ always() }}
+        if: ${{ github.repository_owner == 'hyperspy' }}
         uses: codecov/codecov-action@v4
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}

--- a/hyperspy/_signals/lazy.py
+++ b/hyperspy/_signals/lazy.py
@@ -611,8 +611,8 @@ class LazySignal(BaseSignal):
 
     rebin.__doc__ = BaseSignal.rebin.__doc__
 
-    def __array__(self, dtype=None):
-        return self.data.__array__(dtype=dtype)
+    def __array__(self, dtype=None, copy=None):
+        return self.data.__array__(dtype=dtype, copy=copy)
 
     def _make_sure_data_is_contiguous(self):
         self._make_lazy(rechunk=True)

--- a/hyperspy/_signals/signal2d.py
+++ b/hyperspy/_signals/signal2d.py
@@ -26,12 +26,7 @@ import matplotlib.pyplot as plt
 import numpy as np
 import numpy.ma as ma
 from scipy import ndimage
-
-try:
-    # For scikit-image >= 0.17.0
-    from skimage.registration._phase_cross_correlation import _upsampled_dft
-except ModuleNotFoundError:
-    from skimage.feature.register_translation import _upsampled_dft
+from skimage.registration._phase_cross_correlation import _upsampled_dft
 
 from hyperspy._signals.common_signal2d import CommonSignal2D
 from hyperspy._signals.lazy import LazySignal
@@ -140,8 +135,8 @@ def fft_correlation(in1, in2, normalize=False, real_only=False):
     else:
         fft_f, ifft_f = np.fft.fftn, np.fft.ifftn
 
-    fprod = fft_f(in1, fsize)
-    fprod *= fft_f(in2, fsize).conjugate()
+    fprod = fft_f(in1, fsize, axes=[-2, -1])
+    fprod *= fft_f(in2, fsize, axes=[-2, -1]).conjugate()
 
     if normalize is True:
         fprod = np.nan_to_num(fprod / abs(fprod))

--- a/hyperspy/data/artificial_data.py
+++ b/hyperspy/data/artificial_data.py
@@ -106,7 +106,7 @@ def luminescence_signal(
 
     >>> s1 = hs.data.luminescence_signal(random_state=10)
     >>> s2 = hs.data.luminescence_signal(random_state=10)
-    >>> (s1.data == s2.data).all()
+    >>> print((s1.data == s2.data).all())
     True
 
     2D map

--- a/hyperspy/decorators.py
+++ b/hyperspy/decorators.py
@@ -22,7 +22,7 @@ import warnings
 from functools import wraps
 from typing import Callable, Optional, Union
 
-import numpy as np
+from hyperspy.exceptions import VisibleDeprecationWarning
 
 _logger = logging.getLogger(__name__)
 
@@ -175,13 +175,13 @@ class deprecated:
         def wrapped(*args, **kwargs):
             warnings.simplefilter(
                 action="always",
-                category=np.exceptions.VisibleDeprecationWarning,
+                category=VisibleDeprecationWarning,
                 append=True,
             )
             func_code = func.__code__
             warnings.warn_explicit(
                 message=msg,
-                category=np.exceptions.VisibleDeprecationWarning,
+                category=VisibleDeprecationWarning,
                 filename=func_code.co_filename,
                 lineno=func_code.co_firstlineno + 1,
             )
@@ -231,12 +231,12 @@ class deprecated_argument:
                     )  # replace with alternative kwarg
                 msg += f"See the documentation of `{func.__name__}()` for more details."
                 warnings.simplefilter(
-                    action="always", category=np.exceptions.VisibleDeprecationWarning
+                    action="always", category=VisibleDeprecationWarning
                 )
                 func_code = func.__code__
                 warnings.warn_explicit(
                     message=msg,
-                    category=np.exceptions.VisibleDeprecationWarning,
+                    category=VisibleDeprecationWarning,
                     filename=func_code.co_filename,
                     lineno=func_code.co_firstlineno + 1,
                 )

--- a/hyperspy/decorators.py
+++ b/hyperspy/decorators.py
@@ -174,12 +174,14 @@ class deprecated:
         @wraps(func)
         def wrapped(*args, **kwargs):
             warnings.simplefilter(
-                action="always", category=np.VisibleDeprecationWarning, append=True
+                action="always",
+                category=np.exceptions.VisibleDeprecationWarning,
+                append=True,
             )
             func_code = func.__code__
             warnings.warn_explicit(
                 message=msg,
-                category=np.VisibleDeprecationWarning,
+                category=np.exceptions.VisibleDeprecationWarning,
                 filename=func_code.co_filename,
                 lineno=func_code.co_firstlineno + 1,
             )
@@ -229,12 +231,12 @@ class deprecated_argument:
                     )  # replace with alternative kwarg
                 msg += f"See the documentation of `{func.__name__}()` for more details."
                 warnings.simplefilter(
-                    action="always", category=np.VisibleDeprecationWarning
+                    action="always", category=np.exceptions.VisibleDeprecationWarning
                 )
                 func_code = func.__code__
                 warnings.warn_explicit(
                     message=msg,
-                    category=np.VisibleDeprecationWarning,
+                    category=np.exceptions.VisibleDeprecationWarning,
                     filename=func_code.co_filename,
                     lineno=func_code.co_firstlineno + 1,
                 )

--- a/hyperspy/drawing/_widgets/line2d.py
+++ b/hyperspy/drawing/_widgets/line2d.py
@@ -38,11 +38,11 @@ def angle_between(v1, v2):
 
     Examples
     --------
-    >>> angle_between((1, 0), (0, 1))
+    >>> print(angle_between((1, 0), (0, 1)))
     1.5707963267948966
-    >>> angle_between((1, 0), (1, 0))
+    >>> print(angle_between((1, 0), (1, 0)))
     0.0
-    >>> angle_between((1, 0), (-1, 0))
+    >>> print(angle_between((1, 0), (-1, 0)))
     3.141592653589793
     """
     v1_u = unit_vector(v1)

--- a/hyperspy/drawing/utils.py
+++ b/hyperspy/drawing/utils.py
@@ -1873,7 +1873,7 @@ def _roi_sum(signal, roi, axes, out=None):
         # use np.sum if the data doesn't contain nan
         # ~2x (or more for larger array) faster than nansum
         f = np.nansum if np.isnan(sliced_signal.data).any() else np.sum
-        out.data[:] = f(sliced_signal, axis=axes)
+        out.data[:] = f(sliced_signal.data, axis=axes)
         out.events.data_changed.trigger(obj=out)
     else:
         # we don't case if this is not optimised for speed since this is

--- a/hyperspy/roi.py
+++ b/hyperspy/roi.py
@@ -1313,7 +1313,7 @@ class Line2DROI(BaseInteractiveROI):
         Examples
         --------
         >>> r = hs.roi.Line2DROI(0., 0., 1., 2.)
-        >>> r.angle()
+        >>> print(r.angle())
         63.43494882292201
         """
 

--- a/hyperspy/signal.py
+++ b/hyperspy/signal.py
@@ -2845,11 +2845,22 @@ class BaseSignal(
 
     # TODO: try to find a way to use dask ufuncs when called with lazy data (e.g.
     # np.log(s) -> da.log(s.data) wrapped.
-    def __array__(self, dtype=None):
+    def __array__(self, dtype=None, copy=None):
+        # The copy parameter was added in numpy 2.0
+        if dtype is not None and dtype != self.data.dtype:
+            if copy is not None and not copy:
+                raise ValueError(
+                    f"Converting array from {self.data.dtype} to "
+                    f"{dtype} requires a copy."
+                )
         if dtype:
-            return self.data.astype(dtype)
+            array = self.data.astype(dtype)
         else:
-            return self.data
+            array = self.data
+        if copy:
+            array = np.copy(array)
+
+        return array
 
     def __array_wrap__(self, array, context=None):
         signal = self._deepcopy_with_new_data(array)

--- a/hyperspy/signal.py
+++ b/hyperspy/signal.py
@@ -2862,7 +2862,7 @@ class BaseSignal(
 
         return array
 
-    def __array_wrap__(self, array, context=None):
+    def __array_wrap__(self, array, context=None, return_scalar=False):
         signal = self._deepcopy_with_new_data(array)
         if context is not None:
             # ufunc, argument of the ufunc, domain of the ufunc

--- a/hyperspy/signal_tools.py
+++ b/hyperspy/signal_tools.py
@@ -945,7 +945,7 @@ class ImageContrastEditor(t.HasTraits):
         data = np.ma.masked_outside(data, self._vmin, self._vmax).compressed()
 
         # Sturges rule
-        sturges_bin_width = data.ptp() / (np.log2(data.size) + 1.0)
+        sturges_bin_width = np.ptp(data) / (np.log2(data.size) + 1.0)
 
         iqr = np.subtract(*np.percentile(data, [75, 25]))
         fd_bin_width = 2.0 * iqr * data.size ** (-1.0 / 3.0)
@@ -956,7 +956,7 @@ class ImageContrastEditor(t.HasTraits):
             # limited variance: fd_bin_width may be zero
             bin_width = sturges_bin_width
 
-        self.bins = min(int(np.ceil(data.ptp() / bin_width)), max_num_bins)
+        self.bins = min(int(np.ceil(np.ptp(data) / bin_width)), max_num_bins)
         self.update_histogram()
         self._setup_line()
 

--- a/hyperspy/tests/drawing/test_plot_signal1d.py
+++ b/hyperspy/tests/drawing/test_plot_signal1d.py
@@ -174,7 +174,7 @@ class TestPlotSpectra:
         baseline_dir=baseline_dir, tolerance=default_tol, style=style_pytest_mpl
     )
     def test_plot_spectra_sync(self, figure):
-        s1 = hs.signals.Signal1D(face()).as_signal1D(0).inav[:, :3]
+        s1 = hs.signals.Signal1D(face().astype(float)).as_signal1D(0).inav[:, :3]
         s2 = s1.deepcopy() * -1
         hs.plot.plot_signals([s1, s2])
         if figure == "1nav":

--- a/hyperspy/tests/signals/test_signal_operators.py
+++ b/hyperspy/tests/signals/test_signal_operators.py
@@ -153,3 +153,31 @@ class TestUnaryOperators:
 
     def test_abs(self):
         assert_array_equal(abs(self.s1).data, abs(self.s1.data))
+
+
+def test_numpy_function_on_signals():
+    s = signals.BaseSignal(np.array((1, -1, 4, -3))).T
+    np.testing.assert_allclose(np.sum(s), np.sum(s.data))
+
+
+def test_signal__array__():
+    s = signals.BaseSignal(np.array((1, -1, 4, -3)))
+    arr = s.__array__()
+    assert arr.dtype == int
+
+    arr2 = s.__array__(dtype=float)
+    assert arr2.dtype == float
+    assert arr2 is not s.data
+
+    arr3 = s.__array__(copy=False)
+    assert arr3 is s.data
+
+    arr4 = s.__array__(copy=True)
+    assert arr4 is not s.data
+
+    with pytest.raises(ValueError):
+        _ = s.__array__(dtype=float, copy=False)
+
+    arr5 = s.__array__(dtype=float, copy=True)
+    assert arr5 is not s.data
+    assert arr5.dtype == float

--- a/hyperspy/tests/test_decorators.py
+++ b/hyperspy/tests/test_decorators.py
@@ -19,10 +19,10 @@
 
 import warnings
 
-import numpy as np
 import pytest
 
 from hyperspy.decorators import deprecated, deprecated_argument
+from hyperspy.exceptions import VisibleDeprecationWarning
 
 
 class TestDeprecationWarning:
@@ -37,7 +37,7 @@ class TestDeprecationWarning:
             """Some docstring."""
             return n + 1
 
-        with pytest.warns(np.VisibleDeprecationWarning) as record:
+        with pytest.warns(VisibleDeprecationWarning) as record:
             assert foo(4) == 5
         desired_msg = (
             "Function `foo()` is deprecated and will be removed in version 0.8. Use "
@@ -60,7 +60,7 @@ class TestDeprecationWarning:
             """
             return n + 2
 
-        with pytest.warns(np.VisibleDeprecationWarning) as record:
+        with pytest.warns(VisibleDeprecationWarning) as record:
             assert foo2(4) == 6
         desired_msg2 = "Function `foo2()` is deprecated."
         assert str(record[0].message) == desired_msg2
@@ -77,7 +77,7 @@ class TestDeprecationWarning:
         def foo(n):
             return n + 1
 
-        with pytest.warns(np.VisibleDeprecationWarning) as record:
+        with pytest.warns(VisibleDeprecationWarning) as record:
             assert foo(4) == 5
         desired_msg = (
             "Function `foo()` is deprecated and will be removed in version 0.8. Use "
@@ -116,7 +116,7 @@ class TestDeprecateArgument:
             assert my_foo.bar_arg(b=1) == {"b": 1}
 
         # Warns
-        with pytest.warns(np.VisibleDeprecationWarning) as record1:
+        with pytest.warns(VisibleDeprecationWarning) as record1:
             assert my_foo.bar_arg(a=2) == {"a": 2}
         assert str(record1[0].message) == (
             r"Argument `a` is deprecated and will be removed in version 1.4. "
@@ -125,7 +125,7 @@ class TestDeprecateArgument:
         )
 
         # Warns with alternative
-        with pytest.warns(np.VisibleDeprecationWarning) as record2:
+        with pytest.warns(VisibleDeprecationWarning) as record2:
             assert my_foo.bar_arg_alt(a=3) == {"b": 3}
         assert str(record2[0].message) == (
             r"Argument `a` is deprecated and will be removed in version 1.4. "

--- a/upcoming_changes/3386.maintenance.rst
+++ b/upcoming_changes/3386.maintenance.rst
@@ -1,0 +1,1 @@
+Add support for numpy 2.0.


### PR DESCRIPTION
Now that matplotlib and pint supports numpy 2.0, we can test hyperspy against the pre-release of numpy.

xref https://github.com/hyperspy/hyperspy-extensions-list/pull/56

### Progress of the PR
- [x] Add support for numpy 2.0,
- [x] Add build to test matrix on GitHub CI to test with pre-release of numpy,
- [x] update docstring (if appropriate),
- [n/a] update user guide (if appropriate),
- [x] add an changelog entry in the `upcoming_changes` folder (see [`upcoming_changes/README.rst`](https://github.com/hyperspy/hyperspy/blob/RELEASE_next_minor/upcoming_changes/README.rst)),
- [x] Check formatting changelog entry in the `readthedocs` doc build of this PR (link in github checks)
- [x] add/update tests,
- [x] ready for review.


