### PR TITLE
Consistently return `TupleSA` when indexing `AxesManager`

### DIFF
--- a/hyperspy/axes.py
+++ b/hyperspy/axes.py
@@ -1674,7 +1674,7 @@ class AxesManager(t.HasTraits):
         else:
             axes = [self._axes_getter(ax) for ax in y]
         _, indices = np.unique([_id for _id in map(id, axes)], return_index=True)
-        ans = tuple(axes[i] for i in sorted(indices))
+        ans = TupleSA(axes[i] for i in sorted(indices))
         return ans
 
     def _axes_getter(self, y):

--- a/hyperspy/tests/axes/test_axes_manager.py
+++ b/hyperspy/tests/axes/test_axes_manager.py
@@ -29,6 +29,7 @@ from hyperspy.axes import (
     _serpentine_iter,
 )
 from hyperspy.defaults_parser import preferences
+from hyperspy.misc.utils import TupleSA
 from hyperspy.signals import BaseSignal, Signal1D, Signal2D
 
 
@@ -155,8 +156,13 @@ class TestAxesManager:
         with pytest.raises(ValueError):
             axis = BaseDataAxis()
             am[axis]
+        assert isinstance(am.navigation_axes, TupleSA)
+        assert isinstance(am.signal_axes, TupleSA)
+
         assert am["nav"] == am.navigation_axes
+        assert isinstance(am["nav"], TupleSA)
         assert am["sig"] == am.signal_axes
+        assert isinstance(am["nav"], TupleSA)
 
 
 class TestAxesManagerScaleOffset:


### PR DESCRIPTION
Follow up of https://github.com/hyperspy/hyperspy/pull/2756.

### Progress of the PR
- [x] Fix type when indexing multiple axes in `AxesManager`,
- [n/a] update docstring (if appropriate),
- [n/a] update user guide (if appropriate),
- [n/a] add an changelog entry in the `upcoming_changes` folder (see [`upcoming_changes/README.rst`](https://github.com/hyperspy/hyperspy/blob/RELEASE_next_minor/upcoming_changes/README.rst)),
- [n/a] Check formatting changelog entry in the `readthedocs` doc build of this PR (link in github checks)
- [x] add tests,
- [x] ready for review.

### Minimal example of the bug fix or the new feature
```python
import hyperspy.api as hs

s = hs.data.two_gaussians()
s.axes_manager["nav"].get("units")
```
raises the error:

```python
AttributeError: 'tuple' object has no attribute 'get'
```

while the following doesn't:
```python
s.axes_manager[0].get("units")
```
