### PR TITLE
Tweak automatic chunking in `BaseSignal.map`

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1002,7 +1002,7 @@ Enhancements
 * Improve error message when file not found (`#2597 <https://github.com/hyperspy/hyperspy/pull/2597>`_)
 * Add update instructions to user guide (`#2621 <https://github.com/hyperspy/hyperspy/pull/2621>`_)
 * Improve plotting navigator of lazy signals, add ``navigator`` setter to lazy signals (`#2631 <https://github.com/hyperspy/hyperspy/pull/2631>`_)
-* Use ``'dask_auto'`` when rechunk=True in :py:meth:`~._signals.lazy.LazySignal.change_dtype` for lazy signal (`#2645 <https://github.com/hyperspy/hyperspy/pull/2645>`_)
+* Use ``'dask_auto'`` when rechunk=True in :py:meth:`~.api.signals.BaseSignal.change_dtype` for lazy signal (`#2645 <https://github.com/hyperspy/hyperspy/pull/2645>`_)
 * Use dask chunking when saving lazy signal instead of rechunking and leave the user to decide what is the suitable chunking (`#2629 <https://github.com/hyperspy/hyperspy/pull/2629>`_)
 * Added lazy reading support for FFT and DPC datasets in FEI emd datasets (`#2651 <https://github.com/hyperspy/hyperspy/pull/2651>`_).
 * Improve error message when initialising SpanROI with left >= right (`#2604 <https://github.com/hyperspy/hyperspy/pull/2604>`_)

--- a/hyperspy/_signals/lazy.py
+++ b/hyperspy/_signals/lazy.py
@@ -25,12 +25,12 @@ import dask
 import dask.array as da
 import numpy as np
 from dask.widgets import TEMPLATE_PATHS
-from rsciio.utils import rgb_tools
 from rsciio.utils.tools import get_file_handle
 
 from hyperspy.docstrings.signal import (
     LAZYSIGNAL_DOC,
     MANY_AXIS_PARAMETER,
+    RECHUNK_ARG,
     SHOW_PROGRESSBAR_ARG,
 )
 from hyperspy.external.progressbar import progressbar
@@ -259,11 +259,11 @@ class LazySignal(BaseSignal):
 
         Parameters
         ----------
-        nav_chunks : {tuple, int, "auto", None}
+        nav_chunks : {tuple, int, "auto"}
             The navigation block dimensions to create.
             -1 indicates the full size of the corresponding dimension.
             Default is “auto” which automatically determines chunk sizes.
-        sig_chunks : {tuple, int, "auto", None}
+        sig_chunks : {tuple, int, "auto"}
             The signal block dimensions to create.
             -1 indicates the full size of the corresponding dimension.
             Default is -1 which automatically spans the full signal dimension
@@ -274,11 +274,12 @@ class LazySignal(BaseSignal):
             sig_chunks = (sig_chunks,) * len(self.axes_manager.signal_shape)
         if not isinstance(nav_chunks, tuple):
             nav_chunks = (nav_chunks,) * len(self.axes_manager.navigation_shape)
-        new_chunks = nav_chunks + sig_chunks
+
+        data_ = self.data.rechunk(nav_chunks + sig_chunks, **kwargs)
         if inplace:
-            self.data = self.data.rechunk(new_chunks, **kwargs)
+            self.data = data_
         else:
-            return self._deepcopy_with_new_data(self.data.rechunk(new_chunks, **kwargs))
+            return self._deepcopy_with_new_data(data_)
 
     def close_file(self):
         """Closes the associated data file if any.
@@ -408,34 +409,18 @@ class LazySignal(BaseSignal):
 
     get_chunk_size.__doc__ %= MANY_AXIS_PARAMETER
 
-    def change_dtype(self, dtype, rechunk=False):
-        # To be consistent with the rechunk argument of other method, we use
-        # 'dask_auto' in favour of a chunking which doesn't split signal space.
-        if rechunk:
-            rechunk = "dask_auto"
-
-        if not isinstance(dtype, np.dtype) and (dtype not in rgb_tools.rgb_dtypes):
-            dtype = np.dtype(dtype)
-        super().change_dtype(dtype)
-        self.data = self._lazy_data(rechunk=rechunk, dtype=dtype)
-
-    change_dtype.__doc__ = BaseSignal.change_dtype.__doc__
-
     def _lazy_data(self, axis=None, rechunk=False, dtype=None):
         """
         Return the data as a dask array, rechunked if necessary.
 
         Parameters
         ----------
-        axis: None, :class:`~.axes.DataAxis` or tuple of data axes
+        axis : None, :class:`~.axes.DataAxis` or tuple of data axes
             The data axis that must not be broken into chunks when `rechunk`
-            is `True`. If None, it defaults to the current signal axes.
-        rechunk: bool, "dask_auto" or iterable
-            If `True`, it rechunks the data if necessary making sure that the
-            axes in ``axis`` are not split into chunks. If `False` it does
-            not rechunk at least the data is not a dask array, in which case
-            it chunks as if rechunk was `True`. If "dask_auto", rechunk if
-            necessary using dask's automatic chunk guessing.
+            is ``True``. If None, it defaults to the current signal axes.
+        %s
+        dtype : numpy.dtype
+            The array dtype used to calculate chunking.
 
         Returns
         -------
@@ -444,13 +429,21 @@ class LazySignal(BaseSignal):
         """
         if rechunk == "dask_auto":
             new_chunks = "auto"
-        elif isiterable(rechunk):
+        elif isinstance(rechunk, tuple):
             new_chunks = rechunk
-        else:
+        elif isinstance(rechunk, bool) or rechunk == "auto":
+            # when rechunk is False, still need new_chunks
+            # da.from_array call in case of numpy array
             new_chunks = self._get_dask_chunks(axis=axis, dtype=dtype)
+        else:
+            raise ValueError(
+                "`rechunk` argument must be a tuple, a boolean or "
+                "a str ('auto' or 'dask_auto') "
+            )
         if isinstance(self.data, da.Array):
             res = self.data
-            if res.chunks != new_chunks and rechunk:
+            # rechunk when necessary when rechunk is True, "auto" or "dask_auto"
+            if rechunk and res.chunks != new_chunks:
                 _logger.info("Rechunking.\nOriginal chunks: %s." % str(res.chunks))
                 res = self.data.rechunk(new_chunks)
                 _logger.info("Final chunks: %s." % str(res.chunks))
@@ -462,6 +455,8 @@ class LazySignal(BaseSignal):
             res = da.from_array(data, chunks=new_chunks)
         assert isinstance(res, da.Array)
         return res
+
+    _lazy_data.__doc__ %= RECHUNK_ARG
 
     def _apply_function_on_data_and_remove_axis(
         self, function, axes, out=None, rechunk=False

--- a/hyperspy/_signals/lazy.py
+++ b/hyperspy/_signals/lazy.py
@@ -251,7 +251,8 @@ class LazySignal(BaseSignal):
     compute.__doc__ %= SHOW_PROGRESSBAR_ARG
 
     def rechunk(self, nav_chunks="auto", sig_chunks=-1, inplace=True, **kwargs):
-        """Rechunks the data using the same rechunking formula from Dask
+        """
+        Rechunks the data using the same rechunking formula from Dask
         expect that the navigation and signal chunks are defined seperately.
         Note, for most functions sig_chunks should remain ``None`` so that it
         spans the entire signal axes.
@@ -407,9 +408,6 @@ class LazySignal(BaseSignal):
 
     get_chunk_size.__doc__ %= MANY_AXIS_PARAMETER
 
-    def _make_lazy(self, axis=None, rechunk=False, dtype=None):
-        self.data = self._lazy_data(axis=axis, rechunk=rechunk, dtype=dtype)
-
     def change_dtype(self, dtype, rechunk=False):
         # To be consistent with the rechunk argument of other method, we use
         # 'dask_auto' in favour of a chunking which doesn't split signal space.
@@ -419,36 +417,43 @@ class LazySignal(BaseSignal):
         if not isinstance(dtype, np.dtype) and (dtype not in rgb_tools.rgb_dtypes):
             dtype = np.dtype(dtype)
         super().change_dtype(dtype)
-        self._make_lazy(rechunk=rechunk, dtype=dtype)
+        self.data = self._lazy_data(rechunk=rechunk, dtype=dtype)
 
     change_dtype.__doc__ = BaseSignal.change_dtype.__doc__
 
     def _lazy_data(self, axis=None, rechunk=False, dtype=None):
-        """Return the data as a dask array, rechunked if necessary.
+        """
+        Return the data as a dask array, rechunked if necessary.
 
         Parameters
         ----------
         axis: None, :class:`~.axes.DataAxis` or tuple of data axes
             The data axis that must not be broken into chunks when `rechunk`
             is `True`. If None, it defaults to the current signal axes.
-        rechunk: bool, "dask_auto"
+        rechunk: bool, "dask_auto" or iterable
             If `True`, it rechunks the data if necessary making sure that the
             axes in ``axis`` are not split into chunks. If `False` it does
             not rechunk at least the data is not a dask array, in which case
             it chunks as if rechunk was `True`. If "dask_auto", rechunk if
             necessary using dask's automatic chunk guessing.
 
+        Returns
+        -------
+        dask.array
+            The data as dask array and rechunked if necessary.
         """
         if rechunk == "dask_auto":
             new_chunks = "auto"
+        elif isiterable(rechunk):
+            new_chunks = rechunk
         else:
             new_chunks = self._get_dask_chunks(axis=axis, dtype=dtype)
         if isinstance(self.data, da.Array):
             res = self.data
-            if self.data.chunks != new_chunks and rechunk:
-                _logger.info("Rechunking.\nOriginal chunks: %s" % str(self.data.chunks))
+            if res.chunks != new_chunks and rechunk:
+                _logger.info("Rechunking.\nOriginal chunks: %s." % str(res.chunks))
                 res = self.data.rechunk(new_chunks)
-                _logger.info("Final chunks: %s " % str(res.chunks))
+                _logger.info("Final chunks: %s." % str(res.chunks))
         else:
             if isinstance(self.data, np.ma.masked_array):
                 data = np.where(self.data.mask, np.nan, self.data)
@@ -589,7 +594,7 @@ class LazySignal(BaseSignal):
         axis = {ax.index_in_array: ax for ax in self.axes_manager._axes}[
             factors.argmax()
         ]
-        self._make_lazy(axis=axis, rechunk=rechunk)
+        self.data = self._lazy_data(axis=axis, rechunk=rechunk)
         return super().rebin(
             new_shape=new_shape, scale=scale, crop=crop, dtype=dtype, out=out
         )
@@ -600,7 +605,7 @@ class LazySignal(BaseSignal):
         return self.data.__array__(dtype=dtype, copy=copy)
 
     def _make_sure_data_is_contiguous(self):
-        self._make_lazy(rechunk=True)
+        self.data = self._lazy_data(rechunk=True)
 
     def diff(self, axis, order=1, out=None, rechunk=False):
         if not self.axes_manager[axis].is_uniform:
@@ -823,7 +828,6 @@ class LazySignal(BaseSignal):
         """
         if get is None:
             get = _get()
-        self._make_lazy()
         data = self._data_aligned_with_axes
         nav_chunks = data.chunks[: self.axes_manager.navigation_dimension]
         indices = product(*[range(len(c)) for c in nav_chunks])

--- a/hyperspy/docstrings/signal.py
+++ b/hyperspy/docstrings/signal.py
@@ -50,11 +50,17 @@ OPTIMIZE_ARG = """optimize : bool
             for more information. When operating on lazy signals, if ``True``,
             the chunks are optimised for the new axes configuration."""
 
-RECHUNK_ARG = """rechunk : bool
-            Only has effect when operating on lazy signal. Default ``False``,
-            which means the chunking structure will be retained. If ``True``,
-            the data may be automatically rechunked before performing this
-            operation."""
+# Passed to `_lazy_data`
+RECHUNK_ARG = """rechunk : bool, str or tuple
+            Only for lazy signal, default is ``False``.
+            If ``False``, the chunking structure will be retained.
+            If ``True`` (use ``"auto"``), the data may be automatically rechunked before
+            performing this operation, when the chunking changes.\n
+            Chunking options:
+
+            - ``"auto"``: chunking doesn't split the signal dimension,
+            - ``"dask_auto"``: uses dask's automatic chunking,
+            - ``tuple``: defines the chunking."""
 
 SHOW_PROGRESSBAR_ARG = """show_progressbar : None or bool
             If ``True``, display a progress bar. If ``None``, the default from

--- a/hyperspy/io.py
+++ b/hyperspy/io.py
@@ -840,7 +840,7 @@ def dict2signal(signal_dict, lazy=False):
         lazy=lazy,
     )(**signal_dict)
     if signal._lazy:
-        signal._make_lazy()
+        signal.data = signal._lazy_data()
 
     # This may happen when the signal dimension couldn't be matched with
     # any specialised subclass

--- a/hyperspy/signal.py
+++ b/hyperspy/signal.py
@@ -5277,8 +5277,8 @@ class BaseSignal(
         silence_warnings=False,
         **kwargs,
     ):
-        """Apply a function to the signal data at all the navigation
-        coordinates.
+        """
+        Apply a function to the signal data at all the navigation coordinates.
 
         The function must operate on numpy arrays. It is applied to the data at
         each navigation coordinate pixel-py-pixel. Any extra keyword arguments
@@ -5416,7 +5416,8 @@ class BaseSignal(
         if navigation_chunks is None:
             navigation_chunks = "auto"
             _logger.warning(
-                "Setting `navigaion_chunk=None`, use `navigaion_chunk='auto'` instead."
+                "Using `navigaion_chunk=None` is deprecated, "
+                "`navigaion_chunk='auto'` is used instead."
             )
         if not isinstance(navigation_chunks, tuple) and navigation_chunks != "auto":
             raise ValueError(

--- a/hyperspy/signal.py
+++ b/hyperspy/signal.py
@@ -2658,7 +2658,11 @@ class BaseSignal(
                 self.learning_results = old_learning_results
 
     def as_lazy(
-        self, copy_variance=True, copy_navigator=True, copy_learning_results=True
+        self,
+        chunks="auto",
+        copy_variance=True,
+        copy_navigator=True,
+        copy_learning_results=True,
     ):
         """
         Create a copy of the given Signal as a
@@ -2666,6 +2670,13 @@ class BaseSignal(
 
         Parameters
         ----------
+        chunks : str or tuple
+            Define chunking of the dask array.
+            If ``"auto"``, automatic chunking will be used and the signal
+            dimension will not be split. If ``dask_auto"``, dask's
+            automatic chunking will be used. If tuple, it defines the chunks,
+            see dask documentation for more information on defining chunks.
+            If ``str`` and the array is already a dask array, don't change the chunking.
         copy_variance : bool
             Whether or not to copy the variance from the original Signal to
             the new lazy version. Default is True.
@@ -2688,7 +2699,13 @@ class BaseSignal(
             copy_learning_results=copy_learning_results,
         )
         res._lazy = True
-        res._assign_subclass()
+        # don't rechunk when dask is already a dask array
+        if isinstance(chunks, str) and isinstance(res.data, da.Array):
+            chunks = False
+            _logger.warning(
+                "Ignoring `chunks` argument because data is already a dask array."
+            )
+        res._assign_subclass(chunks=chunks)
         return res
 
     def _summary(self):
@@ -5170,7 +5187,6 @@ class BaseSignal(
         %s
         %s
         %s
-        %s
         **kwargs
             other keyword arguments (weight and density) are described in
             :func:`numpy.histogram`.
@@ -5241,7 +5257,6 @@ class BaseSignal(
         HISTOGRAM_RANGE_ARGS,
         HISTOGRAM_MAX_BIN_ARGS,
         OUT_ARG,
-        RECHUNK_ARG,
     )
 
     def map(
@@ -5251,7 +5266,7 @@ class BaseSignal(
         num_workers=None,
         inplace=True,
         ragged=None,
-        navigation_chunks=None,
+        navigation_chunks="auto",
         output_signal_size=None,
         output_dtype=None,
         lazy_output=None,
@@ -5291,11 +5306,13 @@ class BaseSignal(
             Indicates if the results for each navigation pixel are of identical
             shape (and/or numpy arrays to begin with). If ``None``,
             the output signal will be ragged only if the original signal is ragged.
-        navigation_chunks : str, None, int or tuple of int, default ``None``
-            Set the navigation_chunks argument to a tuple of integers to split
-            the navigation axes into chunks. This can be useful to enable
-            using multiple cores with signals which are less that 100 MB.
-            This argument is passed to :meth:`~._signals.lazy.LazySignal.rechunk`.
+        navigation_chunks : str, or tuple of int, default ``"auto"``
+            Set the ``navigation_chunks`` argument to a tuple of integers to split
+            the navigation axes into chunks, without chunking the signal dimension.
+            If ``"auto"`` and when the data size is less than 100MB * number of cores,
+            the chunking will be optimised to be distributed over the number of cores.
+            This is useful to enable using multiple cores with signals which are
+            less that 100 MB.
         output_signal_size : None, tuple
             Since the size and dtype of the signal dimension of the output
             signal can be different from the input signal, this output signal
@@ -5392,6 +5409,16 @@ class BaseSignal(
             lazy_output = self._lazy
         if ragged is None:
             ragged = self.ragged
+        if navigation_chunks is None:
+            navigation_chunks = "auto"
+            _logger.warning(
+                "Setting `navigaion_chunk=None`, use `navigaion_chunk='auto'` instead."
+            )
+        if not isinstance(navigation_chunks, tuple) and navigation_chunks != "auto":
+            raise ValueError(
+                "`navigation_chunks` argument must be a tuple or `'auto'`."
+            )
+
         if isinstance(silence_warnings, str):
             silence_warnings = (silence_warnings,)
 
@@ -5782,7 +5809,8 @@ class BaseSignal(
         return copy.deepcopy(self)
 
     def change_dtype(self, dtype, rechunk=False):
-        """Change the data type of a Signal.
+        """
+        Change the data type of a Signal.
 
         Parameters
         ----------
@@ -5803,7 +5831,6 @@ class BaseSignal(
             `signal_dimension` becomes 1.
         %s
 
-
         Examples
         --------
         >>> s = hs.signals.Signal1D([1, 2, 3, 4, 5])
@@ -5813,6 +5840,8 @@ class BaseSignal(
         >>> s.data
         array([1., 2., 3., 4., 5.])
         """
+        if rechunk is True:
+            rechunk = "dask_auto"
         if not isinstance(dtype, np.dtype):
             if dtype in rgb_tools.rgb_dtypes:
                 if self.axes_manager.signal_dimension != 1:
@@ -5835,7 +5864,7 @@ class BaseSignal(
                 self.data = rgb_tools.regular_array2rgbx(self.data)
                 self.axes_manager.remove(-1)
                 self.axes_manager._set_signal_dimension(2)
-                self._assign_subclass()
+                self._assign_subclass(chunks=rechunk)
                 if replot:
                     self.plot()
                 return
@@ -5859,15 +5888,15 @@ class BaseSignal(
                 navigate=False,
             )
             self.axes_manager._set_signal_dimension(1)
-            self._assign_subclass()
+            self._assign_subclass(chunks=rechunk)
             if replot:
                 self.plot()
             return
         else:
             self.data = self.data.astype(dtype)
-        self._assign_subclass()
+        self._assign_subclass(chunks=rechunk)
 
-    change_dtype.__doc__ %= RECHUNK_ARG
+    change_dtype.__doc__ %= RECHUNK_ARG.replace('use ``"auto"``', 'use ``"dask_auto"``')
 
     def estimate_poissonian_noise_variance(
         self,
@@ -6338,7 +6367,7 @@ class BaseSignal(
 
     as_signal2D.__doc__ %= (OUT_ARG, OPTIMIZE_ARG)
 
-    def _assign_subclass(self):
+    def _assign_subclass(self, chunks=False):
         mp = self.metadata
         self.__class__ = assign_signal_subclass(
             dtype=self.data.dtype,
@@ -6352,10 +6381,11 @@ class BaseSignal(
             mp.Signal.signal_type = self._signal_type  # set to default!
         self.__init__(self.data, full_initialisation=False)
         if self._lazy:
-            self.data = self._lazy_data()
+            self.data = self._lazy_data(rechunk=chunks)
 
     def set_signal_type(self, signal_type=""):
-        """Set the signal type and convert the current signal accordingly.
+        """
+        Set the signal type and convert the current signal accordingly.
 
         The ``signal_type`` attribute specifies the type of data that the signal
         contains e.g. electron energy-loss spectroscopy data,

--- a/hyperspy/signal.py
+++ b/hyperspy/signal.py
@@ -6352,7 +6352,7 @@ class BaseSignal(
             mp.Signal.signal_type = self._signal_type  # set to default!
         self.__init__(self.data, full_initialisation=False)
         if self._lazy:
-            self._make_lazy()
+            self.data = self._lazy_data()
 
     def set_signal_type(self, signal_type=""):
         """Set the signal type and convert the current signal accordingly.

--- a/hyperspy/signal.py
+++ b/hyperspy/signal.py
@@ -20,6 +20,7 @@ import copy
 import inspect
 import logging
 import numbers
+import os
 import warnings
 from collections.abc import MutableMapping
 from contextlib import contextmanager
@@ -28,6 +29,7 @@ from functools import partial
 from itertools import product
 from pathlib import Path
 
+import dask
 import dask.array as da
 import numpy as np
 import traits.api as t
@@ -2659,7 +2661,7 @@ class BaseSignal(
 
     def as_lazy(
         self,
-        chunks="auto",
+        chunks=None,
         copy_variance=True,
         copy_navigator=True,
         copy_learning_results=True,
@@ -2699,8 +2701,10 @@ class BaseSignal(
             copy_learning_results=copy_learning_results,
         )
         res._lazy = True
-        # don't rechunk when dask is already a dask array
-        if isinstance(chunks, str) and isinstance(res.data, da.Array):
+        if chunks is None:
+            # Set default values
+            chunks = False if isinstance(res.data, da.Array) else "auto"
+        elif isinstance(chunks, str) and isinstance(res.data, da.Array):
             chunks = False
             _logger.warning(
                 "Ignoring `chunks` argument because data is already a dask array."
@@ -5597,8 +5601,31 @@ class BaseSignal(
             lazy_output = self._lazy
 
         if not self._lazy:
-            s_input = self.as_lazy()
-            s_input.rechunk(nav_chunks=navigation_chunks)
+            chunks = "auto"
+            if navigation_chunks == "auto":
+                nav_size = self.axes_manager.navigation_size
+                nav_dim = max(self.axes_manager.navigation_dimension, 1)
+                if num_workers is None:
+                    # Get dask current setting, fall back to os.cpu_count
+                    num_workers = dask.config.get("num_workers", os.cpu_count())
+
+                # Optimise chunking for parallel computing if the navigation size is
+                # large enough (5 * num_workers), the data will be split into chunks
+                # else if the data set is large (chunk of 100MB * num_workers)
+                # we keep "auto" chunking
+                if (
+                    nav_size > 5 * num_workers
+                    and self.data.nbytes < 100e6 * num_workers
+                ):
+                    # optimise chunk size to distribute over num_workers
+                    # factor of 5 is to make smaller chunks
+                    chunk_size = nav_size // (num_workers * 5)
+                    navigation_chunks = (int(chunk_size ** (1 / nav_dim)),) * nav_dim
+
+            if isinstance(navigation_chunks, tuple):
+                chunks = navigation_chunks + (-1,) * self.axes_manager.signal_dimension
+
+            s_input = self.as_lazy(chunks=chunks)
         else:
             s_input = self
 
@@ -5690,10 +5717,13 @@ class BaseSignal(
                 and (mapped.shape == self.data.shape)
                 and (mapped.dtype == self.data.dtype)
             ):
-                # da.store is used to avoid unnecessary amount of memory usage.
-                # By using it here, the contents in mapped is written directly to
-                # the existing NumPy array, avoiding a potential doubling of memory use.
-                _compute(mapped, self.data, show_progressbar, num_workers=num_workers)
+                # use `store_to` to minmize memory usage
+                _compute(
+                    array=mapped,
+                    store_to=self.data,
+                    show_progressbar=show_progressbar,
+                    num_workers=num_workers,
+                )
                 data_stored = True
             else:
                 self.data = mapped

--- a/hyperspy/tests/signals/test_lazy_tools.py
+++ b/hyperspy/tests/signals/test_lazy_tools.py
@@ -25,7 +25,7 @@ from hyperspy.signals import Signal1D, Signal2D
 def test_lazy_changetype_rechunk_True():
     ar = da.ones((50, 50, 512, 512), chunks=(5, 5, 128, 128), dtype="uint8")
     s = Signal2D(ar).as_lazy()
-    s._make_lazy(rechunk=True)
+    s.data = s._lazy_data(rechunk=True)
     assert s.data.dtype is np.dtype("uint8")
     chunks_old = s.data.chunks
     s.change_dtype("float", rechunk=True)
@@ -47,7 +47,7 @@ def test_lazy_changetype_rechunk_True():
 def test_lazy_changetype_rechunk_default():
     ar = da.ones((50, 50, 256, 256), chunks=(5, 5, 256, 256), dtype="uint8")
     s = Signal2D(ar).as_lazy()
-    s._make_lazy(rechunk=True)
+    s.data = s._lazy_data(rechunk=True)
     assert s.data.dtype is np.dtype("uint8")
     chunks_old = s.data.chunks
     s.change_dtype("float")
@@ -58,7 +58,7 @@ def test_lazy_changetype_rechunk_default():
 def test_lazy_changetype_rechunk_False():
     ar = da.ones((50, 50, 256, 256), chunks=(5, 5, 256, 256), dtype="uint8")
     s = Signal2D(ar).as_lazy()
-    s._make_lazy(rechunk=True)
+    s.data = s._lazy_data(rechunk=True)
     assert s.data.dtype is np.dtype("uint8")
     chunks_old = s.data.chunks
     s.change_dtype("float", rechunk=False)

--- a/hyperspy/tests/signals/test_lazy_tools.py
+++ b/hyperspy/tests/signals/test_lazy_tools.py
@@ -18,6 +18,7 @@
 
 import dask.array as da
 import numpy as np
+import pytest
 
 from hyperspy.signals import Signal1D, Signal2D
 
@@ -63,6 +64,12 @@ def test_lazy_changetype_rechunk_False():
     s.change_dtype(float, rechunk=False)
     assert s.data.dtype is np.dtype(float)
     assert chunks_old == s.data.chunks
+
+
+def test_rechunk_error_parameter():
+    s = Signal1D(da.ones((10, 100))).as_lazy()
+    with pytest.raises(ValueError):
+        s._lazy_data(rechunk=0)
 
 
 def test_lazy_reduce_rechunk():

--- a/hyperspy/tests/signals/test_lazy_tools.py
+++ b/hyperspy/tests/signals/test_lazy_tools.py
@@ -23,20 +23,19 @@ from hyperspy.signals import Signal1D, Signal2D
 
 
 def test_lazy_changetype_rechunk_True():
-    ar = da.ones((50, 50, 512, 512), chunks=(5, 5, 128, 128), dtype="uint8")
+    ar = da.ones((50, 50, 512, 512), chunks=(25, 50, 128, 128), dtype=np.uint8)
     s = Signal2D(ar).as_lazy()
-    s.data = s._lazy_data(rechunk=True)
-    assert s.data.dtype is np.dtype("uint8")
+    assert s.data.dtype is np.dtype(np.uint8)
     chunks_old = s.data.chunks
-    s.change_dtype("float", rechunk=True)
-    assert s.data.dtype is np.dtype("float")
+    s.change_dtype(float, rechunk=True)
+    assert s.data.dtype is np.dtype(float)
     chunks_new = s.data.chunks
     # We expect more chunks
     assert len(chunks_old[0]) * len(chunks_old[1]) < len(chunks_new[0]) * len(
         chunks_new[1]
     )
-    s.change_dtype("uint8", rechunk=True)
-    assert s.data.dtype is np.dtype("uint8")
+    s.change_dtype(np.uint8, rechunk=True)
+    assert s.data.dtype is np.dtype(np.uint8)
     chunks_newest = s.data.chunks
     # We expect less chunks
     assert len(chunks_newest[0]) * len(chunks_newest[1]) < len(chunks_new[0]) * len(
@@ -45,24 +44,24 @@ def test_lazy_changetype_rechunk_True():
 
 
 def test_lazy_changetype_rechunk_default():
-    ar = da.ones((50, 50, 256, 256), chunks=(5, 5, 256, 256), dtype="uint8")
+    ar = da.ones((50, 50, 256, 256), chunks=(25, 50, 256, 256), dtype=np.uint8)
     s = Signal2D(ar).as_lazy()
     s.data = s._lazy_data(rechunk=True)
-    assert s.data.dtype is np.dtype("uint8")
+    assert s.data.dtype is np.dtype(np.uint8)
     chunks_old = s.data.chunks
-    s.change_dtype("float")
-    assert s.data.dtype is np.dtype("float")
+    s.change_dtype(float)
+    assert s.data.dtype is np.dtype(float)
     assert chunks_old == s.data.chunks
 
 
 def test_lazy_changetype_rechunk_False():
-    ar = da.ones((50, 50, 256, 256), chunks=(5, 5, 256, 256), dtype="uint8")
+    ar = da.ones((50, 50, 256, 256), chunks=(5, 5, 256, 256), dtype=np.uint8)
     s = Signal2D(ar).as_lazy()
     s.data = s._lazy_data(rechunk=True)
-    assert s.data.dtype is np.dtype("uint8")
+    assert s.data.dtype is np.dtype(np.uint8)
     chunks_old = s.data.chunks
-    s.change_dtype("float", rechunk=False)
-    assert s.data.dtype is np.dtype("float")
+    s.change_dtype(float, rechunk=False)
+    assert s.data.dtype is np.dtype(float)
     assert chunks_old == s.data.chunks
 
 

--- a/hyperspy/tests/signals/test_map_method.py
+++ b/hyperspy/tests/signals/test_map_method.py
@@ -28,7 +28,7 @@ from scipy.ndimage import gaussian_filter, gaussian_filter1d, rotate
 import hyperspy.api as hs
 from hyperspy._signals.lazy import LazySignal
 from hyperspy.decorators import lazifyTestClass
-from hyperspy.misc.utils import _get_block_pattern
+from hyperspy.misc.utils import _get_block_pattern, dummy_context_manager
 
 
 def identify_function(x):
@@ -1415,3 +1415,40 @@ def test_map_chunking_parallel():
         func, lazy_output=True, inplace=False, navigation_chunks=(5, 5)
     )
     assert s5.data.chunks == ((5,) * 4, (5,) * 4, (100,))
+
+
+@pytest.mark.parametrize("navigation_chunks", (None, "auto"))
+def test_map_chunking_parallel_warning_input(caplog, navigation_chunks):
+    data = np.ones((350, 400, 100))
+    s = hs.signals.Signal1D(data)
+
+    def func(x):
+        return x
+
+    cm = caplog.at_level if navigation_chunks is None else dummy_context_manager
+
+    with dask.config.set(num_workers=1):
+        with cm(logging.WARNING):
+            s2 = s.map(
+                func,
+                lazy_output=True,
+                inplace=False,
+                navigation_chunks=navigation_chunks,
+            )
+        if navigation_chunks is None:
+            assert "`navigaion_chunk=None` is deprecated" in caplog.text
+        s2.data.chunks == ((350,), (200, 200), (100,))
+
+
+def test_map_navigation_chunks_error_input():
+    data = np.ones((350, 400, 100))
+    s = hs.signals.Signal1D(data)
+
+    def func(x):
+        return x
+
+    with pytest.raises(ValueError):
+        s.map(func, lazy_output=True, navigation_chunks=-1)
+
+    with pytest.raises(ValueError):
+        s.map(func, lazy_output=True, navigation_chunks="dask_auto")

--- a/hyperspy/tests/signals/test_map_method.py
+++ b/hyperspy/tests/signals/test_map_method.py
@@ -1385,3 +1385,33 @@ def test_silence_warning_scales_units(caplog):
         s.map(np.sum, silence_warnings=False, inplace=False)
     assert "scales" in caplog.text
     assert "units" in caplog.text
+
+
+def test_map_chunking_parallel():
+    data = np.ones((350, 400, 100))
+    s = hs.signals.Signal1D(data)
+
+    def func(x):
+        return x
+
+    with dask.config.set(num_workers=10):
+        s2 = s.inav[:25, :25].map(func, lazy_output=True, inplace=False)
+        s2.data.chunks == (
+            (3, 3, 3, 3, 3, 3, 3, 3, 1),
+            (3, 3, 3, 3, 3, 3, 3, 3, 1),
+            (100,),
+        )
+
+        # not large enough to use optimised chunking for parallelisation
+        s3 = s.inav[:10, :2].map(func, lazy_output=True, inplace=False)
+        assert s3.data.chunks == ((2,), (10,), (100,))
+
+    # data size large enough to use "auto" chunking
+    with dask.config.set(num_workers=1):
+        s4 = s.map(func, lazy_output=True, inplace=False)
+        s4.data.chunks == ((350,), (200, 200), (100,))
+
+    s5 = s.inav[:20, :20].map(
+        func, lazy_output=True, inplace=False, navigation_chunks=(5, 5)
+    )
+    assert s5.data.chunks == ((5,) * 4, (5,) * 4, (100,))

--- a/hyperspy/tests/signals/test_signal_subclass_conversion.py
+++ b/hyperspy/tests/signals/test_signal_subclass_conversion.py
@@ -16,10 +16,13 @@
 # You should have received a copy of the GNU General Public License
 # along with HyperSpy. If not, see <https://www.gnu.org/licenses/#GPL>.
 
+import logging
+
+import dask.array as da
 import numpy as np
 import pytest
 
-from hyperspy import signals
+import hyperspy.api as hs
 from hyperspy.decorators import lazifyTestClass
 from hyperspy.exceptions import DataDimensionError
 from hyperspy.signals import BaseSignal
@@ -28,7 +31,7 @@ from hyperspy.signals import BaseSignal
 @lazifyTestClass
 class Test1d:
     def setup_method(self, method):
-        self.s = BaseSignal(np.arange(2))
+        self.s = hs.signals.BaseSignal(np.arange(2))
 
     def test_as_signal2D(self):
         with pytest.raises(DataDimensionError):
@@ -41,7 +44,7 @@ class Test1d:
 @lazifyTestClass
 class Test2d:
     def setup_method(self, method):
-        self.s = BaseSignal(np.random.random((2, 3)))  # (|3, 2)
+        self.s = hs.signals.BaseSignal(np.random.random((2, 3)))  # (|3, 2)
 
     def test_as_signal2D_T(self):
         assert self.s.data.T.shape == self.s.as_signal2D((1, 0)).data.shape
@@ -92,4 +95,29 @@ class Test3d:
     def test_remove_axis(self):
         im = self.s.as_signal2D((-2, -1))
         im._remove_axis(-1)
-        assert isinstance(im, signals.Signal1D)
+        assert isinstance(im, hs.signals.Signal1D)
+
+
+def test_as_lazy_chunks(caplog):
+    data = np.ones((100, 100, 2000))
+    s = hs.signals.Signal1D(data)
+
+    # chunks is "auto"
+    s2 = s.as_lazy()
+    assert isinstance(s2.data, da.Array)
+    assert s2.data.chunks == ((50, 50), (100,), (2000,))
+
+    s3 = s.as_lazy(chunks="auto")
+    assert s3.data.chunks == ((50, 50), (100,), (2000,))
+
+    s4 = s.as_lazy(chunks="dask_auto")
+    assert s4.data.chunks == ((100,), (100,), (1677, 323))
+
+    s5 = s.as_lazy(chunks=(25, 25, 500))
+    assert s5.data.chunks == ((25,) * 4, (25,) * 4, (500,) * 4)
+
+    # ignore `chunks` since data is already a dask array
+    s6 = s5.as_lazy(chunks="dask_auto")
+    with caplog.at_level(logging.WARNING):
+        assert s6.data.chunks == s5.data.chunks
+    assert "Ignoring `chunks` argument" in caplog.text

--- a/upcoming_changes/3489.enhancements.rst
+++ b/upcoming_changes/3489.enhancements.rst
@@ -1,0 +1,5 @@
+Improve setting chunking:
+
+- add automatic chunking in :meth:`~.api.signals.BaseSignal.map` for non-lazy signal to optimize chunking for multiple core processing,
+- :meth:`~.api.signals.BaseSignal.as_lazy` can now take a the ``chunks`` argument,
+- improve documentation of the ``rechunk`` argument.


### PR DESCRIPTION
Make enough chunks to keep the workers busy, as discussed in https://github.com/hyperspy/hyperspy/pull/3441#discussion_r1947946188.

### Progress of the PR
- [x] Remove `LazySignal._make_lazy` redirection,
- [x] add `chunks` argument to `BaseSignal.as_lazy`,
- [x] add automatic chunking in `BaseSignal.map` for non-lazy signal to optimize chunking to distribute over multiple cores,
- [x] update docstring (if appropriate),
- [n/a] update user guide (if appropriate),
- [x] add an changelog entry in the `upcoming_changes` folder (see [`upcoming_changes/README.rst`](https://github.com/hyperspy/hyperspy/blob/RELEASE_next_minor/upcoming_changes/README.rst)),
- [x] Check formatting changelog entry in the `readthedocs` doc build of this PR (link in github checks)
- [x] add tests,
- [x] ready for review.


