### PR TITLE
Fix old version warning banner in the stable documentation

### DIFF
--- a/doc/_static/switcher.json
+++ b/doc/_static/switcher.json
@@ -5,7 +5,8 @@
         "url": "https://hyperspy.org/hyperspy-doc/dev/"
     },
     {
-        "version": "2.1",
+        "version": "2.1.x",
+        "name": "2.1",
         "url": "https://hyperspy.org/hyperspy-doc/current/",
         "preferred": true
     },

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -13,7 +13,6 @@
 
 import sys
 from datetime import datetime
-from importlib.metadata import version as get_version
 
 import hyperspy
 
@@ -92,7 +91,7 @@ copyright = f"2011-{datetime.today().year}, The HyperSpy development team"
 # built documents.
 #
 # The full version, including alpha/beta/rc tags.
-release = get_version("hyperspy")
+release = hyperspy.__version__
 # The short X.Y version.
 version = ".".join(release.split(".")[:2])
 
@@ -168,8 +167,17 @@ favicons = [
 # For version switcher:
 # For development, we match to the dev version in `switcher.json`
 # for release version, we match to the minor increment
-_version = hyperspy.__version__
-version_match = "dev" if "dev" in _version else ".".join(_version.split(".")[:2])
+
+# The old version banner used `release` to compare to the "prefered" version
+# using https://www.npmjs.com/package/compare-versions
+# To play well with our documentation structure (the preferred version point
+# to the latest minor or patch release without having to update on patch release),
+# we add a ".x".
+# See https://github.com/pydata/pydata-sphinx-theme/issues/1552 for more context
+# On a minor release, the version switcher json is updated.
+# In the version switcher json, version needs to be defined with a `x`, e.g. 2.1.x
+# in as it is done here to make sure that they match!
+version_match = "dev" if "dev" in release else ".".join(release.split(".")[:2] + ["x"])
 
 print("version_match:", version_match)
 

--- a/upcoming_changes/3409.bugfix.rst
+++ b/upcoming_changes/3409.bugfix.rst
@@ -1,0 +1,1 @@
+Fix old version warning banner in the stable documentation.


### PR DESCRIPTION
Follow up of https://github.com/hyperspy/hyperspy/pull/3397 and the last patch release, which broke the "old version warning" banner: it shows on the stable version because, the matching with the "preferred" version doesn't work (2.1 doesn't match with 2.1.1)

For wider context, this is a similar issue as described https://github.com/pydata/pydata-sphinx-theme/issues/1552 and this is happening because what we use as stable version is the most recent minor or patch release.

I updated the current version switcher and https://github.com/hyperspy/hyperspy-doc/commit/24d801355a16c4c829c24782bb33aa562e77af58 and rebuild the stable doc with the fix of this PR to remove the banner showing up in the documentation of the stable release, but this has been overwritten by an [automatic build push](https://github.com/hyperspy/hyperspy-doc/commit/32764dc75558ac7c9449b9c4b8fd96ec34f0f6d5#diff-ff114210ba33f00a5e0f9376b61017be236feab9fe45ea83001038ad5cd32d39).

### Progress of the PR
- [x] Update the version switcher configuration to play well with the old version banner,
- [n/a] update docstring (if appropriate),
- [n/a] update user guide (if appropriate),
- [x] add an changelog entry in the `upcoming_changes` folder (see [`upcoming_changes/README.rst`](https://github.com/hyperspy/hyperspy/blob/RELEASE_next_minor/upcoming_changes/README.rst)),
- [x] Check formatting changelog entry in the `readthedocs` doc build of this PR (link in github checks)
- [n/a] add tests,
- [x] ready for review.


