### PR TITLE
Plotting: Cache nearby chunks as well as the central chunk.

### DIFF
--- a/hyperspy/_signals/complex_signal.py
+++ b/hyperspy/_signals/complex_signal.py
@@ -232,7 +232,12 @@ class ComplexSignal(BaseSignal):
     unwrapped_phase.__doc__ %= (SHOW_PROGRESSBAR_ARG, NUM_WORKERS_ARG)
 
     def _get_current_data(
-        self, axes_manager=None, power_spectrum=False, fft_shift=False, as_numpy=None
+        self,
+        axes_manager=None,
+        power_spectrum=False,
+        fft_shift=False,
+        as_numpy=None,
+        get_result=False,
     ):
         value = super()._get_current_data(
             axes_manager=axes_manager, fft_shift=fft_shift, as_numpy=as_numpy

--- a/hyperspy/_signals/lazy.py
+++ b/hyperspy/_signals/lazy.py
@@ -121,12 +121,48 @@ class LazySignal(BaseSignal):
         # the NumPy array originates from.
         self._cache_dask_chunk = None
         self._cache_dask_chunk_slice = None
+        self._cache_dask_chunk_index = None
+
+        self._neighbor_cache_dask_indexes = []
+        self._neighbor_cache_arrays = []
+
+        self._client = None
+
         if self._clear_cache_dask_data not in self.events.data_changed.connected:
             self.events.data_changed.connect(self._clear_cache_dask_data)
 
     __init__.__doc__ = BaseSignal.__init__.__doc__.replace(
         ":class:`numpy.ndarray`", ":class:`dask.array.Array`"
     )
+
+    @property
+    def client(self):
+        """Get the Dask client if one if running"""
+        if self._client is not None:  # first check if we have a client set
+            return self._client
+        # if not, try to get the Global client if available
+        try:
+            from dask.distributed import get_client
+
+            return get_client()
+        except ImportError or ValueError:
+            return None
+
+    @client.setter
+    def client(self, client):
+        """Set the Dask client"""
+        try:
+            from dask.distributed.client import Client
+
+            if isinstance(client, Client):
+                self._client = client
+            else:
+                raise ValueError("client must be an instance of distributed.Client")
+        except ImportError:
+            raise ImportError(
+                "Dask distributed is not available, please install it to set the client"
+            )
+        self._client = client
 
     def _repr_html_(self):
         try:
@@ -543,23 +579,94 @@ class LazySignal(BaseSignal):
 
         """
 
+        # this is more complicated as we do allow data which is not chunked
+        # only in the navigation dimension.  Potentially this could be
+        # slow, but we can't do much about it.
         sig_dim = self.axes_manager.signal_dimension
         chunks = self.get_chunk_size(self.axes_manager.navigation_axes)
         navigation_indices = indices[:-sig_dim]
-        chunk_slice = _get_navigation_dimension_chunk_slice(navigation_indices, chunks)
+        chunk_slice, center_block, neighbor_blocks = (
+            _get_navigation_dimension_chunk_slice(navigation_indices, chunks)
+        )
 
+        # most computers have multiple cores, so we should try to cache the center
+        # of the chunk and then get the neighboring chunks as well.
+
+        # If we are using the distributed scheduler, we can use futures for this.
+
+        to_compute_neighbors = []  # list of dask arrays to compute
+        to_compute_neighbor_indices = []  # list of indices to compute
+        to_compute_center = []  # This is "blocking"
         if (
-            chunk_slice != self._cache_dask_chunk_slice
+            center_block != self._cache_dask_chunk_index
             or self._cache_dask_chunk is None
         ):
-            self._cache_dask_chunk = self.data.__getitem__(chunk_slice).compute()
+            # first test to see if this is cached as a neighboring block...
             self._cache_dask_chunk_slice = chunk_slice
+
+            if center_block in self._neighbor_cache_dask_indexes:
+                index = self._neighbor_cache_dask_indexes.index(center_block)
+                self._cache_dask_chunk = self._neighbor_cache_arrays.pop(index)
+                self._neighbor_cache_dask_indexes.remove(center_block)
+            else:
+                to_compute_center.append(self.data.blocks[center_block])
+
+            # now we need to compute the neighbors
+            for neighbor_block in neighbor_blocks:
+                if neighbor_block not in self._neighbor_cache_dask_indexes:
+                    to_compute_neighbors.append(self.data.blocks[neighbor_block])
+                    to_compute_neighbor_indices.append(neighbor_block)
+
+            for i in self._neighbor_cache_dask_indexes:
+                if i not in neighbor_blocks:
+                    index = self._neighbor_cache_dask_indexes.index(i)
+                    self._neighbor_cache_dask_indexes.remove(i)
+                    arr = self._neighbor_cache_arrays.pop(index)
+                    if self.client is not None:
+                        arr.cancel(
+                            reason="No longer in Relevant Area"
+                        )  # Don't calculate this anymore
+
+        if len(to_compute_center) > 0:
+            self._cache_dask_chunk_index = center_block
+
+        if self.client is None:
+            if len(to_compute_center) + len(to_compute_neighbors) > 0:
+                computed_chunks = da.compute(*to_compute_center, *to_compute_neighbors)
+                if len(to_compute_center) > 0:
+                    self._cache_dask_chunk = computed_chunks[0]
+                for i, neighbor_block in enumerate(to_compute_neighbor_indices):
+                    self._neighbor_cache_dask_indexes.append(neighbor_block)
+                    self._neighbor_cache_arrays.append(
+                        computed_chunks[i + len(to_compute_center)]
+                    )
+
+        else:
+            if len(to_compute_center) > 0:
+                self._cache_dask_chunk = self.client.compute(
+                    *to_compute_center
+                )  # This is non-blocking, returns a future
+            if len(to_compute_neighbors) > 0:
+                for i, neighbor_block in enumerate(
+                    to_compute_neighbors
+                ):  # This is non-blocking, returns a list of futures
+                    self._neighbor_cache_dask_indexes.append(
+                        to_compute_neighbor_indices[i]
+                    )
+                    self._neighbor_cache_arrays.append(
+                        self.client.compute(neighbor_block)
+                    )
 
         indices = list(indices)
         for i, temp_slice in enumerate(chunk_slice):
             indices[i] -= temp_slice.start
         indices = tuple(indices)
-        value = self._cache_dask_chunk[indices]
+        # block for now... we can make this non-blocking later by
+        # retunring a fut
+        if self.client is not None:
+            value = self._cache_dask_chunk.result()[indices]
+        else:
+            value = self._cache_dask_chunk[indices]
         return value
 
     def rebin(

--- a/hyperspy/_signals/lazy.py
+++ b/hyperspy/_signals/lazy.py
@@ -35,7 +35,7 @@ from hyperspy.docstrings.signal import (
 )
 from hyperspy.external.progressbar import progressbar
 from hyperspy.misc.array_tools import (
-    _get_navigation_dimension_chunk_slice,
+    CachedDaskArray,
     _requires_linear_rebin,
     get_signal_chunk_slice,
 )
@@ -119,14 +119,15 @@ class LazySignal(BaseSignal):
         # _cache_dask_chunk has the NumPy array itself, while
         # _cache_dask_chunk_slice has the navigation dimension chunk which
         # the NumPy array originates from.
-        self._cache_dask_chunk = None
-        self._cache_dask_chunk_slice = None
-        self._cache_dask_chunk_index = None
 
-        self._neighbor_cache_dask_indexes = []
-        self._neighbor_cache_arrays = []
+        # set self.cached_dask_array on `plot` call
+        self.cached_dask_array = None
 
         self._client = None
+        if self.client is not None:
+            self.cache_pad = 1
+        else:
+            self.cache_pad = 0
 
         if self._clear_cache_dask_data not in self.events.data_changed.connected:
             self.events.data_changed.connect(self._clear_cache_dask_data)
@@ -145,7 +146,9 @@ class LazySignal(BaseSignal):
             from dask.distributed import get_client
 
             return get_client()
-        except ImportError or ValueError:
+        except ImportError:
+            return None
+        except ValueError:
             return None
 
     @client.setter
@@ -163,46 +166,6 @@ class LazySignal(BaseSignal):
                 "Dask distributed is not available, please install it to set the client"
             )
         self._client = client
-
-    def _repr_html_(self):
-        try:
-            from dask import config
-            from dask.array.svg import svg
-            from dask.utils import format_bytes
-            from dask.widgets import get_template
-
-            nav_chunks = self.get_chunk_size(self.axes_manager.navigation_axes)
-            sig_chunks = self.get_chunk_size(self.axes_manager.signal_axes)
-            if nav_chunks == ():
-                nav_grid = ""
-            else:
-                nav_grid = svg(
-                    chunks=nav_chunks, size=config.get("array.svg.size", 160)
-                )
-            if sig_chunks == ():
-                sig_grid = ""
-            else:
-                sig_grid = svg(
-                    chunks=sig_chunks, size=config.get("array.svg.size", 160)
-                )
-            nbytes = format_bytes(self.data.nbytes)
-            cbytes = format_bytes(
-                np.prod(self.data.chunksize) * self.data.dtype.itemsize
-            )
-            return get_template("lazy_signal.html.j2").render(
-                nav_grid=nav_grid,
-                sig_grid=sig_grid,
-                dim=self.axes_manager._get_dimension_str(),
-                chunks=self._get_chunk_string(),
-                array=self.data,
-                signal_type=self._signal_type,
-                nbytes=nbytes,
-                cbytes=cbytes,
-                title=self.metadata.General.title,
-            )
-
-        except ModuleNotFoundError:
-            return self
 
     def _get_chunk_string(self):
         nav_chunks = self.data.chunksize[: len(self.axes_manager.navigation_shape)][
@@ -535,7 +498,7 @@ class LazySignal(BaseSignal):
             s._remove_axis([ax.index_in_axes_manager for ax in axes])
             return s
 
-    def _get_cache_dask_chunk(self, indices):
+    def _get_cache_dask_chunk(self, indices, get_result=True):
         """Method for handling caching of dask chunks, when using __call__.
 
         When accessing data in a chunked HDF5 file, the whole chunks needs
@@ -578,96 +541,15 @@ class LazySignal(BaseSignal):
         >>> s._clear_cache_dask_data() # Clearing both of these
 
         """
-
-        # this is more complicated as we do allow data which is not chunked
-        # only in the navigation dimension.  Potentially this could be
-        # slow, but we can't do much about it.
-        sig_dim = self.axes_manager.signal_dimension
-        chunks = self.get_chunk_size(self.axes_manager.navigation_axes)
-        navigation_indices = indices[:-sig_dim]
-        chunk_slice, center_block, neighbor_blocks = (
-            _get_navigation_dimension_chunk_slice(navigation_indices, chunks)
+        if self.cached_dask_array is None:
+            self.cached_dask_array = CachedDaskArray(self, cache_padding=self.cache_pad)
+        res = self.cached_dask_array.get_index(
+            indices,
+            force_compute=get_result,
+            nav_dim=len(self.axes_manager.navigation_axes),
+            sum_data=True,
         )
-
-        # most computers have multiple cores, so we should try to cache the center
-        # of the chunk and then get the neighboring chunks as well.
-
-        # If we are using the distributed scheduler, we can use futures for this.
-
-        to_compute_neighbors = []  # list of dask arrays to compute
-        to_compute_neighbor_indices = []  # list of indices to compute
-        to_compute_center = []  # This is "blocking"
-        if (
-            center_block != self._cache_dask_chunk_index
-            or self._cache_dask_chunk is None
-        ):
-            # first test to see if this is cached as a neighboring block...
-            self._cache_dask_chunk_slice = chunk_slice
-
-            if center_block in self._neighbor_cache_dask_indexes:
-                index = self._neighbor_cache_dask_indexes.index(center_block)
-                self._cache_dask_chunk = self._neighbor_cache_arrays.pop(index)
-                self._neighbor_cache_dask_indexes.remove(center_block)
-            else:
-                to_compute_center.append(self.data.blocks[center_block])
-
-            # now we need to compute the neighbors
-            for neighbor_block in neighbor_blocks:
-                if neighbor_block not in self._neighbor_cache_dask_indexes:
-                    to_compute_neighbors.append(self.data.blocks[neighbor_block])
-                    to_compute_neighbor_indices.append(neighbor_block)
-
-            for i in self._neighbor_cache_dask_indexes:
-                if i not in neighbor_blocks:
-                    index = self._neighbor_cache_dask_indexes.index(i)
-                    self._neighbor_cache_dask_indexes.remove(i)
-                    arr = self._neighbor_cache_arrays.pop(index)
-                    if self.client is not None:
-                        arr.cancel(
-                            reason="No longer in Relevant Area"
-                        )  # Don't calculate this anymore
-
-        if len(to_compute_center) > 0:
-            self._cache_dask_chunk_index = center_block
-
-        if self.client is None:
-            if len(to_compute_center) + len(to_compute_neighbors) > 0:
-                computed_chunks = da.compute(*to_compute_center, *to_compute_neighbors)
-                if len(to_compute_center) > 0:
-                    self._cache_dask_chunk = computed_chunks[0]
-                for i, neighbor_block in enumerate(to_compute_neighbor_indices):
-                    self._neighbor_cache_dask_indexes.append(neighbor_block)
-                    self._neighbor_cache_arrays.append(
-                        computed_chunks[i + len(to_compute_center)]
-                    )
-
-        else:
-            if len(to_compute_center) > 0:
-                self._cache_dask_chunk = self.client.compute(
-                    *to_compute_center
-                )  # This is non-blocking, returns a future
-            if len(to_compute_neighbors) > 0:
-                for i, neighbor_block in enumerate(
-                    to_compute_neighbors
-                ):  # This is non-blocking, returns a list of futures
-                    self._neighbor_cache_dask_indexes.append(
-                        to_compute_neighbor_indices[i]
-                    )
-                    self._neighbor_cache_arrays.append(
-                        self.client.compute(neighbor_block)
-                    )
-
-        indices = list(indices)
-        for i, temp_slice in enumerate(chunk_slice):
-            indices[i] -= temp_slice.start
-        indices = tuple(indices)
-        # block for now... we can make this non-blocking later by
-        # retunring a fut
-        if self.client is not None:
-            value = self._cache_dask_chunk.result()[indices]
-        else:
-            value = self._cache_dask_chunk[indices]
-        return value
+        return res
 
     def rebin(
         self,
@@ -1304,6 +1186,7 @@ class LazySignal(BaseSignal):
     def plot(self, navigator="auto", **kwargs):
         if self.axes_manager.ragged:
             raise RuntimeError("Plotting ragged signal is not supported.")
+        self.cached_dask_array = CachedDaskArray(self)
         if isinstance(navigator, str):
             if navigator == "spectrum":
                 # We don't support the 'spectrum' option to keep it simple

--- a/hyperspy/drawing/markers.py
+++ b/hyperspy/drawing/markers.py
@@ -497,6 +497,7 @@ class Markers:
         otherwise compute the kwargs and cache them.
         """
         chunks = {key: value.chunks for key, value in self.dask_kwargs.items()}
+        indices = np.array(indices)[np.newaxis, :]
         chunk_slices = {
             key: _get_navigation_dimension_chunk_slice(indices, chunk)
             for key, chunk in chunks.items()
@@ -506,7 +507,7 @@ class Markers:
             index_slice = chunk_slices[key]
             current_slice = self._cache_dask_chunk_kwargs_slice.get(key, None)
             if current_slice is None or current_slice != index_slice:
-                to_compute[key] = value[index_slice]
+                to_compute[key] = value.blocks[index_slice[0]]
                 self._cache_dask_chunk_kwargs_slice[key] = index_slice
 
         if len(to_compute) > 0:
@@ -648,7 +649,7 @@ class Markers:
         """
         current_keys = {}
         if self._is_iterating:
-            indices = self._axes_manager.indices
+            indices = np.array(self._axes_manager.indices)
             for key, value in self.kwargs.items():
                 if is_iterating(value):
                     if key not in self.dask_kwargs:

--- a/hyperspy/misc/array_tools.py
+++ b/hyperspy/misc/array_tools.py
@@ -15,7 +15,6 @@
 # You should have received a copy of the GNU General Public License
 # along with HyperSpy. If not, see <https://www.gnu.org/licenses/#GPL>
 
-
 import logging
 import math
 
@@ -25,6 +24,14 @@ import numpy as np
 from hyperspy.decorators import jit_ifnumba
 from hyperspy.docstrings.utils import REBIN_ARGS
 from hyperspy.misc.math_tools import anyfloatin
+
+try:
+    from dask.distributed import Future
+
+    distributed_installed = True
+except ImportError:
+    distributed_installed = False
+    Future = None
 
 _logger = logging.getLogger(__name__)
 
@@ -656,7 +663,9 @@ def round_half_away_from_zero(array, decimals=0):  # pragma: no cover
     )
 
 
-def _get_navigation_dimension_chunk_slice(navigation_indices, chunks):
+def _get_navigation_dimension_chunk_slice(
+    navigation_indices, chunks, surrounding_blocks=1
+):
     """Get the slice necessary to get the dask data chunk containing the
     navigation indices.
 
@@ -701,64 +710,69 @@ def _get_navigation_dimension_chunk_slice(navigation_indices, chunks):
     >>> print(chunk_slice)
     (slice(64, 96, None), slice(96, 128, None))
     >>> data_chunk = data[chunk_slice]
-
     """
-    chunk_slice_list = da.core.slices_from_chunks(chunks)
-    block_indexes = np.meshgrid(*[np.arange(0, len(n)) for n in chunks])
-    n_dim = len(chunks)
-    if len(block_indexes) == 0:
-        block_indexes_flat = [()]
+
+    n_dim = navigation_indices.shape[1]
+    block_indexes = np.meshgrid(
+        *[np.arange(0, len(n) - 1) for n in zip(chunks, range(n_dim))]
+    )  # only for n_dim
+    cum_sum_chunks = [np.cumsum(chunks) for chunks in chunks]
+    if n_dim == 0:
+        return (
+            [
+                tuple(),
+            ],
+            [
+                tuple(),
+            ],
+            navigation_indices,
+        )
     else:
-        block_indexes_flat = np.array(block_indexes).T.reshape(-1, n_dim)
+        block_indexes_flat = np.array(block_indexes).reshape(-1, n_dim)
         block_indexes_flat = block_indexes_flat
 
-    # iterate through and just find the slice that contains the navigation indices
-    center_slice = None
-    is_slice = True
-    for chunk_slice, block_index in zip(chunk_slice_list, block_indexes_flat):
-        is_slice = True
-        for index_nav in range(len(navigation_indices)):
-            temp_slice = chunk_slice[index_nav]
-            nav = navigation_indices[index_nav]
-
-            if not (temp_slice.start <= nav < temp_slice.stop):
-                is_slice = False
-                break
-        if is_slice:  # if the slice contains the navigation indices
-            center_slice = chunk_slice
-            center_block_index = block_index
-            break
-    if not is_slice:
-        return False
-
-    if center_slice == ():
-        return (
-            center_slice,
-            center_block_index,
-            [
-                (),
-            ],
+    blocks = np.array(
+        [
+            np.searchsorted(chunks, navigation_indices[:, i], side="right")
+            for i, chunks in zip(np.arange(navigation_indices.shape[1]), cum_sum_chunks)
+        ]
+    ).T
+    core_block_ind, index = np.unique(blocks, return_inverse=True, axis=0)
+    cum_sum_chunks_0 = [np.insert(c, 0, 0) for c in cum_sum_chunks]
+    if core_block_ind.ndim == 1:
+        offset_by_slic = np.array(
+            [cum_sum_chunks_0[i][core_block_ind[i]] for i in range(len(core_block_ind))]
         )
-    around = [-1, 0, 1]
+    else:
+        offset_by_slic = np.array(
+            [
+                cum_sum_chunks_0[i][core_block_ind[:, i]]
+                for i in range(core_block_ind.shape[1])
+            ]
+        ).T
+
+    ind_by_block = [
+        navigation_indices[index == i] - offset_by_slic[i]
+        for i, core_block_ind in enumerate(core_block_ind)
+    ]
+
+    if len(ind_by_block) == 0:
+        return
+
+        # get the blocks around the core chunks which are absolutely needed for plotting...
+    around = np.arange(-surrounding_blocks, surrounding_blocks + 1)
     surrounding_block_indexes = np.array(np.meshgrid(*(around,) * n_dim)).T.reshape(
         -1, n_dim
     )
-    surrounding_block_indexes = np.array(
-        [
-            center_block_index + i
-            for i in surrounding_block_indexes
-            if np.any(
-                i
-                != np.array(
-                    [
-                        0,
-                    ]
-                    * n_dim
-                )
-            )
-        ]
+    # remove duplicates and the "core" blocks which are needed for the ind.
+    shifted_blocks = np.reshape(
+        [u + surrounding_block_indexes for u in core_block_ind], (-1, n_dim)
     )
-
+    surrounding_block_indexes = np.unique(shifted_blocks, axis=0)
+    for u in core_block_ind:
+        surrounding_block_indexes = surrounding_block_indexes[
+            np.any(surrounding_block_indexes != u, axis=1)
+        ]
     is_in = np.prod(
         np.array(
             [
@@ -768,7 +782,274 @@ def _get_navigation_dimension_chunk_slice(navigation_indices, chunks):
         ),
         axis=0,
     ).astype(bool)
-
     surrounding_block_indexes = surrounding_block_indexes[is_in]
     surrounding_block_indexes = [tuple(s) for s in surrounding_block_indexes]
-    return center_slice, tuple(center_block_index), surrounding_block_indexes
+    core_block_ind = [tuple(b) for b in core_block_ind]
+    return core_block_ind, surrounding_block_indexes, ind_by_block
+
+
+class CachedDaskArray:
+    """
+    A custom dask array class that caches the current chunk in memory and loads nearby chunks as well.
+
+    There are two ways that this class can be used:
+
+    1. With the default dask scheduler in this case all the chunks are computed and stored in memory.
+
+    2. With the distributed scheduler, in this case the chunks are computed and stored in memory on the workers.
+       When the data is needed, however, the data will be transferred from the workers and stored in memory there.
+       This case has a two-step buffer, which allows plotting to be asynchronous but also some added latency from
+       the copying of data from the workers to the client (even if the worker/client are on the same machine).
+
+    In either case, data which ends up stored in memory and will be kept there until the object goes out of scope.
+    In which case it is deleted. Increasing the cache_padding will increase the amount of data that is stored
+    in memory. But can be an effective strategy especially with the distributed scheduler and very especially
+    when the data is stored on a networked file system which increases the latency of transfer from the disk
+    and from the workers.
+
+    Parameters
+    ----------
+    array : dask.array.Array
+        The dask array to be cached.
+    cache_padding : int
+        The number of blocks around the current index to cache as well.
+
+    """
+
+    def __init__(self, signal, cache_padding=1):
+        self.signal = signal
+        self.array = signal.data
+        self.current_indices = None
+        self.core_cached_blocks = []
+        self.core_cached_block_inds = []
+        self.surrounding_cached_blocks = []
+        self.surrounding_cached_block_inds = []
+        self.cache_padding = cache_padding
+        self._client = None
+
+    def _repr_html_(self):
+        try:
+            from dask import config
+            from dask.array.svg import svg
+            from dask.utils import format_bytes
+            from dask.widgets import get_template
+
+            nav_chunks = self.signal.get_chunk_size(
+                self.signal.axes_manager.navigation_axes
+            )
+            sig_chunks = self.signal.get_chunk_size(
+                self.signal.axes_manager.signal_axes
+            )
+            if nav_chunks == ():
+                nav_grid = ""
+            else:
+                nav_grid = svg(
+                    chunks=nav_chunks, size=config.get("array.svg.size", 160)
+                )
+            if sig_chunks == ():
+                sig_grid = ""
+            else:
+                sig_grid = svg(
+                    chunks=sig_chunks, size=config.get("array.svg.size", 160)
+                )
+            nbytes = format_bytes(self.signal.data.nbytes)
+            cbytes = format_bytes(
+                np.prod(self.signal.data.chunksize) * self.signal.data.dtype.itemsize
+            )
+            return get_template("lazy_signal.html.j2").render(
+                nav_grid=nav_grid,
+                sig_grid=sig_grid,
+                dim=self.signal.axes_manager._get_dimension_str(),
+                chunks=self.signal._get_chunk_string(),
+                array=self.signal.data,
+                signal_type=self.signal._signal_type,
+                nbytes=nbytes,
+                cbytes=cbytes,
+                title="Cached Dask Array",
+            )
+
+        except ModuleNotFoundError:
+            return self
+
+    @property
+    def client(self):
+        if self._client is not None:  # first check if we have a client set
+            return self._client
+        # if not, try to get the Global client if available
+        try:
+            from dask.distributed import get_client
+
+            client = get_client()
+            return client
+        except ImportError:
+            return None
+        except ValueError:
+            return None
+
+    def get_index(
+        self, indices, nav_dim, force_compute=True, sum_data=True, data_on_workers=True
+    ):
+        """
+        The first time that a dask result is called the chunk is loaded into memory
+        and kept there until it goes out of scope...
+
+         -------------               -------------------                   -----------
+        | Numpy Cache |<-(1-50 ms)- | Dask Result Cache | <-(100-1000ms)- | Hard Disk |
+         -------------               -------------------                   -----------
+
+         When no client is used, the data is loaded into memory on the host machine. It might be
+         worth having cache_padding = 0 in this case and maybe only computing what is absolutely
+         necessary as we can't really do things asynchronously....
+         -------------                    -----------
+        | Numpy Cache | <-(100-1000ms)- | Hard Disk |
+         -------------                   -----------
+
+        """
+        try:
+            indices = np.array([inds[:nav_dim] for inds in indices])
+        except TypeError:
+            indices = np.array(indices[:nav_dim])[np.newaxis, :]
+        except IndexError:
+            indices = np.array(indices[:nav_dim])[np.newaxis, :]
+        # First get the indices for the core and surrounding blocks as well as the slic for the blocks
+        core_block_ind, surrounding_block_indexes, ind_by_block = (
+            _get_navigation_dimension_chunk_slice(
+                indices, self.array.chunks, self.cache_padding
+            )
+        )
+        # most computers have multiple cores, so we should try to cache the center
+        # of the chunk and then get the neighboring chunks as well.
+        # If we are using the distributed scheduler, we can use futures for this.
+        all_cached_block_ind = (
+            self.core_cached_block_inds + self.surrounding_cached_block_inds
+        )
+        all_new_block_ind = core_block_ind + surrounding_block_indexes
+        to_compute_core_inds = [
+            c for c in core_block_ind if c not in all_cached_block_ind
+        ]
+        to_compute_surrounding_inds = [
+            c for c in surrounding_block_indexes if c not in all_cached_block_ind
+        ]
+
+        # remove unused blocks first...
+        for cached_block in all_cached_block_ind:
+            if (
+                cached_block not in all_new_block_ind
+            ):  # remove the block and block ind...
+                if cached_block in self.core_cached_block_inds:
+                    ind = self.core_cached_block_inds.index(cached_block)
+                    self.core_cached_block_inds.remove(cached_block)
+                    removed_block = self.core_cached_blocks.pop(ind)
+                    del removed_block  # stop future or remove object
+                else:  # cached_block in self.surrounding_cached_block_inds:
+                    ind = self.surrounding_cached_block_inds.index(cached_block)
+                    self.surrounding_cached_block_inds.remove(cached_block)
+                    removed_block = self.surrounding_cached_blocks.pop(ind)
+                    del removed_block  # stop future or remove object
+            else:  # Swap core <--> surroundings
+                if (
+                    cached_block in self.core_cached_block_inds
+                    and cached_block in core_block_ind
+                    or cached_block in self.surrounding_cached_block_inds
+                    and cached_block in surrounding_block_indexes
+                ):
+                    pass
+                # elif swap core --> surrounding
+                elif (
+                    cached_block in self.core_cached_block_inds
+                    and cached_block in surrounding_block_indexes
+                ):
+                    ind = self.core_cached_block_inds.index(cached_block)
+                    self.core_cached_block_inds.remove(cached_block)
+                    self.surrounding_cached_block_inds.append(cached_block)
+                    self.surrounding_cached_blocks.append(
+                        self.core_cached_blocks.pop(ind)
+                    )
+                elif (
+                    cached_block in self.surrounding_cached_block_inds
+                    and cached_block in core_block_ind
+                ):
+                    ind = self.surrounding_cached_block_inds.index(cached_block)
+                    self.surrounding_cached_block_inds.remove(cached_block)
+                    self.core_cached_block_inds.append(cached_block)
+                    self.core_cached_blocks.append(
+                        self.surrounding_cached_blocks.pop(ind)
+                    )
+        new_core_blocks = [
+            self.array.blocks[new_core_ind] for new_core_ind in to_compute_core_inds
+        ]
+        new_surrounding_blocks = [
+            self.array.blocks[new_surr_ind]
+            for new_surr_ind in to_compute_surrounding_inds
+        ]
+
+        if self.client is not None:
+            new_core_blocks_to_add = self.client.compute(new_core_blocks)
+            self.core_cached_blocks.extend(new_core_blocks_to_add)
+            self.core_cached_block_inds.extend(to_compute_core_inds)
+            new_surrounding_blocks_to_add = self.client.compute(new_surrounding_blocks)
+            self.surrounding_cached_blocks.extend(new_surrounding_blocks_to_add)
+            self.surrounding_cached_block_inds.extend(to_compute_surrounding_inds)
+        else:  # compute everything...
+            new_blocks_to_add = da.compute(*new_core_blocks, *new_surrounding_blocks)
+            self.core_cached_blocks.extend(new_blocks_to_add[: len(new_core_blocks)])
+            self.core_cached_block_inds.extend(to_compute_core_inds)
+            self.surrounding_cached_blocks.extend(
+                new_blocks_to_add[len(new_core_blocks) :]
+            )
+            self.surrounding_cached_block_inds.extend(to_compute_surrounding_inds)
+
+        if distributed_installed and self.client and data_on_workers:
+            # get the data from the workers...
+            results = []
+            for block_ind, slic_inds in zip(core_block_ind, ind_by_block):
+                b_ind = self.core_cached_block_inds.index(block_ind)
+                slices = tuple([slic_inds[:, i] for i in range(slic_inds.shape[1])])
+                results.append(
+                    self.client.submit(
+                        get_inds,
+                        self.core_cached_blocks[b_ind],
+                        slices,
+                        sum_data=sum_data,
+                    )
+                )
+            if force_compute or np.all([c.done() for c in results]):
+                return np.sum([r.result() for r in results], axis=0)
+            else:
+                return
+
+        elif distributed_installed and self.client is not None:
+            for i, c in enumerate(self.core_cached_blocks):
+                if isinstance(c, Future) and force_compute:
+                    self.core_cached_blocks[i] = (
+                        c.result()
+                    )  # force computation... results is now numpy array.
+                elif isinstance(c, Future) and c.done():
+                    self.core_cached_blocks[i] = (
+                        c.result()
+                    )  # computation done, move results to host (1 ms overhead?)
+                elif isinstance(
+                    c, Future
+                ):  # computations are still running try not to block...
+                    return
+                    # all other results are numpy arrays instead of futures...
+        arrays = []
+
+        for block_ind, slic_inds in zip(core_block_ind, ind_by_block):
+            b_ind = self.core_cached_block_inds.index(block_ind)
+            if len(slic_inds.shape) == 1:  # account for 0 dim arrays...
+                slic_inds = slic_inds[np.newaxis, :]
+            slices = tuple([slic_inds[:, i] for i in range(slic_inds.shape[1])])
+            arrays.append(self.core_cached_blocks[b_ind][slices])
+        arrays = np.vstack(arrays)
+        if sum_data:
+            return np.sum(arrays, axis=0)
+        else:
+            return arrays
+
+
+def get_inds(arrs, indices, sum_data=True):
+    if sum_data:
+        return np.sum(arrs[indices], axis=0)
+    else:
+        return arrs[indices]

--- a/hyperspy/misc/array_tools.py
+++ b/hyperspy/misc/array_tools.py
@@ -1013,7 +1013,7 @@ class CachedDaskArray:
                         sum_data=sum_data,
                     )
                 )
-            if force_compute or np.all([c.done() for c in results]):
+            if force_compute or np.all([c.done() for c in self.core_cached_blocks]):
                 return np.sum([r.result() for r in results], axis=0)
             else:
                 return

--- a/hyperspy/misc/array_tools.py
+++ b/hyperspy/misc/array_tools.py
@@ -704,14 +704,71 @@ def _get_navigation_dimension_chunk_slice(navigation_indices, chunks):
 
     """
     chunk_slice_list = da.core.slices_from_chunks(chunks)
-    for chunk_slice in chunk_slice_list:
+    block_indexes = np.meshgrid(*[np.arange(0, len(n)) for n in chunks])
+    n_dim = len(chunks)
+    if len(block_indexes) == 0:
+        block_indexes_flat = [()]
+    else:
+        block_indexes_flat = np.array(block_indexes).T.reshape(-1, n_dim)
+        block_indexes_flat = block_indexes_flat
+
+    # iterate through and just find the slice that contains the navigation indices
+    center_slice = None
+    is_slice = True
+    for chunk_slice, block_index in zip(chunk_slice_list, block_indexes_flat):
         is_slice = True
         for index_nav in range(len(navigation_indices)):
             temp_slice = chunk_slice[index_nav]
             nav = navigation_indices[index_nav]
+
             if not (temp_slice.start <= nav < temp_slice.stop):
                 is_slice = False
                 break
-        if is_slice:
-            return chunk_slice
-    return False
+        if is_slice:  # if the slice contains the navigation indices
+            center_slice = chunk_slice
+            center_block_index = block_index
+            break
+    if not is_slice:
+        return False
+
+    if center_slice == ():
+        return (
+            center_slice,
+            center_block_index,
+            [
+                (),
+            ],
+        )
+    around = [-1, 0, 1]
+    surrounding_block_indexes = np.array(np.meshgrid(*(around,) * n_dim)).T.reshape(
+        -1, n_dim
+    )
+    surrounding_block_indexes = np.array(
+        [
+            center_block_index + i
+            for i in surrounding_block_indexes
+            if np.any(
+                i
+                != np.array(
+                    [
+                        0,
+                    ]
+                    * n_dim
+                )
+            )
+        ]
+    )
+
+    is_in = np.prod(
+        np.array(
+            [
+                np.isin(surrounding_block_indexes[:, i], block_indexes_flat[:, i])
+                for i in np.arange(block_indexes_flat.shape[1])
+            ]
+        ),
+        axis=0,
+    ).astype(bool)
+
+    surrounding_block_indexes = surrounding_block_indexes[is_in]
+    surrounding_block_indexes = [tuple(s) for s in surrounding_block_indexes]
+    return center_slice, tuple(center_block_index), surrounding_block_indexes

--- a/hyperspy/signal.py
+++ b/hyperspy/signal.py
@@ -3015,12 +3015,16 @@ class BaseSignal(
             axes = []
         return axes
 
-    def _get_current_data(self, axes_manager=None, fft_shift=False, as_numpy=False):
+    def _get_current_data(
+        self, axes_manager=None, fft_shift=False, as_numpy=False, get_result=False
+    ):
         if axes_manager is None:
             axes_manager = self.axes_manager
         indices = axes_manager._getitem_tuple
         if self._lazy:
-            value = self._get_cache_dask_chunk(indices)
+            value = self._get_cache_dask_chunk(indices, get_result=get_result)
+            if get_result:
+                return value
         else:
             value = self.data.__getitem__(indices)
         if as_numpy:
@@ -3028,6 +3032,7 @@ class BaseSignal(
         value = np.atleast_1d(value)
         if fft_shift:
             value = np.fft.fftshift(value)
+
         return value
 
     @property
@@ -3098,7 +3103,15 @@ class BaseSignal(
             )
 
         self._plot.axes_manager = axes_manager
-        self._plot.signal_data_function = partial(self._get_current_data, as_numpy=True)
+        if hasattr(self, "client") and self.client is not None:
+            get_result = True
+        else:
+            get_result = False
+        _logger.info(f"Get Result:{get_result}")
+
+        self._plot.signal_data_function = partial(
+            self._get_current_data, as_numpy=True, get_result=get_result
+        )
 
         if self.metadata.has_item("Signal.quantity"):
             self._plot.quantity_label = self.metadata.Signal.quantity

--- a/hyperspy/tests/signals/test_lazy.py
+++ b/hyperspy/tests/signals/test_lazy.py
@@ -227,9 +227,8 @@ class TestGetTemporaryDaskChunk:
             value_output = s._get_cache_dask_chunk(
                 (chunk_slice[0].start, chunk_slice[1].start, slice(None), slice(None))
             )
-            assert s._cache_dask_chunk.shape == (5, 5, 50, 50)
-            assert np.all(s._cache_dask_chunk == value)
-            assert chunk_slice == s._cache_dask_chunk_slice
+            assert s.cached_dask_array.core_cached_blocks[0].shape == (5, 5, 50, 50)
+            assert np.all(s.cached_dask_array.core_cached_blocks[0] == value)
             assert value == value_output.mean(dtype=np.uint16)
 
     def test_change_position(self):
@@ -237,18 +236,18 @@ class TestGetTemporaryDaskChunk:
             da.zeros((10, 10, 20, 20), chunks=(5, 5, 10, 10))
         )
         s._get_cache_dask_chunk((0, 0, slice(None), slice(None)))
-        chunk_slice0 = s._cache_dask_chunk_slice
+        chunk_slice0 = s.cached_dask_array.core_cached_block_inds[0]
 
-        s._cache_dask_chunk[:] = 2
+        s.cached_dask_array.core_cached_blocks[0][:] = 2
 
         s._get_cache_dask_chunk((4, 4, slice(None), slice(None)))
-        chunk_slice1 = s._cache_dask_chunk_slice
+        chunk_slice1 = s.cached_dask_array.core_cached_block_inds[0]
         assert chunk_slice0 == chunk_slice1
-        assert np.all(s._cache_dask_chunk == 2)
+        assert np.all(s.cached_dask_array.core_cached_blocks[0] == 2)
 
         s._get_cache_dask_chunk((6, 4, slice(None), slice(None)))
         s._get_cache_dask_chunk((0, 0, slice(None), slice(None)))
-        assert np.all(s._cache_dask_chunk == 0)
+        assert np.all(s.cached_dask_array.core_cached_blocks[0] == 0)
 
     @pytest.mark.parametrize(
         "shape",
@@ -295,9 +294,8 @@ class TestGetTemporaryDaskChunk:
         data = da.from_array(data, chunks=(2, 2, 10))
         s = _lazy_signals.LazySignal1D(data)
         value = s._get_cache_dask_chunk(s.axes_manager._getitem_tuple)
-        assert len(s._cache_dask_chunk_slice) == 2
-        assert s._cache_dask_chunk.shape == (2, 2, 20)
-        assert s._cache_dask_chunk_slice == np.s_[0:2, 0:2]
+        assert len(s.cached_dask_array.core_cached_block_inds) == 1
+        assert s.cached_dask_array.core_cached_blocks[0].shape == (2, 2, 20)
         assert len(value.shape) == 1
         assert len(value) == 20
         s.axes_manager.indices = (5, 5)
@@ -308,19 +306,18 @@ class TestGetTemporaryDaskChunk:
         s = _lazy_signals.LazySignal2D(da.zeros((6, 6, 8, 8), chunks=(2, 2, 4, 4)))
         position = s.axes_manager._getitem_tuple
         s._get_cache_dask_chunk(position)
-        assert s._cache_dask_chunk is not None
-        assert s._cache_dask_chunk_slice is not None
+        assert s.cached_dask_array is not None
+        assert s.cached_dask_array.core_cached_block_inds is not None
         s.events.data_changed.trigger(None)
-        assert s._cache_dask_chunk is None
-        assert s._cache_dask_chunk_slice is None
+        assert s.cached_dask_array is None
 
     def test_map_inplace_data_changing(self):
         s = _lazy_signals.LazySignal2D(da.zeros((6, 6, 8, 8), chunks=(2, 2, 4, 4)))
         s._get_current_data()
-        assert len(s._cache_dask_chunk.shape) == 4
+        assert len(s.cached_dask_array.core_cached_blocks[0].shape) == 4
         s.map(np.sum, axis=1, ragged=False, inplace=True)
         s._get_current_data()
-        assert len(s._cache_dask_chunk.shape) == 3
+        assert len(s.cached_dask_array.core_cached_blocks[0].shape) == 3
 
     def test_clear_cache_dask_data_method(self):
         s = _lazy_signals.LazySignal2D(da.zeros((6, 6, 8, 8), chunks=(2, 2, 4, 4)))
@@ -350,9 +347,8 @@ class TestLazyPlot:
         for value, chunk_slice in zip(value_list, chunk_slice_list):
             s.plot()
             s.axes_manager.indices = (chunk_slice[1].start, chunk_slice[0].start)
-            assert s._cache_dask_chunk.shape == (5, 5, 50, 50)
-            assert np.all(s._cache_dask_chunk == value)
-            assert chunk_slice == s._cache_dask_chunk_slice
+            assert s.cached_dask_array.core_cached_blocks[0].shape == (5, 5, 50, 50)
+            assert np.all(s.cached_dask_array.core_cached_blocks[0] == value)
             s._plot.close()
 
     @pytest.mark.parametrize(


### PR DESCRIPTION
### Description of the change

More of a proof of concept than anything.  If you are using the distributed scheduler you get access to `futures` which are quite nice for things like plotting.

The gneral idea here is that we can calculate the "surrounding" chunks as well but have those be non-blocking.  Those will compute in the background using whatever cores are available and then if you want to "cross" a chunk boundry it isn't slow.

This also makes plotting effectively parallel for things like plotting lazy objects with bigger task graphs.

Eventually I would like to make it so that "Shift + +" not only makes the red box bigger but will actually integrate over that area. With lazy loading, that is a little harder so it makes sense to limit to size to effectively "1 Chunk" and then cache neighboring chunks.  One other thing we could consider is for lazy signals to load the neighboring chunks, and then when the integrating marker gets too large add a second level of neighboring chunks to load. 

You can see the red marker still lags behind the mouse slightly, but it no longer catches at the boundry between chunks!  One other thing we might want to do is make the entire function non-blocking. Currently it cancels the neighboring chunk futures if they aren't used but we could do the same thing for the center chunk and it would allow things to only be calculated when the user actually has their mouse over some point for long enough for it to be calculated. 

https://github.com/user-attachments/assets/1131d1e5-9309-4435-8d73-0872391ed19b


### Progress of the PR
- [x] Cache neighboring chunks 
- [ ] Make sure this doesn't effect Models and fitting (currently it does)
- [ ] update user guide (if appropriate),
- [ ] add an changelog entry in the `upcoming_changes` folder (see [`upcoming_changes/README.rst`](https://github.com/hyperspy/hyperspy/blob/RELEASE_next_minor/upcoming_changes/README.rst)),
- [ ] Check formatting changelog entry in the `readthedocs` doc build of this PR (link in github checks)
- [ ] add tests,
- [ ] ready for review.

### Minimal example of the bug fix or the new feature
```python
import hyperspy.api as hs
import dask.array as da
from dask.distributed import Client
client = Client() 

rand_arr = da.random.random((256,256,100,100), chunks=(32,32,-1,-1))
lz_arr = hs.signals.Signal2D(rand_arr).as_lazy()
lz_arr.save("test.zspy")
test_dset = hs.load("test.zspy", lazy=True)
lz_arr.plot()
```

@ericpre  @magnunor You might find this interesting
