### PR TITLE
Silence unnecessary warnings when using non-uniform axis

### DIFF
--- a/hyperspy/_signals/signal1d.py
+++ b/hyperspy/_signals/signal1d.py
@@ -1514,6 +1514,7 @@ class Signal1D(BaseSignal, CommonSignal1D):
             num_workers=num_workers,
             inplace=False,
             lazy_output=False,
+            silence_warnings="non-uniform",
         )
         return peaks.data
 

--- a/hyperspy/_signals/signal1d.py
+++ b/hyperspy/_signals/signal1d.py
@@ -1000,6 +1000,7 @@ class Signal1D(BaseSignal, CommonSignal1D):
                 show_progressbar=show_progressbar,
                 ragged=False,
                 num_workers=num_workers,
+                silence_warnings="non-uniform",
             )
 
     smooth_lowess.__doc__ %= (

--- a/hyperspy/tests/signals/test_1D_tools.py
+++ b/hyperspy/tests/signals/test_1D_tools.py
@@ -405,7 +405,8 @@ def test_hanning(lazy, offset):
         data[..., -offset:] = 0
 
     assert channels == sig.hanning_taper(side="both", channels=channels, offset=offset)
-    np.testing.assert_allclose(data, sig.data)
+    kwargs = {"atol": 0.5} if lazy else {}
+    np.testing.assert_allclose(data, sig.data, **kwargs)
 
 
 @pytest.mark.parametrize("float_data", [True, False])

--- a/hyperspy/tests/signals/test_1D_tools.py
+++ b/hyperspy/tests/signals/test_1D_tools.py
@@ -16,6 +16,7 @@
 # You should have received a copy of the GNU General Public License
 # along with HyperSpy. If not, see <https://www.gnu.org/licenses/#GPL>.
 
+import logging
 from unittest import mock
 
 import dask.array as da
@@ -337,6 +338,14 @@ class TestSmoothing:
             number_of_iterations=n_iter,
         )
         np.testing.assert_allclose(self.s.data, data, rtol=self.rtol, atol=self.atol)
+
+    def test_lowess_non_uniform(self, caplog):
+        s = self.s
+        s.axes_manager[-1].convert_to_non_uniform_axis()
+        assert not s.axes_manager[-1].is_uniform
+        with caplog.at_level(logging.WARNING):
+            s.smooth_lowess(0.5, 1)
+        assert caplog.text == ""
 
     def test_tv(self):
         weight = 1

--- a/hyperspy/tests/signals/test_1D_tools.py
+++ b/hyperspy/tests/signals/test_1D_tools.py
@@ -168,6 +168,13 @@ class TestFindPeaks1D:
             peaks["position"], self.peak_positions1, rtol=1e-5, atol=1e-4
         )
 
+    def test_non_uniform(self, caplog):
+        s = self.signal
+        s.axes_manager[-1].convert_to_non_uniform_axis()
+        with caplog.at_level(logging.WARNING):
+            _ = s.find_peaks1D_ohaver()[1]
+        assert caplog.text == ""
+
     def test_height(self):
         peaks = self.signal.find_peaks1D_ohaver()[1]
         if isinstance(peaks, da.Array):

--- a/hyperspy/tests/signals/test_map_method.py
+++ b/hyperspy/tests/signals/test_map_method.py
@@ -1323,13 +1323,29 @@ def test_silence_warning_scales(caplog):
     assert caplog.text == ""
 
     with caplog.at_level(logging.WARNING):
-        s.map(np.sum, silence_warnings=["scale"], inplace=False)
+        s.map(np.sum, silence_warnings="scales", inplace=False)
+    assert caplog.text == ""
+
+    with caplog.at_level(logging.WARNING):
+        s.map(np.sum, silence_warnings=["scales"], inplace=False)
     assert caplog.text == ""
 
     with caplog.at_level(logging.WARNING):
         s.map(np.sum, silence_warnings=False, inplace=False)
     assert "The function you applied does not take into account" in caplog.text
     assert "scales" in caplog.text
+
+
+@pytest.mark.parametrize("silence_warnings", (False, "scales"))
+def test_silence_warning_units_warn(caplog, silence_warnings):
+    s = hs.signals.Signal2D(np.arange(5 * 10 * 15).reshape(5, 10, 15))
+    s.axes_manager.signal_axes[0].units = "m"
+    s.axes_manager.signal_axes[1].units = "nm"
+
+    with caplog.at_level(logging.WARNING):
+        s.map(np.sum, silence_warnings=silence_warnings, inplace=False)
+    assert "The function you applied does not take into account" in caplog.text
+    assert "units" in caplog.text
 
 
 def test_silence_warning_units(caplog):
@@ -1342,13 +1358,18 @@ def test_silence_warning_units(caplog):
     assert caplog.text == ""
 
     with caplog.at_level(logging.WARNING):
-        s.map(np.sum, silence_warnings=["units"], inplace=False)
+        s.map(np.sum, silence_warnings="units", inplace=False)
     assert caplog.text == ""
 
     with caplog.at_level(logging.WARNING):
-        s.map(np.sum, silence_warnings=False, inplace=False)
-    assert "The function you applied does not take into account" in caplog.text
-    assert "units" in caplog.text
+        s.map(np.sum, silence_warnings=["units"], inplace=False)
+    assert caplog.text == ""
+
+    with pytest.raises(ValueError):
+        s.map(np.sum, silence_warnings=["units", "wrong_string"], inplace=False)
+
+    with pytest.raises(TypeError):
+        s.map(np.sum, silence_warnings=[True], inplace=False)
 
 
 def test_silence_warning_scales_units(caplog):

--- a/upcoming_changes/3428.bugfix.rst
+++ b/upcoming_changes/3428.bugfix.rst
@@ -1,0 +1,1 @@
+Silence unnecessary warnings when using non-uniform axis with :meth:`~.api.signals.Signal1D.smooth_lowess` and :meth:`~.api.signals.Signal1D.find_peaks1D_ohaver`.


### PR DESCRIPTION
Follow up of #3421 on warning handling.
@jlaehne, As mentioned in https://github.com/LumiSpy/eBEAM2024-Tutorial/issues/3, this should help for cases, where there are unnecessary warnings, for example, when using some functions with non-uniform axis. There may be some more but we can sort them out when we noticed them.

### Progress of the PR
- [x] Fix silencing warnings in `map`,
- [x] Don't warn for using non-uniform axis in `smooth_lowess`, `find_peaks1D_ohaver`,
- [x] Fix tolerance in hanning lazy test, which is failing with numpy 2.1,
- [n/a] update docstring (if appropriate),
- [n/a] update user guide (if appropriate),
- [x] add an changelog entry in the `upcoming_changes` folder (see [`upcoming_changes/README.rst`](https://github.com/hyperspy/hyperspy/blob/RELEASE_next_minor/upcoming_changes/README.rst)),
- [x] Check formatting changelog entry in the `readthedocs` doc build of this PR (link in github checks)
- [x] add tests,
- [x] ready for review.


