### PR TITLE
Update azure pipeline CI configuration to use miniforge in place of deprecated mambaforge

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -21,34 +21,34 @@ resources:
       # For more details on service connection endpoint, see
       # https://docs.microsoft.com/en-us/azure/devops/pipelines/library/service-endpoints
       endpoint: hyperspy # Azure DevOps service connection
-      ref: use_mamba
+      ref: use_miniforge
 
 strategy:
   matrix:
     Linux_Python39:
       vmImage: 'ubuntu-latest'
       PYTHON_VERSION: '3.9'
-      MAMBAFORGE_PATH: $(Agent.BuildDirectory)/mambaforge
+      MINIFORGE_PATH: $(Agent.BuildDirectory)/miniforge3
     Linux_Python310:
       vmImage: 'ubuntu-latest'
       PYTHON_VERSION: '3.10'
-      MAMBAFORGE_PATH: $(Agent.BuildDirectory)/mambaforge
+      MINIFORGE_PATH: $(Agent.BuildDirectory)/miniforge3
     MacOS_Python39:
       vmImage: 'macOS-latest'
       PYTHON_VERSION: '3.9'
-      MAMBAFORGE_PATH: $(Agent.BuildDirectory)/mambaforge
+      MINIFORGE_PATH: $(Agent.BuildDirectory)/miniforge3
     MacOS_Python310:
       vmImage: 'macOS-latest'
       PYTHON_VERSION: '3.10'
-      MAMBAFORGE_PATH: $(Agent.BuildDirectory)/mambaforge
+      MINIFORGE_PATH: $(Agent.BuildDirectory)/miniforge3
     Windows_Python39:
       vmImage: 'windows-latest'
       PYTHON_VERSION: '3.9'
-      MAMBAFORGE_PATH: $(Agent.BuildDirectory)\mambaforge
+      MINIFORGE_PATH: $(Agent.BuildDirectory)\miniforge3
     Windows_Python310:
       vmImage: 'windows-latest'
       PYTHON_VERSION: '3.10'
-      MAMBAFORGE_PATH: $(Agent.BuildDirectory)\mambaforge
+      MINIFORGE_PATH: $(Agent.BuildDirectory)\miniforge3
 
 pool:
   vmImage: '$(vmImage)'
@@ -57,7 +57,7 @@ steps:
 - checkout: self
   fetchDepth: '1' # Fetch only one commit
 - template: azure_pipelines/clone_ci-scripts_repo.yml@templates
-- template: azure_pipelines/install_mambaforge.yml@templates
+- template: azure_pipelines/install_miniforge.yml@templates
 - template: azure_pipelines/activate_conda.yml@templates
 - template: azure_pipelines/setup_anaconda_packages.yml@templates
 


### PR DESCRIPTION
Same as https://github.com/LumiSpy/lumispy/pull/216.