### PR TITLE
Add default behavior for .pop('fill') in markers.py

### DIFF
--- a/hyperspy/misc/_markers.py
+++ b/hyperspy/misc/_markers.py
@@ -207,7 +207,7 @@ def markers_dict_to_markers(marker_dict):
             kwargs["offsets"] = offsets
             kwargs["widths"] = widths
             kwargs["heights"] = heights
-            fill = kwargs.pop("fill")
+            fill = kwargs.pop("fill", False)
             if not fill:
                 kwargs["facecolor"] = "none"
             markers_class = "Rectangles"

--- a/hyperspy/misc/_markers.py
+++ b/hyperspy/misc/_markers.py
@@ -101,7 +101,7 @@ def markers_dict_to_markers(marker_dict):
             kwargs["offsets"], kwargs["sizes"] = dict2vector(
                 marker_dict["data"], keys=["x1", "y1"], return_size=True
             )
-            kwargs["facecolors"] = kwargs["color"]
+            kwargs["facecolor"] = kwargs["color"]
             kwargs["units"] = "dots"
             if "size" not in kwargs:
                 kwargs["size"] = 20
@@ -207,8 +207,7 @@ def markers_dict_to_markers(marker_dict):
             kwargs["offsets"] = offsets
             kwargs["widths"] = widths
             kwargs["heights"] = heights
-            fill = kwargs.pop("fill", False)
-            if not fill:
+            if not kwargs.pop("fill", False):
                 kwargs["facecolor"] = "none"
             markers_class = "Rectangles"
 
@@ -226,8 +225,7 @@ def markers_dict_to_markers(marker_dict):
             kwargs["heights"] = dict2vector(
                 marker_dict["data"], keys=["y2"], return_size=False
             )
-            fill = kwargs.pop("fill")
-            if not fill:
+            if not kwargs.pop("fill", False):
                 kwargs["facecolor"] = "none"
             markers_class = "Ellipses"
 

--- a/hyperspy/tests/drawing/test_markers.py
+++ b/hyperspy/tests/drawing/test_markers.py
@@ -1258,3 +1258,31 @@ def test_plot_markers_relative_to_data_non_uniform_axes():
     )
     s.add_marker(m, permanent=True)
     s.plot()
+
+
+@pytest.mark.parametrize("marker_type", ("Ellipse", "Rectangle"))
+def test_markers_conversion_fill(marker_type):
+    # Default from old markers API
+    marker_dict = {
+        "marker_type": marker_type,
+        "data": {"y1": 1.0, "x1": 2.0, "y2": 3.0, "x2": 4.0},
+    }
+    markers_ = markers_dict_to_markers(marker_dict)
+    assert markers_.kwargs["facecolor"] == "none"
+
+    marker_dict = {
+        "marker_type": marker_type,
+        "data": {"y1": 1.0, "x1": 2.0, "y2": 3.0, "x2": 4.0},
+        "fill": False,
+    }
+    markers_ = markers_dict_to_markers(marker_dict)
+    assert markers_.kwargs["facecolor"] == "none"
+
+    marker_dict = {
+        "marker_type": marker_type,
+        "data": {"y1": 1.0, "x1": 2.0, "y2": 3.0, "x2": 4.0},
+        "fill": True,
+    }
+    markers_ = markers_dict_to_markers(marker_dict)
+    # default to
+    assert "facecolor" not in markers_.kwargs["facecolor"]

--- a/upcoming_changes/3501.bugfix.rst
+++ b/upcoming_changes/3501.bugfix.rst
@@ -1,0 +1,1 @@
+Fix conversion of markers with hyperspy v1 API and fix loading ``.bcf`` files containing markers.


### PR DESCRIPTION
Adding default behavior if fill is not present as can happen in some bcf files

### Requirements
* Read the [developer guide](https://hyperspy.org/hyperspy-doc/current/dev_guide/intro.html).
* Base your pull request on the [correct branch](https://hyperspy.org/hyperspy-doc/current/dev_guide/git.html#semantic-versioning-and-hyperspy-main-branches).
* Filling out the template; it helps the review process and it is useful to summarise the PR.
* This template can be updated during the progression of the PR to summarise its status. 

*You can delete this section after you read it.*

### Description of the change
A few sentences and/or a bulleted list to describe and motivate the change:
- Change A.
- Change B.
- etc.

### Progress of the PR
- [ ] Change implemented (can be split into several points),
- [ ] update docstring (if appropriate),
- [ ] update user guide (if appropriate),
- [ ] add an changelog entry in the `upcoming_changes` folder (see [`upcoming_changes/README.rst`](https://github.com/hyperspy/hyperspy/blob/RELEASE_next_minor/upcoming_changes/README.rst)),
- [ ] Check formatting changelog entry in the `readthedocs` doc build of this PR (link in github checks)
- [ ] add tests,
- [ ] ready for review.

### Minimal example of the bug fix or the new feature
```python
import hyperspy.api as hs
import numpy as np
s = hs.signals.Signal1D(np.arange(10))
# Your new feature...
```
Note that this example can be useful to update the user guide.

