### PR TITLE
Allow src-layout for extension packages

### DIFF
--- a/hyperspy/extensions.py
+++ b/hyperspy/extensions.py
@@ -62,7 +62,7 @@ for _external_extension in _external_extensions:
         ]
         with _files[0].locate().open() as json_data:
             _path = url2pathname(urlparse(json.load(json_data)["url"]).path)
-            _path = Path(_path) / _external_extension.name / "hyperspy_extension.yaml"
+            _path = Path(_path) / _external_extension.value / "hyperspy_extension.yaml"
     else:
         _path = _files.pop().locate()
 


### PR DESCRIPTION
### Requirements
Fixes #3445.

### Description of the change
* Use entry point value instead of name when getting the path to an extension's YAML file

### Progress of the PR
- [x] Change implemented
- [n/a] update docstring
- [ ] update user guide
- [ ] add an changelog entry in the `upcoming_changes` folder
- [ ] Check formatting changelog entry in the `readthedocs` doc build of this PR (link in github checks)
- [ ] add tests
- [ ] ready for review

### Minimal example of the bug fix or the new feature
See #3445.
