### PR TITLE
Release 2.1.1

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,6 +10,37 @@ https://hyperspy.readthedocs.io/en/latest/changes.html
 
 .. towncrier release notes start
 
+2.1.1 (2024-07-11)
+==================
+
+Enhancements
+------------
+
+- Only import gui widget when the toolkit is enabled. (`#3366 <https://github.com/hyperspy/hyperspy/issues/3366>`_)
+- Tweak documention on dask scheduler. (`#3380 <https://github.com/hyperspy/hyperspy/issues/3380>`_)
+
+
+Bug Fixes
+---------
+
+- Fix updating residual line in model plot when changing components. (`#3355 <https://github.com/hyperspy/hyperspy/issues/3355>`_)
+- Avoid changing ``data`` object when using :meth:`~.api.signals.BaseSignal.add_gaussian_noise` and :meth:`~.api.signals.BaseSignal.add_poissonian_noise`. (`#3379 <https://github.com/hyperspy/hyperspy/issues/3379>`_)
+- Avoid replacing the original mask in :meth:`~.api.signals.BaseSignal.blind_source_separation` (`#3384 <https://github.com/hyperspy/hyperspy/issues/3384>`_)
+- Fix gradients in some expression based components (`#3388 <https://github.com/hyperspy/hyperspy/issues/3388>`_)
+
+
+Improved Documentation
+----------------------
+
+- Add old version warning banner in documentation. (`#3397 <https://github.com/hyperspy/hyperspy/issues/3397>`_)
+
+
+Maintenance
+-----------
+
+- Add support for numpy 2.0. (`#3386 <https://github.com/hyperspy/hyperspy/issues/3386>`_)
+
+
 2.1.0 (2024-05-08)
 ==================
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -227,7 +227,7 @@ where = ["."]
 "*" = ["*.png"]
 
 [tool.setuptools_scm]
-fallback_version = "2.1.1.dev0"
+fallback_version = "2.1.2.dev0"
 
 [tool.towncrier]
 directory = "upcoming_changes/"

--- a/upcoming_changes/3355.bugfix.rst
+++ b/upcoming_changes/3355.bugfix.rst
@@ -1,1 +1,0 @@
-Fix updating residual line in model plot when changing components.

--- a/upcoming_changes/3366.enhancements.rst
+++ b/upcoming_changes/3366.enhancements.rst
@@ -1,1 +1,0 @@
-Only import gui widget when the toolkit is enabled.

--- a/upcoming_changes/3379.bugfix.rst
+++ b/upcoming_changes/3379.bugfix.rst
@@ -1,1 +1,0 @@
-Avoid changing ``data`` object when using :meth:`~.api.signals.BaseSignal.add_gaussian_noise` and :meth:`~.api.signals.BaseSignal.add_poissonian_noise`.

--- a/upcoming_changes/3380.enhancements.rst
+++ b/upcoming_changes/3380.enhancements.rst
@@ -1,1 +1,0 @@
-Tweak documention on dask scheduler.

--- a/upcoming_changes/3384.bugfix.rst
+++ b/upcoming_changes/3384.bugfix.rst
@@ -1,3 +1,0 @@
-Avoid replacing the original mask in :meth:`~.api.signals.BaseSignal.blind_source_separation`
-
-

--- a/upcoming_changes/3386.maintenance.rst
+++ b/upcoming_changes/3386.maintenance.rst
@@ -1,1 +1,0 @@
-Add support for numpy 2.0.

--- a/upcoming_changes/3388.bugfix.rst
+++ b/upcoming_changes/3388.bugfix.rst
@@ -1,1 +1,0 @@
-Fix gradients in some expression based components

--- a/upcoming_changes/3397.doc.rst
+++ b/upcoming_changes/3397.doc.rst
@@ -1,1 +1,0 @@
-Add old version warning banner in documentation.


### PR DESCRIPTION
Sympy 1.13 has been release and a release is needed to include bug fixes of some components (#3388).

xref https://github.com/hyperspy/hyperspy/blob/RELEASE_next_minor/releasing_guide.md
