### PR TITLE
Fix and improve `BaseModel.as_signal`

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -27,7 +27,7 @@ jobs:
             OLDEST_SUPPORTED_VERSION: true
             # Don't install pillow 10.4.0 because of its incompatibility with numpy 1.20.x
             # https://github.com/python-pillow/Pillow/pull/8187
-            DEPENDENCIES: dask[array]==2021.5.1 matplotlib==3.6.0 numba==0.52 numpy==1.20.0 scipy==1.6 scikit-image==0.18 scikit-learn==1.0.1 pillow!=10.4.0
+            DEPENDENCIES: dask[array]==2022.9.2 matplotlib==3.6.0 numba==0.52 numpy==1.20.0 scipy==1.6 scikit-image==0.18 scikit-learn==1.0.1 pillow!=10.4.0
             LABEL: -oldest
           # test minimum requirement
           - os: ubuntu

--- a/.github/workflows/tests_extension.yml
+++ b/.github/workflows/tests_extension.yml
@@ -16,13 +16,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        #EXTENSION_VERSION: ['release', 'dev']
-        EXTENSION_VERSION: ['dev']
+        EXTENSION_VERSION: ['release', 'dev']
 
     env:
       MPLBACKEND: agg
       EXTENSION: kikuchipy lumispy pyxem atomap
       TEST_DEPS: pytest pytest-xdist pytest-rerunfailures pytest-instafail
+      PYTHON_VERSION: '3.12'
     defaults:
       run:
         shell: bash -l {0}
@@ -32,19 +32,22 @@ jobs:
 
       - uses: conda-incubator/setup-miniconda@v3
         with:
-          miniforge-variant: Mambaforge
           miniforge-version: latest
-          # use base environment, so that when using pip, this is from the
-          # mambaforge distribution
-          auto-activate-base: true
-          activate-environment: ""
+          python-version: ${{ env.PYTHON_VERSION }}
+          activate-environment: "test"
+          conda-remove-defaults: "true"
 
+      - name: Install pip and Test dependencies
+        run: |
+          mamba install pip ${{ env.TEST_DEPS }}
+          
       - name: Conda info
         run: |
           conda info
           conda list
 
-      - name: Install extensions and Test dependencies
+      - name: Install extensions (release)
+        if: contains(matrix.EXTENSION_VERSION, 'release')
         run: |
           mamba install hyperspy-base ${{ env.EXTENSION }} ${{ env.TEST_DEPS }}
 
@@ -56,7 +59,7 @@ jobs:
         run: |
           pip install .
 
-      - name: Install Extension Dev
+      - name: Install Extension (dev)
         if: contains(matrix.EXTENSION_VERSION, 'dev')
         run: |
           pip install https://github.com/lumispy/lumispy/archive/main.zip
@@ -75,7 +78,6 @@ jobs:
         if: ${{ always() }}
         run: |
           # Virtual buffer (xvfb) required for tests using PyVista
-          sudo apt-get install xvfb
           xvfb-run python -m pytest --pyargs kikuchipy
 
       - name: Run LumiSpy Test Suite
@@ -98,10 +100,7 @@ jobs:
         run: |
           python -m pytest --pyargs exspy
   
-      #  The currently released version of Atomap (0.3.1) does not work with this test
-      #  environment. Thus, only the dev version is currently tested. If a newer version
-      #  of Atomap is released, the "if" can be changed to always().
       - name: Run atomap Test Suite
-        if: contains(matrix.EXTENSION_VERSION, 'dev')
+        if: ${{ always() }}
         run: |
           python -m pytest --pyargs atomap

--- a/.github/workflows/tests_extension.yml
+++ b/.github/workflows/tests_extension.yml
@@ -20,7 +20,7 @@ jobs:
 
     env:
       MPLBACKEND: agg
-      EXTENSION: kikuchipy lumispy pyxem atomap
+      EXTENSION: atomap etspy exspy holospy kikuchipy lumispy pyxem
       TEST_DEPS: pytest pytest-xdist pytest-rerunfailures pytest-instafail
       PYTHON_VERSION: '3.12'
     defaults:
@@ -37,9 +37,10 @@ jobs:
           activate-environment: "test"
           conda-remove-defaults: "true"
 
-      - name: Install pip and Test dependencies
+      - name: Install pip, astra-toolbox, ffmpeg and test dependencies
         run: |
-          mamba install pip ${{ env.TEST_DEPS }}
+          # astra-toolbox and ffmpeg are etspy dependencies
+          mamba install pip astra-toolbox ffmpeg ${{ env.TEST_DEPS }} 
           
       - name: Conda info
         run: |
@@ -49,7 +50,7 @@ jobs:
       - name: Install extensions (release)
         if: contains(matrix.EXTENSION_VERSION, 'release')
         run: |
-          mamba install hyperspy-base ${{ env.EXTENSION }} ${{ env.TEST_DEPS }}
+          mamba install hyperspy-base ${{ env.EXTENSION }}
 
       - name: Conda list
         run: |
@@ -62,12 +63,13 @@ jobs:
       - name: Install Extension (dev)
         if: contains(matrix.EXTENSION_VERSION, 'dev')
         run: |
-          pip install https://github.com/lumispy/lumispy/archive/main.zip
-          pip install https://github.com/pyxem/kikuchipy/archive/develop.zip
-          pip install https://github.com/pyxem/pyxem/archive/main.zip
-          pip install https://gitlab.com/atomap/atomap/-/archive/master/atomap-master.zip
-          pip install https://github.com/hyperspy/holospy/archive/main.zip
+          pip install https://github.com/atomap-dev/atomap/archive/main.zip
+          pip install https://github.com/usnistgov/etspy/archive/master.zip
           pip install https://github.com/hyperspy/exspy/archive/main.zip
+          pip install https://github.com/hyperspy/holospy/archive/main.zip
+          pip install https://github.com/pyxem/kikuchipy/archive/develop.zip
+          pip install https://github.com/lumispy/lumispy/archive/main.zip
+          pip install https://github.com/pyxem/pyxem/archive/main.zip
 
       - name: Install xvfb
         run: |
@@ -104,3 +106,8 @@ jobs:
         if: ${{ always() }}
         run: |
           python -m pytest --pyargs atomap
+
+      - name: Run ETSpy Test Suite
+        if: ${{ always() }}
+        run: |
+          python -m pytest --pyargs etspy

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -576,7 +576,7 @@ Maintenance
 - Drop support for python 3.7, update oldest supported dependencies and simplify code accordingly (`#3144 <https://github.com/hyperspy/hyperspy/issues/3144>`_)
 - IPython and IParallel are now optional dependencies (`#3145 <https://github.com/hyperspy/hyperspy/issues/3145>`_)
 - Fix Numpy 1.25 deprecation: implicit array to scalar conversion in :py:meth:`~.signals.Signal2D.align2D` (`#3189 <https://github.com/hyperspy/hyperspy/issues/3189>`_)
-- Replace deprecated :mod:`scipy.misc` by :mod:`scipy.datasets` in documentation (`#3225 <https://github.com/hyperspy/hyperspy/issues/3225>`_)
+- Replace deprecated ``scipy.misc`` by :mod:`scipy.datasets` in documentation (`#3225 <https://github.com/hyperspy/hyperspy/issues/3225>`_)
 - Fix documentation version switcher (`#3228 <https://github.com/hyperspy/hyperspy/issues/3228>`_)
 - Replace deprecated :py:class:`scipy.interpolate.interp1d` with :py:func:`scipy.interpolate.make_interp_spline` (`#3233 <https://github.com/hyperspy/hyperspy/issues/3233>`_)
 - Add support for python 3.12 (`#3256 <https://github.com/hyperspy/hyperspy/issues/3256>`_)

--- a/conda_environment.yml
+++ b/conda_environment.yml
@@ -2,7 +2,7 @@ name: test_env
 channels:
 - conda-forge
 dependencies:
-- dask-core >=2021.3.1
+- dask-core >=2022.9.2
 - dill
 - importlib-metadata
 - h5py

--- a/doc/user_guide/model/model_components.rst
+++ b/doc/user_guide/model/model_components.rst
@@ -148,6 +148,25 @@ following template to suit your needs:
             p2 = self.parameter_2.value
             return p1 + x * p2
 
+        # Define the function for several navigation position 
+        # as a function of the already parameters defined p.map
+        # This method is necessary to be able vectorised implementation
+        # of `BaseModel.as_signal`
+        def function_nd(self, x, parameters_values=None):
+            if parameters_values is None:
+                parameters_values = [
+                    self.parameter_1.map["values"],
+                    self.parameter_2.map["values"],
+                    ]
+        if self._is_navigation_multidimensional:
+            x = x[np.newaxis, :]
+            p1 = parameters_values[0][..., np.newaxis]
+            p2 = parameters_values[1][..., np.newaxis]
+        else:
+            p1 = self.parameter_1.value
+            p2 = self.parameter_2.value
+        return np.ones_like(x) * p1 + x * p2
+
         # Optionally define the gradients of each parameter
         def grad_parameter_1(self, x):
             """
@@ -160,6 +179,7 @@ following template to suit your needs:
             Returns d(function)/d(parameter_2)
             """
             return x
+
 
 Define components from a fixed-pattern
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/doc/user_guide/model/model_components.rst
+++ b/doc/user_guide/model/model_components.rst
@@ -148,24 +148,38 @@ following template to suit your needs:
             p2 = self.parameter_2.value
             return p1 + x * p2
 
-        # Define the function for several navigation position 
-        # as a function of the already parameters defined p.map
-        # This method is necessary to be able vectorised implementation
-        # of `BaseModel.as_signal`
+        # Optional vectorised implementation of function to optimize
+        # performance for specific features such as linear fitting and
+        # `BaseModel.as_signal`
         def function_nd(self, x, parameters_values=None):
+            """
+            Parameters
+            ----------
+            x : numpy.ndarray
+                The axis used to calculate the 
+            parameters_values : list of numpy.ndarray or None
+                The list of parameters values.
+                If None, the parameters values will obtained
+                from ``Parameter.map["values"]``.
+            
+            Returns
+            -------
+            numpy.ndarray
+                Results of the component calculated over the axis ``x``.
+            """
             if parameters_values is None:
                 parameters_values = [
                     self.parameter_1.map["values"],
                     self.parameter_2.map["values"],
                     ]
-        if self._is_navigation_multidimensional:
-            x = x[np.newaxis, :]
-            p1 = parameters_values[0][..., np.newaxis]
-            p2 = parameters_values[1][..., np.newaxis]
-        else:
-            p1 = self.parameter_1.value
-            p2 = self.parameter_2.value
-        return np.ones_like(x) * p1 + x * p2
+            if self._is_navigation_multidimensional:
+                x = x[np.newaxis, :]
+                p1 = parameters_values[0][..., np.newaxis]
+                p2 = parameters_values[1][..., np.newaxis]
+            else:
+                p1 = self.parameter_1.value
+                p2 = self.parameter_2.value
+            return np.ones_like(x) * p1 + x * p2
 
         # Optionally define the gradients of each parameter
         def grad_parameter_1(self, x):

--- a/examples/simple_simulations/two_gaussians.py
+++ b/examples/simple_simulations/two_gaussians.py
@@ -27,7 +27,7 @@ gs1 = hs.model.components1D.Gaussian()
 m.append(gs1)
 
 # Set the parameters
-gs1.sigma.value = 10
+m.set_parameters_value('sigma', 10, component_list=[gs1])
 # Make the center vary in the -5,5 range around 128
 gs1.centre.map['values'][:] = 256 + (np.random.random((32, 32)) - 0.5) * 10
 gs1.centre.map['is_set'][:] = True
@@ -42,7 +42,7 @@ gs2 = hs.model.components1D.Gaussian()
 m.append(gs2)
 
 # Set the parameters
-gs2.sigma.value = 20
+m.set_parameters_value('sigma', 20, component_list=[gs2])
 
 # Make the center vary in the -10,10 range around 768
 gs2.centre.map['values'][:] = 768 + (np.random.random((32, 32)) - 0.5) * 20

--- a/hyperspy/_components/doniach.py
+++ b/hyperspy/_components/doniach.py
@@ -127,7 +127,6 @@ class Doniach(Expression):
         x2 : float
             Defines the right limit of the spectral range to use for the
             estimation.
-
         only_current : bool
             If False estimates the parameters for the full dataset.
 
@@ -175,5 +174,6 @@ class Doniach(Expression):
             self.sigma.map["is_set"][:] = True
             self.centre.map["values"][:] = centre
             self.centre.map["is_set"][:] = True
+            self.alpha.map["is_set"][:] = True
             self.fetch_stored_values()
             return True

--- a/hyperspy/_components/expression.py
+++ b/hyperspy/_components/expression.py
@@ -352,8 +352,25 @@ class Expression(Component):
                     "The gradients can not be computed with sympy.", UserWarning
                 )
 
-    def function_nd(self, *args):
-        """%s"""
+    def function_nd(self, *args, parameters_values=None):
+        """
+        Calculate the component over given axes and with given parameter values.
+
+        Parameters
+        ----------
+        *args : numpy.ndarray
+            The axes onto which the component is calculated.
+            For 1D component, only a single array of dimension 1 is necessary.
+            For 2D component, two arrays of dimension 1 are necessary.
+        %s
+
+        Returns
+        -------
+        numpy.ndarray : the component values
+        """
+        if parameters_values is None:
+            parameters_values = [p.map["values"] for p in self.parameters]
+
         if self._is2D:
             x, y = args[0], args[1]
             # navigation dimension is 0, f_nd same as f
@@ -363,10 +380,7 @@ class Expression(Component):
                 return self._f(
                     x[np.newaxis, ...],
                     y[np.newaxis, ...],
-                    *[
-                        p.map["values"][..., np.newaxis, np.newaxis]
-                        for p in self.parameters
-                    ],
+                    *[p[..., np.newaxis, np.newaxis] for p in self.parameters],
                 )
         else:
             x = args[0]
@@ -375,7 +389,7 @@ class Expression(Component):
             else:
                 return self._f(
                     x[np.newaxis, ...],
-                    *[p.map["values"][..., np.newaxis] for p in self.parameters],
+                    *[p[..., np.newaxis] for p in parameters_values],
                 )
 
     function_nd.__doc__ %= FUNCTION_ND_DOCSTRING

--- a/hyperspy/_components/expression.py
+++ b/hyperspy/_components/expression.py
@@ -369,7 +369,14 @@ class Expression(Component):
         numpy.ndarray : the component values
         """
         if parameters_values is None:
-            parameters_values = [p.map["values"] for p in self.parameters]
+            parameters_values = []
+            try:
+                parameters_values = [p.map["values"] for p in self.parameters]
+            except TypeError:
+                # When p.map is None
+                raise RuntimeError(
+                    "The parameter map must be set before using `function_nd`."
+                )
 
         if self._is2D:
             x, y = args[0], args[1]
@@ -380,7 +387,7 @@ class Expression(Component):
                 return self._f(
                     x[np.newaxis, ...],
                     y[np.newaxis, ...],
-                    *[p[..., np.newaxis, np.newaxis] for p in self.parameters],
+                    *[p[..., np.newaxis, np.newaxis] for p in parameters_values],
                 )
         else:
             x = args[0]

--- a/hyperspy/_components/expression.py
+++ b/hyperspy/_components/expression.py
@@ -366,7 +366,8 @@ class Expression(Component):
 
         Returns
         -------
-        numpy.ndarray : the component values
+        numpy.ndarray
+            The component values.
         """
         if parameters_values is None:
             parameters_values = []

--- a/hyperspy/_components/offset.py
+++ b/hyperspy/_components/offset.py
@@ -129,7 +129,8 @@ class Offset(Component):
 
         Returns
         -------
-        numpy.ndarray : the component values
+        numpy.ndarray
+            The component values.
         """
         if parameters_values is None:
             parameters_values = [self.offset.map["values"]]

--- a/hyperspy/_components/offset.py
+++ b/hyperspy/_components/offset.py
@@ -117,11 +117,25 @@ class Offset(Component):
             self.fetch_stored_values()
             return True
 
-    def function_nd(self, axis):
-        """%s"""
+    def function_nd(self, axis, parameters_values=None):
+        """
+        Calculate the component over given axes and with given parameter values.
+
+        Parameters
+        ----------
+        axis : numpy.ndarray
+            The axis onto which the component is calculated.
+        %s
+
+        Returns
+        -------
+        numpy.ndarray : the component values
+        """
+        if parameters_values is None:
+            parameters_values = [self.offset.map["values"]]
         if self._is_navigation_multidimensional:
             x = axis[np.newaxis, :]
-            o = self.offset.map["values"][..., np.newaxis]
+            o = parameters_values[0][..., np.newaxis]
         else:
             x = axis
             o = self.offset.value

--- a/hyperspy/_components/power_law.py
+++ b/hyperspy/_components/power_law.py
@@ -181,6 +181,8 @@ class PowerLaw(Expression):
             self.A.map["is_set"][:] = True
             self.r.map["values"][:] = r
             self.r.map["is_set"][:] = True
+            self.origin.map["is_set"] = True
+            self.left_cutoff.map["is_set"] = True
             self.fetch_stored_values()
             return True
 

--- a/hyperspy/_components/scalable_fixed_pattern.py
+++ b/hyperspy/_components/scalable_fixed_pattern.py
@@ -154,7 +154,8 @@ class ScalableFixedPattern(Component):
 
         Returns
         -------
-        numpy.ndarray : the component values
+        numpy.ndarray
+            The component values.
         """
         if self._is_navigation_multidimensional:
             x = axis[np.newaxis, :]

--- a/hyperspy/_components/scalable_fixed_pattern.py
+++ b/hyperspy/_components/scalable_fixed_pattern.py
@@ -80,7 +80,7 @@ class ScalableFixedPattern(Component):
     """
 
     def __init__(self, signal1D, yscale=1.0, xscale=1.0, shift=0.0, interpolate=True):
-        Component.__init__(self, ["yscale", "xscale", "shift"], ["yscale"])
+        Component.__init__(self, ["xscale", "yscale", "shift"], ["yscale"])
 
         self._position = self.shift
         self._whitelist["signal1D"] = ("init,sig", signal1D)
@@ -142,14 +142,26 @@ class ScalableFixedPattern(Component):
     def function(self, x):
         return self._function(x, self.xscale.value, self.yscale.value, self.shift.value)
 
-    def function_nd(self, axis):
-        """%s"""
+    def function_nd(self, axis, parameters_values=None):
+        """
+        Calculate the component over given axes and with given parameter values.
+
+        Parameters
+        ----------
+        axis : numpy.ndarray
+            The axis onto which the component is calculated.
+        %s
+
+        Returns
+        -------
+        numpy.ndarray : the component values
+        """
         if self._is_navigation_multidimensional:
             x = axis[np.newaxis, :]
-            xscale = self.xscale.map["values"][..., np.newaxis]
-            yscale = self.yscale.map["values"][..., np.newaxis]
-            shift = self.shift.map["values"][..., np.newaxis]
-            return self._function(x, xscale, yscale, shift)
+            if parameters_values is None:
+                parameters_values = [p.map["values"] for p in self.parameters]
+            parameters_values = [p[..., np.newaxis] for p in parameters_values]
+            return self._function(x, *parameters_values)
         else:
             return self.function(axis)
 

--- a/hyperspy/_components/split_voigt.py
+++ b/hyperspy/_components/split_voigt.py
@@ -137,7 +137,8 @@ class SplitVoigt(Component):
 
         Returns
         -------
-        numpy.ndarray : the component values
+        numpy.ndarray
+            The component values.
         """
         if self._is_navigation_multidimensional:
             if parameters_values is None:

--- a/hyperspy/_components/split_voigt.py
+++ b/hyperspy/_components/split_voigt.py
@@ -216,6 +216,7 @@ class SplitVoigt(Component):
             self.sigma2.map["is_set"][:] = True
             self.centre.map["values"][:] = centre
             self.centre.map["is_set"][:] = True
+            self.fraction.map["is_set"][:] = True
             self.fetch_stored_values()
             return True
 

--- a/hyperspy/_components/split_voigt.py
+++ b/hyperspy/_components/split_voigt.py
@@ -85,7 +85,7 @@ class SplitVoigt(Component):
         self.isbackground = False
         self.convolved = True
 
-    def _function(self, x, A, sigma1, sigma2, fraction, centre):
+    def _function(self, x, A, sigma1, sigma2, centre, fraction):
         arg = x - centre
         lor1 = (A / (1.0 + ((1.0 * arg) / sigma1) ** 2)) / (
             0.5 * np.pi * (sigma1 + sigma2)
@@ -122,31 +122,30 @@ class SplitVoigt(Component):
             weight for lorentzian peak in the linear combination,
             and (1-fraction) is the weight for gaussian peak.
         """
-        A = self.A.value
-        sigma1 = self.sigma1.value
-        sigma2 = self.sigma2.value
-        fraction = self.fraction.value
-        centre = self.centre.value
+        parameters_value = [p.value for p in self.parameters]
+        return self._function(x, *parameters_value)
 
-        return self._function(x, A, sigma1, sigma2, fraction, centre)
+    def function_nd(self, axis, parameters_values=None):
+        """
+        Calculate the component over given axes and with given parameter values.
 
-    def function_nd(self, axis):
-        """%s"""
+        Parameters
+        ----------
+        axis : numpy.ndarray
+            The axis onto which the component is calculated.
+        %s
+
+        Returns
+        -------
+        numpy.ndarray : the component values
+        """
         if self._is_navigation_multidimensional:
-            x = axis[np.newaxis, :]
-            A = self.A.map["values"][..., np.newaxis]
-            sigma1 = self.sigma1.map["values"][..., np.newaxis]
-            sigma2 = self.sigma2.map["values"][..., np.newaxis]
-            fraction = self.fraction.map["values"][..., np.newaxis]
-            centre = self.centre.map["values"][..., np.newaxis]
+            if parameters_values is None:
+                parameters_values = [p.map["values"] for p in self.parameters]
+            parameters_values = [p[..., np.newaxis] for p in parameters_values]
+            return self._function(axis[np.newaxis, :], *parameters_values)
         else:
-            x = axis
-            A = self.A.value
-            sigma1 = self.sigma1.value
-            sigma2 = self.sigma2.value
-            fraction = self.fraction.value
-            centre = self.centre.value
-        return self._function(x, A, sigma1, sigma2, fraction, centre)
+            return self.function(axis)
 
     function_nd.__doc__ %= FUNCTION_ND_DOCSTRING
 

--- a/hyperspy/_components/voigt.py
+++ b/hyperspy/_components/voigt.py
@@ -182,6 +182,7 @@ class Voigt(Expression):
             self.sigma.map["is_set"][:] = True
             self.centre.map["values"][:] = centre
             self.centre.map["is_set"][:] = True
+            self.gamma.map["is_set"][:] = True
             self.fetch_stored_values()
             return True
 

--- a/hyperspy/_signals/signal1d.py
+++ b/hyperspy/_signals/signal1d.py
@@ -1130,7 +1130,9 @@ class Signal1D(BaseSignal, CommonSignal1D):
             model.multifit(show_progressbar=show_progressbar, iterpath="serpentine")
             model.reset_signal_range()
 
-        result = self - model.as_signal()
+        result = self - model.as_signal(
+            out_of_range_to_nan=False, show_progressbar=show_progressbar
+        )
 
         if zero_fill:
             if self._lazy:

--- a/hyperspy/_signals/signal1d.py
+++ b/hyperspy/_signals/signal1d.py
@@ -1130,22 +1130,7 @@ class Signal1D(BaseSignal, CommonSignal1D):
             model.multifit(show_progressbar=show_progressbar, iterpath="serpentine")
             model.reset_signal_range()
 
-        if self._lazy:
-            result = self - model.as_signal(show_progressbar=show_progressbar)
-        else:
-            try:
-                axis = self.axes_manager.signal_axes[0]
-                if axis.is_binned:
-                    if axis.is_uniform:
-                        scale_factor = axis.scale
-                    else:
-                        scale_factor = np.gradient(axis.axis)
-                else:
-                    scale_factor = 1
-                bkg = background_estimator.function_nd(axis.axis) * scale_factor
-                result = self - bkg
-            except MemoryError:
-                result = self - model.as_signal(show_progressbar=show_progressbar)
+        result = self - model.as_signal()
 
         if zero_fill:
             if self._lazy:

--- a/hyperspy/axes.py
+++ b/hyperspy/axes.py
@@ -1671,6 +1671,7 @@ class AxesManager(t.HasTraits):
                 axes = self.signal_axes
             else:
                 return self[(y,)][0]
+            return axes
         else:
             axes = [self._axes_getter(ax) for ax in y]
         _, indices = np.unique([_id for _id in map(id, axes)], return_index=True)

--- a/hyperspy/axes.py
+++ b/hyperspy/axes.py
@@ -1671,7 +1671,6 @@ class AxesManager(t.HasTraits):
                 axes = self.signal_axes
             else:
                 return self[(y,)][0]
-            return axes
         else:
             axes = [self._axes_getter(ax) for ax in y]
         _, indices = np.unique([_id for _id in map(id, axes)], return_index=True)

--- a/hyperspy/data/two_gaussians.py
+++ b/hyperspy/data/two_gaussians.py
@@ -76,7 +76,8 @@ def two_gaussians(add_noise=True, return_model=False):
     gs01 = hs.model.components1D.GaussianHF()
     gs01.name = "wide"
     m.append(gs01)
-    gs01.fwhm.value = 60
+    gs01.fwhm.map["values"][:] = 60
+    gs01.fwhm.map["is_set"][:] = True
     gs01.centre.map["values"][:] = center_wide
     gs01.centre.map["is_set"][:] = True
     gs01.height.map["values"][:] = h_wide
@@ -85,7 +86,8 @@ def two_gaussians(add_noise=True, return_model=False):
     gs02 = hs.model.components1D.GaussianHF()
     gs02.name = "narrow"
     m.append(gs02)
-    gs02.fwhm.value = 6
+    gs02.fwhm.map["values"][:] = 6
+    gs02.fwhm.map["is_set"][:] = True
     gs02.centre.map["values"][:] = center_narrow
     gs02.centre.map["is_set"][:] = True
     gs02.height.map["values"][:] = h_narrow

--- a/hyperspy/docstrings/parameters.py
+++ b/hyperspy/docstrings/parameters.py
@@ -18,7 +18,10 @@
 
 """Common docstring snippets for parameters."""
 
-FUNCTION_ND_DOCSTRING = """Returns a numpy array containing the value of the component for all
-        indices. If enough memory is available, this is useful to quickly to
-        obtain the fitted component without iterating over the navigation axes.
+FUNCTION_ND_DOCSTRING = """parameters_values : list, None, optional
+            List of parameters values used to calculate the component.
+            The order of the parameter in the list is defined in the
+            ``parameters`` attributes of the components
+            If ``None``, the parameters values for all navigation positions
+            are considered. The default is None.
         """

--- a/hyperspy/misc/array_tools.py
+++ b/hyperspy/misc/array_tools.py
@@ -409,6 +409,69 @@ def get_signal_chunk_slice(index, chunks):
     raise ValueError("Index out of signal range.")
 
 
+def get_chunk_slice(
+    shape,
+    signal_dimension,
+    chunks="auto",
+    block_size_limit=None,
+    dtype=None,
+):
+    """
+    Takes a shape and chunks and returns an array of the slices to be used with
+    :func:`dask.array.map_blocks`.
+
+    Parameters
+    ----------
+    shape : tuple
+        Shape of the data.
+    signal_dimension : int
+        The signal dimension of the signal.
+    chunks : "auto", "dask_auto" or tuple
+        If ``"auto"``, no chunking is created in the signal dimension. If ``"dask_auto"``, the
+        dask "auto" chunking is used - see :func:`dask.array.core.normalize_chunks` for more
+        information. The default is "auto".
+    block_size_limit : int, optional
+        Maximum size of a block in bytes. The default is None. This is passed
+        to the :func:`dask.array.core.normalize_chunks` function when chunks == "auto".
+    dtype : numpy.dtype, optional
+        Data type. The default is None. This is passed to the
+        :func:`dask.array.core.normalize_chunks` function when chunks == "auto".
+
+    Returns
+    -------
+    numpy.ndarray of slices
+        Dask array of the slices.
+    tuple
+        Tuple of the chunks.
+
+    Note
+    ----
+    Adapted from https://github.com/hyperspy/rosettasciio/blob/main/rsciio/utils/distributed.py
+    """
+    if chunks == "auto":
+        # no chunking along signal_dimension
+        chunks = ("auto",) * len(shape[:-signal_dimension]) + (-1,)
+    elif chunks == "dask_auto":
+        # Use dask auto
+        chunks = "auto"
+
+    chunks = da.core.normalize_chunks(
+        chunks=chunks, shape=shape, limit=block_size_limit, dtype=dtype
+    )
+    chunks_shape = tuple([len(c) for c in chunks])
+    slices = np.empty(
+        shape=chunks_shape + (len(chunks_shape), 2),
+        dtype=int,
+    )
+    for ind in np.ndindex(chunks_shape):
+        current_chunk = [chunk[i] for i, chunk in zip(ind, chunks)]
+        starts = [int(np.sum(chunk[:i])) for i, chunk in zip(ind, chunks)]
+        stops = [s + c for s, c in zip(starts, current_chunk)]
+        slices[ind] = [[start, stop] for start, stop in zip(starts, stops)]
+
+    return slices, chunks
+
+
 @jit_ifnumba(cache=True)
 def numba_closest_index_round(axis_array, value_array):
     """For each value in value_array, find the closest value in axis_array and

--- a/hyperspy/model.py
+++ b/hyperspy/model.py
@@ -854,7 +854,6 @@ class BaseModel(list):
                         self, component_list, chunks, block_size_limit
                     )
                 else:
-                    print("ooooooo")
                     if out_of_range_to_nan:
                         raise ValueError(
                             "'out_of_range_to_nan' is not supported for dask < 2024.12.0."

--- a/hyperspy/model.py
+++ b/hyperspy/model.py
@@ -178,7 +178,7 @@ def _get_model_data_function_nd(
     shape=None,
 ):
     """
-    Compute the model data in a vectorised manner
+    Compute the model data in a vectorised manner.
 
     Parameters
     ----------
@@ -205,6 +205,14 @@ def _get_model_data_function_nd(
 
     data_ = np.zeros(shape, dtype=float)
     for component in component_list:
+        for p in component.parameters:
+            if not p.map["is_set"][nav_slices].all():
+                raise ValueError(
+                    f"The parameter {p.name} of the component {component.name} "
+                    "has unset values. Set the values by using the `multifit` or "
+                    "the `set_parameters_value` methods."
+                )
+
         axis_ = model.axes_manager["sig"].get("axis")["axis"]
         if len(axis_) >= 2:
             axis_ = np.meshgrid(*axis_)

--- a/hyperspy/models/model1d.py
+++ b/hyperspy/models/model1d.py
@@ -309,29 +309,6 @@ class Model1D(BaseModel):
 
     remove.__doc__ = BaseModel.remove.__doc__
 
-    def _get_model_data(self, component_list=None, ignore_channel_switches=False):
-        """
-        Return the model data at the current position
-
-        Parameters
-        ----------
-        component_list : list or None
-            If None, the model is constructed with all active components. Otherwise,
-            the model is constructed with the components in component_list.
-
-        Returns:
-        --------
-        model_data: `ndarray`
-        """
-        if component_list is None:
-            component_list = self
-        slice_ = slice(None) if ignore_channel_switches else self._channel_switches
-        axis = self.axis.axis[slice_]
-        model_data = np.zeros(len(axis))
-        for component in component_list:
-            model_data += component.function(axis)
-        return model_data
-
     def _get_current_data(
         self,
         onlyactive=False,
@@ -357,8 +334,6 @@ class Model1D(BaseModel):
             If true, the entire signal axis are returned
             without checking _channel_switches.
 
-        cursor: 1 or 2
-
         Returns
         -------
         numpy array
@@ -373,10 +348,13 @@ class Model1D(BaseModel):
             component_list = [
                 component for component in component_list if component.active
             ]
-        model_data = self._get_model_data(
-            component_list=component_list,
-            ignore_channel_switches=ignore_channel_switches,
-        )
+
+        slice_ = slice(None) if ignore_channel_switches else self._channel_switches
+        axis = self.axis.axis[slice_]
+        model_data = np.zeros(len(axis))
+        for component in component_list:
+            model_data += component.function(axis)
+
         if binned is None:
             # use self.axis instead of self.signal.axes_manager[-1]
             # to avoid small overhead (~10 us) which isn't negligeable when

--- a/hyperspy/tests/component/test_components2D.py
+++ b/hyperspy/tests/component/test_components2D.py
@@ -415,7 +415,7 @@ class TestExpression2D:
             ),
         )
 
-    def test_no_function_nd(self):
+    def test_function_nd_no_signal(self):
         g = hs.model.components2D.Expression(
             GAUSSIAN2D_EXPR,
             name="gaussian2d",
@@ -429,7 +429,10 @@ class TestExpression2D:
         g.y0.value = 1
         values = np.linspace(-2, 2, 5)
         x, y = np.meshgrid(values, values)
-        np.testing.assert_allclose(g.function_nd(x, y), self.array0)
+        parameters_values = [p.value for p in g.parameters]
+        np.testing.assert_allclose(
+            g.function_nd(x, y, parameters_values=parameters_values), self.array0
+        )
 
     def test_no_function_nd_signal(self):
         g = hs.model.components2D.Expression(

--- a/hyperspy/tests/component/test_expression.py
+++ b/hyperspy/tests/component/test_expression.py
@@ -53,7 +53,10 @@ class TestExpression:
         np.testing.assert_allclose(self.g.grad_fwhm(2), 0.00033845077175778578)
 
     def test_function_nd(self):
-        assert self.g.function_nd(0) == 1
+        with pytest.raises(RuntimeError):
+            self.g.function_nd(0)
+        parameters_values = [p.value for p in self.g.parameters]
+        assert self.g.function_nd(0, parameters_values=parameters_values) == 1
 
 
 def test_expression_symbols():

--- a/hyperspy/tests/component/test_gaussian.py
+++ b/hyperspy/tests/component/test_gaussian.py
@@ -159,6 +159,7 @@ class TestGaussian:
     @pytest.mark.parametrize(("only_current", "binned"), TRUE_FALSE_2_TUPLE)
     def test_estimate_parameters_binned(self, only_current, binned):
         self.m.signal.axes_manager[-1].is_binned = binned
+        self.m.assign_current_values_to_all()
         s = self.m.as_signal()
         assert s.axes_manager[-1].is_binned == binned
         g = hs.model.components1D.Gaussian()
@@ -171,6 +172,7 @@ class TestGaussian:
     @pytest.mark.parametrize("binned", (True, False))
     def test_function_nd(self, binned):
         self.m.signal.axes_manager[-1].is_binned = binned
+        self.m.assign_current_values_to_all()
         s = self.m.as_signal()
         s2 = hs.stack([s] * 2)
         g = hs.model.components1D.Gaussian()

--- a/hyperspy/tests/component/test_offset.py
+++ b/hyperspy/tests/component/test_offset.py
@@ -39,6 +39,7 @@ class TestOffset:
     @pytest.mark.parametrize(("only_current", "binned"), TRUE_FALSE_2_TUPLE)
     def test_estimate_parameters(self, only_current, binned, uniform):
         self.m.signal.axes_manager[-1].is_binned = binned
+        self.m.assign_current_values_to_all()
         s = self.m.as_signal()
         if not uniform:
             s.axes_manager[-1].convert_to_non_uniform_axis()
@@ -53,6 +54,7 @@ class TestOffset:
     @pytest.mark.parametrize(("binned"), (True, False))
     def test_function_nd(self, binned, uniform):
         self.m.signal.axes_manager[-1].is_binned = binned
+        self.m.assign_current_values_to_all()
         s = self.m.as_signal()
         s = hs.stack([s] * 2)
         o = hs.model.components1D.Offset()

--- a/hyperspy/tests/component/test_polynomial.py
+++ b/hyperspy/tests/component/test_polynomial.py
@@ -22,7 +22,6 @@ import numpy as np
 import pytest
 
 import hyperspy.api as hs
-from hyperspy.models.model1d import Model1D
 
 TRUE_FALSE_2_TUPLE = [p for p in itertools.product((True, False), repeat=2)]
 
@@ -93,9 +92,11 @@ class TestPolynomial:
             m.append(hs.model.components1D.Polynomial(order=0))
 
     def test_2d_signal(self):
-        # This code should run smoothly, any exceptions should trigger failure
+        for p in self.m_2d[0].parameters:
+            p.map["values"] = p.value
         s = self.m_2d.as_signal()
-        model = Model1D(s)
+
+        model = s.create_model()
         p = hs.model.components1D.Polynomial(order=2)
         model.append(p)
         p.estimate_parameters(s, 0, 100, only_current=False)
@@ -104,9 +105,11 @@ class TestPolynomial:
         np.testing.assert_allclose(p.a0.map["values"], 3)
 
     def test_3d_signal(self):
-        # This code should run smoothly, any exceptions should trigger failure
+        for p in self.m_3d[0].parameters:
+            p.map["values"] = p.value
         s = self.m_3d.as_signal()
-        model = Model1D(s)
+
+        model = s.create_model()
         p = hs.model.components1D.Polynomial(order=2)
         model.append(p)
         p.estimate_parameters(s, 0, 100, only_current=False)

--- a/hyperspy/tests/component/test_polynomial.py
+++ b/hyperspy/tests/component/test_polynomial.py
@@ -72,6 +72,7 @@ class TestPolynomial:
     @pytest.mark.parametrize(("only_current", "binned"), TRUE_FALSE_2_TUPLE)
     def test_estimate_parameters(self, only_current, binned, uniform, order, mapnone):
         self.m.signal.axes_manager[-1].is_binned = binned
+        self.m.assign_current_values_to_all()
         s = self.m.as_signal()
         s.axes_manager[-1].is_binned = binned
         if not uniform:
@@ -94,6 +95,7 @@ class TestPolynomial:
     def test_2d_signal(self):
         for p in self.m_2d[0].parameters:
             p.map["values"] = p.value
+            p.map["is_set"] = True
         s = self.m_2d.as_signal()
 
         model = s.create_model()
@@ -107,6 +109,7 @@ class TestPolynomial:
     def test_3d_signal(self):
         for p in self.m_3d[0].parameters:
             p.map["values"] = p.value
+            p.map["is_set"] = True
         s = self.m_3d.as_signal()
 
         model = s.create_model()
@@ -118,6 +121,7 @@ class TestPolynomial:
         np.testing.assert_allclose(p.a0.map["values"], 3)
 
     def test_function_nd(self):
+        self.m.assign_current_values_to_all()
         s = self.m.as_signal()
         s = hs.stack([s] * 2)
         p = hs.model.components1D.Polynomial(order=2)

--- a/hyperspy/tests/component/test_powerlaw.py
+++ b/hyperspy/tests/component/test_powerlaw.py
@@ -102,6 +102,7 @@ class TestPowerLaw:
     @pytest.mark.parametrize(("only_current", "binned"), TRUE_FALSE_2_TUPLE)
     def test_estimate_parameters(self, only_current, binned):
         self.m.signal.axes_manager[-1].is_binned = binned
+        self.m.assign_current_values_to_all()
         s = self.m.as_signal()
         assert s.axes_manager[-1].is_binned == binned
         g = hs.model.components1D.PowerLaw()
@@ -123,6 +124,7 @@ class TestPowerLaw:
 
     def test_missing_data(self):
         g = hs.model.components1D.PowerLaw()
+        self.m.assign_current_values_to_all()
         s = self.m.as_signal()
         s2 = hs.signals.Signal1D(s.data)
         g.estimate_parameters(s2, None, None)

--- a/hyperspy/tests/model/test_linear_model.py
+++ b/hyperspy/tests/model/test_linear_model.py
@@ -32,6 +32,11 @@ from hyperspy.misc.utils import dummy_context_manager
 from hyperspy.signals import Signal1D, Signal2D
 
 
+def _skip_test(s):
+    if s._lazy and Version(dask.__version__) < Version("2024.12.0"):
+        pytest.skip("dask version must be >= 2024.12.0.")
+
+
 def test_fit_binned():
     rng = np.random.default_rng(1)
     s = Signal1D(rng.normal(scale=2, size=10000)).get_histogram()
@@ -74,6 +79,7 @@ class TestMultiFitLinear:
             s.estimate_poissonian_noise_variance()
 
     def test_gaussian(self, weighted):
+        _skip_test(self.s)
         self._post_setup_method(weighted)
         m = self.m
         L = Gaussian(centre=15.0)
@@ -132,6 +138,7 @@ class TestMultiFitLinear:
         np.testing.assert_equal(L.A.map["std"], np.nan)
 
     def test_offset(self, weighted):
+        _skip_test(self.s)
         self._post_setup_method(weighted)
         m = self.m
         L = Offset(offset=1.0)
@@ -156,10 +163,7 @@ class TestMultiFitLinear:
         )
 
     def test_channel_switches(self, weighted):
-        if self.s._lazy and Version(dask.__version__) < Version("2024.12.0"):
-            pytest.skip(
-                "out_of_range_to_nan not supported lazily with dask < 2024.12.0"
-            )
+        _skip_test(self.s)
         self._post_setup_method(weighted)
         m = self.m
         m._channel_switches[5:-5] = False
@@ -273,6 +277,7 @@ class TestFitAlgorithms:
         self.nonlinear_fit_std = [p.std for p in m._free_parameters if p.std]
 
     def test_compare_lstsq(self, weighted):
+        _skip_test(self.m.signal)
         self._post_setup_method(weighted)
         m = self.m
         m.fit(optimizer="lstsq")
@@ -286,6 +291,7 @@ class TestFitAlgorithms:
         np.testing.assert_allclose(self.nonlinear_fit_std, linear_std, atol=1e-8)
 
     def test_nonactive_component(self, weighted):
+        _skip_test(self.m.signal)
         self._post_setup_method(weighted)
         m = self.m
         m[1].active = False
@@ -300,6 +306,7 @@ class TestFitAlgorithms:
         )
 
     def test_compare_ridge(self, weighted):
+        _skip_test(self.m.signal)
         self._post_setup_method(weighted)
         pytest.importorskip("sklearn")
         m = self.m

--- a/hyperspy/tests/model/test_linear_model.py
+++ b/hyperspy/tests/model/test_linear_model.py
@@ -83,8 +83,8 @@ class TestMultiFitLinear:
         m.fit(optimizer="lstsq")
         # Use out_of_range_to_nan=False to test lazily
         # with dask version < 2024.12.0
-        single = m.as_signal(out_of_range_to_nan=False)
         m.assign_current_values_to_all()
+        single = m.as_signal(out_of_range_to_nan=False)
         cm = (
             pytest.warns(UserWarning)
             if weighted and not self.s._lazy
@@ -140,8 +140,8 @@ class TestMultiFitLinear:
         m.fit(optimizer="lstsq")
         # Use out_of_range_to_nan=False to test lazily
         # with dask version < 2024.12.0
-        single = m.as_signal(out_of_range_to_nan=False)
         m.assign_current_values_to_all()
+        single = m.as_signal(out_of_range_to_nan=False)
         cm = (
             pytest.warns(UserWarning)
             if weighted and not self.s._lazy
@@ -168,8 +168,8 @@ class TestMultiFitLinear:
         m.append(L)
 
         m.fit(optimizer="lstsq")
-        single = m.as_signal()
         m.assign_current_values_to_all()
+        single = m.as_signal()
         cm = (
             pytest.warns(UserWarning)
             if weighted and not self.s._lazy
@@ -771,6 +771,7 @@ def test_power_law():
     pl_ref.A.value = 100
     pl_ref.r.value = 4
 
+    m_ref.assign_current_values_to_all()
     s = m_ref.as_signal()
 
     m = s.create_model()
@@ -800,6 +801,7 @@ def test_lorentzian():
     l_ref.A.value = 100
     l_ref.centre.value = 15
 
+    m_ref.assign_current_values_to_all()
     s = m_ref.as_signal()
 
     m = s.create_model()
@@ -828,6 +830,7 @@ def test_expression_multiple_linear_parameter(nav_dim):
 
     m_ref = s_ref.create_model()
     m_ref.extend([p_ref])
+    m_ref.assign_current_values_to_all()
     s = m_ref.as_signal()
 
     if nav_dim >= 1:
@@ -859,6 +862,7 @@ def test_fitter(optimizer):
 
     m_ref = s_ref.create_model()
     m_ref.extend([p_ref])
+    m_ref.assign_current_values_to_all()
     s = m_ref.as_signal()
 
     m = s.create_model()

--- a/hyperspy/tests/model/test_model.py
+++ b/hyperspy/tests/model/test_model.py
@@ -720,6 +720,18 @@ class TestAsSignal:
                 _ = m.as_signal(out_of_range_to_nan=False)
             assert "don't implement the `function_nd`" in caplog.text
 
+    def test_value_unset(self):
+        s = self.m.signal
+        m = s.create_model()
+        m.append(hs.model.components1D.Offset())
+        with pytest.raises(ValueError):
+            # the value are not set
+            m.as_signal()
+
+        m.set_parameters_value("offset", 1)
+        out = m.as_signal()
+        np.testing.assert_allclose(out.data, np.ones_like(out.data))
+
 
 @lazifyTestClass
 class TestCreateModel:

--- a/hyperspy/tests/signals/test_remove_background.py
+++ b/hyperspy/tests/signals/test_remove_background.py
@@ -18,12 +18,19 @@
 
 import gc
 
+import dask
 import numpy as np
 import pytest
+from packaging.version import Version
 
 import hyperspy.api as hs
 from hyperspy import components1d
 from hyperspy.decorators import lazifyTestClass
+
+
+def _skip_test(s):
+    if s._lazy and Version(dask.__version__) < Version("2024.12.0"):
+        pytest.skip("dask version must be >= 2024.12.0.")
 
 
 def teardown_module(module):
@@ -50,6 +57,7 @@ class TestRemoveBackground1DGaussian:
     @pytest.mark.parametrize("return_model", [False, True])
     def test_background_remove(self, binning, fast, return_model, uniform):
         signal = self.signal
+        _skip_test(signal)
         signal.axes_manager[-1].is_binned = binning
         if not uniform:
             signal.axes_manager[-1].convert_to_non_uniform_axis()
@@ -75,6 +83,7 @@ class TestRemoveBackground1DGaussian:
 
     @pytest.mark.parametrize("fast", [True, False])
     def test_background_remove_navigation(self, fast):
+        _skip_test(self.signal)
         # Check it calculate the chisq
         s2 = hs.stack([self.signal] * 2)
         (s, model) = s2.remove_background(
@@ -104,6 +113,7 @@ class TestRemoveBackground1DLorentzian:
         self.signal.axes_manager[0].is_binned = False
 
     def test_background_remove_lorentzian(self):
+        _skip_test(self.signal)
         # Fast is not accurate
         s1 = self.signal.remove_background(
             signal_range=(None, None), background_type="Lorentzian"
@@ -111,6 +121,7 @@ class TestRemoveBackground1DLorentzian:
         np.testing.assert_allclose(s1.data, 0.0, atol=0.2)
 
     def test_background_remove_lorentzian_full_fit(self):
+        _skip_test(self.signal)
         s1 = self.signal.remove_background(
             signal_range=(None, None), background_type="Lorentzian", fast=False
         )
@@ -134,6 +145,7 @@ class TestRemoveBackground1DPowerLaw:
         self.atol_zero_fill = 0.04 * abs(self.signal.isig[10:].data).max()
 
     def test_background_remove_pl(self):
+        _skip_test(self.signal)
         s1 = self.signal.remove_background(
             signal_range=(None, None), background_type="PowerLaw"
         )
@@ -141,6 +153,7 @@ class TestRemoveBackground1DPowerLaw:
         assert s1.axes_manager.navigation_dimension == 0
 
     def test_background_remove_pl_zero(self):
+        _skip_test(self.signal)
         s1 = self.signal_noisy.remove_background(
             signal_range=(110.0, 190.0), background_type="PowerLaw", zero_fill=True
         )
@@ -148,6 +161,7 @@ class TestRemoveBackground1DPowerLaw:
         np.testing.assert_allclose(s1.data[:10], np.zeros(10))
 
     def test_background_remove_pl_int(self):
+        _skip_test(self.signal)
         self.signal.change_dtype("int")
         s1 = self.signal.remove_background(
             signal_range=(None, None), background_type="PowerLaw"
@@ -155,6 +169,7 @@ class TestRemoveBackground1DPowerLaw:
         np.testing.assert_allclose(s1.data, 0.0, atol=self.atol)
 
     def test_background_remove_pl_int_zero(self):
+        _skip_test(self.signal)
         self.signal_noisy.change_dtype("int")
         s1 = self.signal_noisy.remove_background(
             signal_range=(110.0, 190.0), background_type="PowerLaw", zero_fill=True
@@ -177,12 +192,14 @@ class TestRemoveBackground1DSkewNormal:
 
     def test_background_remove_skewnormal(self):
         # Fast is not accurate
+        _skip_test(self.signal)
         s1 = self.signal.remove_background(
             signal_range=(None, None), background_type="SkewNormal"
         )
         np.testing.assert_allclose(s1.data, 0.0, atol=0.2)
 
     def test_background_remove_skewnormal_full_fit(self):
+        _skip_test(self.signal)
         s1 = self.signal.remove_background(
             signal_range=(None, None), background_type="SkewNormal", fast=False
         )
@@ -203,12 +220,14 @@ class TestRemoveBackground1DVoigt:
 
     def test_background_remove_voigt(self):
         # resort to fast=False as estimator guesses only Gaussian width
+        _skip_test(self.signal)
         s1 = self.signal.remove_background(
             signal_range=(None, None), background_type="Voigt", fast=False
         )
         np.testing.assert_allclose(s1.data, 0.0, atol=1e-12)
 
     def test_background_remove_voigt_full_fit(self):
+        _skip_test(self.signal)
         s1 = self.signal.remove_background(
             signal_range=(None, None), background_type="Voigt", fast=False
         )
@@ -230,12 +249,14 @@ class TestRemoveBackground1DExponential:
 
     def test_background_remove_exponential(self):
         # Fast is not accurate
+        _skip_test(self.signal)
         s1 = self.signal.remove_background(
             signal_range=(None, None), background_type="Exponential"
         )
         np.testing.assert_allclose(s1.data, 0.0, atol=self.atol)
 
     def test_background_remove_exponential_full_fit(self):
+        _skip_test(self.signal)
         s1 = self.signal.remove_background(
             signal_range=(None, None), background_type="Exponential", fast=False
         )

--- a/hyperspy/tests/signals/test_remove_background.py
+++ b/hyperspy/tests/signals/test_remove_background.py
@@ -63,23 +63,32 @@ class TestRemoveBackground1DGaussian:
             s1 = out[0]
             model = out[1]
             np.testing.assert_allclose(model.chisq.data, 0.0, atol=1e-12)
-            np.testing.assert_allclose(model.as_signal().data, signal.data, atol=1e-12)
+            # Use out_of_range_to_nan=False to test lazily
+            # with dask version < 2024.12.0
+            np.testing.assert_allclose(
+                model.as_signal(out_of_range_to_nan=False).data, signal.data, atol=1e-12
+            )
         else:
             s1 = out
 
         np.testing.assert_allclose(s1.data, 0.0, atol=1e-12)
 
-    def test_background_remove_navigation(self):
+    @pytest.mark.parametrize("fast", [True, False])
+    def test_background_remove_navigation(self, fast):
         # Check it calculate the chisq
         s2 = hs.stack([self.signal] * 2)
         (s, model) = s2.remove_background(
             signal_range=(None, None),
             background_type="Gaussian",
-            fast=True,
+            fast=fast,
             return_model=True,
         )
         np.testing.assert_allclose(model.chisq.data, np.array([0.0, 0.0]), atol=1e-12)
-        np.testing.assert_allclose(model.as_signal().data, s2.data)
+        # Use out_of_range_to_nan=False to test lazily
+        # with dask version < 2024.12.0
+        np.testing.assert_allclose(
+            model.as_signal(out_of_range_to_nan=False).data, s2.data
+        )
         np.testing.assert_allclose(s.data, 0.0, atol=1e-12)
 
 

--- a/hyperspy/tests/utils/test_roi.py
+++ b/hyperspy/tests/utils/test_roi.py
@@ -453,7 +453,7 @@ class TestROIs:
         # Test correct inferred axes
         rs_navigation = roi(s, axes=s.axes_manager.navigation_axes)
         rs_inferred = roi(s)
-        assert np.array_equal(rs_inferred.data, rs_navigation.data, equal_nan=True)
+        np.testing.assert_allclose(rs_inferred.data, rs_navigation.data, equal_nan=True)
 
         # Test set vertices from widget
         desired_vertices = [(10, 20), (30, 40), (50, 60)]
@@ -482,7 +482,7 @@ class TestROIs:
         s = self.s_s.copy()
         # converting to non-uniform axis
         s.axes_manager.navigation_axes[0].convert_to_functional_data_axis(
-            expression="1/x",
+            expression="1/(1+ x)",
         )
         roi = PolygonROI([(1, 2), (3, 4), (5, 6)])
         with pytest.raises(NotImplementedError):
@@ -576,7 +576,7 @@ class TestROIs:
         # Test using ``out`` parameter
         out = Signal1D(np.ones_like(sr_square))
         r_square(s, inverted=True, out=out)
-        assert np.array_equal(out.data, sr_square.data, equal_nan=True)
+        np.testing.assert_allclose(out.data, sr_square.data, equal_nan=True)
 
         # Test empty ROI
         r_empty = PolygonROI()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ classifiers = [
 ]
 dependencies = [
     "cloudpickle",
-    "dask[array]>=2021.5.1",
+    "dask[array]>=2022.9.2",
     "importlib-metadata>=3.6",
     "jinja2",
     "matplotlib>=3.6",

--- a/upcoming_changes/3476.enhancements.rst
+++ b/upcoming_changes/3476.enhancements.rst
@@ -1,0 +1,4 @@
+Fix and improve :meth:`~.model.BaseModel.as_signal`:
+
+-  Fix lazy support which stops working from dask version 2024.12.0.
+-  Add vectorised implementation using ``function_nd`` method of Components. For components not implementing ``function_nd`` (for example, in HyperSpy extensions, old or custom components), the old slow implementation is used. All :class:`~.api.model.components1D.Expression` based-components have the ``function_nd`` created automatically.


### PR DESCRIPTION
Since dask 2024.12.0 (in particular https://github.com/dask/dask/pull/11524), `BaseModel.as_signal` doesn't work lazily anymore, because it is not possible assign values to a dask array and the issue is at: https://github.com/hyperspy/hyperspy/blob/e1ef3b0d84e9cde1185533610aefc53e2d3d18c2/hyperspy/model.py#L697-L699.
The new implementation of `as_signal` is vectorised using the `function_nd` method (significantly faster) and the lazy implementation uses `da.map_blocks` to create the dask array.

### Progress of the PR
- [x] Add `parameters_values` argument to `function_nd` methods to be used when processing lazily,
- [x] vectorise `BaseModel.as_signal` using `function_nd` - for components not implementing `function_nd`, use old slow code path,
- [x] fix lazy support in `BaseModel.as_signal`, which was broken since dask 2024.12.0,
- [x] update docstring (if appropriate),
- [x] update user guide (if appropriate),
- [x] add an changelog entry in the `upcoming_changes` folder (see [`upcoming_changes/README.rst`](https://github.com/hyperspy/hyperspy/blob/RELEASE_next_minor/upcoming_changes/README.rst)),
- [x] Check formatting changelog entry in the `readthedocs` doc build of this PR (link in github checks)
- [x] add tests,
- [x] ready for review.

