### PR TITLE
Various `get_histogram` fixes

### DIFF
--- a/hyperspy/_signals/lazy.py
+++ b/hyperspy/_signals/lazy.py
@@ -24,6 +24,7 @@ from itertools import product
 import dask
 import dask.array as da
 import numpy as np
+import traits.api as t
 from rsciio.utils import rgb_tools
 from rsciio.utils.tools import get_file_handle
 
@@ -741,10 +742,19 @@ class LazySignal(BaseSignal):
             # we always overwrite the data because the computation is lazy ->
             # the result signal is lazy. Assume that the `out` is already lazy
             hist_spec.data = hist
+
+        name = self.metadata.get_item("Signal.quantity", "value")
+        units = t.Undefined
+        if "(" in name:
+            name, units = name.split("(")
+            name = name.strip()
+            units = units.strip(")")
+        hist_spec.axes_manager[0].name = name
+        hist_spec.axes_manager[0].units = units
+
         hist_spec.axes_manager[0].scale = bin_edges[1] - bin_edges[0]
         hist_spec.axes_manager[0].offset = bin_edges[0]
         hist_spec.axes_manager[0].size = hist.shape[-1]
-        hist_spec.axes_manager[0].name = "value"
         hist_spec.axes_manager[0].is_binned = True
         hist_spec.metadata.General.title = self.metadata.General.title + " histogram"
         if out is None:

--- a/hyperspy/_signals/lazy.py
+++ b/hyperspy/_signals/lazy.py
@@ -725,14 +725,16 @@ class LazySignal(BaseSignal):
 
     valuemin.__doc__ = BaseSignal.valuemin.__doc__
 
-    def get_histogram(self, bins="fd", out=None, rechunk=False, **kwargs):
+    def get_histogram(
+        self, bins="fd", range_bins=None, out=None, rechunk=False, **kwargs
+    ):
         if "range_bins" in kwargs:
-            _logger.warning("'range_bins' argument not supported for lazy " "signals")
+            _logger.warning("'range_bins' argument not supported for lazy signals")
             del kwargs["range_bins"]
         from hyperspy.signals import Signal1D
 
         data = self._lazy_data(rechunk=rechunk).flatten()
-        hist, bin_edges = histogram_dask(data, bins=bins, **kwargs)
+        hist, bin_edges = histogram_dask(data, bins=bins, range=range_bins, **kwargs)
         if out is None:
             hist_spec = Signal1D(hist)
             hist_spec._lazy = True

--- a/hyperspy/_signals/lazy.py
+++ b/hyperspy/_signals/lazy.py
@@ -728,9 +728,6 @@ class LazySignal(BaseSignal):
     def get_histogram(
         self, bins="fd", range_bins=None, out=None, rechunk=False, **kwargs
     ):
-        if "range_bins" in kwargs:
-            _logger.warning("'range_bins' argument not supported for lazy signals")
-            del kwargs["range_bins"]
         from hyperspy.signals import Signal1D
 
         data = self._lazy_data(rechunk=rechunk).flatten()

--- a/hyperspy/_signals/signal1d.py
+++ b/hyperspy/_signals/signal1d.py
@@ -320,8 +320,14 @@ class Signal1D(BaseSignal, CommonSignal1D):
         # arbitrary cutoff for number of spectra necessary before histogram
         # data is compressed by finding maxima of each spectrum
         tmp = BaseSignal(der) if n < 2000 else BaseSignal(np.ravel(der.max(-1)))
-
-        s_ = tmp.get_histogram(**kwargs)
+        with warnings.catch_warnings():
+            warnings.filterwarnings(
+                "ignore",
+                category=Warning,
+                message="Estimated number of bins using",
+                module="hyperspy",
+            )
+            s_ = tmp.get_histogram(**kwargs)
         s_.axes_manager[0].name = "Derivative magnitude"
         s_.metadata.Signal.quantity = "Counts"
         s_.metadata.General.title = "Spikes Analysis"

--- a/hyperspy/docstrings/signal.py
+++ b/hyperspy/docstrings/signal.py
@@ -140,6 +140,22 @@ HISTOGRAM_MAX_BIN_ARGS = """max_num_bins : int, default 250
            number of bins is capped by this number to avoid a MemoryError
            being raised by :func:`numpy.histogram`."""
 
+
+HISTOGRAM_RANGE_ARGS = """range : (float, float), optional
+        The lower and upper range of the bins.  If not provided, range
+        is simply ``(a.min(), a.max())``.  Values outside the range are
+        ignored. The first element of the range must be less than or
+        equal to the second. `range` affects the automatic bin
+        computation as well. While bin width is computed to be optimal
+        based on the actual data within `range`, the bin count will fill
+        the entire range including portions containing no data."""
+
+HISTOGRAM_WEIGHTS_ARGS = """weights : array_like, optional
+        An array of weights, of the same shape as `a`.  Each value in
+        `a` only contributes its associated weight towards the bin count
+        (instead of 1). This is currently not used by any of the bin estimators,
+        but may be in the future."""
+
 SIGNAL_MASK_ARG = """signal_mask : numpy.ndarray of bool
             Restricts the operation to the signal locations not marked
             as True (masked)."""

--- a/hyperspy/docstrings/signal.py
+++ b/hyperspy/docstrings/signal.py
@@ -49,112 +49,94 @@ OPTIMIZE_ARG = """optimize : bool
             the chunks are optimised for the new axes configuration."""
 
 RECHUNK_ARG = """rechunk : bool
-           Only has effect when operating on lazy signal. Default ``False``,
-           which means the chunking structure will be retained. If ``True``,
-           the data may be automatically rechunked before performing this
-           operation."""
+            Only has effect when operating on lazy signal. Default ``False``,
+            which means the chunking structure will be retained. If ``True``,
+            the data may be automatically rechunked before performing this
+            operation."""
 
 SHOW_PROGRESSBAR_ARG = """show_progressbar : None or bool
-           If ``True``, display a progress bar. If ``None``, the default from
-           the preferences settings is used."""
+            If ``True``, display a progress bar. If ``None``, the default from
+            the preferences settings is used."""
 
 LAZY_OUTPUT_ARG = """lazy_output : None or bool
-           If ``True``, the output will be returned as a lazy signal. This means
-           the calculation itself will be delayed until either compute() is used,
-           or the signal is stored as a file.
-           If ``False``, the output will be returned as a non-lazy signal, this
-           means the outputs will be calculated directly, and loaded into memory.
-           If ``None`` the output will be lazy if the input signal is lazy, and
-           non-lazy if the input signal is non-lazy."""
+            If ``True``, the output will be returned as a lazy signal. This means
+            the calculation itself will be delayed until either compute() is used,
+            or the signal is stored as a file.
+            If ``False``, the output will be returned as a non-lazy signal, this
+            means the outputs will be calculated directly, and loaded into memory.
+            If ``None`` the output will be lazy if the input signal is lazy, and
+            non-lazy if the input signal is non-lazy."""
 
 NUM_WORKERS_ARG = """num_workers : None or int
-           Number of worker used by dask. If None, default
-           to dask default value."""
+            Number of worker used by dask. If None, default
+            to dask default value."""
 
 CLUSTER_SIGNALS_ARG = """signal : {"mean", "sum", "centroid"}, optional
-           If "mean" or "sum" return the mean signal or sum respectively
-           over each cluster. If "centroid", returns the signals closest
-           to the centroid."""
+            If "mean" or "sum" return the mean signal or sum respectively
+            over each cluster. If "centroid", returns the signals closest
+            to the centroid."""
 
 HISTOGRAM_BIN_ARGS = """bins : int or sequence of float or str, default "fd"
-           If ``bins`` is an int, it defines the number of equal-width
-           bins in the given range. If ``bins`` is a
-           sequence, it defines the bin edges, including the rightmost
-           edge, allowing for non-uniform bin widths.
+            If ``bins`` is an int, it defines the number of equal-width
+            bins in the given range. If ``bins`` is a
+            sequence, it defines the bin edges, including the rightmost
+            edge, allowing for non-uniform bin widths.
 
-           If ``bins`` is a string from the list below, will use
-           the method chosen to calculate the optimal bin width and
-           consequently the number of bins (see Notes for more detail on
-           the estimators) from the data that falls within the requested
-           range. While the bin width will be optimal for the actual data
-           in the range, the number of bins will be computed to fill the
-           entire range, including the empty portions. For visualisation,
-           using the ``'auto'`` option is suggested. Weighted data is not
-           supported for automated bin size selection.
+            If ``bins`` is a string from the list below, will use
+            the method chosen to calculate the optimal bin width and
+            consequently the number of bins (see Notes for more detail on
+            the estimators) from the data that falls within the requested
+            range. While the bin width will be optimal for the actual data
+            in the range, the number of bins will be computed to fill the
+            entire range, including the empty portions. For visualisation,
+            using the ``'auto'`` option is suggested. Weighted data is not
+            supported for automated bin size selection.
 
-           'auto'
-               Maximum of the 'sturges' and 'fd' estimators. Provides good
-               all around performance.
+            Possible strings are:
 
-           'fd' (Freedman Diaconis Estimator)
-               Robust (resilient to outliers) estimator that takes into
-               account data variability and data size.
-
-           'doane'
-               An improved version of Sturges' estimator that works better
-               with non-normal datasets.
-
-           'scott'
-               Less robust estimator that that takes into account data
-               variability and data size.
-
-           'stone'
-               Estimator based on leave-one-out cross-validation estimate of
-               the integrated squared error. Can be regarded as a generalization
-               of Scott's rule.
-
-           'rice'
-               Estimator does not take variability into account, only data
-               size. Commonly overestimates number of bins required.
-
-           'sturges'
-               R's default method, only accounts for data size. Only
-               optimal for gaussian data and underestimates number of bins
-               for large non-gaussian datasets.
-
-           'sqrt'
-               Square root (of data size) estimator, used by Excel and
-               other programs for its speed and simplicity.
-
-           'knuth'
-               Knuth's rule is a fixed-width, Bayesian approach to determining
-               the optimal bin width of a histogram.
-
-           'blocks'
-               Determination of optimal adaptive-width histogram bins using
-               the Bayesian Blocks algorithm.
-    """
+            - ``'auto'`` : Maximum of the 'sturges' and 'fd' estimators.
+              Provides good all around performance.
+            - ``'fd'`` : Freedman Diaconis Estimator, robust
+              (resilient to outliers) estimator that takes into
+              account data variability and data size.
+            - ``'doane'`` : An improved version of Sturges' estimator
+              that works better with non-normal datasets.
+            - ``'scott'`` : Less robust estimator that that takes into
+              account data variability and data size.
+            - ``'stone'`` : Estimator based on leave-one-out cross-validation
+              estimate of the integrated squared error. Can be regarded
+              as a generalization of Scott's rule.
+            - ``'rice'`` : Estimator does not take variability into account,
+              only data size. Commonly overestimates number of bins required.
+            - ``'sturges'`` : R's default method, only accounts for data size.
+              Only optimal for gaussian data and underestimates number
+              of bins for large non-gaussian datasets.
+            - ``'sqrt'`` : Square root (of data size) estimator, used by Excel
+              and other programs for its speed and simplicity.
+            - ``'knuth'`` : Knuth's rule is a fixed-width, Bayesian approach to
+              determining the optimal bin width of a histogram.
+            - ``'blocks'`` : Determination of optimal adaptive-width histogram
+              bins using the Bayesian Blocks algorithm."""
 
 HISTOGRAM_MAX_BIN_ARGS = """max_num_bins : int, default 250
-           When estimating the bins using one of the str methods, the
-           number of bins is capped by this number to avoid a MemoryError
-           being raised by :func:`numpy.histogram`."""
+            When estimating the bins using one of the str methods, the
+            number of bins is capped by this number to avoid a MemoryError
+            being raised by :func:`numpy.histogram`."""
 
-
-HISTOGRAM_RANGE_ARGS = """range : (float, float), optional
-        The lower and upper limit of the range of bins. If not provided,
-        range is simply ``(a.min(), a.max())``. Values outside the range are
-        ignored. The first element of the range must be less than or
-        equal to the second. `range` affects the automatic bin
-        computation as well. While bin width is computed to be optimal
-        based on the actual data within `range`, the bin count will fill
-        the entire range including portions containing no data."""
+HISTOGRAM_RANGE_ARGS = """range_bins : (float, float), optional
+            The lower and upper limit of the range of bins. If not provided,
+            range is simply ``(a.min(), a.max())``. Values outside the range are
+            ignored. The first element of the range must be less than or
+            equal to the second. `range` affects the automatic bin
+            computation as well. While bin width is computed to be optimal
+            based on the actual data within `range`, the bin count will fill
+            the entire range including portions containing no data."""
 
 HISTOGRAM_WEIGHTS_ARGS = """weights : array_like, optional
-        An array of weights, of the same shape as `a`.  Each value in
-        `a` only contributes its associated weight towards the bin count
-        (instead of 1). This is currently not used by any of the bin estimators,
-        but may be in the future."""
+            An array of weights, of the same shape as `a`.  Each value in
+            `a` only contributes its associated weight towards the bin count
+            (instead of 1). This is currently not used by any of the bin estimators,
+            but may be in the future."""
 
 SIGNAL_MASK_ARG = """signal_mask : numpy.ndarray of bool
             Restricts the operation to the signal locations not marked

--- a/hyperspy/docstrings/signal.py
+++ b/hyperspy/docstrings/signal.py
@@ -142,8 +142,8 @@ HISTOGRAM_MAX_BIN_ARGS = """max_num_bins : int, default 250
 
 
 HISTOGRAM_RANGE_ARGS = """range : (float, float), optional
-        The lower and upper range of the bins.  If not provided, range
-        is simply ``(a.min(), a.max())``.  Values outside the range are
+        The lower and upper limit of the range of bins. If not provided,
+        range is simply ``(a.min(), a.max())``. Values outside the range are
         ignored. The first element of the range must be less than or
         equal to the second. `range` affects the automatic bin
         computation as well. While bin width is computed to be optimal

--- a/hyperspy/drawing/utils.py
+++ b/hyperspy/drawing/utils.py
@@ -38,6 +38,7 @@ from rsciio.utils import rgb_tools
 import hyperspy
 import hyperspy.api as hs
 from hyperspy.defaults_parser import preferences
+from hyperspy.docstrings.signal import HISTOGRAM_BIN_ARGS, HISTOGRAM_RANGE_ARGS
 from hyperspy.misc.utils import to_numpy
 
 _logger = logging.getLogger(__name__)
@@ -1705,16 +1706,8 @@ def plot_histograms(
     signal_list : iterable
         Ordered list of spectra to plot. If ``style`` is ``"cascade"`` or
         ``"mosaic"``, the spectra can have different size and axes.
-    bins : int, list or str, optional
-        If bins is a string, then it must be one of:
-
-         - ``'knuth'`` : use Knuth's rule to determine bins,
-         - ``'scott'`` : use Scott's rule to determine bins,
-         - ``'fd'`` : use the Freedman-diaconis rule to determine bins,
-         - ``'blocks'`` : use bayesian blocks for dynamic bin widths.
-    range_bins : None or tuple, optional
-        The minimum and maximum range for the histogram. If not specified,
-        it will be (``x.min()``, ``x.max()``).
+    %s
+    %s
     color : None, (list of) matplotlib color, optional
         Sets the color of the lines of the plots. For a list, if its length is
         less than the number of spectra to plot, the colors will be cycled.
@@ -1763,6 +1756,9 @@ def plot_histograms(
         legend=legend,
         fig=fig,
     )
+
+
+plot_histograms.__doc__ %= (HISTOGRAM_BIN_ARGS, HISTOGRAM_RANGE_ARGS)
 
 
 def picker_kwargs(value, kwargs=None):

--- a/hyperspy/misc/hist_tools.py
+++ b/hyperspy/misc/hist_tools.py
@@ -20,6 +20,7 @@ import logging
 
 import dask.array as da
 import numpy as np
+import traits.api as t
 
 from hyperspy.docstrings.signal import (
     HISTOGRAM_BIN_ARGS,
@@ -31,6 +32,21 @@ from hyperspy.external.astropy.bayesian_blocks import bayesian_blocks
 from hyperspy.external.astropy.histogram import knuth_bin_width
 
 _logger = logging.getLogger(__name__)
+
+
+def _set_histogram_metadata(signal, histogram, **kwargs):
+    name = signal.metadata.get_item("Signal.quantity", "value")
+    units = t.Undefined
+    if "(" in name:
+        name, units = name.split("(")
+        name = name.strip()
+        units = units.strip(")")
+    histogram.axes_manager[0].name = name
+    histogram.axes_manager[0].units = units
+    histogram.axes_manager[0].is_binned = True
+    histogram.metadata.General.title = signal.metadata.General.title + " histogram"
+    quantity = "Probability density" if kwargs.get("density") else "Count"
+    histogram.metadata.Signal.quantity = quantity
 
 
 def histogram(a, bins="fd", range=None, max_num_bins=250, weights=None, **kwargs):

--- a/hyperspy/misc/hist_tools.py
+++ b/hyperspy/misc/hist_tools.py
@@ -16,7 +16,7 @@
 # You should have received a copy of the GNU General Public License
 # along with HyperSpy. If not, see <https://www.gnu.org/licenses/#GPL>.
 
-import logging
+import warnings
 
 import dask.array as da
 import numpy as np
@@ -30,8 +30,6 @@ from hyperspy.docstrings.signal import (
 )
 from hyperspy.external.astropy.bayesian_blocks import bayesian_blocks
 from hyperspy.external.astropy.histogram import knuth_bin_width
-
-_logger = logging.getLogger(__name__)
 
 
 def _set_histogram_metadata(signal, histogram, **kwargs):
@@ -111,7 +109,7 @@ def histogram(a, bins="fd", range=None, max_num_bins=250, weights=None, **kwargs
         # https://github.com/hyperspy/hyperspy/issues/784,
         # we log a warning and cap the number of bins at
         # a sensible value.
-        _logger.warning(
+        warnings.warn(
             f"Estimated number of bins using `bins='{_old_bins}'` "
             f"is too large ({_bins_len}). Capping the number of bins "
             f"at `max_num_bins={max_num_bins}`. Consider using an "
@@ -200,7 +198,7 @@ def histogram_dask(a, bins="fd", range=None, max_num_bins=250, weights=None, **k
         # https://github.com/hyperspy/hyperspy/issues/784,
         # we log a warning and cap the number of bins at
         # a sensible value.
-        _logger.warning(
+        warnings.warn(
             f"Estimated number of bins using `bins='{_old_bins}'` "
             f"is too large ({_bins_len}). Capping the number of bins "
             f"at `max_num_bins={max_num_bins}`. Consider using an "

--- a/hyperspy/misc/hist_tools.py
+++ b/hyperspy/misc/hist_tools.py
@@ -107,7 +107,7 @@ def histogram(a, bins="fd", range=None, max_num_bins=250, weights=None, **kwargs
     if _bins_len > max_num_bins:
         # To avoid memory errors such as that detailed in
         # https://github.com/hyperspy/hyperspy/issues/784,
-        # we log a warning and cap the number of bins at
+        # we raise a warning and cap the number of bins at
         # a sensible value.
         warnings.warn(
             f"Estimated number of bins using `bins='{_old_bins}'` "
@@ -126,7 +126,7 @@ def histogram(a, bins="fd", range=None, max_num_bins=250, weights=None, **kwargs
 
 histogram.__doc__ %= (
     HISTOGRAM_BIN_ARGS,
-    HISTOGRAM_RANGE_ARGS,
+    HISTOGRAM_RANGE_ARGS.replace("range_bins : ", "range : "),
     HISTOGRAM_MAX_BIN_ARGS,
     HISTOGRAM_WEIGHTS_ARGS,
 )

--- a/hyperspy/signal.py
+++ b/hyperspy/signal.py
@@ -79,7 +79,7 @@ from hyperspy.io import assign_signal_subclass
 from hyperspy.io import save as io_save
 from hyperspy.learn.mva import MVA, LearningResults
 from hyperspy.misc.array_tools import rebin as array_rebin
-from hyperspy.misc.hist_tools import histogram
+from hyperspy.misc.hist_tools import _set_histogram_metadata, histogram
 from hyperspy.misc.math_tools import check_random_state, hann_window_nth_order, outer_nd
 from hyperspy.misc.signal_tools import are_signals_aligned, broadcast_signals
 from hyperspy.misc.slicing import FancySlicing, SpecialSlicers
@@ -5156,18 +5156,8 @@ class BaseSignal(
             hist_spec.axes_manager[0].offset = bin_edges[0]
             hist_spec.axes_manager[0].size = hist.shape[-1]
 
-        name = self.metadata.get_item("Signal.quantity", "value")
-        units = t.Undefined
-        if "(" in name:
-            name, units = name.split("(")
-            name = name.strip()
-            units = units.strip(")")
-        hist_spec.axes_manager[0].name = name
-        hist_spec.axes_manager[0].units = units
-        hist_spec.axes_manager[0].is_binned = True
-        hist_spec.metadata.General.title = self.metadata.General.title + " histogram"
-        quantity = "Probability density" if kwargs.get("density") else "Count"
-        hist_spec.metadata.Signal.quantity = quantity
+        _set_histogram_metadata(self, hist_spec, **kwargs)
+
         if out is None:
             return hist_spec
         else:

--- a/hyperspy/signal.py
+++ b/hyperspy/signal.py
@@ -5107,6 +5107,11 @@ class BaseSignal(
         hist_spec : :class:`~.api.signals.Signal1D`
             A 1D spectrum instance containing the histogram.
 
+        Note
+        ----
+        See :func:`numpy.histogram` for more details of the
+        meaning of the returned values.
+
         See Also
         --------
         hyperspy.api.signals.BaseSignal.print_summary_statistics,
@@ -5151,9 +5156,18 @@ class BaseSignal(
             hist_spec.axes_manager[0].offset = bin_edges[0]
             hist_spec.axes_manager[0].size = hist.shape[-1]
 
-        hist_spec.axes_manager[0].name = "value"
+        name = self.metadata.get_item("Signal.quantity", "value")
+        units = t.Undefined
+        if "(" in name:
+            name, units = name.split("(")
+            name = name.strip()
+            units = units.strip(")")
+        hist_spec.axes_manager[0].name = name
+        hist_spec.axes_manager[0].units = units
         hist_spec.axes_manager[0].is_binned = True
         hist_spec.metadata.General.title = self.metadata.General.title + " histogram"
+        quantity = "Probability density" if kwargs.get("density") else "Count"
+        hist_spec.metadata.Signal.quantity = quantity
         if out is None:
             return hist_spec
         else:

--- a/hyperspy/signal.py
+++ b/hyperspy/signal.py
@@ -53,6 +53,7 @@ from hyperspy.docstrings.signal import (
     CLUSTER_SIGNALS_ARG,
     HISTOGRAM_BIN_ARGS,
     HISTOGRAM_MAX_BIN_ARGS,
+    HISTOGRAM_RANGE_ARGS,
     LAZY_OUTPUT_ARG,
     MANY_AXIS_PARAMETER,
     NAN_FUNC,
@@ -5092,9 +5093,7 @@ class BaseSignal(
         Parameters
         ----------
         %s
-        range_bins : tuple or None, optional
-            the minimum and maximum range for the histogram. If
-            `range_bins` is ``None``, (``x.min()``, ``x.max()``) will be used.
+        %s
         %s
         %s
         %s
@@ -5107,8 +5106,8 @@ class BaseSignal(
         hist_spec : :class:`~.api.signals.Signal1D`
             A 1D spectrum instance containing the histogram.
 
-        Note
-        ----
+        Notes
+        -----
         See :func:`numpy.histogram` for more details on the
         meaning of the returned values.
 
@@ -5165,6 +5164,7 @@ class BaseSignal(
 
     get_histogram.__doc__ %= (
         HISTOGRAM_BIN_ARGS,
+        HISTOGRAM_RANGE_ARGS,
         HISTOGRAM_MAX_BIN_ARGS,
         OUT_ARG,
         RECHUNK_ARG,

--- a/hyperspy/signal.py
+++ b/hyperspy/signal.py
@@ -5109,7 +5109,7 @@ class BaseSignal(
 
         Note
         ----
-        See :func:`numpy.histogram` for more details of the
+        See :func:`numpy.histogram` for more details on the
         meaning of the returned values.
 
         See Also

--- a/hyperspy/tests/misc/test_hist_tools.py
+++ b/hyperspy/tests/misc/test_hist_tools.py
@@ -23,6 +23,7 @@ import pytest
 
 import hyperspy.api as hs
 from hyperspy.decorators import lazifyTestClass
+from hyperspy.misc.hist_tools import histogram
 
 
 def generate_bad_toy_data():
@@ -120,3 +121,10 @@ class TestHistogramBinMethodsBadDataset:
         axis = out.axes_manager[-1].axis
         np.testing.assert_allclose(axis[0], 1e-10)
         np.testing.assert_allclose(axis[-1], 0.498)
+
+
+def test_histogram_dask_array_fallback():
+    s = generate_bad_toy_data().as_lazy()
+    out, bins = histogram(s.data, bins=10)
+    assert bins.shape == (11,)
+    np.testing.assert_allclose(out, [5014, 56, 32, 24, 20, 12, 12, 12, 8, 10])

--- a/hyperspy/tests/misc/test_hist_tools.py
+++ b/hyperspy/tests/misc/test_hist_tools.py
@@ -73,15 +73,18 @@ def test_unsupported_lazy():
         s1.get_histogram(bins="sturges")
 
 
+@pytest.mark.parametrize("density", (True, False))
 @pytest.mark.parametrize("lazy", (True, False))
-def test_histogram_quantity(lazy):
+def test_histogram_metadata(lazy, density):
     s1 = generate_bad_toy_data()
     if lazy:
         s1 = s1.as_lazy()
     s1.metadata.Signal.quantity = "Intensity (Count)"
-    out = s1.get_histogram(bins=200)
+    out = s1.get_histogram(bins=200, density=density)
     assert out.axes_manager[-1].name == "Intensity"
     assert out.axes_manager[-1].units == "Count"
+    quantity = "Probability density" if density else "Count"
+    assert out.metadata.Signal.quantity == quantity
 
 
 @lazifyTestClass

--- a/hyperspy/tests/misc/test_hist_tools.py
+++ b/hyperspy/tests/misc/test_hist_tools.py
@@ -107,3 +107,13 @@ class TestHistogramBinMethodsBadDataset:
     def test_working_bins(self, bins, size):
         out = self.s1.get_histogram(bins=bins)
         assert out.data.shape == size
+
+    def test_range_bins(self, caplog):
+        # when falling back to capping the number of bins to 250, make sure
+        # that the kwargs are passed correctly
+        with caplog.at_level(logging.WARNING):
+            out = self.s1.get_histogram(range_bins=[1e-10, 0.5])
+
+        axis = out.axes_manager[-1].axis
+        np.testing.assert_allclose(axis[0], 1e-10)
+        np.testing.assert_allclose(axis[-1], 0.498)

--- a/hyperspy/tests/misc/test_hist_tools.py
+++ b/hyperspy/tests/misc/test_hist_tools.py
@@ -73,6 +73,17 @@ def test_unsupported_lazy():
         s1.get_histogram(bins="sturges")
 
 
+@pytest.mark.parametrize("lazy", (True, False))
+def test_histogram_quantity(lazy):
+    s1 = generate_bad_toy_data()
+    if lazy:
+        s1 = s1.as_lazy()
+    s1.metadata.Signal.quantity = "Intensity (Count)"
+    out = s1.get_histogram(bins=200)
+    assert out.axes_manager[-1].name == "Intensity"
+    assert out.axes_manager[-1].units == "Count"
+
+
 @lazifyTestClass
 class TestHistogramBinMethodsBadDataset:
     def setup_method(self, method):

--- a/hyperspy/tests/misc/test_hist_tools.py
+++ b/hyperspy/tests/misc/test_hist_tools.py
@@ -16,7 +16,6 @@
 # You should have received a copy of the GNU General Public License
 # along with HyperSpy. If not, see <https://www.gnu.org/licenses/#GPL>.
 
-import logging
 
 import numpy as np
 import pytest
@@ -49,14 +48,12 @@ def test_types_of_bins(bins):
     assert out.data.shape == (10,)
 
 
-def test_knuth_bad_data_set(caplog):
+def test_knuth_bad_data_set():
     s1 = generate_bad_toy_data()
-    with caplog.at_level(logging.WARNING):
+    with pytest.warns(UserWarning, match="Capping the number of bins"):
         out = s1.get_histogram("knuth")
 
     assert out.data.shape == (250,)
-    assert "Initial estimation of number of bins using Freedman-Diaconis" in caplog.text
-    assert "Capping the number of bins" in caplog.text
 
 
 def test_bayesian_blocks_warning():
@@ -93,29 +90,27 @@ class TestHistogramBinMethodsBadDataset:
     def setup_method(self, method):
         self.s1 = generate_bad_toy_data()
 
-    def test_fd_logger_warning(self, caplog):
-        with caplog.at_level(logging.WARNING):
+    def test_fd_logger_warning(self):
+        with pytest.warns(UserWarning, match="Capping the number of bins"):
             out = self.s1.get_histogram()
 
         assert out.data.shape == (250,)
-        assert "Capping the number of bins" in caplog.text
 
-    def test_int_bins_logger_warning(self, caplog):
-        with caplog.at_level(logging.WARNING):
+    def test_int_bins_logger_warning(self):
+        with pytest.warns(UserWarning, match="Capping the number of bins"):
             out = self.s1.get_histogram(bins=251)
 
         assert out.data.shape == (250,)
-        assert "Capping the number of bins" in caplog.text
 
     @pytest.mark.parametrize("bins, size", [("scott", (58,)), (10, (10,))])
     def test_working_bins(self, bins, size):
         out = self.s1.get_histogram(bins=bins)
         assert out.data.shape == size
 
-    def test_range_bins(self, caplog):
+    def test_range_bins(self):
         # when falling back to capping the number of bins to 250, make sure
         # that the kwargs are passed correctly
-        with caplog.at_level(logging.WARNING):
+        with pytest.warns(UserWarning, match="Capping the number of bins"):
             out = self.s1.get_histogram(range_bins=[1e-10, 0.5])
 
         axis = out.axes_manager[-1].axis

--- a/upcoming_changes/3422.bugfix.rst
+++ b/upcoming_changes/3422.bugfix.rst
@@ -1,0 +1,4 @@
+:meth:`~.api.signals.BaseSignal.get_histogram` fixes:
+- fix setting range when falling back to capped bin number,
+- set name and units of the returned signal
+- don't remove ``range_bins`` parameter for lazy signal since dask now supports it.

--- a/upcoming_changes/3422.bugfix.rst
+++ b/upcoming_changes/3422.bugfix.rst
@@ -1,4 +1,5 @@
 :meth:`~.api.signals.BaseSignal.get_histogram` fixes:
+
 - fix setting range when falling back to capped bin number,
-- set name and units of the returned signal
+- set name and units of the returned signal,
 - don't remove ``range_bins`` parameter for lazy signal since dask now supports it.


### PR DESCRIPTION
The `range_bins` parameter was ignored when the number of bins was capped automatically.

### Progress of the PR
- [x] Fix setting range histogram when falling back to capped bin number,
- [x] set name and units of the returned signal, 
- [x] don't remove `range_bins` parameter for lazy signal since dask now supports it, 
- [x] update docstring (if appropriate),
- [n/a] update user guide (if appropriate),
- [x] add an changelog entry in the `upcoming_changes` folder (see [`upcoming_changes/README.rst`](https://github.com/hyperspy/hyperspy/blob/RELEASE_next_minor/upcoming_changes/README.rst)),
- [x] Check formatting changelog entry in the `readthedocs` doc build of this PR (link in github checks)
- [x] add tests,
- [x] ready for review.

