### PR TITLE
Fix interactive normalise in `hs.plot.plot_spectra`

### DIFF
--- a/hyperspy/drawing/utils.py
+++ b/hyperspy/drawing/utils.py
@@ -1978,7 +1978,7 @@ def plot_roi_map(
         Whether to plot on a single figure or several figures.
         If True, :func:`~.api.plot.plot_images` or :func:`~.plot.plot_spectra`
         will be used, depending on the navigation dimension of the signal.
-    single_figure_kwargs : dict
+    single_figure_kwargs : dict, None
         Only when ``single_figure=True``. Keywords arguments are passed to
         :func:`~.api.plot.plot_images` or :func:`~.plot.plot_spectra`
         depending on the navigation dimension of the signal.
@@ -2112,14 +2112,15 @@ def plot_roi_map(
                 _add_colored_frame(roi_sum._plot.signal_plot.ax, color_)
 
     if single_figure:
+        if single_figure_kwargs is None:
+            single_figure_kwargs = {}
         if nav_dims == 1:
-            axs = plot_spectra(roi_sums, color=color, **kwargs)
+            axs = plot_spectra(roi_sums, color=color, **single_figure_kwargs)
         else:
             # default plot kwargs
-            single_figure_kwargs_ = dict(scalebar=[0], axes_decor="off", suptitle="")
-            # overwrite defaults with user defined kwargs
-            single_figure_kwargs_.update(kwargs)
-            axs = plot_images(roi_sums, cmap=cmap, **single_figure_kwargs_)
+            for k, v in zip(["scalebar", "axes_decor", "suptitle"], [0, "off", ""]):
+                single_figure_kwargs.setdefault(k, v)
+            axs = plot_images(roi_sums, cmap=cmap, **single_figure_kwargs)
             if add_colored_frame:
                 # hs.plot.plot_images doesn't use blitting
                 for ax, color_ in zip(axs, color):

--- a/hyperspy/drawing/utils.py
+++ b/hyperspy/drawing/utils.py
@@ -1644,9 +1644,9 @@ def plot_spectra(
             ax.set_ylabel("Spectra")
     ax = ax if style != "mosaic" else subplots
 
-    def update_line(spectrum, line, factor):
+    def update_line(spectrum, line, normalise):
         x_axis = spectrum.axes_manager[-1].axis
-        line.set_data(x_axis, spectrum.data / factor)
+        line.set_data(x_axis, _parse_array(spectrum, normalise))
         fig = line.get_figure()
         ax = fig.get_axes()[0]
         # `relim` needs to be called before `autoscale_view`
@@ -1663,15 +1663,11 @@ def plot_spectra(
                 "auto_update=True is only supported with " "style='overlap'."
             )
 
-        for spectrum, line in zip(spectra, ax.get_lines()):
-            if normalise:
-                factor = spectrum.data.max()
-            else:
-                factor = 1
-            f = partial(update_line, spectrum, line, factor)
-            spectrum.events.data_changed.connect(f, [])
+        for s, line in zip(spectra, ax.get_lines()):
+            f = partial(update_line, s, line=line, normalise=normalise)
+            s.events.data_changed.connect(f, [])
             # disconnect event when closing figure
-            disconnect = partial(spectrum.events.data_changed.disconnect, f)
+            disconnect = partial(s.events.data_changed.disconnect, f)
             on_figure_window_close(fig, disconnect)
 
     return ax

--- a/hyperspy/tests/drawing/test_plot_roi_map.py
+++ b/hyperspy/tests/drawing/test_plot_roi_map.py
@@ -298,6 +298,32 @@ def test_single_figure_image(cmap):
     return plt.gcf()
 
 
+def test_single_figure_kwargs():
+    pytest.importorskip("matplotlib", minversion="3.8")
+
+    rng = np.random.default_rng(0)
+    data = rng.random(size=(10, 10, 50))
+    s = hs.signals.Signal1D(data)
+
+    title = "A title"
+    hs.plot.plot_roi_map(
+        s, rois=3, single_figure=True, single_figure_kwargs={"suptitle": title}
+    )
+    fig = plt.gcf()
+    assert fig.get_suptitle() == title
+
+    s2 = s.T
+    legend = ["Custom text 0", "Custom text 1"]
+    hs.plot.plot_roi_map(
+        s2, rois=2, single_figure=True, single_figure_kwargs={"legend": legend}
+    )
+
+    ax = plt.gca()
+    texts = ax.get_legend().get_texts()
+    for text, expected_text in zip(texts, legend[::-1]):
+        assert text.get_text() == expected_text
+
+
 @pytest.mark.parametrize("color", (None, ["C0", "C1"], ["r", "b"]))
 def test_single_figure_spectra(color):
     rng = np.random.default_rng(0)

--- a/hyperspy/tests/drawing/test_plot_signal1d.py
+++ b/hyperspy/tests/drawing/test_plot_signal1d.py
@@ -484,6 +484,28 @@ def test_plot_spectra_normalise(style):
     return ax.get_figure()
 
 
+def test_plot_spectra_normalise_interactive():
+    s = hs.signals.Signal1D(np.arange(100)) + 100
+    s2 = np.sqrt(s)
+
+    ax = hs.plot.plot_spectra([s, s2], normalise=True)
+    lines = ax.get_lines()
+    assert lines[0].get_data()[1][0] == 0
+    assert lines[0].get_data()[1][-1] == 1
+    assert lines[1].get_data()[1][0] == 0
+    assert lines[1].get_data()[1][-1] == 1
+
+    # Simulate data changed
+    s.data = s.data * -1
+    s.events.data_changed.trigger(s)
+
+    # check the values
+    assert lines[0].get_data()[1][0] == 1
+    assert lines[0].get_data()[1][-1] == 0
+    assert lines[1].get_data()[1][0] == 0
+    assert lines[1].get_data()[1][-1] == 1
+
+
 def test_plot_empty_slice_autoscale():
     s = hs.signals.Signal1D(np.arange(100))
     s.plot()


### PR DESCRIPTION
Follow up of https://github.com/hyperspy/hyperspy/pull/3419 to support normalisation when the signals are updated, for example:

```python
import hyperspy.api as hs
import holospy as holo

im0 = holo.data.Fe_needle_reference_hologram()
im1 = holo.data.Fe_needle_hologram()

im0.plot()
im1.plot()

line_roi = hs.roi.Line2DROI(400, 250, 220, 600, 5)

profile1 = line_roi.interactive(im0, color='C0')
profile2 = line_roi.interactive(im1, color='C1')

hs.plot.plot_spectra([profile1, profile2], normalise=True)
```

### Progress of the PR
- [x] Add support for `normalise` parameter in `hs.plot.plot_spectra`,
- [x] Fix passing `single_figure_kwargs` in `hs.plot.plot_roi_map` to `hs.plot.plot_spectra`, 
- [n/a] update docstring (if appropriate),
- [n/a] update user guide (if appropriate),
- [n/a] add an changelog entry in the `upcoming_changes` folder (see [`upcoming_changes/README.rst`](https://github.com/hyperspy/hyperspy/blob/RELEASE_next_minor/upcoming_changes/README.rst)),
- [n/a] Check formatting changelog entry in the `readthedocs` doc build of this PR (link in github checks)
- [x] add tests,
- [x] ready for review.

