### PR TITLE
Fix plotting single spectra in `hs.plot.plot_spectra` with `style="mosaic"`

### DIFF
--- a/hyperspy/drawing/utils.py
+++ b/hyperspy/drawing/utils.py
@@ -1675,25 +1675,30 @@ def plot_spectra(
     elif style == "mosaic":
         if legend is None:
             legend = [legend] * len(spectra)
-        for spectrum, ax_, color, linestyle, legend in zip(
+        if not np.iterable(ax):
+            # make sure it is a list
+            ax = [ax]
+        for spectra_, ax_, color_, linestyle_, legend_ in zip(
             spectra, ax, color, linestyle, legend
         ):
-            spectrum = _transpose_if_required(spectrum, 1)
+            spectra_ = _transpose_if_required(spectra_, 1)
             _plot_spectrum(
-                spectrum,
+                spectra_,
                 ax_,
                 normalise,
-                color=color,
-                linestyle=linestyle,
+                color=color_,
+                linestyle=linestyle_,
                 drawstyle=drawstyle,
             )
             ax_.set_ylabel(ylabel)
-            if legend is not None:
-                ax_.set_title(legend)
+            if legend_ is not None:
+                ax_.set_title(legend_)
+            # Add xlabel for each axes (list of BaseSignal)
             if not isinstance(spectra, BaseSignal):
-                _set_spectrum_xlabel(spectrum, ax_)
+                _set_spectrum_xlabel(spectra_, ax_)
+        # Add xlabel at the very bottom (single BaseSignal)
         if isinstance(spectra, BaseSignal):
-            _set_spectrum_xlabel(spectrum, ax_)
+            _set_spectrum_xlabel(spectra, ax[-1])
         fig.tight_layout()
 
     elif style == "heatmap":

--- a/hyperspy/tests/drawing/test_plot_signal1d.py
+++ b/hyperspy/tests/drawing/test_plot_signal1d.py
@@ -551,3 +551,9 @@ def test_plot_spectra_ax():
     ax[4].set_title("mosaic 1")
 
     return fig
+
+
+@pytest.mark.parametrize("style", ("overlap", "cascade", "mosaic"))
+def test_plot_spectra_single(style):
+    s = hs.signals.Signal1D([0, 1, 2])
+    hs.plot.plot_spectra([s], style=style)

--- a/upcoming_changes/3483.bugfix.rst
+++ b/upcoming_changes/3483.bugfix.rst
@@ -1,0 +1,1 @@
+Fix plotting single spectra in :func:`~.api.plot.plot_spectra` with ``style="mosaic"``.


### PR DESCRIPTION
### Progress of the PR
- [x] Fix plotting single spectra,
- [n/a] update docstring (if appropriate),
- [n/a] update user guide (if appropriate),
- [x] add an changelog entry in the `upcoming_changes` folder (see [`upcoming_changes/README.rst`](https://github.com/hyperspy/hyperspy/blob/RELEASE_next_minor/upcoming_changes/README.rst)),
- [x] Check formatting changelog entry in the `readthedocs` doc build of this PR (link in github checks)
- [x] add tests,
- [x] ready for review.

### Minimal example of the bug fix or the new feature

```python
import hyperspy.api as hs

s = hs.signals.Signal1D([0, 1, 2])
hs.plot.plot_spectra([s], style="mosaic")
```
raise the following error:
```python
---------------------------------------------------------------------------
TypeError                                 Traceback (most recent call last)
File c:\users\m0041user\untitled3.py:11
      8 import hyperspy.api as hs
     10 s = hs.signals.Signal1D([0, 1, 2])
---> 11 hs.plot.plot_spectra([s], style="mosaic")

File ~\Dev\hyperspy\hyperspy\drawing\utils.py:1681, in plot_spectra(spectra, style, color, linestyle, drawstyle, padding, legend, legend_picking, legend_loc, fig, ax, auto_update, normalise, **kwargs)
   1679 if legend is None:
   1680     legend = [legend] * len(spectra)
-> 1681 for spectrum, ax_, color, linestyle, legend in zip(
   1682     spectra, ax, color, linestyle, legend
   1683 ):
   1684     spectrum = _transpose_if_required(spectrum, 1)
   1685     _plot_spectrum(
   1686         spectrum,
   1687         ax_,
   (...)
   1691         drawstyle=drawstyle,
   1692     )

TypeError: 'Axes' object is not iterable
```
