### PR TITLE
Fix regression when fetching `red_chisq` in background removal tool

### DIFF
--- a/hyperspy/signal_tools.py
+++ b/hyperspy/signal_tools.py
@@ -1390,7 +1390,10 @@ class BackgroundRemoval(SpanSelectorInSignal1D):
             self.model._calculate_chisq()
         else:
             self.model.fit()
-        self.red_chisq = self.model.red_chisq.data[self.model.axes_manager.indices][0]
+        # for navigation dimension 0, use (0, ) instead of ()
+        # to avoid numpy array to float conversion
+        indices = self.model.axes_manager.indices or (0,)
+        self.red_chisq = float(self.model.red_chisq.data[indices])
 
     def _update_line(self):
         if self.bg_line is None:

--- a/hyperspy/tests/signals/test_remove_background.py
+++ b/hyperspy/tests/signals/test_remove_background.py
@@ -26,6 +26,7 @@ from packaging.version import Version
 import hyperspy.api as hs
 from hyperspy import components1d
 from hyperspy.decorators import lazifyTestClass
+from hyperspy.signal_tools import BackgroundRemoval
 
 
 def _skip_test(s):
@@ -329,3 +330,22 @@ def test_remove_background_metadata_axes_manager_copy(
     )
     compare_axes_manager_metadata(s, s_r)
     assert s_r.data.shape == s.data.shape
+
+
+@pytest.mark.parametrize("fast", [True, False])
+@pytest.mark.parametrize("nav_dim", [0, 1])
+def test_BackgroundRemoval_tool(nav_dim, fast):
+    pl = components1d.PowerLaw()
+    pl.A.value = 1e10
+    pl.r.value = 3
+    s = hs.signals.Signal1D(pl.function(np.arange(100, 200)))
+    if nav_dim == 1:
+        s = hs.stack([s] * 2)
+    s.axes_manager[0].offset = 100
+    s.add_poissonian_noise(random_state=1)
+
+    br = BackgroundRemoval(s, background_type="Power Law", fast=fast)
+    br.span_selector.extents = (20, 40)
+    br.span_selector_changed()
+    br._fit()
+    assert isinstance(br.red_chisq, float)

--- a/upcoming_changes/3504.bugfix.rst
+++ b/upcoming_changes/3504.bugfix.rst
@@ -1,0 +1,1 @@
+Fix regression in :meth:`~.api.signals.Signal1D.remove_background` when used interactively and the navigation dimension is > 0. The regression was introduced in hyperspy 2.0.1 (`#3320 <https://github.com/hyperspy/hyperspy/pull/3320>`__) when fixing numpy deprecation warnings.


### PR DESCRIPTION
Fix regression introduced in #3320 when fixing numpy deprecation warnings, that breaks fetching reduced chi square when navigation dimension was > 0 in interactive `remove_background`. 

### Progress of the PR
- [x] Fix regression fetching reduced chi square when navigation dimension was > 0,
- [n/a] update docstring (if appropriate),
- [n/a] update user guide (if appropriate),
- [x] add an changelog entry in the `upcoming_changes` folder (see [`upcoming_changes/README.rst`](https://github.com/hyperspy/hyperspy/blob/RELEASE_next_minor/upcoming_changes/README.rst)),
- [x] Check formatting changelog entry in the `readthedocs` doc build of this PR (link in github checks)
- [x] add tests,
- [x] ready for review.

### Minimal example of the bug fix or the new feature
```python
import hyperspy.api as hs
import numpy as np

nav_dim = 1

pl = hs.model.components1D.PowerLaw()
pl.A.value = 1e10
pl.r.value = 3
s = hs.signals.Signal1D(pl.function(np.arange(100, 200)))
s.axes_manager[0].offset = 100  
s.add_poissonian_noise(random_state=1)

if nav_dim > 0:
   s = hs.stack([s]*2)

s.remove_background()
# then select a signal range in the signal figure
```
When selecting a signal range, it should draw the span selector and the fitted line but doesn't and no error is raised, most likely because the error is swallowed by the `traits` handler.
