### PR TITLE
Use custom version scheme in `setuptools_scm`

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -179,6 +179,7 @@ favicons = [
 # in as it is done here to make sure that they match!
 version_match = "dev" if "dev" in release else ".".join(release.split(".")[:2] + ["x"])
 
+print("version", release)
 print("version_match:", version_match)
 
 html_theme_options = {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -170,6 +170,7 @@ omit = [
     "hyperspy/conftest.py",
     "hyperspy/tests/*",
     "prepare_release.py",
+    "setup.py",
 ]
 source = ["hyperspy"]
 

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,23 @@
+from setuptools import setup
+
+
+def custom_version_scheme(version):
+    def guess_version(version, retain):
+        parts = [int(i) for i in str(version.tag).split(".")[:retain]]
+        # Add missing parts up to retain
+        while len(parts) < retain:
+            parts.append(0)
+        parts[-1] += 1
+        # Add missing parts
+        while len(parts) < 3:
+            parts.append(0)
+
+        return ".".join(str(i) for i in parts)
+
+    # On RELEASE_next_major, "retain" needs to be 1
+    # On RELEASE_next_minor, "retain" needs to be 2
+    # On RELEASE_next_patch, "retain" needs to be 3
+    return version.format_next_version(guess_version, retain=2)
+
+
+setup(use_scm_version={"version_scheme": custom_version_scheme})

--- a/upcoming_changes/3457.bugfix.rst
+++ b/upcoming_changes/3457.bugfix.rst
@@ -1,0 +1,1 @@
+Use custom version scheme in ``setuptools_scm`` to fix the version in the development version of the documentation for next major and next minor release branches. Previously, only the patch segment was incremented.


### PR DESCRIPTION
This is to make sure the version development of the next minor release is always correct. Before, in the dev documentation it will show 2.1.2:
![image](https://github.com/user-attachments/assets/18ee09b5-2d57-4e9c-b076-0bbe2b71a76d)
and with this PR it will shows 2.2.0.dev...

### Progress of the PR
- [x] Use custom version scheme in `setuptools_scm`,
- [n/a] update docstring (if appropriate),
- [n/a] update user guide (if appropriate),
- [x] add an changelog entry in the `upcoming_changes` folder (see [`upcoming_changes/README.rst`](https://github.com/hyperspy/hyperspy/blob/RELEASE_next_minor/upcoming_changes/README.rst)),
- [x] Check formatting changelog entry in the `readthedocs` doc build of this PR (link in github checks)
- [n/a] add tests,
- [x] ready for review.


