### PR TITLE
Linear optimizer improvements

### DIFF
--- a/doc/user_guide/model/fitting_model.rst
+++ b/doc/user_guide/model/fitting_model.rst
@@ -460,7 +460,7 @@ solve the problem as a linear regression problem! This can be done using two app
     Gaussian peaks with well-defined energy (``Gaussian.centre``) and peak widths
     (``Gaussian.sigma``). This dataset can be fit extremely fast with a linear optimizer.
 
-There are two implementations of linear least squares fitting in hyperspy:
+There are several implementations of linear least squares fitting in HyperSpy:
 
 - ``'lstsq'``: least squares using :func:`numpy.linalg.lstsq`, or
   :func:`dask.array.linalg.lstsq` for lazy signals,
@@ -469,7 +469,7 @@ There are two implementations of linear least squares fitting in hyperspy:
   :class:`sklearn.linear_model.LinearRegression`,
 - ``'ridge'``: least square supporting regularisation using
   :class:`sklearn.linear_model.Ridge`. The parameter ``alpha`` controls the
-  regularization strength and can significantly affects the results.
+  regularization strength and can significantly affect the results.
 
 See the corresponding documentation in `scikit-learn <https://scikit-learn.org/stable/modules/linear_model.html>`_
 or :func:`numpy.linalg.lstsq` for passing parameters to :meth:`~hyperspy.model.BaseModel.fit` or
@@ -477,7 +477,7 @@ or :func:`numpy.linalg.lstsq` for passing parameters to :meth:`~hyperspy.model.B
 Only the ``'lstsq'`` optimizer supports lazy signals.
 
 As for non-linear least squares fitting, :ref:`weighted least squares <weighted_least_squares-label>`
-is supported.
+are supported.
 
 In the following example, we first generate a 300x300 navigation signal of varying total intensity,
 and then populate it with an EDS spectrum at each point. The signal can be fitted with a polynomial

--- a/doc/user_guide/model/fitting_model.rst
+++ b/doc/user_guide/model/fitting_model.rst
@@ -43,7 +43,11 @@ whether the optimizers find a local or global optima.
     +---------------------------------+----------+-----------+----------+---------------+--------+--------+
     | ``"lstsq"``                     |  No      | No        | Yes [1]_ | Only ``"ls"`` | global | Yes    |
     +---------------------------------+----------+-----------+----------+---------------+--------+--------+
-    | ``"ridge_regression"``          |  No      | No        | Yes [1]_ | Only ``"ls"`` | global | Yes    |
+    | ``"ols"``                       |  No      | No        | Yes [1]_ | Only ``"ls"`` | global | Yes    |
+    +---------------------------------+----------+-----------+----------+---------------+--------+--------+
+    | ``"nnls"``                      |  No      | No        | Yes [1]_ | Only ``"ls"`` | global | Yes    |
+    +---------------------------------+----------+-----------+----------+---------------+--------+--------+
+    | ``"ridge"``                     |  No      | No        | Yes [1]_ | Only ``"ls"`` | global | Yes    |
     +---------------------------------+----------+-----------+----------+---------------+--------+--------+
     | :func:`scipy.optimize.minimize` | Yes [2]_ | Yes [2]_  | No       | All           | local  | No     |
     +---------------------------------+----------+-----------+----------+---------------+--------+--------+
@@ -458,11 +462,19 @@ solve the problem as a linear regression problem! This can be done using two app
 
 There are two implementations of linear least squares fitting in hyperspy:
 
-- the ``'lstsq'`` optimizer, which uses :func:`numpy.linalg.lstsq`, or
-  :func:`dask.array.linalg.lstsq` for lazy signals.
-- the ``'ridge_regression'`` optimizer, which supports regularization
-  (see :class:`sklearn.linear_model.Ridge` for arguments to pass to
-  :meth:`~hyperspy.model.BaseModel.fit`), but does not support lazy signals.
+- ``'lstsq'``: least squares using :func:`numpy.linalg.lstsq`, or
+  :func:`dask.array.linalg.lstsq` for lazy signals,
+- ``'ols'``: ordinary least squares, using :class:`sklearn.linear_model.LinearRegression`,
+- ``'nnls'``: least squares with positive constraints on the coefficients using
+  :class:`sklearn.linear_model.LinearRegression`,
+- ``'ridge'``: least square supporting regularisation using
+  :class:`sklearn.linear_model.Ridge`. The parameter ``alpha`` controls the
+  regularization strength and can significantly affects the results.
+
+See the corresponding documentation in `scikit-learn <https://scikit-learn.org/stable/modules/linear_model.html>`_
+or :func:`numpy.linalg.lstsq` for passing parameters to :meth:`~hyperspy.model.BaseModel.fit` or
+:meth:`~hyperspy.model.BaseModel.multifit`.
+Only the ``'lstsq'`` optimizer supports lazy signals.
 
 As for non-linear least squares fitting, :ref:`weighted least squares <weighted_least_squares-label>`
 is supported.

--- a/hyperspy/docstrings/model.py
+++ b/hyperspy/docstrings/model.py
@@ -23,7 +23,7 @@
 FIT_PARAMETERS_ARG = """optimizer : str or None, default None
             The optimization algorithm used to perform the fitting.
 
-            * Non-linear optimizer
+            * Non-linear optimizers:
 
               * ``"lm"`` performs least-squares optimization using the
                 Levenberg-Marquardt algorithm, and supports bounds
@@ -53,7 +53,7 @@ FIT_PARAMETERS_ARG = """optimizer : str or None, default None
                 :func:`scipy.optimize.shgo` for more details on available
                 options. Requires ``scipy >= 1.2.0``.
 
-            * Linear optimizer
+            * Linear optimizers:
 
               * ``"lstsq"`` - least square using :func:`numpy.linalg.lstsq`.
               * ``"ols"`` - Ordinary least square using

--- a/hyperspy/docstrings/model.py
+++ b/hyperspy/docstrings/model.py
@@ -23,33 +23,49 @@
 FIT_PARAMETERS_ARG = """optimizer : str or None, default None
             The optimization algorithm used to perform the fitting.
 
-            * ``"lm"`` performs least-squares optimization using the
-              Levenberg-Marquardt algorithm, and supports bounds
-              on parameters.
-            * ``"trf"`` performs least-squares optimization using the
-              Trust Region Reflective algorithm, and supports
-              bounds on parameters.
-            * ``"dogbox"`` performs least-squares optimization using the
-              dogleg algorithm with rectangular trust regions, and
-              supports bounds on parameters.
-            * ``"odr"`` performs the optimization using the orthogonal
-              distance regression (ODR) algorithm. It does not support
-              bounds on parameters. See :mod:`scipy.odr` for more details.
-            * All of the available methods for :func:`scipy.optimize.minimize`
-              can be used here. See the :ref:`User Guide <model.fitting>`
-              documentation for more details.
-            * ``"Differential Evolution"`` is a global optimization method.
-              It does support bounds on parameters. See
-              :func:`scipy.optimize.differential_evolution` for more
-              details on available options.
-            * ``"Dual Annealing"`` is a global optimization method.
-              It does support bounds on parameters. See
-              :func:`scipy.optimize.dual_annealing` for more
-              details on available options. Requires ``scipy >= 1.2.0``.
-            * ``"SHGO"`` (simplicial homology global optimization) is a global
-              optimization method. It does support bounds on parameters. See
-              :func:`scipy.optimize.shgo` for more details on available
-              options. Requires ``scipy >= 1.2.0``.
+            * Non-linear optimizer
+
+              * ``"lm"`` performs least-squares optimization using the
+                Levenberg-Marquardt algorithm, and supports bounds
+                on parameters.
+              * ``"trf"`` performs least-squares optimization using the
+                Trust Region Reflective algorithm, and supports
+                bounds on parameters.
+              * ``"dogbox"`` performs least-squares optimization using the
+                dogleg algorithm with rectangular trust regions, and
+                supports bounds on parameters.
+              * ``"odr"`` performs the optimization using the orthogonal
+                distance regression (ODR) algorithm. It does not support
+                bounds on parameters. See :mod:`scipy.odr` for more details.
+              * All of the available methods for :func:`scipy.optimize.minimize`
+                can be used here. See the :ref:`User Guide <model.fitting>`
+                documentation for more details.
+              * ``"Differential Evolution"`` is a global optimization method.
+                It does support bounds on parameters. See
+                :func:`scipy.optimize.differential_evolution` for more
+                details on available options.
+              * ``"Dual Annealing"`` is a global optimization method.
+                It does support bounds on parameters. See
+                :func:`scipy.optimize.dual_annealing` for more
+                details on available options. Requires ``scipy >= 1.2.0``.
+              * ``"SHGO"`` (simplicial homology global optimization) is a global
+                optimization method. It does support bounds on parameters. See
+                :func:`scipy.optimize.shgo` for more details on available
+                options. Requires ``scipy >= 1.2.0``.
+
+            * Linear optimizer
+
+              * ``"lstsq"`` - least square using :func:`numpy.linalg.lstsq`.
+              * ``"ols"`` - Ordinary least square using
+                :class:`sklearn.linear_model.LinearRegression`
+              * ``"nnls"`` - Linear regression with positive constraints on the
+                regression coefficients using
+                :class:`sklearn.linear_model.LinearRegression`
+              * ``"ridge"`` - least square supporting regularisation using
+                :class:`sklearn.linear_model.Ridge`. The parameter
+                ``alpha`` (default set to 0.01) controlling regularization
+                strength can be passed as keyword argument, see
+                :class:`sklearn.linear_model.Ridge` for more information.
 
         loss_function : {``"ls"``, ``"ML-poisson"``, ``"huber"``, callable}, default ``"ls"``
             The loss function to use for minimization. Only ``"ls"`` is available

--- a/hyperspy/model.py
+++ b/hyperspy/model.py
@@ -1109,13 +1109,13 @@ class BaseModel(list):
               as keyword argument, see :class:`sklearn.linear_model.Ridge`
               for more information.
 
-            Only 'lstsq' suppors lazy signal.
+            Only 'lstsq' suppors lazy signals.
         calculate_errors : bool, default is False
             If True, calculate the errors.
         only_current : bool, default is True
             Fit the current index only, instead of the whole navigation space.
         kwargs : dict, optional
-            Keywords arguments are passed to the corresponding optimizer.
+            Keyword arguments are passed to the corresponding optimizer.
 
         Notes
         -----

--- a/hyperspy/model.py
+++ b/hyperspy/model.py
@@ -45,6 +45,7 @@ from hyperspy.defaults_parser import preferences
 from hyperspy.docstrings.model import FIT_PARAMETERS_ARG
 from hyperspy.docstrings.signal import SHOW_PROGRESSBAR_ARG
 from hyperspy.events import Event, Events, EventSuppressor
+from hyperspy.exceptions import VisibleDeprecationWarning
 from hyperspy.extensions import ALL_EXTENSIONS
 from hyperspy.external.mpfit.mpfit import mpfit
 from hyperspy.external.progressbar import progressbar
@@ -1095,17 +1096,26 @@ class BaseModel(list):
         Parameters
         ----------
         optimizer : str, default is "lstsq"
-            'lstsq' - Default, supports lazy signal
-            'ridge_regression' - Supports regularisation, doesn't support lazy
-            signal.
-            'nnls' - Linear regression with positive
+
+            * ``'lstsq'`` - Default, least square using :func:`numpy.linalg.lstsq`.
+            * ``'ols'`` - Ordinary least square using
+              :class:`sklearn.linear_model.LinearRegression`
+            * ``'nnls'`` - Linear regression with positive constraints on the
+              regression coefficients using
+              :class:`sklearn.linear_model.LinearRegression`
+            * ``'ridge'`` - least square supporting regularisation using
+              :class:`sklearn.linear_model.Ridge`. The parameter
+              ``alpha`` controlling regularization strength can be passed
+              as keyword argument, see :class:`sklearn.linear_model.Ridge`
+              for more information.
+
+            Only 'lstsq' suppors lazy signal.
         calculate_errors : bool, default is False
             If True, calculate the errors.
         only_current : bool, default is True
             Fit the current index only, instead of the whole navigation space.
         kwargs : dict, optional
-            Keywords arguments are passed to
-            :func:`sklearn.linear_model.ridge_regression`.
+            Keywords arguments are passed to the corresponding optimizer.
 
         Notes
         -----
@@ -1121,6 +1131,13 @@ class BaseModel(list):
         fitting is hence currently only useful for fitting a dataset in the
         vectorized manner.
         """
+        if optimizer == "ridge_regression":
+            warnings.warn(
+                "`'ridge_regression'` has been renamed to `'ridge'`. "
+                "Use `optimizer='ridge'` instead.",
+                VisibleDeprecationWarning,
+            )
+            optimizer = "ridge"
 
         signal_axes = self.signal.axes_manager.signal_axes
         if any([not ax.is_uniform and ax.is_binned for ax in signal_axes]):
@@ -1251,42 +1268,49 @@ class BaseModel(list):
             comp_values = comp_values * weights
             target_signal = target_signal * weights
 
+        if self.signal._lazy and optimizer in ["ols", "nnls", "ridge"]:
+            raise ValueError(
+                f"The optimizer {optimizer} can't operate lazily, "
+                "use the `lstsq` optimizer instead."
+            )
+
         if optimizer == "lstsq":
-            xp = da if self.signal._lazy else np
-            kw = dict(rcond=None) if not self.signal._lazy else {}
+            if self.signal._lazy:
+                xp = da
+                kw = {}
+            else:
+                xp = np
+                kw = kwargs
+                kw.setdefault("rcond", None)
 
             result, residual, *_ = np.linalg.lstsq(
                 xp.asanyarray(comp_values.T), target_signal.T, **kw
             )
             coefficient_array = result.T
 
-        elif optimizer == "ridge_regression":
-            if self.signal._lazy:
-                raise ValueError(
-                    "The `ridge_regression` solver can't operate lazily, the "
-                    "`lstsq` solver can be used instead."
-                )
-
-            kwargs.setdefault("alpha", 0.0)
-            coefficient_array = import_sklearn.sklearn.linear_model.ridge_regression(
-                X=comp_values.T, y=target_signal.T, **kwargs
-            )
-            residual = None
-        elif optimizer == "nnls":
-            if self.signal._lazy:
-                raise ValueError(
-                    "The `nnls` solver can't operate lazily, the "
-                    "`lstsq` solver can be used instead."
-                )
-            kwargs["positive"] = True
+        elif optimizer in ["ols", "nnls"]:
+            if optimizer == "nnls":
+                kwargs["positive"] = True
+            kwargs.setdefault("fit_intercept", False)
             reg = import_sklearn.sklearn.linear_model.LinearRegression(**kwargs)
+            results = reg.fit(X=comp_values.T, y=target_signal.T)
+            coefficient_array = results.coef_
+            residual = None
+
+        elif optimizer == "ridge":
+            # scikit-learn documentation advices against setting alpha=0.0
+            # for numerical consideration
+            # https://scikit-learn.org/stable/modules/generated/sklearn.linear_model.Ridge.html
+            kwargs.setdefault("alpha", 0.01)
+            kwargs.setdefault("fit_intercept", False)
+            reg = import_sklearn.sklearn.linear_model.Ridge(**kwargs)
             results = reg.fit(X=comp_values.T, y=target_signal.T)
             coefficient_array = results.coef_
             residual = None
         else:
             raise ValueError(
-                f"Optimizer {optimizer} not supported. Use "
-                "'lstsq', 'ridge_regression' or 'nnls'."
+                f"Optimizer `'{optimizer}'` not supported. "
+                "Use 'lstsq', 'ols', 'nnls' or 'ridge'."
             )
 
         fit_output = {"x": coefficient_array}
@@ -1787,7 +1811,7 @@ class BaseModel(list):
                 self.p0 = self.fit_output.x
                 self.p_std = self.fit_output.perror
 
-            elif optimizer in ["lstsq", "ridge_regression", "nnls"]:
+            elif optimizer in ["lstsq", "ols", "nnls", "ridge", "ridge_regression"]:
                 # multifit pass this kwargs when necessary
                 only_current = kwargs.get("only_current", True)
                 # Errors are calculated when specifying calculate_errors=True
@@ -1975,8 +1999,10 @@ class BaseModel(list):
             )
         linear_fitting = kwargs.get("optimizer", "") in [
             "lstsq",
-            "ridge_regression",
+            "ols",
             "nnls",
+            "ridge",
+            "ridge_regression",
         ]
 
         masked_elements = 0 if mask is None else mask.sum()

--- a/hyperspy/tests/model/test_linear_model.py
+++ b/hyperspy/tests/model/test_linear_model.py
@@ -188,10 +188,10 @@ class TestMultiFitLinear:
 
         if m.signal._lazy:
             with pytest.raises(ValueError):
-                m.multifit(optimizer="ridge_regression")
+                m.multifit(optimizer="ridge")
             return
         else:
-            m.multifit(optimizer="ridge_regression")
+            m.multifit(optimizer="ridge")
 
 
 class TestLinearFitting:
@@ -288,14 +288,14 @@ class TestFitAlgorithms:
         m = self.m
         if m.signal._lazy:
             with pytest.raises(ValueError):
-                m.fit(optimizer="ridge_regression")
+                m.fit(optimizer="ridge")
             return
         else:
-            m.fit(optimizer="ridge_regression")
+            m.fit(optimizer="ridge")
         ridge_fit = m.as_signal()
-        np.testing.assert_allclose(self.nonlinear_fit_res, ridge_fit.data, rtol=5e-6)
+        np.testing.assert_allclose(self.nonlinear_fit_res, ridge_fit.data, rtol=5e-3)
         linear_std = [para.std for para in m._free_parameters if para.std]
-        np.testing.assert_allclose(self.nonlinear_fit_std, linear_std, atol=1e-8)
+        np.testing.assert_allclose(self.nonlinear_fit_std, linear_std, atol=1e-2)
 
 
 class TestWarningSlowMultifit:
@@ -382,10 +382,10 @@ class TestWarningSlowMultifit:
     def test_heteroscedastic_variance(self):
         m = self.m
         m.signal.estimate_poissonian_noise_variance()
-        with pytest.warns(UserWarning):
-            m.multifit(
-                optimizer="lstsq", match="noise of the signal is not homoscedastic"
-            )
+        with pytest.warns(
+            UserWarning, match="noise of the signal is not homoscedastic"
+        ):
+            m.multifit(optimizer="lstsq")
 
 
 class TestLinearModel2D:
@@ -820,3 +820,27 @@ def test_expression_multiple_linear_parameter(nav_dim):
         np.testing.assert_allclose(p.a0.map["values"].mean(), p_ref.a0.value)
         np.testing.assert_allclose(p.a1.map["values"].mean(), p_ref.a1.value)
         np.testing.assert_allclose(p.a2.map["values"].mean(), p_ref.a2.value)
+
+
+@pytest.mark.parametrize("optimizer", ("lstsq", "ols", "nnls", "ridge"))
+def test_fitter(optimizer):
+    if optimizer in ["ols", "nnls", "ridge"]:
+        pytest.importorskip("sklearn")
+    s_ref = hs.signals.Signal1D(np.ones(20))
+    p_ref = hs.model.components1D.Polynomial(order=2, a0=25, a1=50, a2=2.5)
+
+    m_ref = s_ref.create_model()
+    m_ref.extend([p_ref])
+    s = m_ref.as_signal()
+
+    m = s.create_model()
+    p = hs.model.components1D.Polynomial(order=2)
+    m.append(p)
+    m.fit(optimizer=optimizer)
+
+    rtol = 5e-3 if optimizer == "ridge" else 1e-7
+
+    np.testing.assert_allclose(p_ref.a0.value, p.a0.value, rtol=rtol)
+    np.testing.assert_allclose(p_ref.a1.value, p.a1.value, rtol=rtol)
+    np.testing.assert_allclose(p_ref.a2.value, p.a2.value, rtol=rtol)
+    np.testing.assert_allclose(m.as_signal().data, s.data, rtol=rtol)

--- a/hyperspy/tests/model/test_linear_model.py
+++ b/hyperspy/tests/model/test_linear_model.py
@@ -246,6 +246,7 @@ class TestFitAlgorithms:
         g1.sigma.free = False
         g1.centre.free = False
         c = Expression("a*x+b", "line with offset")
+        c.b.value = 3
         m.extend([g1, c])
         self.m = m
 

--- a/upcoming_changes/3426.api.rst
+++ b/upcoming_changes/3426.api.rst
@@ -1,0 +1,1 @@
+Linear optimizer ``"ridge_regression"`` is renamed to ``"ridge"`` in :meth:`~.model.BaseModel.fit`.

--- a/upcoming_changes/3426.enhancements.rst
+++ b/upcoming_changes/3426.enhancements.rst
@@ -1,0 +1,5 @@
+Linear optimizer improvements:
+
+- add linear optimizer using :class:`sklearn.linear_model.LinearRegression` with/without positive constraint; they can be used with ```optimizer="ols"``` or ```optimizer="nnls"``,
+- improve linear optimizer documentation, mention ``alpha`` parameter when using :class:`sklearn.linear_model.Ridge`,
+- pass parameters through to corresponding scikit-learn class or numpy function.

--- a/upcoming_changes/3426.enhancements.rst
+++ b/upcoming_changes/3426.enhancements.rst
@@ -1,5 +1,5 @@
 Linear optimizer improvements:
 
-- add linear optimizer using :class:`sklearn.linear_model.LinearRegression` with/without positive constraint; they can be used with ```optimizer="ols"``` or ```optimizer="nnls"``,
+- add linear optimizer using :class:`sklearn.linear_model.LinearRegression` with/without positive constraint; they can be used with ``optimizer="ols"`` or ``optimizer="nnls"``,
 - improve linear optimizer documentation, mention ``alpha`` parameter when using :class:`sklearn.linear_model.Ridge`,
 - pass parameters through to corresponding scikit-learn class or numpy function.


### PR DESCRIPTION
### Progress of the PR
- [x] Add linear optimizer using [`sklearn.linear_model.LinearRegression`](https://scikit-learn.org/stable/modules/generated/sklearn.linear_model.LinearRegression.html) with/without positive constraint,
- [x] rename (with deprecation) `"rigde_regression"` to `"ridge"`,
- [x] pass parameters through to corresponding scikit-learn class or numpy function,   
- [x] update docstring (if appropriate),
- [x] update user guide (if appropriate),
- [x] add an changelog entry in the `upcoming_changes` folder (see [`upcoming_changes/README.rst`](https://github.com/hyperspy/hyperspy/blob/RELEASE_next_minor/upcoming_changes/README.rst)),
- [x] Check formatting changelog entry in the `readthedocs` doc build of this PR (link in github checks)
- [x] add tests,
- [x] ready for review.

### Minimal example of the bug fix or the new feature
```python
import hyperspy.api as hs
import numpy as np

s_ref = hs.signals.Signal1D(np.ones(20))
p_ref = hs.model.components1D.Polynomial(order=2, a0=25, a1=50, a2=2.5)

m_ref = s_ref.create_model()
m_ref.extend([p_ref])
s = m_ref.as_signal()

m = s.create_model()
p = hs.model.components1D.Polynomial(order=2)
m.append(p)
m.fit(optimizer="nnls")
```

