### PR TITLE
Allow rebinning uniform axis of signal containing non-uniform axis

### DIFF
--- a/hyperspy/signal.py
+++ b/hyperspy/signal.py
@@ -3574,8 +3574,8 @@ class BaseSignal(
         elif new_shape:
             if len(new_shape) != len(self.data.shape):
                 raise ValueError("Wrong new_shape size")
-            for axis in self.axes_manager._axes:
-                if axis.is_uniform is False:
+            for i, axis in enumerate(self.axes_manager._axes):
+                if axis.is_uniform is False and new_shape[i] != self.data.shape[i]:
                     raise NotImplementedError(
                         "Rebinning of non-uniform axes is not yet implemented."
                     )
@@ -3589,8 +3589,8 @@ class BaseSignal(
         else:
             if len(scale) != len(self.data.shape):
                 raise ValueError("Wrong scale size")
-            for axis in self.axes_manager._axes:
-                if axis.is_uniform is False:
+            for i, axis in enumerate(self.axes_manager._axes):
+                if axis.is_uniform is False and scale[i] != 1:
                     raise NotImplementedError(
                         "Rebinning of non-uniform axes is not yet implemented."
                     )
@@ -3683,8 +3683,10 @@ class BaseSignal(
         s.get_dimensions_from_data()
         for axis, axis_src in zip(s.axes_manager._axes, self.axes_manager._axes):
             factor = factors[axis.index_in_array]
-            axis.scale = axis_src.scale * factor
-            axis.offset = axis_src.offset + (factor - 1) * axis_src.scale / 2
+            if factor != 1:
+                # Change scale, offset only when necessary
+                axis.scale = axis_src.scale * factor
+                axis.offset = axis_src.offset + (factor - 1) * axis_src.scale / 2
         if s.metadata.has_item("Signal.Noise_properties.variance"):
             if isinstance(s.metadata.Signal.Noise_properties.variance, BaseSignal):
                 var = s.metadata.Signal.Noise_properties.variance

--- a/hyperspy/tests/test_io.py
+++ b/hyperspy/tests/test_io.py
@@ -220,11 +220,12 @@ def test_file_reader_warning(caplog, tmp_path):
     try:
         with caplog.at_level(logging.WARNING):
             _ = hs.load(f, reader="some_unknown_file_extension")
-
-        assert "Unable to infer file type from extension" in caplog.text
-    except (ValueError, OSError):
+    except (ValueError, OSError, IndexError):
         # Test fallback to Pillow imaging library
+        # IndexError is for oldest supported version build on Github CI
         pass
+
+    assert "Unable to infer file type from extension" in caplog.text
 
 
 def test_file_reader_options(tmp_path):

--- a/hyperspy/tests/test_non-uniform_not-implemented.py
+++ b/hyperspy/tests/test_non-uniform_not-implemented.py
@@ -16,6 +16,7 @@
 # You should have received a copy of the GNU General Public License
 # along with HyperSpy. If not, see <https://www.gnu.org/licenses/#GPL>.
 
+import numpy as np
 import pytest
 
 from hyperspy.signals import (
@@ -33,8 +34,6 @@ def test_signal():
         s.ifft()
     with pytest.raises(NotImplementedError):
         s.diff(0)
-    with pytest.raises(NotImplementedError):
-        s.rebin(scale=[1])
     with pytest.raises(NotImplementedError):
         s.split(number_of_parts=2, axis=0)
 
@@ -71,3 +70,14 @@ def test_lazy():
     print(s)
     with pytest.raises(NotImplementedError):
         s.diff(0)
+
+
+def test_rebin():
+    s = Signal1D(np.arange(100).reshape(10, 10))
+    s.axes_manager[-1].convert_to_non_uniform_axis()
+    s.rebin(scale=(2, 1))
+    s.rebin(new_shape=(5, 10))
+    with pytest.raises(NotImplementedError):
+        s.rebin(scale=(1, 2))
+    with pytest.raises(NotImplementedError):
+        s.rebin(new_shape=(1, 5))

--- a/upcoming_changes/3407.bugfix.rst
+++ b/upcoming_changes/3407.bugfix.rst
@@ -1,0 +1,1 @@
+Allow rebinning uniform axis of signal containing non-uniform axis.


### PR DESCRIPTION
### Progress of the PR
- [x] Allow rebinning uniform axis of signal containing non-uniform axis,
- [n/a] update docstring (if appropriate),
- [n/a] update user guide (if appropriate),
- [x] add an changelog entry in the `upcoming_changes` folder (see [`upcoming_changes/README.rst`](https://github.com/hyperspy/hyperspy/blob/RELEASE_next_minor/upcoming_changes/README.rst)),
- [x] Check formatting changelog entry in the `readthedocs` doc build of this PR (link in github checks)
- [x] add tests,
- [x] ready for review.

### Minimal example of the bug fix or the new feature

Allow the follow example to work, rebin the uniform axis while leaving the non-uniform axis unchanged:
```python
import hyperspy.api as hs
import numpy as np

s = hs.signals.Signal1D(np.arange(100).reshape(10, 10))
s.axes_manager[-1].convert_to_non_uniform_axis()
s.rebin(scale=(2, 1))
```

