### PR TITLE
Add style parameter to `print_known_signal_types`

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -404,6 +404,7 @@ numpydoc_xref_ignore = {
     "widget",
     "strategy",
     "module",
+    "prettytable",
 }
 
 # if Version(numpydoc.__version__) >= Version("1.6.0rc0"):

--- a/hyperspy/tests/utils/test_print_known_signal_types.py
+++ b/hyperspy/tests/utils/test_print_known_signal_types.py
@@ -1,3 +1,5 @@
+from prettytable import MARKDOWN
+
 from hyperspy.utils import print_known_signal_types
 
 
@@ -7,3 +9,14 @@ def test_text_output(capsys):
     assert "signal_type" in captured.out
     # the output will be str, not html
     assert "<p>" not in captured.out
+
+
+def test_style(capsys):
+    print_known_signal_types(style=MARKDOWN)
+    captured = capsys.readouterr()
+
+    assert "signal_type" in captured.out
+    # the output will be markdown, not ascii
+    assert ":--" in captured.out  # markdown
+    assert "<p>" not in captured.out  # not html
+    assert "+--" not in captured.out  # not ascii

--- a/hyperspy/utils/__init__.py
+++ b/hyperspy/utils/__init__.py
@@ -37,11 +37,16 @@ Subpackages:
 import importlib
 
 
-def print_known_signal_types():
+def print_known_signal_types(style=None):
     r"""Print all known `signal_type`\s
 
     This includes `signal_type`\s from all installed packages that
     extend HyperSpy.
+
+    Parameters
+    ----------
+    style : prettytable style or None
+        If None, the default prettytable style will be used.
 
     Examples
     --------
@@ -65,6 +70,8 @@ def print_known_signal_types():
 
     table = PrettyTable()
     table.field_names = ["signal_type", "aliases", "class name", "package"]
+    if style is not None:
+        table.set_style(style)
     for sclass, sdict in ALL_EXTENSIONS["signals"].items():
         # skip lazy signals and non-data-type specific signals
         if sdict["lazy"] or not sdict["signal_type"]:
@@ -77,6 +84,7 @@ def print_known_signal_types():
         package = sdict["module"].split(".")[0]
         table.add_row([sdict["signal_type"], aliases, sclass, package])
         table.sortby = "class name"
+
     display(table)
 
 

--- a/upcoming_changes/3439.enhancements.rst
+++ b/upcoming_changes/3439.enhancements.rst
@@ -1,0 +1,1 @@
+Add ``style`` parameter to the :func:`~.api.print_known_signal_types` function.


### PR DESCRIPTION
### Progress of the PR
- [x] Add style parameter to `print_known_signal_types`,
- [x] update docstring (if appropriate),
- [n/a] update user guide (if appropriate),
- [x] add an changelog entry in the `upcoming_changes` folder (see [`upcoming_changes/README.rst`](https://github.com/hyperspy/hyperspy/blob/RELEASE_next_minor/upcoming_changes/README.rst)),
- [x] Check formatting changelog entry in the `readthedocs` doc build of this PR (link in github checks)
- [x] add tests,
- [x] ready for review.

### Minimal example of the bug fix or the new feature
```python
import hyperspy.api as hs
from prettytable import MARKDOWN

hs.print_known_signal_types(style=MARKDOWN)
```
