### PR TITLE
Fix plotting "relative" marker on non-uniform axes

### DIFF
--- a/hyperspy/drawing/markers.py
+++ b/hyperspy/drawing/markers.py
@@ -689,14 +689,14 @@ class Markers:
             key = self._position_key
 
         x_positions = kwds[key][..., 0]
-        if len(x_positions) == 0:
+        if x_positions.size == 0:
             # can't scale as there is no marker at this coordinate
             return kwds
 
         new_kwds = deepcopy(kwds)
         current_data = self._signal._get_current_data(as_numpy=True)
         axis = self._axes_manager.signal_axes[0]
-        indexes = np.round((x_positions - axis.offset) / axis.scale).astype(int)
+        indexes = axis.value2index(x_positions)
         y_positions = new_kwds[key][..., 1]
         new_y_positions = current_data[indexes] * y_positions
 

--- a/hyperspy/tests/drawing/test_markers.py
+++ b/hyperspy/tests/drawing/test_markers.py
@@ -1240,3 +1240,17 @@ def test_position_texts_with_mathtext():
     s.add_marker([point_marker, text_marker])
 
     return s._plot.signal_plot.figure
+
+
+def test_plot_markers_relative_to_data_non_uniform_axes():
+    # create a signal with a non-uniform axis
+    s = hs.data.luminescence_signal()
+
+    index_max = s.data.argmax()
+    x_position = s.axes_manager[0].axis[index_max]
+
+    m = hs.plot.markers.Texts(
+        offsets=[x_position, 1], texts=["A peak"], offset_transform="relative", sizes=5
+    )
+    s.add_marker(m, permanent=True)
+    s.plot()

--- a/upcoming_changes/3551.bugfix.rst
+++ b/upcoming_changes/3551.bugfix.rst
@@ -1,0 +1,1 @@
+Fix plotting marker using relative transform on non-uniform axes.


### PR DESCRIPTION
### Progress of the PR
- [x] Fix plotting "relative" markers on non-uniform axes.
- [n/a] update docstring (if appropriate),
- [n/a] update user guide (if appropriate),
- [x] add an changelog entry in the `upcoming_changes` folder (see [`upcoming_changes/README.rst`](https://github.com/hyperspy/hyperspy/blob/RELEASE_next_minor/upcoming_changes/README.rst)),
- [x] Check formatting changelog entry in the `readthedocs` doc build of this PR (link in github checks)
- [x] add tests,
- [x] ready for review.

### Minimal example of the bug fix or the new feature
```python
import hyperspy.api as hs
import numpy as np

s = hs.data.luminescence_signal()

index_max = s.data.argmax()
x_position = s.axes_manager[0].axis[index_max]

m = hs.plot.markers.Texts(
    offsets=[x_position, 1], texts=["A peak"], offset_transform="relative", sizes=5
    )

s.add_marker(m, permanent=True)
s.plot()
```

