### PR TITLE
Add example: live FFT

### DIFF
--- a/examples/region_of_interest/fast_fourier_transform_live.py
+++ b/examples/region_of_interest/fast_fourier_transform_live.py
@@ -3,18 +3,21 @@ Live FFT
 ========
 
 Get interactive fast Fourier transform (FFT) from a subset of a Signal2D
-using RectangularROi.
-
-Note: the FFT of the example signal is different from what you would expect
-in an atomic resolution Transmission Electron Microscopy image.
+using RectangularROI.
 
 """
 
 import hyperspy.api as hs
+import numpy as np
 
 #%%
 # Create a signal:
 s = hs.data.atomic_resolution_image()
+
+#%%
+# Add noise to the signal to make it more realistic
+s.data *= 1E3
+s.data += np.random.default_rng().poisson(s.data)
 
 #%%
 # Create the ROI, here a :py:class:`~.api.roi.RectangularROI`:
@@ -32,5 +35,8 @@ sliced_signal = roi.interactive(s, recompute_out_event=None)
 
 #%%
 # Get the FFT of this sliced signal, and plot it
+# Apodization is used to smoothen the edge of the image before taking the FFT
+# to remove streaks from the FFT - see the :ref:`signal.fft` section of the
+# user guide for more details:
 s_fft = hs.interactive(sliced_signal.fft, apodization=True, shift=True, recompute_out_event=None)
 s_fft.plot(power_spectrum=True)

--- a/examples/region_of_interest/fast_fourier_transform_live.py
+++ b/examples/region_of_interest/fast_fourier_transform_live.py
@@ -1,0 +1,36 @@
+"""
+Live FFT
+========
+
+Get interactive fast Fourier transform (FFT) from a subset of a Signal2D
+using RectangularROi.
+
+Note: the FFT of the example signal is different from what you would expect
+in an atomic resolution Transmission Electron Microscopy image.
+
+"""
+
+import hyperspy.api as hs
+
+#%%
+# Create a signal:
+s = hs.data.atomic_resolution_image()
+
+#%%
+# Create the ROI, here a :py:class:`~.api.roi.RectangularROI`:
+roi = hs.roi.RectangularROI()
+
+#%%
+# Slice signal with the ROI. By using the `interactive` function, the
+# output signal ``sliced_signal`` will update automatically.
+# The ROI will be added automatically on the signal plot.
+s.plot()
+sliced_signal = roi.interactive(s, recompute_out_event=None)
+
+# Choose the second figure as gallery thumbnail:
+# sphinx_gallery_thumbnail_number = 2
+
+#%%
+# Get the FFT of this sliced signal, and plot it
+s_fft = hs.interactive(sliced_signal.fft, apodization=True, shift=True, recompute_out_event=None)
+s_fft.plot(power_spectrum=True)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -122,7 +122,8 @@ doc = [
     "sphinx>=1.7",
     "sphinxcontrib-mermaid",
     "sphinxcontrib-towncrier>=0.3.0a0",
-    "towncrier",
+    # unpin when sphinxcontrib-towncrier support more recent version to towncrier
+    "towncrier<24",
 ]
 gui-jupyter = [
     "hyperspy_gui_ipywidgets>=2.0",

--- a/upcoming_changes/3400.doc.rst
+++ b/upcoming_changes/3400.doc.rst
@@ -1,0 +1,1 @@
+Add example: live fast Fourier transform of Signal2D using region of interest.


### PR DESCRIPTION
### Description of the change

- This pull request adds an example showing how to get a live fourier transform from an interactive region of interest.

### Progress of the PR
- [x] Change implemented (can be split into several points),
- [x] add an changelog entry in the `upcoming_changes` folder (see [`upcoming_changes/README.rst`](https://github.com/hyperspy/hyperspy/blob/RELEASE_next_minor/upcoming_changes/README.rst)),
- [ ] Check formatting changelog entry in the `readthedocs` doc build of this PR (link in github checks)
- [ ] ready for review.

### Discussion

The FFT of the example signal (`hs.data.atomic_resolution_image()`), looks really strange. So I'm tempted to also add a new example atomic resolution signal.

