### PR TITLE
Improve `hs.data.atomic_resolution_image`

### DIFF
--- a/hyperspy/tests/test_data.py
+++ b/hyperspy/tests/test_data.py
@@ -16,18 +16,37 @@
 # You should have received a copy of the GNU General Public License
 # along with HyperSpy. If not, see <https://www.gnu.org/licenses/#GPL>.
 
+import numpy as np
 import pytest
 
 import hyperspy.api as hs
+from hyperspy.data.artificial_data import _get_largest_rectangle_from_rotation
+
+
+@pytest.mark.parametrize("add_noise", (True, False))
+@pytest.mark.parametrize("size", (200, (200, 200)))
+@pytest.mark.parametrize("spacing", (0.2, (0.2, 0.3)))
+@pytest.mark.parametrize("rotation_angle", (0, 10))
+def test_atomic_resolution_image(size, spacing, rotation_angle, add_noise):
+    s = hs.data.atomic_resolution_image(
+        size, spacing, rotation_angle=rotation_angle, add_noise=add_noise
+    )
+    expected_shape = (200, 200) if rotation_angle == 0 else (173, 173)
+    assert s.data.shape == expected_shape
+
+
+def test_atomic_resolution_image_error():
+    with pytest.raises(ValueError):
+        _ = hs.data.atomic_resolution_image(size=4.0)
+    with pytest.raises(ValueError):
+        _ = hs.data.atomic_resolution_image(spacing="4.0")
 
 
 @pytest.mark.parametrize("navigation_dimension", (0, 1, 2, 3))
 @pytest.mark.parametrize("uniform", (True, False))
 @pytest.mark.parametrize("add_baseline", (True, False))
 @pytest.mark.parametrize("add_noise", (True, False))
-def test_get_luminescence_signal(
-    navigation_dimension, uniform, add_baseline, add_noise
-):
+def test_luminescence_signal(navigation_dimension, uniform, add_baseline, add_noise):
     # Creating signal
     s = hs.data.luminescence_signal(
         navigation_dimension, uniform, add_baseline, add_noise
@@ -51,6 +70,18 @@ def test_get_luminescence_signal(
 
 @pytest.mark.parametrize("shape", ((128, 128), (256, 256)))
 @pytest.mark.parametrize("add_noise", (True, False))
-def test_get_wave_image(shape, add_noise):
+def test_wave_image(shape, add_noise):
     s = hs.data.wave_image(shape=shape, add_noise=add_noise)
     assert s.data.shape == shape
+
+
+def test_get_largest_rectangle_from_rotation():
+    assert (0, 0) == _get_largest_rectangle_from_rotation(0, 0, 10)
+
+    np.testing.assert_allclose(
+        (27.483482, 13.341346), _get_largest_rectangle_from_rotation(30, 20, 15)
+    )
+
+    np.testing.assert_allclose(
+        (38.637033, 10.352761), _get_largest_rectangle_from_rotation(50, 20, 15)
+    )

--- a/upcoming_changes/3420.enhancements.rst
+++ b/upcoming_changes/3420.enhancements.rst
@@ -1,0 +1,1 @@
+Add parameters to :func:`~.api.data.atomic_resolution_image` to set the spacing and rotation of the lattice and the size of the signal.


### PR DESCRIPTION
### Progress of the PR
- [x] Add parameters to `hs.data.atomic_resolution_image` to set the size, spacing and rotation of lattice,
- [x] update docstring (if appropriate),
- [n/a] update user guide (if appropriate),
- [x] add an changelog entry in the `upcoming_changes` folder (see [`upcoming_changes/README.rst`](https://github.com/hyperspy/hyperspy/blob/RELEASE_next_minor/upcoming_changes/README.rst)),
- [x] Check formatting changelog entry in the `readthedocs` doc build of this PR (link in github checks)
- [x] add tests,
- [x] ready for review.

### Minimal example of the bug fix or the new feature
```python
import hyperspy.api as hs

s = hs.data.atomic_resolution_image(spacing=(0.2, 0.3), rotation_angle=30, size=2048, add_noise=True)
s.plot()
```

