### PR TITLE
Disable snap to axes for non uniform axis

### DIFF
--- a/hyperspy/drawing/utils.py
+++ b/hyperspy/drawing/utils.py
@@ -1876,9 +1876,12 @@ def _roi_sum(signal, roi, axes, out=None):
         out.data[:] = f(sliced_signal.data, axis=axes)
         out.events.data_changed.trigger(obj=out)
     else:
-        # we don't case if this is not optimised for speed since this is
+        # we don't care if this is not optimised for speed since this is
         # expected to be called only when setting up the out signal
-        s = sliced_signal.nansum(axis=axes)
+        with warnings.catch_warnings():
+            # Catch warning for non-uniform axis
+            warnings.filterwarnings("ignore", category=UserWarning, module="hyperspy")
+            s = sliced_signal.nansum(axis=axes)
         # Reset signal to default Signal1D or Signal2D
         s.set_signal_type("")
         s.metadata.General.title = "Integrated intensity"

--- a/hyperspy/drawing/widget.py
+++ b/hyperspy/drawing/widget.py
@@ -614,6 +614,11 @@ class ResizableDraggableWidgetBase(DraggableWidgetBase):
         return value
 
     def _set_snap_size(self, value):
+        if value and any(not axis.is_uniform for axis in self.axes):
+            raise ValueError(
+                "The snap to axes values feature is not supported "
+                "for non-uniform axes."
+            )
         self._snap_size = value
         if value:
             snap_value = self._do_snap_size(self._size)

--- a/hyperspy/roi.py
+++ b/hyperspy/roi.py
@@ -487,7 +487,7 @@ class BaseInteractiveROI(BaseROI):
         self.events.changed.trigger(self)
 
     def add_widget(
-        self, signal, axes=None, widget=None, color="green", snap=True, **kwargs
+        self, signal, axes=None, widget=None, color="green", snap=None, **kwargs
     ):
         """Add a widget to visually represent the ROI, and connect it so any
         changes in either are reflected in the other. Note that only one
@@ -507,8 +507,10 @@ class BaseInteractiveROI(BaseROI):
             The color for the widget. Any format that matplotlib uses should be
             ok. This will not change the color for any widget passed with the
             ``'widget'`` argument.
-        snap : bool, default True
-            If True, the ROI will be snapped to the axes values.
+        snap : bool or None, default None
+            If True, the ROI will be snapped to the axes values, non-uniform
+            axes are not supported. If None, it will be disabled (set to
+            ``False``) for signals containing non-uniform axes.
         **kwargs : dict
             All keyword arguments are passed to the widget constructor.
 
@@ -549,6 +551,14 @@ class BaseInteractiveROI(BaseROI):
         widget.axes = axes
         with widget.events.changed.suppress_callback(self._on_widget_change):
             self._apply_roi2widget(widget)
+
+            if snap is None:
+                if any(not axis.is_uniform for axis in axes):
+                    # Disable snapping for non-uniform axes
+                    snap = False
+                else:
+                    snap = True
+
             # We need to snap after the widget value have been set
             if hasattr(widget, "snap_all"):
                 widget.snap_all = snap

--- a/hyperspy/tests/drawing/test_plot_widgets.py
+++ b/hyperspy/tests/drawing/test_plot_widgets.py
@@ -20,6 +20,7 @@ import matplotlib
 import numpy as np
 import pytest
 
+import hyperspy.api as hs
 from hyperspy.drawing import widgets
 from hyperspy.misc.test_utils import mock_event
 from hyperspy.signals import Signal1D, Signal2D
@@ -530,3 +531,20 @@ class TestSquareWidget:
         assert count_calls.counter == 0
         assert im.axes_manager.navigation_axes[0].index == 0
         # drag down and check that it doesn't change
+
+
+def test_widgets_non_uniform_axis():
+    s = hs.data.luminescence_signal(uniform=False).isig[10:20]
+    roi = hs.roi.SpanROI()
+    s.plot()
+    roi.add_widget(s)
+    np.testing.assert_allclose(roi.left, 1.61375935)
+    np.testing.assert_allclose(roi.right, 1.61887959)
+
+    roi2 = hs.roi.SpanROI()
+    with pytest.raises(ValueError):
+        roi2.add_widget(s, snap=True)
+
+    w = list(roi.widgets)[0]
+    with pytest.raises(ValueError):
+        w.snap_size = True

--- a/upcoming_changes/3418.bugfix.rst
+++ b/upcoming_changes/3418.bugfix.rst
@@ -1,0 +1,1 @@
+Disable snap to axes for non uniform axis to avoid error when using ROI on non-uniform axis.


### PR DESCRIPTION
### Progress of the PR
- [x] Disable snap to axes for non uniform axis to allow using ROI on non-uniform axis,
- [x] catch warning in `hs.plot.plot_roi_map` when summing on non-uniform axis, 
- [x] update docstring (if appropriate),
- [n/a] update user guide (if appropriate),
- [x] add an changelog entry in the `upcoming_changes` folder (see [`upcoming_changes/README.rst`](https://github.com/hyperspy/hyperspy/blob/RELEASE_next_minor/upcoming_changes/README.rst)),
- [x] Check formatting changelog entry in the `readthedocs` doc build of this PR (link in github checks)
- [x] add tests,
- [x] ready for review.

### Minimal example of the bug fix or the new feature
```python
import hyperspy.api as hs

s = hs.data.luminescence_signal(uniform=False).isig[10:20]

roi = hs.roi.SpanROI()
s.plot()
roi.add_widget(s)
```
