### PR TITLE
Fix overwriting zspy file - regression introduced in implementation of output_folder

### DIFF
--- a/hyperspy/signal.py
+++ b/hyperspy/signal.py
@@ -3459,15 +3459,12 @@ class BaseSignal(
         if not isinstance(filename, MutableMapping):
             filename = Path(filename)
 
-            # Check if filename is clearly a directory path.
-            # We only consider it a directory path if:
-            # 1. It's an existing directory, OR
-            # 2. The path explicitly ends with a directory separator ('/' or '\')
-            # This conservative approach ensures we don't accidentally treat
-            # filenames without extensions as directories.
-            is_directory_path = filename.is_dir() or str(filename).endswith(("/", "\\"))
-
-            if is_directory_path and self.tmp_parameters.has_item("filename"):
+            # zspy can also be directory, make sure this is treated as a base directory
+            if (
+                filename.is_dir()
+                and not filename.suffix == ".zspy"
+                and self.tmp_parameters.has_item("filename")
+            ):
                 # Filename is a directory path, construct full filename
 
                 # Determine extension from file_format, extension parameter, or tmp_parameters.extension

--- a/hyperspy/tests/test_io.py
+++ b/hyperspy/tests/test_io.py
@@ -453,12 +453,15 @@ def test_save_file_format_parameter_with_directory_path(tmp_path):
     assert (output_dir / "source.msa").exists()
 
 
-def test_save_extension_precedence_with_file_format_fallback(tmp_path):
+@pytest.mark.parametrize("file_format", ["hspy", "zspy"])
+def test_save_extension_precedence_with_file_format_fallback(tmp_path, file_format):
     """Test the precedence order when extension is deprecated."""
+    if file_format == "zspy":
+        pytest.importorskip("zspy")
     s = Signal1D(np.arange(10))
 
     # Create a source file to get tmp_parameters
-    source_file = tmp_path / "source.hspy"
+    source_file = tmp_path / f"source.{file_format}"
     s.save(source_file)
     s_loaded = hs.load(source_file)
 
@@ -466,16 +469,17 @@ def test_save_extension_precedence_with_file_format_fallback(tmp_path):
     output_dir.mkdir()
 
     # When only file_format is provided (no extension), it should use file_format
-    s_loaded.save(output_dir, file_format="msa", overwrite=True)
-    assert (output_dir / "source.msa").exists()
+    s_loaded.save(output_dir, file_format=file_format, overwrite=True)
+    assert (output_dir / f"source.{file_format}").exists()
 
-    # Clean up
-    (output_dir / "source.msa").unlink()
-
+    s_loaded.data *= 2
     # When neither extension nor file_format is provided, should fall back to current tmp_parameters
-    # Note: tmp_parameters are updated after each save, so this will use .msa format
+    # Note: tmp_parameters are updated after each save, so this will use file_format
     s_loaded.save(output_dir, overwrite=True)
-    assert (output_dir / "source.msa").exists()
+    assert (output_dir / f"source.{file_format}").exists()
+    # Check that the file has been overwritten
+    s_loaded2 = hs.load(output_dir / f"source.{file_format}")
+    np.testing.assert_allclose(s_loaded2.data, s_loaded.data)
 
 
 def test_save_extension_parameter_maps_to_file_format(tmp_path):


### PR DESCRIPTION
Fix failure in the rosettesciio test suite.

### Progress of the PR
- [x] Fix regression introduced in #3525,
- [n/a] update docstring (if appropriate),
- [n/a] update user guide (if appropriate),
- [n/a] add an changelog entry in the `upcoming_changes` folder (see [`upcoming_changes/README.rst`](https://github.com/hyperspy/hyperspy/blob/RELEASE_next_minor/upcoming_changes/README.rst)),
- [n/a] Check formatting changelog entry in the `readthedocs` doc build of this PR (link in github checks)
- [x] add tests,
- [z] ready for review.

