### PR TITLE
Release 2.2.0

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,6 +10,82 @@ https://hyperspy.readthedocs.io/en/latest/changes.html
 
 .. towncrier release notes start
 
+2.2.0 (2024-11-08)
+==================
+
+New features
+------------
+
+- Added :class:`~.api.roi.PolygonROI` and related functionality:
+
+  - Added the ROI :class:`~.api.roi.PolygonROI` to create ROIs of arbitrary shape.
+  - Added functions :func:`~.api.roi.combine_rois` and :func:`~.api.roi.mask_from_rois` to use multiple ROIs to slice signals and create masks, respectively. Currently only :class:`~.api.roi.PolygonROI` is supported. (`#3030 <https://github.com/hyperspy/hyperspy/issues/3030>`_)
+- Add support for plotting navigator and signal plot on same figure using `matplotlib subfigures <https://matplotlib.org/stable/gallery/subplots_axes_and_figures/subfigures.html>`_. See examples in the :ref:`custom layout for plots <subfigure_examples_label>` section. (`#3343 <https://github.com/hyperspy/hyperspy/issues/3343>`_)
+
+
+Enhancements
+------------
+
+- New :attr:`~.axes.AxesManager.signal_axes` and :attr:`~.axes.AxesManager.navigation_axes` :meth:`~.misc.utils.TupleSA.set`
+  and :meth:`~.misc.utils.TupleSA.get` methods to set/get multiple attributes of multiple axes at once. See :ref:`Setting_axis_properties`. (`#2756 <https://github.com/hyperspy/hyperspy/issues/2756>`_)
+- Allow setting optional ``hidden`` key in definition of signals extending hyperspy, which prevents them from being shown by :func:`~.api.print_known_signal_types`. (`#3302 <https://github.com/hyperspy/hyperspy/issues/3302>`_)
+- Improvement of indexing of the :class:`~.axes.AxesManager`: ``"nav"`` and ``"sig"`` can be used to index the navigation and signal axes, respectively. This can also be used for the ``axes`` or ``axis`` keywords arguments, for example ``s.sum(axis="sig")`` will compute the sum over the signal axes. (`#3385 <https://github.com/hyperspy/hyperspy/issues/3385>`_)
+- Add support to convert to uniform axis in :meth:`~.api.signals.BaseSignal.interpolate_on_axis`. (`#3410 <https://github.com/hyperspy/hyperspy/issues/3410>`_)
+- Add parameter to normalise spectra in :func:`~.api.plot.plot_spectra` (`#3419 <https://github.com/hyperspy/hyperspy/issues/3419>`_)
+- Add parameters to :func:`~.api.data.atomic_resolution_image` to set the spacing and rotation of the lattice and the size of the signal. (`#3420 <https://github.com/hyperspy/hyperspy/issues/3420>`_)
+- Add option to silence warning when :meth:`~.api.signals.BaseSignal.map` operates on signal containing non-uniform axes or different scales or units. (`#3421 <https://github.com/hyperspy/hyperspy/issues/3421>`_)
+- Add ``ax`` parameter to :func:`~.api.plot.plot_images`, :func:`~.api.plot.plot_spectra` and :func:`~.api.plot.plot_histograms` to specify the :external+matplotlib:class:`matplotlib.axis.Axis` to use - see examples in :ref:`sphx_glr_auto_examples_data_visualization`. (`#3423 <https://github.com/hyperspy/hyperspy/issues/3423>`_)
+- Linear optimizer improvements:
+
+  - add linear optimizer using :class:`sklearn.linear_model.LinearRegression` with/without positive constraint; they can be used with ``optimizer="ols"`` or ``optimizer="nnls"``,
+  - improve linear optimizer documentation, mention ``alpha`` parameter when using :class:`sklearn.linear_model.Ridge`,
+  - pass parameters through to corresponding scikit-learn class or numpy function. (`#3426 <https://github.com/hyperspy/hyperspy/issues/3426>`_)
+- Add ``style`` parameter to the :func:`~.api.print_known_signal_types` function. (`#3439 <https://github.com/hyperspy/hyperspy/issues/3439>`_)
+
+
+Bug Fixes
+---------
+
+- Allow rebinning uniform axis of signal containing non-uniform axis. (`#3407 <https://github.com/hyperspy/hyperspy/issues/3407>`_)
+- Fix old version warning banner in the stable documentation. (`#3409 <https://github.com/hyperspy/hyperspy/issues/3409>`_)
+- Fixes :meth:`~.axes.BaseDataAxis.convert_to_uniform_axis`, which was incorrectly raising an ``AttributeError`` when used on :class:`~.axes.FunctionalDataAxis`. (`#3410 <https://github.com/hyperspy/hyperspy/issues/3410>`_)
+- Fix loading :class:`~.api.model.components1D.Polynomial` component saved with hyperspy <= 2.1.1. (`#3413 <https://github.com/hyperspy/hyperspy/issues/3413>`_)
+- Disable snap to axes for non uniform axis to avoid error when using ROI on non-uniform axis. (`#3418 <https://github.com/hyperspy/hyperspy/issues/3418>`_)
+- Fix non-lazy :meth:`~.api.signals.BaseSignal.map` when using dask processes scheduler. (`#3421 <https://github.com/hyperspy/hyperspy/issues/3421>`_)
+- :meth:`~.api.signals.BaseSignal.get_histogram` fixes:
+
+  - fix setting range when falling back to capped bin number,
+  - set name and units of the returned signal,
+  - don't remove ``range_bins`` parameter for lazy signal since dask now supports it. (`#3422 <https://github.com/hyperspy/hyperspy/issues/3422>`_)
+- Silence unnecessary warnings when using non-uniform axis with :meth:`~.api.signals.Signal1D.smooth_lowess` and :meth:`~.api.signals.Signal1D.find_peaks1D_ohaver`. (`#3428 <https://github.com/hyperspy/hyperspy/issues/3428>`_)
+- Fix horizontal plotting with ipympl 0.9.4/ipython 8.24. (`#3437 <https://github.com/hyperspy/hyperspy/issues/3437>`_)
+- Add support for extensions with ``src`` layout. (`#3449 <https://github.com/hyperspy/hyperspy/issues/3449>`_)
+- Fix bug in :func:`~.api.plot.plot_spectra` when reversing legend handles since matplotlib expects a list and not an iterator. (`#3456 <https://github.com/hyperspy/hyperspy/issues/3456>`_)
+- Use custom version scheme in ``setuptools_scm`` to fix the version in the development version of the documentation for next major and next minor release branches. Previously, only the patch segment was incremented. (`#3457 <https://github.com/hyperspy/hyperspy/issues/3457>`_)
+
+
+API changes
+-----------
+
+- Explicitely deprecate ``rechunk`` keyword argument in :meth:`~.api.signals.BaseSignal.derivative`, which isn't doing anything since HyperSpy 1.7. (`#3385 <https://github.com/hyperspy/hyperspy/issues/3385>`_)
+- Linear optimizer ``"ridge_regression"`` is renamed to ``"ridge"`` in :meth:`~.model.BaseModel.fit`. (`#3426 <https://github.com/hyperspy/hyperspy/issues/3426>`_)
+
+
+Improved Documentation
+----------------------
+
+- Add examples for overlaying a quad mesh marker to an image using the :class:`~.api.plot.markers.Markers` class
+  and the :class:`matplotlib.collections.QuadMesh` class. (`#3333 <https://github.com/hyperspy/hyperspy/issues/3333>`_)
+- Add example: live fast Fourier transform of Signal2D using region of interest. (`#3400 <https://github.com/hyperspy/hyperspy/issues/3400>`_)
+- Update docstring of ``set_signal_type`` to better represent the HyperSpy2.0 ecosystem (`#3435 <https://github.com/hyperspy/hyperspy/issues/3435>`_)
+
+
+Maintenance
+-----------
+
+- Set ``matplotlib`` version requirement to >=3.6. (`#3450 <https://github.com/hyperspy/hyperspy/issues/3450>`_)
+
+
 2.1.1 (2024-07-11)
 ==================
 

--- a/doc/_static/switcher.json
+++ b/doc/_static/switcher.json
@@ -5,10 +5,14 @@
         "url": "https://hyperspy.org/hyperspy-doc/dev/"
     },
     {
-        "version": "2.1.x",
-        "name": "2.1",
+        "version": "2.2.x",
+        "name": "2.2",
         "url": "https://hyperspy.org/hyperspy-doc/current/",
         "preferred": true
+    },
+    {
+        "version": "2.1",
+        "url": "https://hyperspy.org/hyperspy-doc/v2.1/",
     },
     {
         "version": "2.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -229,7 +229,7 @@ where = ["."]
 "*" = ["*.png"]
 
 [tool.setuptools_scm]
-fallback_version = "2.2.0.dev0"
+fallback_version = "2.3.0.dev0"
 
 [tool.towncrier]
 directory = "upcoming_changes/"

--- a/upcoming_changes/2756.enhancements.rst
+++ b/upcoming_changes/2756.enhancements.rst
@@ -1,2 +1,0 @@
-New :attr:`~.axes.AxesManager.signal_axes` and :attr:`~.axes.AxesManager.navigation_axes` :meth:`~.misc.utils.TupleSA.set`
-and :meth:`~.misc.utils.TupleSA.get` methods to set/get multiple attributes of multiple axes at once. See :ref:`Setting_axis_properties`.

--- a/upcoming_changes/3030.new.rst
+++ b/upcoming_changes/3030.new.rst
@@ -1,4 +1,0 @@
-Added :class:`~.api.roi.PolygonROI` and related functionality:
-
-- Added the ROI :class:`~.api.roi.PolygonROI` to create ROIs of arbitrary shape.
-- Added functions :func:`~.api.roi.combine_rois` and :func:`~.api.roi.mask_from_rois` to use multiple ROIs to slice signals and create masks, respectively. Currently only :class:`~.api.roi.PolygonROI` is supported.

--- a/upcoming_changes/3302.enhancements.rst
+++ b/upcoming_changes/3302.enhancements.rst
@@ -1,1 +1,0 @@
-Allow setting optional ``hidden`` key in definition of signals extending hyperspy, which prevents them from being shown by ``print_known_signal_types()``.

--- a/upcoming_changes/3333.doc.rst
+++ b/upcoming_changes/3333.doc.rst
@@ -1,2 +1,0 @@
-Add examples for overlaying a quad mesh marker to an image using the :class:`~.api.plot.markers.Markers` class
-and the :class:`matplotlib.collections.QuadMesh` class.

--- a/upcoming_changes/3343.new.rst
+++ b/upcoming_changes/3343.new.rst
@@ -1,1 +1,0 @@
-Add support for plotting navigator and signal plot on same figure using `matplotlib subfigures <https://matplotlib.org/stable/gallery/subplots_axes_and_figures/subfigures.html>`_. See examples in the :ref:`custom layout for plots <subfigure_examples_label>` section.

--- a/upcoming_changes/3385.api.rst
+++ b/upcoming_changes/3385.api.rst
@@ -1,1 +1,0 @@
-Explicitely deprecate ``rechunk`` keyword argument in :meth:`~.api.signals.BaseSignal.derivative`, which isn't doing anything since HyperSpy 1.7.

--- a/upcoming_changes/3385.enhancements.rst
+++ b/upcoming_changes/3385.enhancements.rst
@@ -1,1 +1,0 @@
-Improvement of indexing of the :class:`~.axes.AxesManager`: ``"nav"`` and ``"sig"`` can be used to index the navigation and signal axes, respectively. This can also be used for the ``axes`` or ``axis`` keywords arguments, for example ``s.sum(axis="sig")`` will compute the sum over the signal axes.

--- a/upcoming_changes/3400.doc.rst
+++ b/upcoming_changes/3400.doc.rst
@@ -1,1 +1,0 @@
-Add example: live fast Fourier transform of Signal2D using region of interest.

--- a/upcoming_changes/3407.bugfix.rst
+++ b/upcoming_changes/3407.bugfix.rst
@@ -1,1 +1,0 @@
-Allow rebinning uniform axis of signal containing non-uniform axis.

--- a/upcoming_changes/3409.bugfix.rst
+++ b/upcoming_changes/3409.bugfix.rst
@@ -1,1 +1,0 @@
-Fix old version warning banner in the stable documentation.

--- a/upcoming_changes/3410.bugfix.rst
+++ b/upcoming_changes/3410.bugfix.rst
@@ -1,1 +1,0 @@
-Fixes :meth:`~.axes.BaseDataAxis.convert_to_uniform_axis`, which was incorrectly raising an ``AttributeError`` when used on :class:`~.axes.FunctionalDataAxis`.

--- a/upcoming_changes/3410.enhancements.rst
+++ b/upcoming_changes/3410.enhancements.rst
@@ -1,1 +1,0 @@
-Add support to convert to uniform axis in :meth:`~.api.signals.BaseSignal.interpolate_on_axis`.

--- a/upcoming_changes/3413.bugfix.rst
+++ b/upcoming_changes/3413.bugfix.rst
@@ -1,1 +1,0 @@
-Fix loading :class:`~.api.model.components1D.Polynomial` component saved with hyperspy <= 2.1.1.

--- a/upcoming_changes/3418.bugfix.rst
+++ b/upcoming_changes/3418.bugfix.rst
@@ -1,1 +1,0 @@
-Disable snap to axes for non uniform axis to avoid error when using ROI on non-uniform axis.

--- a/upcoming_changes/3419.enhancements.rst
+++ b/upcoming_changes/3419.enhancements.rst
@@ -1,1 +1,0 @@
-Add parameter to normalise spectra in :func:`~.api.plot.plot_spectra`

--- a/upcoming_changes/3420.enhancements.rst
+++ b/upcoming_changes/3420.enhancements.rst
@@ -1,1 +1,0 @@
-Add parameters to :func:`~.api.data.atomic_resolution_image` to set the spacing and rotation of the lattice and the size of the signal.

--- a/upcoming_changes/3421.bugfix.rst
+++ b/upcoming_changes/3421.bugfix.rst
@@ -1,1 +1,0 @@
-Fix non-lazy :meth:`~.api.signals.BaseSignal.map` when using dask processes scheduler.

--- a/upcoming_changes/3421.enhancements.rst
+++ b/upcoming_changes/3421.enhancements.rst
@@ -1,1 +1,0 @@
-Add option to silence warning when :meth:`~.api.signals.BaseSignal.map` operates on signal containing non-uniform axes or different scales or units.

--- a/upcoming_changes/3422.bugfix.rst
+++ b/upcoming_changes/3422.bugfix.rst
@@ -1,5 +1,0 @@
-:meth:`~.api.signals.BaseSignal.get_histogram` fixes:
-
-- fix setting range when falling back to capped bin number,
-- set name and units of the returned signal,
-- don't remove ``range_bins`` parameter for lazy signal since dask now supports it.

--- a/upcoming_changes/3423.enhancements.rst
+++ b/upcoming_changes/3423.enhancements.rst
@@ -1,1 +1,0 @@
-Add ``ax`` parameter to :func:`~.api.plot.plot_images`, :func:`~.api.plot.plot_spectra` and :func:`~.api.plot.plot_histograms` to specify the :external+matplotlib:class:`matplotlib.axis.Axis` to use - see examples in :ref:`sphx_glr_auto_examples_data_visualization`.

--- a/upcoming_changes/3426.api.rst
+++ b/upcoming_changes/3426.api.rst
@@ -1,1 +1,0 @@
-Linear optimizer ``"ridge_regression"`` is renamed to ``"ridge"`` in :meth:`~.model.BaseModel.fit`.

--- a/upcoming_changes/3426.enhancements.rst
+++ b/upcoming_changes/3426.enhancements.rst
@@ -1,5 +1,0 @@
-Linear optimizer improvements:
-
-- add linear optimizer using :class:`sklearn.linear_model.LinearRegression` with/without positive constraint; they can be used with ``optimizer="ols"`` or ``optimizer="nnls"``,
-- improve linear optimizer documentation, mention ``alpha`` parameter when using :class:`sklearn.linear_model.Ridge`,
-- pass parameters through to corresponding scikit-learn class or numpy function.

--- a/upcoming_changes/3428.bugfix.rst
+++ b/upcoming_changes/3428.bugfix.rst
@@ -1,1 +1,0 @@
-Silence unnecessary warnings when using non-uniform axis with :meth:`~.api.signals.Signal1D.smooth_lowess` and :meth:`~.api.signals.Signal1D.find_peaks1D_ohaver`.

--- a/upcoming_changes/3435.doc.rst
+++ b/upcoming_changes/3435.doc.rst
@@ -1,1 +1,0 @@
-Update docstring of ``set_signal_type`` to better represent the HyperSpy2.0 ecosystem

--- a/upcoming_changes/3437.bugfix.rst
+++ b/upcoming_changes/3437.bugfix.rst
@@ -1,1 +1,0 @@
-Fix horizontal plotting with ipympl 0.9.4/ipython 8.24.

--- a/upcoming_changes/3439.enhancements.rst
+++ b/upcoming_changes/3439.enhancements.rst
@@ -1,1 +1,0 @@
-Add ``style`` parameter to the :func:`~.api.print_known_signal_types` function.

--- a/upcoming_changes/3449.bugfix.rst
+++ b/upcoming_changes/3449.bugfix.rst
@@ -1,1 +1,0 @@
-Add support for extensions with ``src`` layout.

--- a/upcoming_changes/3450.maintenance.rst
+++ b/upcoming_changes/3450.maintenance.rst
@@ -1,1 +1,0 @@
-Set ``matplotlib`` version requirement to >=3.6.

--- a/upcoming_changes/3456.bugfix.rst
+++ b/upcoming_changes/3456.bugfix.rst
@@ -1,1 +1,0 @@
-Fix bug in :func:`~.api.plot.plot_spectra` when reversing legend handles since matplotlib expects a list and not an iterator.

--- a/upcoming_changes/3457.bugfix.rst
+++ b/upcoming_changes/3457.bugfix.rst
@@ -1,1 +1,0 @@
-Use custom version scheme in ``setuptools_scm`` to fix the version in the development version of the documentation for next major and next minor release branches. Previously, only the patch segment was incremented.


### PR DESCRIPTION
https://github.com/hyperspy/hyperspy/blob/RELEASE_next_minor/releasing_guide.md

- [x] Release notes updated,
- [x] the relevant changes to archive the 2.1.x documentation are done in https://github.com/hyperspy/hyperspy-doc/commit/8051af7cd084c2cf6775867e9a5d887b8e6edcb3.
- [x] documentation version switcher updated,

