### PR TITLE
Add support to convert to uniform axis in `interpolate_on_axis`

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -37,12 +37,6 @@ jobs:
             LABEL: -minimum
           - os: ubuntu
             os_version: latest
-            PYTHON_VERSION: '3.12'
-            PIP_SELECTOR: '[tests, coverage]'
-            NUMPY20: true
-            LABEL: -npy20
-          - os: ubuntu
-            os_version: latest
             PYTHON_VERSION: '3.8'
             PIP_SELECTOR: '[all, tests, coverage]'
           - os: ubuntu
@@ -94,11 +88,6 @@ jobs:
         if: ${{ matrix.OLDEST_SUPPORTED_VERSION }}
         run: |
           pip install ${{ matrix.DEPENDENCIES }} -v
-
-      - name: Install numpy 2.0
-        if: ${{ matrix.NUMPY20 }}
-        run: |
-          pip install --pre numpy
 
       - name: Install
         shell: bash

--- a/hyperspy/axes.py
+++ b/hyperspy/axes.py
@@ -729,29 +729,92 @@ class BaseDataAxis(t.HasTraits):
             any_changes = True
         return any_changes
 
-    def convert_to_uniform_axis(self, log_scale_error=True):
+    def convert_to_uniform_axis(self, keep_bounds=True, log_scale_error=True):
         """
         Convert to an uniform axis.
 
         Parameters
         ----------
+        keep_bounds : bool
+            If ``True``, the first and last value of the axis will not be changed.
+            The new scale is calculated by substracting the last value by the first
+            value and dividing by the number of intervals.
+            the axis. If ``False``, the scale and offset are calculated using
+            :meth:`numpy.polynomial.polynomial.Polynomial.fit`, which minimises
+            the scale difference over the whole axis range but the bounds of
+            the axis can change. Default is ``True``.
         log_scale_error : bool
-            If ``True``, The maximum scale error will be logged as INFO.
+            If ``True``, the maximum scale error will be logged as INFO.
             Default is ``True``.
+
+        Examples
+        --------
+        Using ``keep_bounds=True`` (default):
+
+        >>> s = hs.data.luminescence_signal(uniform=False)
+        >>> print(s.axes_manager)
+        <Axes manager, axes: (|1024)>
+                    Name |   size |  index |  offset |   scale |  units
+        ================ | ====== | ====== | ======= | ======= | ======
+        ---------------- | ------ | ------ | ------- | ------- | ------
+                  Energy |   1024 |      0 | non-uniform axis |     eV
+        >>> s.axes_manager[-1].convert_to_uniform_axis(keep_bounds=True)
+        >>> print(s.axes_manager)
+        <Axes manager, axes: (|1024)>
+                    Name |   size |  index |  offset |   scale |  units
+        ================ | ====== | ====== | ======= | ======= | ======
+        ---------------- | ------ | ------ | ------- | ------- | ------
+                  Energy |   1024 |      0 |     1.6 |  0.0039 |     eV
+
+        Using ``keep_bounds=False``:
+
+        >>> s = hs.data.luminescence_signal(uniform=False)
+        >>> print(s.axes_manager)
+        <Axes manager, axes: (|1024)>
+                    Name |   size |  index |  offset |   scale |  units
+        ================ | ====== | ====== | ======= | ======= | ======
+        ---------------- | ------ | ------ | ------- | ------- | ------
+                  Energy |   1024 |      0 | non-uniform axis |     eV
+        >>> s.axes_manager[-1].convert_to_uniform_axis(keep_bounds=False)
+        >>> print(s.axes_manager)
+        <Axes manager, axes: (|1024)>
+                    Name |   size |  index |  offset |   scale |  units
+        ================ | ====== | ====== | ======= | ======= | ======
+        ---------------- | ------ | ------ | ------- | ------- | ------
+                  Energy |   1024 |      0 |     1.1 |  0.0033 |     eV
+
+
+        See Also
+        --------
+        hyperspy.api.signals.BaseSignal.interpolate_on_axis
+
+        Notes
+        -----
+        The function only convert the axis type and doesn't interpolate
+        the data itself - see :meth:`~.api.signals.BaseSignal.interpolate_on_axis`
+        to interpolate data on a uniform axis.
+
         """
-        steps = self.axis[1:] - self.axis[:-1]
-        scale = np.mean(steps)
+        indices = np.arange(self.size)
+        if keep_bounds:
+            scale = (self.axis[-1] - self.axis[0]) / (self.size - 1)
+            offset = self.axis[0]
+        else:
+            # polyfit minimize the error over the whole axis
+            offset, scale = np.polynomial.Polynomial.fit(
+                indices, self.axis, deg=1
+            ).convert()
         d = self.get_axis_dictionary()
         axes_manager = self.axes_manager
         if "axis" in d:
             del d["axis"]
         if len(self.axis) > 1 and log_scale_error:
-            scale_err = max(steps) - scale
+            scale_err = np.max(self.axis - (scale * indices + offset))
             _logger.info("The maximum scale error is {}.".format(scale_err))
         d["_type"] = "UniformDataAxis"
         d["size"] = self.size
         self.__class__ = UniformDataAxis
-        self.__init__(**d, scale=scale, offset=self.low_value)
+        self.__init__(**d, scale=scale, offset=offset)
         self.axes_manager = axes_manager
 
     @property

--- a/hyperspy/axes.py
+++ b/hyperspy/axes.py
@@ -739,16 +739,19 @@ class BaseDataAxis(t.HasTraits):
             If ``True``, The maximum scale error will be logged as INFO.
             Default is ``True``.
         """
-        scale = (self.high_value - self.low_value) / self.size
+        steps = self.axis[1:] - self.axis[:-1]
+        scale = np.mean(steps)
         d = self.get_axis_dictionary()
         axes_manager = self.axes_manager
-        del d["axis"]
+        if "axis" in d:
+            del d["axis"]
         if len(self.axis) > 1 and log_scale_error:
-            scale_err = max(self.axis[1:] - self.axis[:-1]) - scale
+            scale_err = max(steps) - scale
             _logger.info("The maximum scale error is {}.".format(scale_err))
         d["_type"] = "UniformDataAxis"
+        d["size"] = self.size
         self.__class__ = UniformDataAxis
-        self.__init__(**d, size=self.size, scale=scale, offset=self.low_value)
+        self.__init__(**d, scale=scale, offset=self.low_value)
         self.axes_manager = axes_manager
 
     @property

--- a/hyperspy/axes.py
+++ b/hyperspy/axes.py
@@ -739,10 +739,11 @@ class BaseDataAxis(t.HasTraits):
             If ``True``, the first and last value of the axis will not be changed.
             The new scale is calculated by substracting the last value by the first
             value and dividing by the number of intervals.
-            the axis. If ``False``, the scale and offset are calculated using
+            If ``False``, the scale and offset are calculated using
             :meth:`numpy.polynomial.polynomial.Polynomial.fit`, which minimises
             the scale difference over the whole axis range but the bounds of
-            the axis can change. Default is ``True``.
+            the axis can change (in some cases quite significantly, in particular when the
+            interval width is changing continuously). Default is ``True``.
         log_scale_error : bool
             If ``True``, the maximum scale error will be logged as INFO.
             Default is ``True``.
@@ -790,7 +791,7 @@ class BaseDataAxis(t.HasTraits):
 
         Notes
         -----
-        The function only convert the axis type and doesn't interpolate
+        The function only converts the axis type and doesn't interpolate
         the data itself - see :meth:`~.api.signals.BaseSignal.interpolate_on_axis`
         to interpolate data on a uniform axis.
 

--- a/hyperspy/axes.py
+++ b/hyperspy/axes.py
@@ -729,15 +729,23 @@ class BaseDataAxis(t.HasTraits):
             any_changes = True
         return any_changes
 
-    def convert_to_uniform_axis(self):
-        """Convert to an uniform axis."""
+    def convert_to_uniform_axis(self, log_scale_error=True):
+        """
+        Convert to an uniform axis.
+
+        Parameters
+        ----------
+        log_scale_error : bool
+            If ``True``, The maximum scale error will be logged as INFO.
+            Default is ``True``.
+        """
         scale = (self.high_value - self.low_value) / self.size
         d = self.get_axis_dictionary()
         axes_manager = self.axes_manager
         del d["axis"]
-        if len(self.axis) > 1:
+        if len(self.axis) > 1 and log_scale_error:
             scale_err = max(self.axis[1:] - self.axis[:-1]) - scale
-            _logger.warning("The maximum scale error is {}.".format(scale_err))
+            _logger.info("The maximum scale error is {}.".format(scale_err))
         d["_type"] = "UniformDataAxis"
         self.__class__ = UniformDataAxis
         self.__init__(**d, size=self.size, scale=scale, offset=self.low_value)

--- a/hyperspy/signal.py
+++ b/hyperspy/signal.py
@@ -3427,7 +3427,7 @@ class BaseSignal(
             If this new axis exceeds the range of the old axis,
             a warning is raised that the data will be extrapolated.
             If ``"uniform"``, convert the axis specified by the ``axis``
-            parameter to a uniform axis.
+            parameter to a uniform axis with the same number of data points.
         axis : int or str, default 0
             Specifies the axis which will be replaced using the index of the
             axis in the `axes_manager`. The axis can be specified using the index of the
@@ -3444,6 +3444,30 @@ class BaseSignal(
         :class:`~.api.signals.BaseSignal` (or subclass)
             A copy of the object with the axis exchanged and the data interpolated.
             This only occurs when inplace is set to ``False``, otherwise nothing is returned.
+
+        Examples
+        --------
+        >>> s = hs.data.luminescence_signal(uniform=False)
+        >>> s2 = s.interpolate_on_axis("uniform", -1, inplace=False)
+        >>> hs.plot.plot_spectra(
+        ...     [s, s2],
+        ...     legend=["FunctionalAxis", "Interpolated (identical bounds)"],
+        ...     drawstyle='steps-mid',
+        ... )
+        <Axes: xlabel='Energy (eV)', ylabel='Intensity'>
+
+        Specifying a uniform axis:
+
+        >>> s = hs.data.luminescence_signal(uniform=False)
+        >>> new_axis = s.axes_manager[-1].copy()
+        >>> new_axis.convert_to_uniform_axis()
+        >>> s3 = s.interpolate_on_axis(new_axis, -1, inplace=False)
+        >>> hs.plot.plot_spectra(
+        ...     [s, s3],
+        ...     legend=["FunctionalAxis", "Interpolated (polyfit)"],
+        ...     drawstyle='steps-mid',
+        ... )
+        <Axes: xlabel='Energy (eV)', ylabel='Intensity'>
         """
         old_axis = self.axes_manager[axis]
         axis_idx = old_axis.index_in_array

--- a/hyperspy/signal.py
+++ b/hyperspy/signal.py
@@ -3451,7 +3451,7 @@ class BaseSignal(
         >>> s2 = s.interpolate_on_axis("uniform", -1, inplace=False)
         >>> hs.plot.plot_spectra(
         ...     [s, s2],
-        ...     legend=["FunctionalAxis", "Interpolated (identical bounds)"],
+        ...     legend=["FunctionalAxis", "Interpolated"],
         ...     drawstyle='steps-mid',
         ... )
         <Axes: xlabel='Energy (eV)', ylabel='Intensity'>
@@ -3464,7 +3464,7 @@ class BaseSignal(
         >>> s3 = s.interpolate_on_axis(new_axis, -1, inplace=False)
         >>> hs.plot.plot_spectra(
         ...     [s, s3],
-        ...     legend=["FunctionalAxis", "Interpolated (polyfit)"],
+        ...     legend=["FunctionalAxis", "Interpolated"],
         ...     drawstyle='steps-mid',
         ... )
         <Axes: xlabel='Energy (eV)', ylabel='Intensity'>

--- a/hyperspy/signal.py
+++ b/hyperspy/signal.py
@@ -3631,9 +3631,13 @@ class BaseSignal(
             if len(new_shape) != len(self.data.shape):
                 raise ValueError("Wrong new_shape size")
             for i, axis in enumerate(self.axes_manager._axes):
+                # If the shape doesn't change, there is nothing to do
+                # and we don't need to raise an error
                 if axis.is_uniform is False and new_shape[i] != self.data.shape[i]:
                     raise NotImplementedError(
-                        "Rebinning of non-uniform axes is not yet implemented."
+                        "Rebinning of non-uniform axes is not yet implemented. "
+                        "An alternative is to interpolate the data on an uniform axis "
+                        "using `interpolate_on_axis` before rebinning."
                     )
             new_shape_in_array = np.array(
                 [

--- a/hyperspy/tests/axes/test_data_axis.py
+++ b/hyperspy/tests/axes/test_data_axis.py
@@ -167,7 +167,7 @@ class TestDataAxis:
         np.testing.assert_allclose(self.axis.axis, np.arange(0, 10, 2) ** 2)
 
     def test_convert_to_uniform_axis(self):
-        scale = (self.axis.high_value - self.axis.low_value) / self.axis.size
+        scale = np.mean(self.axis.axis[1:] - self.axis.axis[:-1])
         is_binned = self.axis.is_binned
         navigate = self.axis.navigate
         self.axis.name = "parrot"
@@ -335,6 +335,12 @@ class TestFunctionalDataAxis:
         assert index_in_array == s.axes_manager[0].index_in_array
         assert is_binned == s.axes_manager[0].is_binned
         assert navigate == s.axes_manager[0].navigate
+
+    def test_convert_to_uniform_axis(self):
+        ax = FunctionalDataAxis(size=10, expression="a * x + b", a=2, b=100)
+        axis_before = copy.deepcopy(ax.axis)
+        ax.convert_to_uniform_axis()
+        np.testing.assert_allclose(axis_before, ax.axis)
 
     def test_update_from(self):
         ax2 = FunctionalDataAxis(size=2, units="nm", expression="x ** power", power=3)

--- a/hyperspy/tests/axes/test_data_axis.py
+++ b/hyperspy/tests/axes/test_data_axis.py
@@ -167,7 +167,6 @@ class TestDataAxis:
         np.testing.assert_allclose(self.axis.axis, np.arange(0, 10, 2) ** 2)
 
     def test_convert_to_uniform_axis(self):
-        scale = np.mean(self.axis.axis[1:] - self.axis.axis[:-1])
         is_binned = self.axis.is_binned
         navigate = self.axis.navigate
         self.axis.name = "parrot"
@@ -179,13 +178,21 @@ class TestDataAxis:
         assert s.axes_manager[0].name == "parrot"
         assert s.axes_manager[0].units == "plumage"
         assert s.axes_manager[0].size == 16
-        assert s.axes_manager[0].scale == scale
+        np.testing.assert_allclose(s.axes_manager[0].scale, 15)
         assert s.axes_manager[0].offset == 0
         assert s.axes_manager[0].low_value == 0
-        assert s.axes_manager[0].high_value == 15 * scale
+        assert s.axes_manager[0].high_value == 15 * 15
         assert index_in_array == s.axes_manager[0].index_in_array
         assert is_binned == s.axes_manager[0].is_binned
         assert navigate == s.axes_manager[0].navigate
+
+    def test_convert_to_uniform_axis_keep_bounds_False(self):
+        # estimated offset, scale using numpy polyfit
+        s = Signal1D(np.arange(10), axes=[self.axis])
+        s.axes_manager[0].convert_to_uniform_axis(keep_bounds=False)
+        assert s.axes_manager[0].size == 16
+        np.testing.assert_allclose(s.axes_manager[0].scale, 15)
+        np.testing.assert_allclose(s.axes_manager[0].offset, -35.0)
 
     def test_value2index(self):
         assert self.axis.value2index(10.15) == 3

--- a/hyperspy/tests/signals/test_interpolate_on_axis.py
+++ b/hyperspy/tests/signals/test_interpolate_on_axis.py
@@ -129,6 +129,7 @@ def test_interpolate_convert_to_uniform():
     s2 = s.interpolate_on_axis("uniform", -1, inplace=False)
     assert s2.axes_manager[-1].is_uniform
     np.testing.assert_allclose(s.data, s2.data)
+    np.testing.assert_allclose(axis.axis, s2.axes_manager[-1].axis)
 
     s.interpolate_on_axis("uniform", -1, inplace=True)
     # Check that the object is still the same

--- a/hyperspy/tests/signals/test_interpolate_on_axis.py
+++ b/hyperspy/tests/signals/test_interpolate_on_axis.py
@@ -128,7 +128,7 @@ def test_interpolate_convert_to_uniform():
     assert not s.axes_manager[-1].is_uniform
     s2 = s.interpolate_on_axis("uniform", -1, inplace=False)
     assert s2.axes_manager[-1].is_uniform
-    np.testing.assert_allclose(s.data, s2.data, rtol=0.011)
+    np.testing.assert_allclose(s.data, s2.data)
 
     s.interpolate_on_axis("uniform", -1, inplace=True)
     # Check that the object is still the same

--- a/hyperspy/tests/signals/test_interpolate_on_axis.py
+++ b/hyperspy/tests/signals/test_interpolate_on_axis.py
@@ -121,6 +121,24 @@ class TestInterpolateAxis1D:
             self.s0.interpolate_on_axis(x_uniform, 0)
 
 
+def test_interpolate_convert_to_uniform():
+    s = signals.Signal1D(np.arange(100))
+    axis = s.axes_manager[-1]
+    axis.convert_to_non_uniform_axis()
+    assert not s.axes_manager[-1].is_uniform
+    s2 = s.interpolate_on_axis("uniform", -1, inplace=False)
+    assert s2.axes_manager[-1].is_uniform
+    np.testing.assert_allclose(s.data, s2.data, rtol=0.011)
+
+    s.interpolate_on_axis("uniform", -1, inplace=True)
+    # Check that the object is still the same
+    assert axis is s.axes_manager[-1]
+
+    with pytest.raises(ValueError):
+        # already changed to uniform axis
+        s.interpolate_on_axis("uniform", -1, inplace=True)
+
+
 def test_interpolate_on_axis_2D():
     d = np.arange(0, 140).reshape(7, 20)
     x_initial = {"offset": 0, "scale": 1, "size": 20, "name": "X"}

--- a/upcoming_changes/3410.bugfix.rst
+++ b/upcoming_changes/3410.bugfix.rst
@@ -1,0 +1,1 @@
+Fixes :meth:`~.axes.BaseDataAxis.convert_to_uniform_axis`, which was incorrectly raising an ``AttributeError`` when used on :class:`~.axes.FunctionalDataAxis`.

--- a/upcoming_changes/3410.enhancements.rst
+++ b/upcoming_changes/3410.enhancements.rst
@@ -1,0 +1,1 @@
+Add support to convert to uniform axis in :meth:`~.api.signals.BaseSignal.interpolate_on_axis`.


### PR DESCRIPTION
### Progress of the PR
- [x] Add support to convert to uniform axis in `interpolate_on_axis`,
- [x] Fixes `FunctionalDataAxis.convert_to_uniform_axis` (`AttributeError`),
- [n/a] update docstring (if appropriate),
- [n/a] update user guide (if appropriate),
- [x] add an changelog entry in the `upcoming_changes` folder (see [`upcoming_changes/README.rst`](https://github.com/hyperspy/hyperspy/blob/RELEASE_next_minor/upcoming_changes/README.rst)),
- [x] Check formatting changelog entry in the `readthedocs` doc build of this PR (link in github checks)
- [x] add tests,
- [x] ready for review.

### Minimal example of the bug fix or the new feature
```python
import hyperspy.api as hs
import numpy as np

dict0 = {'expression': 'x**2', 'size': 500}
s = hs.signals.Signal1D(np.arange(500), axes=[dict0])

# s = hs.signals.Signal1D(np.arange(100), axes=)
s2 = s.interpolate_on_axis("uniform", -1, inplace=False)

hs.plot.plot_spectra([s, s2], legend=["FunctionalAxis", "Interpolated"])
```

