### PR TITLE
Clean-up dependencies

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,7 @@
+.. _RosettaSciIO: https://hyperspy.org/rosettasciio
+.. _eXSpy: https://hyperspy.org/exspy
+.. _holoSpy: https://hyperspy.org/holospy
+
 .. _changelog:
 
 Changelog
@@ -211,11 +215,11 @@ Release Highlights
 ------------------
 - Hyperspy has split off some of the file reading/writing and domain specific functionalities into separate libraries!
   
-  - `RosettaSciIO <https://hyperspy.org/rosettasciio>`_: A library for reading and writing scientific data files.
+  - RosettaSciIO_: A library for reading and writing scientific data files.
     See `RosettaSciIO release notes <https://hyperspy.org/rosettasciio/changes.html>`_ for new features and supported formats.
-  - `exSpy <https://exspy.readthedocs.io>`_: A library for EELS and EDS analysis.
-    See `exSpy release notes <https://hyperspy.org/exspy/changes.html>`_ for new features.
-  - `holoSpy <https://holospy.readthedocs.io>`_: A library for analysis of (off-axis) electron holography data.
+  - eXSpy_: A library for EELS and EDS analysis.
+    See `eXSpy release notes <https://hyperspy.org/exspy/changes.html>`_ for new features.
+  - holoSpy_: A library for analysis of (off-axis) electron holography data.
     See `holoSpy release notes <https://holospy.readthedocs.io/en/latest/changes.html>`_ for new features.
 
 - The :py:mod:`~.api.plot.markers` API has been refactored

--- a/conda_environment.yml
+++ b/conda_environment.yml
@@ -2,7 +2,7 @@ name: test_env
 channels:
 - conda-forge
 dependencies:
-- dask-core >=2021.3.1
+- dask-core >=2021.5.1
 - dill
 - importlib-metadata
 - h5py
@@ -15,9 +15,7 @@ dependencies:
 - packaging
 - pint >=0.10
 - prettytable >=2.3
-- python-dateutil >=2.5.0
 - pyyaml
-- requests
 - rosettasciio-base
 - scikit-image >=0.18
 - scikit-learn >=1.0.1

--- a/hyperspy/_signals/lazy.py
+++ b/hyperspy/_signals/lazy.py
@@ -24,6 +24,7 @@ from itertools import product
 import dask
 import dask.array as da
 import numpy as np
+from dask.widgets import TEMPLATE_PATHS
 from rsciio.utils import rgb_tools
 from rsciio.utils.tools import get_file_handle
 
@@ -48,16 +49,10 @@ _logger = logging.getLogger(__name__)
 
 lazyerror = NotImplementedError("This method is not available in lazy signals")
 
-
-try:
-    from dask.widgets import TEMPLATE_PATHS
-
-    templates_path = os.path.join(
-        os.path.dirname(os.path.abspath(__file__)), "..", "misc", "dask_widgets"
-    )
-    TEMPLATE_PATHS.append(templates_path)
-except ModuleNotFoundError:
-    _logger.info("Dask widgets not loaded (dask >=2021.11.1 is required)")
+templates_path = os.path.join(
+    os.path.dirname(os.path.abspath(__file__)), "..", "misc", "dask_widgets"
+)
+TEMPLATE_PATHS.append(templates_path)
 
 
 def _get():

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,17 +24,14 @@ dependencies = [
     "cloudpickle",
     "dask[array]>=2021.5.1",
     "importlib-metadata>=3.6",
-    "jinja2",
+    "jinja2", # improves representation of lazy signals by dask
     "matplotlib>=3.6",
     "natsort",
     "numpy>=1.20.0",
     "packaging",
     "pint>=0.10",
-    "pooch",
     "prettytable>=2.3",
-    "python-dateutil>=2.5.0",
     "pyyaml",
-    "requests",
     "rosettasciio[hdf5]",
     "scikit-image>=0.18",
     "scipy>=1.6.0",
@@ -144,6 +141,7 @@ speed = [
     "numexpr",
 ]
 tests = [
+    "pooch",
     "pytest-instafail",
     "pytest-mpl",
     "pytest-rerunfailures",

--- a/upcoming_changes/3482.maintenance.rst
+++ b/upcoming_changes/3482.maintenance.rst
@@ -1,0 +1,1 @@
+Clean up dependencies, which are now used in eXSpy_ and RosettaSciIO_.


### PR DESCRIPTION
### Description of the change
As identified in #3481, we still have some leftover dependencies from the split out of `exspy` and `rosettasciio`.

Closes #3481

### Progress of the PR
- [x] Change implemented (can be split into several points),
- [n/a] update docstring (if appropriate),
- [n/a] update user guide (if appropriate),
- [x] add an changelog entry in the `upcoming_changes` folder (see [`upcoming_changes/README.rst`](https://github.com/hyperspy/hyperspy/blob/RELEASE_next_minor/upcoming_changes/README.rst)),
- [x] Check formatting changelog entry in the `readthedocs` doc build of this PR (link in github checks)
- [n/a] add tests,
- [x] ready for review.
