### PR TITLE
Add graphviz to readthedocs build to render properly graph in the con…

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -220,7 +220,7 @@ html_theme_options = {
         "version_match": version_match,
     },
     "navbar_start": ["navbar-logo", "version-switcher"],
-    "announcement": "HyperSpy API has changed in version 2.0, see the <a href='https://hyperspy.org/hyperspy-doc/current/changes.html#changes-2-0'>release notes!</a>",
+    # "announcement": "",
 }
 # If not '', a 'Last updated on:' timestamp is inserted at every page bottom,
 # using the given strftime format.

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -34,12 +34,12 @@ extensions = [
     "IPython.sphinxext.ipython_directive",  # Needed in basic_usage.rst
     "numpydoc",
     "sphinxcontrib.towncrier",
+    "sphinxcontrib.mermaid",
     "sphinx_design",
     "sphinx.ext.autodoc",
     "sphinx.ext.autosummary",
     "sphinx.ext.doctest",
     "sphinx.ext.githubpages",
-    "sphinx.ext.graphviz",
     "sphinx.ext.mathjax",
     "sphinx.ext.inheritance_diagram",
     "sphinx.ext.intersphinx",
@@ -443,8 +443,6 @@ sphinx_gallery_conf = {
     "notebook_images": "https://hyperspy.org/hyperspy-doc/current/",  # folder for loading images in gallery
     "reference_url": {"hyperspy": None},
 }
-
-graphviz_output_format = "svg"
 
 # -- Sphinx-copybutton -----------
 

--- a/doc/dev_guide/writing_extensions.rst
+++ b/doc/dev_guide/writing_extensions.rst
@@ -80,6 +80,17 @@ for your function, you should consider creating your own.
 
 
 .. mermaid::
+    :config: {"theme": "base"}
+
+    %%{
+    init: {
+        'theme': 'base',
+        'themeVariables': {
+        'primaryColor': '#AFEEEE',
+        'lineColor': '#6495ED'
+        }
+    }
+    }%%
 
     graph TD
 
@@ -93,16 +104,16 @@ for your function, you should consider creating your own.
       H{Does a signal for that sort<br/>of data exists?}
       I(Contribute to package<br/>providing the relevant<br/>signal)
       J(Create your own package<br/>and signal subclass to<br/>host the function)
-      A-->B
-      B-- Yes -->C
-      B-- No  -->D
-      D-- Yes -->F
-      D-- No  -->E
-      E-->F
-      F-- Yes -->H
-      F-- No  -->G
-      H-- Yes -->I
-      H-- No -->J
+      A==>B
+      B== Yes ==>C
+      B== No  ==>D
+      D== Yes ==>F
+      D== No  ==>E
+      E==>F
+      F== Yes ==>H
+      F== No  ==>G
+      H== Yes ==>I
+      H== No ==>J
 
 
 Registering a new BaseSignal subclass
@@ -179,6 +190,17 @@ a new hyperspy model :class:`hyperspy.component.Component`
 for your function, should you consider creating your own.
 
 .. mermaid::
+    :config: {"theme": "base"}
+
+    %%{
+    init: {
+        'theme': 'base',
+        'themeVariables': {
+        'primaryColor': '#AFEEEE',
+        'lineColor': '#6495ED'
+        }
+    }
+    }%%
 
     graph TD
 
@@ -194,17 +216,17 @@ for your function, should you consider creating your own.
       J[Contribute it to<br/>the relevant package]
       K[Create your own<br/>package to host it]
 
-      A-->B
-      B-- Yes -->C
-      B-- No  -->F
-      C-- No  -->D
-      C-- Yes -->E
-      E-->G
-      F-->G
-      G-- Yes --> H
-      G-- No  --> I
-      I-- Yes --> J
-      I-- No  --> K
+      A==>B
+      B== Yes ==>C
+      B== No  ==>F
+      C== No  ==>D
+      C== Yes ==>E
+      E==>G
+      F==>G
+      G== Yes ==> H
+      G== No  ==> I
+      I== Yes ==> J
+      I== No  ==> K
 
 
 Registering new components

--- a/doc/dev_guide/writing_extensions.rst
+++ b/doc/dev_guide/writing_extensions.rst
@@ -9,13 +9,6 @@ Writing packages that extend HyperSpy
   External packages can extend HyperSpy by registering signals,
   components and widgets.
 
-.. warning::
-  The mechanism to register extensions is in beta state. This means that it can
-  change between minor and patch versions. Therefore, if you maintain a package
-  that registers HyperSpy extensions, please verify that it works properly with
-  any future HyperSpy release. We expect it to reach maturity with the release
-  of HyperSpy 2.0.
-
 External packages can extend HyperSpy by registering signals, components and
 widgets. Objects registered by external packages are "first-class citizens" i.e.
 they can be used, saved and loaded like any of those objects shipped with

--- a/doc/dev_guide/writing_extensions.rst
+++ b/doc/dev_guide/writing_extensions.rst
@@ -85,61 +85,31 @@ The flowchart below can help you decide where to add
 a new data analysis function. Notice that only if no suitable package exists
 for your function, you should consider creating your own.
 
-..  This is the original mermaid code. It produces a nicer looking diagram
-    with the defaults, but, as of version 0.3.1, it raises an exception in
-    ReadTheDocs, so we use graphviz below instead.
 
-    .. mermaid::
+.. mermaid::
 
-       graph TD
+    graph TD
 
-         A(New function needed!)
-         B{Is it useful for data of any type and dimensions?}
-         C(Contribute it to BaseSignal)
-         D{Does a SignalxD for the required dimension exist in HyperSpy?}
-         E[Contribute new SignalxD to HyperSpy]
-         F{Is the function useful for a specific type of data only?}
-         G(Contribute it to SignalxD)
-         H{Does a signal for that sort of data exists?}
-         I(Contribute to package providing the relevant signal)
-         J(Create you own package and signal subclass to host the funtion)
-         A-->B
-         B-- Yes -->C
-         B-- No  -->D
-         D-- Yes -->F
-         D-- No  -->E
-         E-->F
-         F-- Yes -->H
-         F-- No  -->G
-         H-- Yes -->I
-         H-- No -->J
-
-
-.. graphviz::
-
-    digraph G {
-         A [label="New function needed!"]
-         B [label="Is it useful for data of any type and dimensions?",shape="diamond"]
-         C [label="Contribute it to BaseSignal"]
-         D [label="Does a SignalxD for the required dimension exist in HyperSpy?",shape="diamond"]
-         E [label="Contribute new SignalxD to HyperSpy"]
-         F [label="Is the function useful for a specific type of data only?",shape="diamond"]
-         G [label="Contribute it to SignalxD"]
-         H [label="Does a signal for that sort of data exist?",shape="diamond"]
-         I [label="Contribute to package providing the relevant signal"]
-         J [label="Create you own package and signal subclass to host the funtion"]
-         A->B
-         B->C [label="Yes"]
-         B->D [label="No"]
-         D->F [label="Yes"]
-         D->E [label="No"]
-         E->F
-         F->H [label="Yes"]
-         F->G [label="No"]
-         H->I [label="Yes"]
-         H->J [label="No"]
-
-    }
+      A(New function needed!)
+      B{Is it useful for data of<br/>any type and dimensions?}
+      C(Contribute it to BaseSignal)
+      D{Does a SignalxD for the<br/>required dimension exist<br/>in HyperSpy?}
+      E[Contribute new SignalxD<br/>to HyperSpy]
+      F{Is the function useful for a<br/>specific type of data only?}
+      G(Contribute it to SignalxD)
+      H{Does a signal for that sort<br/>of data exists?}
+      I(Contribute to package<br/>providing the relevant<br/>signal)
+      J(Create you own package<br/>and signal subclass to<br/>host the funtion)
+      A-->B
+      B-- Yes -->C
+      B-- No  -->D
+      D-- Yes -->F
+      D-- No  -->E
+      E-->F
+      F-- Yes -->H
+      F-- No  -->G
+      H-- Yes -->I
+      H-- No -->J
 
 
 Registering a new BaseSignal subclass
@@ -215,69 +185,33 @@ The flowchart below can help you decide when and where to add
 a new hyperspy model :class:`hyperspy.component.Component`
 for your function, should you consider creating your own.
 
-..  This is the original mermaid code. It produces a nicer looking diagram
-    with the defaults, but, as of version 0.3.1, it raises an exception in
-    ReadTheDocs, so we use graphviz below instead.
+.. mermaid::
 
+    graph TD
 
-    .. mermaid::
+      A(New component needed!)
+      B{Can it be declared<br/>using Expression?}
+      C{Can it be useful<br/>to other users?}
+      D(Just use Expression)
+      E[Create new component<br/>using Expression]
+      F[Create new component<br/>from scratch]
+      G{Is it useful for<br/>general users?}
+      H(Contribute it to HyperSpy)
+      I{Does a suitable<br/>package exist?}
+      J[Contribute it to<br/>the relevant package]
+      K[Create your own<br/>package to host it]
 
-       graph TD
-
-         A(New component needed!)
-         B{Can it be declared using Expression?}
-         C{Can it be useful to other users?}
-         D(Just use Expression)
-         E[Create new component using Expression]
-         F[Create new component from scratch]
-         G{Is it useful for general users?}
-         H(Contribute it to HyperSpy)
-         I{Does a suitable package exist?}
-         J[Contribute it to the relevant package]
-         K[Create your own package to host it]
-
-         A-->B
-         B-- Yes -->C
-         B-- No  -->F
-         C-- No  -->D
-         C-- Yes -->E
-         E-->G
-         F-->G
-         G-- Yes --> H
-         G-- No  --> I
-         I-- Yes --> J
-         I-- No  --> K
-
-
-.. graphviz::
-
-    digraph G {
-
-
-        A [label="New component needed!"]
-        B [label="Can it be declared using Expression?",shape="diamond"]
-        C [label="Can it be useful to other users?",shape="diamond"]
-        D [label="Just use Expression"]
-        E [label="Create new component using Expression"]
-        F [label="Create new component from scratch"]
-        G [label="Is it useful for general users?",shape="diamond"]
-        H [label="Contribute it to HyperSpy"]
-        I [label="Does a suitable package exist?",shape="diamond"]
-        J [label="Contribute it to the relevant package"]
-        K [label="Create your own package to host it"]
-
-        A->B
-        B->C [label="Yes"]
-        B->F [label="No"]
-        C->E [label="Yes"]
-        C->D [label="No"]
-        E->G
-        F->G
-        G->H [label="Yes"]
-        G->I [label="No"]
-        I->J [label="Yes"]
-        I->K [label="No"]
-    }
+      A-->B
+      B-- Yes -->C
+      B-- No  -->F
+      C-- No  -->D
+      C-- Yes -->E
+      E-->G
+      F-->G
+      G-- Yes --> H
+      G-- No  --> I
+      I-- Yes --> J
+      I-- No  --> K
 
 
 Registering new components

--- a/doc/dev_guide/writing_extensions.rst
+++ b/doc/dev_guide/writing_extensions.rst
@@ -92,7 +92,7 @@ for your function, you should consider creating your own.
       G(Contribute it to SignalxD)
       H{Does a signal for that sort<br/>of data exists?}
       I(Contribute to package<br/>providing the relevant<br/>signal)
-      J(Create you own package<br/>and signal subclass to<br/>host the funtion)
+      J(Create your own package<br/>and signal subclass to<br/>host the function)
       A-->B
       B-- Yes -->C
       B-- No  -->D

--- a/readthedocs.yaml
+++ b/readthedocs.yaml
@@ -10,6 +10,8 @@ build:
   os: ubuntu-22.04
   tools:
     python: "3.11"
+  apt_packages:
+    - optipng
 
 # Build documentation in the docs/ directory with Sphinx
 sphinx:

--- a/upcoming_changes/3514.bugfix.rst
+++ b/upcoming_changes/3514.bugfix.rst
@@ -1,0 +1,1 @@
+Fix rendering mermaid graph in the contributor guide.


### PR DESCRIPTION
### Progress of the PR
- [x] Use `sphinx-mermaid` to render the mermaid graph in the contributor guide, since it is now working fine on readthedocs,
- [x] add `optipng` to remove doc build warning and compress thumbnails. 
- [x] remove warning regarding extension maturity since hyperspy 2.0 has been release,
- [x] remove announcement regarding hyperspy 2.0 API changes, since it has been released more than a year ago,
- [n/a] update docstring (if appropriate),
- [n/a] update user guide (if appropriate),
- [x] add an changelog entry in the `upcoming_changes` folder (see [`upcoming_changes/README.rst`](https://github.com/hyperspy/hyperspy/blob/RELEASE_next_minor/upcoming_changes/README.rst)),
- [x] Check formatting changelog entry in the `readthedocs` doc build of this PR (link in github checks)
- [n/a] add tests,
- [x] ready for review.


