### PR TITLE
Add old version warning banner in documentation

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -25,7 +25,9 @@ jobs:
             PYTHON_VERSION: '3.8'
             PIP_SELECTOR: '[all, tests, coverage]'
             OLDEST_SUPPORTED_VERSION: true
-            DEPENDENCIES: dask[array]==2021.5.1 matplotlib==3.1.3 numba==0.52 numpy==1.20.0 scipy==1.6 scikit-image==0.18 scikit-learn==1.0.1
+            # Don't install pillow 10.4.0 because of its incompatibility with numpy 1.20.x
+            # https://github.com/python-pillow/Pillow/pull/8187
+            DEPENDENCIES: dask[array]==2021.5.1 matplotlib==3.1.3 numba==0.52 numpy==1.20.0 scipy==1.6 scikit-image==0.18 scikit-learn==1.0.1 pillow!=10.4.0
             LABEL: -oldest
           # test minimum requirement
           - os: ubuntu

--- a/doc/_static/switcher.json
+++ b/doc/_static/switcher.json
@@ -6,7 +6,8 @@
     },
     {
         "version": "2.1",
-        "url": "https://hyperspy.org/hyperspy-doc/current/"
+        "url": "https://hyperspy.org/hyperspy-doc/current/",
+        "preferred": true
     },
     {
         "version": "2.0",

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -202,6 +202,7 @@ html_theme_options = {
         },
     ],
     "header_links_before_dropdown": 7,
+    "show_version_warning_banner": True,
     "switcher": {
         # Update when merged and released
         "json_url": "https://hyperspy.org/hyperspy-doc/dev/_static/switcher.json",

--- a/doc/intro.rst
+++ b/doc/intro.rst
@@ -136,7 +136,7 @@ Citing HyperSpy
 
 If HyperSpy has been significant to a project that leads to an academic
 publication, please acknowledge that fact by citing it. The DOI in the
-badge below is the `Concept DOI <https://help.zenodo.org/faq/#versioning>`_ of
+badge below is the `Concept DOI <https://support.zenodo.org/help/en-gb/1-upload-deposit/97-what-is-doi-versioning>`_ of
 HyperSpy. It can be used to cite the project without referring to a specific
 version. If you are citing HyperSpy because you have used it to process data,
 please use the DOI of the specific version that you have employed. You can

--- a/doc/user_guide/signal/indexing.rst
+++ b/doc/user_guide/signal/indexing.rst
@@ -15,7 +15,7 @@ Those new to Python may find indexing a somewhat esoteric concept but once
 mastered it is one of the most powerful features of Python based code and
 greatly simplifies many common tasks. HyperSpy's Signal indexing is similar
 to numpy array indexing and those new to Python are encouraged to read the
-associated `numpy documentation on the subject <https://docs.scipy.org/doc/numpy/reference/arrays.indexing.html>`_.
+corresponding `numpy documentation <https://numpy.org/doc/stable/user/basics.indexing.html>`_.
 
 
 Key features of indexing in HyperSpy are as follows (note that some of these

--- a/upcoming_changes/3397.doc.rst
+++ b/upcoming_changes/3397.doc.rst
@@ -1,0 +1,1 @@
+Add old version warning banner in documentation.


### PR DESCRIPTION
Fix https://github.com/hyperspy/hyperspy/issues/3396. `pydata-sphinx-theme` supports such a warning banner:
https://pydata-sphinx-theme.readthedocs.io/en/stable/user_guide/announcements.html#version-warning-banners

### Progress of the PR
- [x] Add `preferred` property to version switcher configuration file,
- [x] fix broken link to numpy documentation 
- [n/a] update docstring (if appropriate),
- [n/a] update user guide (if appropriate),
- [x] add an changelog entry in the `upcoming_changes` folder (see [`upcoming_changes/README.rst`](https://github.com/hyperspy/hyperspy/blob/RELEASE_next_minor/upcoming_changes/README.rst)),
- [x] Check formatting changelog entry in the `readthedocs` doc build of this PR (link in github checks)
- [n/a] add tests,
- [x] ready for review.


