### PR TITLE
Replace iterators by list in `hs.plot.plot_spectra` which fails with matplotlib 3.10

### DIFF
--- a/hyperspy/drawing/utils.py
+++ b/hyperspy/drawing/utils.py
@@ -1577,7 +1577,7 @@ def plot_spectra(
             handles = line.legend_handles
         else:
             handles = line.legendHandles
-        ax_.legend(reversed(handles), reversed(labels), loc=legend_loc_)
+        ax_.legend(handles[::-1], labels[::-1], loc=legend_loc_)
 
     # Before v1.3 default would read the value from prefereces.
     if style == "default":

--- a/upcoming_changes/3456.bugfix.rst
+++ b/upcoming_changes/3456.bugfix.rst
@@ -1,1 +1,1 @@
-Fix bug in :func:`~.api.plot.plot_spectra` when reserving legend handles since matplotlib expect a list and not an iterator.
+Fix bug in :func:`~.api.plot.plot_spectra` when reversing legend handles since matplotlib expects a list and not an iterator.

--- a/upcoming_changes/3456.bugfix.rst
+++ b/upcoming_changes/3456.bugfix.rst
@@ -1,0 +1,1 @@
+Fix bug in :func:`~.api.plot.plot_spectra` when reserving legend handles since matplotlib expect a list and not an iterator.


### PR DESCRIPTION
The matplotlib 3.10 rc available on pypi.org make CI fails because `reversed` (returns an iterators) is used instead of `[::-1]` and matplotlib expect a list.

The error is:
```python
________________ TestPlotSpectra.test_plot_spectra_legend_pick _________________

self = <hyperspy.tests.drawing.test_plot_signal1d.TestPlotSpectra object at 0x7f26bde5a310>

    def test_plot_spectra_legend_pick(self):
        x = np.linspace(0.0, 2.0, 512)
        n = np.arange(1, 5)
        x_pow_n = x[None, :] ** n[:, None]
        s = hs.signals.Signal1D(x_pow_n)
        my_legend = [r"x^" + str(io) for io in n]
        f = plt.figure()
>       ax = hs.plot.plot_spectra(s, legend=my_legend, fig=f)

/opt/hostedtoolcache/Python/3.11.10/x64/lib/python3.11/site-packages/hyperspy/tests/drawing/test_plot_signal1d.py:194: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
/opt/hostedtoolcache/Python/3.11.10/x64/lib/python3.11/site-packages/hyperspy/drawing/utils.py:1659: in plot_spectra
    _reverse_legend(ax, legend_loc)
/opt/hostedtoolcache/Python/3.11.10/x64/lib/python3.11/site-packages/hyperspy/drawing/utils.py:1580: in _reverse_legend
    ax_.legend(reversed(handles), reversed(labels), loc=legend_loc_)
/opt/hostedtoolcache/Python/3.11.10/x64/lib/python3.11/site-packages/matplotlib/axes/_axes.py:337: in legend
    self.legend_ = mlegend.Legend(self, handles, labels, **kwargs)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

self = <matplotlib.legend.Legend object at 0x7f269191fe10>
parent = <Axes: xlabel='<undefined> (<undefined>)', ylabel='Intensity'>
handles = <list_reverseiterator object at 0x7f26917a7940>
labels = <list_reverseiterator object at 0x7f26907224a0>

    @_docstring.interpd
    def __init__(
        self, parent, handles, labels,
        *,
        loc=None,
        numpoints=None,      # number of points in the legend line
        markerscale=None,    # relative size of legend markers vs. original
        markerfirst=True,    # left/right ordering of legend marker and label
        reverse=False,       # reverse ordering of legend marker and label
        scatterpoints=None,  # number of scatter points
        scatteryoffsets=None,
        prop=None,           # properties for the legend texts
        fontsize=None,       # keyword to set font size directly
        labelcolor=None,     # keyword to set the text color
    
        # spacing & pad defined as a fraction of the font-size
        borderpad=None,      # whitespace inside the legend border
        labelspacing=None,   # vertical space between the legend entries
        handlelength=None,   # length of the legend handles
        handleheight=None,   # height of the legend handles
        handletextpad=None,  # pad between the legend handle and text
        borderaxespad=None,  # pad between the Axes and legend border
        columnspacing=None,  # spacing between columns
    
        ncols=1,     # number of columns
        mode=None,  # horizontal distribution of columns: None or "expand"
    
        fancybox=None,  # True: fancy box, False: rounded box, None: rcParam
        shadow=None,
        title=None,           # legend title
        title_fontsize=None,  # legend title font size
        framealpha=None,      # set frame alpha
        edgecolor=None,       # frame patch edgecolor
        facecolor=None,       # frame patch facecolor
    
        bbox_to_anchor=None,  # bbox to which the legend will be anchored
        bbox_transform=None,  # transform for the bbox
        frameon=None,         # draw frame
        handler_map=None,
        title_fontproperties=None,  # properties for the legend title
        alignment="center",       # control the alignment within the legend box
        ncol=1,  # synonym for ncols (backward compatibility)
        draggable=False  # whether the legend can be dragged with the mouse
    ):
        """
        Parameters
        ----------
        parent : `~matplotlib.axes.Axes` or `.Figure`
            The artist that contains the legend.
    
        handles : list of (`.Artist` or tuple of `.Artist`)
            A list of Artists (lines, patches) to be added to the legend.
    
        labels : list of str
            A list of labels to show next to the artists. The length of handles
            and labels should be the same. If they are not, they are truncated
            to the length of the shorter list.
    
        Other Parameters
        ----------------
        %(_legend_kw_doc)s
    
        Attributes
        ----------
        legend_handles
            List of `.Artist` objects added as legend entries.
    
            .. versionadded:: 3.7
        """
        # local import only to avoid circularity
        from matplotlib.axes import Axes
        from matplotlib.figure import FigureBase
    
        super().__init__()
    
        if prop is None:
            self.prop = FontProperties(size=mpl._val_or_rc(fontsize, "legend.fontsize"))
        else:
            self.prop = FontProperties._from_any(prop)
            if isinstance(prop, dict) and "size" not in prop:
                self.prop.set_size(mpl.rcParams["legend.fontsize"])
    
        self._fontsize = self.prop.get_size_in_points()
    
        self.texts = []
        self.legend_handles = []
        self._legend_title_box = None
    
        #: A dictionary with the extra handler mappings for this Legend
        #: instance.
        self._custom_handler_map = handler_map
    
        self.numpoints = mpl._val_or_rc(numpoints, 'legend.numpoints')
        self.markerscale = mpl._val_or_rc(markerscale, 'legend.markerscale')
        self.scatterpoints = mpl._val_or_rc(scatterpoints, 'legend.scatterpoints')
        self.borderpad = mpl._val_or_rc(borderpad, 'legend.borderpad')
        self.labelspacing = mpl._val_or_rc(labelspacing, 'legend.labelspacing')
        self.handlelength = mpl._val_or_rc(handlelength, 'legend.handlelength')
        self.handleheight = mpl._val_or_rc(handleheight, 'legend.handleheight')
        self.handletextpad = mpl._val_or_rc(handletextpad, 'legend.handletextpad')
        self.borderaxespad = mpl._val_or_rc(borderaxespad, 'legend.borderaxespad')
        self.columnspacing = mpl._val_or_rc(columnspacing, 'legend.columnspacing')
        self.shadow = mpl._val_or_rc(shadow, 'legend.shadow')
    
        if reverse:
            labels = [*reversed(labels)]
            handles = [*reversed(handles)]
    
>       if len(handles) < 2:
E       TypeError: object of type 'list_reverseiterator' has no len()

/opt/hostedtoolcache/Python/3.11.10/x64/lib/python3.11/site-packages/matplotlib/legend.py:462: TypeError
```

### Progress of the PR
- [x] replace iterator by list,
- [n/a] update docstring (if appropriate),
- [n/a] update user guide (if appropriate),
- [n/a] add an changelog entry in the `upcoming_changes` folder (see [`upcoming_changes/README.rst`](https://github.com/hyperspy/hyperspy/blob/RELEASE_next_minor/upcoming_changes/README.rst)),
- [ ] Check formatting changelog entry in the `readthedocs` doc build of this PR (link in github checks)
- [n/a] add tests,
- [ ] ready for review.
