### PR TITLE
Fix horizontal plotting with ipympl 0.9.4/ipython 8.24

### DIFF
--- a/upcoming_changes/3437.bugfix.rst
+++ b/upcoming_changes/3437.bugfix.rst
@@ -1,0 +1,1 @@
+Fix horizontal plotting with ipympl 0.9.4/ipython 8.24.


### PR DESCRIPTION
The ` ipympl` backend changed name from `ipympl` to `widget`.

### Progress of the PR
- [x] Support `ipympl` and `widget` as backend name for ipympl,
- [n/a] update docstring (if appropriate),
- [n/a] update user guide (if appropriate),
- [x] add an changelog entry in the `upcoming_changes` folder (see [`upcoming_changes/README.rst`](https://github.com/hyperspy/hyperspy/blob/RELEASE_next_minor/upcoming_changes/README.rst)),
- [x] Check formatting changelog entry in the `readthedocs` doc build of this PR (link in github checks)
- [n/a] add tests,
- [x] ready for review.
