### PR TITLE
`remove_spikes` typos

### DIFF
--- a/doc/user_guide/signal/generic_tools.rst
+++ b/doc/user_guide/signal/generic_tools.rst
@@ -935,8 +935,8 @@ In this case method will not return anything.
 Spike removal
 ^^^^^^^^^^^^^
 
-Comic ray or X-ray can cause intense pixels in the data. To correct for these experimental
-artifact, two approaches are implemented in HyperSpy to remove spikes:
+Cosmic rays or X-rays can cause intense pixels in the data. To correct for these experimental
+artifacts, two approaches are implemented in HyperSpy to remove spikes:
 
 - using a median filter - see :meth:`~.api.signals.BaseSignal.remove_spikes`
 - using interpolation (Signal1D only) - see :meth:`~.api.signals.Signal1D.spikes_removal_tool`
@@ -944,7 +944,7 @@ artifact, two approaches are implemented in HyperSpy to remove spikes:
 Using a median filter
 """""""""""""""""""""
 
-The :meth:`~.api.signals.BaseSignal.remove_spikes` find spikes using the following condition:
+The :meth:`~.api.signals.BaseSignal.remove_spikes` finds spikes using the following condition:
 
 .. math::
 
@@ -952,7 +952,7 @@ The :meth:`~.api.signals.BaseSignal.remove_spikes` find spikes using the followi
 
 where :math:`\sigma` is the standard deviation.
 
-Where the condition above is fullfill, the value are replace by their local median.
+Where the condition above is fullfilled, the values are replaced by their local median.
 The parameter ``threshold_factor`` can be specified by the user (default value is 5)
 and the axes along which the median and the standard deviation are calculated can be specified
 using the ``axes`` parameter.

--- a/hyperspy/_signals/signal1d.py
+++ b/hyperspy/_signals/signal1d.py
@@ -364,7 +364,8 @@ class Signal1D(BaseSignal, CommonSignal1D):
 
         See Also
         --------
-        spikes_removal_tool, hyperspy.api.signals.BaseSignal.remove_spikes
+        hyperspy.api.signals.Signal1D.spikes_removal_tool,
+        hyperspy.api.signals.BaseSignal.remove_spikes
 
         """
         self._spikes_diagnosis(

--- a/hyperspy/signal.py
+++ b/hyperspy/signal.py
@@ -7189,25 +7189,25 @@ class BaseSignal(
         Parameters
         ----------
         threshold_factor : int, float
-            Factor used in the thresholding calculation. Higher value will
-            give higher threshold value to find spikes and less spikes will
-            removed. It must a positive number. Default is 5.
+            Factor used in the thresholding calculation. A higher value will
+            give a higher threshold value to find spikes and less spikes will
+            removed. It must be a positive number. Default is 5.
         axes : int, str, :class:`~hyperspy.axes.DataAxis` or tuple
             Specify the axes used for calculating the local median. It is recommended
-            to use axes of similar nature where the local median is representative
-            of the current value (for example, spatial position of mapped values)
-            ``axes`` can be a single or many axes in a tuple. In both cases the
+            to use axes of similar nature, where the local median is representative
+            of the current value (for example, spatial position of mapped values).
+            ``axes`` can be a single or multiple axes in a tuple. In both cases, the
             axes can be passed directly, or specified using the index in
             :attr:`~.api.signals.BaseSignal.axes_manager` or the name of the axis.
             If ``None``, for :class:`~.api.signals.Signal1D`, the navigation axes are
             used. For signals with signal dimension >= 2, the signal axes are used.
             For signals with a signal dimension of 0, all axes are used.
         inplace : bool, default True
-            If ``True``, the data is replaced by the result. Otherwise
-            a new Signal with the results is returned.
+            If ``True``, the data is replaced by the result. Otherwise,
+            a new Signal with the result is returned.
         **kwargs : dict
-            keyword arguments are passed to :func:`scipy.ndimage.median_filter`
-            of :func:`dask_image.ndfilters.median_filter` for lazy signal.
+            Keyword arguments are passed to :func:`scipy.ndimage.median_filter`
+            of :func:`dask_image.ndfilters.median_filter` for lazy signals.
 
         Returns
         -------


### PR DESCRIPTION
Small follow-up to #3436 to fix some typos in the documentation and docstring.