### PR TITLE
Make scikit-image optional

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -44,7 +44,7 @@ jobs:
             PYTHON_VERSION: '3.11'
             PIP_SELECTOR: '[all, tests, coverage]'
           - os: macos
-            os_version: '13'
+            os_version: '15-intel'
             PYTHON_VERSION: '3.11'
             PIP_SELECTOR: '[all, tests, coverage]'
 

--- a/doc/user_guide/install.rst
+++ b/doc/user_guide/install.rst
@@ -173,6 +173,10 @@ use:
 See the following list of selectors to select the installation of optional
 dependencies required by specific functionalities:
 
+* ``image`` to install `scikit-image <https://scikit-image.org/>`_ for image
+  processing functionalities, such as subpixel :meth:`~hyperspy.api.signals.Signal2D.align2D`,
+  :meth:`~hyperspy.api.signals.Signal2D.find_peaks` and
+  :meth:`~hyperspy.api.signals.ComplexSignal.unwrapped_phase`.
 * ``ipython`` for integration with the `ipython` terminal and parallel processing using `ipyparallel`,
 * ``learning`` for some machine learning features,
 * ``gui-jupyter`` to use the `Jupyter widgets <https://ipywidgets.readthedocs.io/en/stable/>`_

--- a/hyperspy/_signals/signal2d.py
+++ b/hyperspy/_signals/signal2d.py
@@ -26,7 +26,6 @@ import matplotlib.pyplot as plt
 import numpy as np
 import numpy.ma as ma
 from scipy import ndimage
-from skimage.registration._phase_cross_correlation import _upsampled_dft
 
 from hyperspy._signals.common_signal2d import CommonSignal2D
 from hyperspy._signals.lazy import LazySignal
@@ -48,17 +47,6 @@ from hyperspy.misc.math_tools import antisymmetrize, optimal_fft_size, symmetriz
 from hyperspy.signal import BaseSignal
 from hyperspy.signal_tools import PeaksFinder2D, Signal2DCalibration
 from hyperspy.ui_registry import DISPLAY_DT, TOOLKIT_DT
-from hyperspy.utils.peakfinders2D import (
-    _get_peak_position_and_intensity,
-    find_local_max,
-    find_peaks_dog,
-    find_peaks_log,
-    find_peaks_max,
-    find_peaks_minmax,
-    find_peaks_stat,
-    find_peaks_xc,
-    find_peaks_zaefferer,
-)
 
 _logger = logging.getLogger(__name__)
 
@@ -273,6 +261,8 @@ def estimate_image_shift(
     # The following code is more or less copied from
     # skimage.feature.register_feature, to gain access to the maximum value:
     if sub_pixel_factor != 1:
+        from skimage.registration._phase_cross_correlation import _upsampled_dft
+
         # Initial shift estimate in upsampled grid
         shifts = np.round(shifts * sub_pixel_factor) / sub_pixel_factor
         upsampled_region_size = np.ceil(sub_pixel_factor * 1.5)
@@ -1053,6 +1043,18 @@ class Signal2D(BaseSignal, CommonSignal2D):
             pixel coordinates of peaks found in each image sorted
             first along `y` and then along `x`.
         """
+        from hyperspy.utils.peakfinders2D import (
+            _get_peak_position_and_intensity,
+            find_local_max,
+            find_peaks_dog,
+            find_peaks_log,
+            find_peaks_max,
+            find_peaks_minmax,
+            find_peaks_stat,
+            find_peaks_xc,
+            find_peaks_zaefferer,
+        )
+
         method_dict = {
             "local_max": find_local_max,
             "max": find_peaks_max,

--- a/hyperspy/misc/tv_denoise.py
+++ b/hyperspy/misc/tv_denoise.py
@@ -163,10 +163,10 @@ def _tv_denoise_2d(im, weight=50, eps=2.0e-4, keep_type=False, n_iter_max=200):
 
     Examples
     ---------
-    >>> import skimage
-    >>> camera = skimage.data.camera().astype(float)
-    >>> camera += 0.5 * camera.std() * np.random.randn(*camera.shape)
-    >>> denoised_camera = _tv_denoise_2d(camera, weight=60.0)
+    >>> import scipy
+    >>> face = scipy.datasets.face().astype(float)
+    >>> face += 0.5 * face.std() * np.random.randn(*face.shape)
+    >>> denoised_face = _tv_denoise_2d(face, weight=60.0)
     """
     im_type = im.dtype
     if im_type is not float:
@@ -349,10 +349,10 @@ def tv_denoise(im, weight=50, eps=2.0e-4, keep_type=False, n_iter_max=200):
 
     Examples
     ---------
-    >>> import skimage
-    >>> camera = skimage.data.camera().astype(float)
-    >>> camera += 0.5 * camera.std() * np.random.randn(*camera.shape)
-    >>> denoised_camera = tv_denoise(camera, weight=60)
+    >>> import scipy
+    >>> face = scipy.datasets.face().astype(float)
+    >>> face += 0.5 * face.std() * np.random.randn(*face.shape)
+    >>> denoised_face = tv_denoise(face, weight=60)
     >>> # 3D example on synthetic data
     >>> x, y, z = np.ogrid[0:40, 0:40, 0:40]
     >>> mask = (x -22)**2 + (y - 20)**2 + (z - 17)**2 < 8**2

--- a/hyperspy/roi.py
+++ b/hyperspy/roi.py
@@ -1259,16 +1259,18 @@ class Line2DROI(BaseInteractiveROI):
             The end point of the scan line.
         linewidth : int, optional
             Width of the scan, perpendicular to the line
+
         Returns
         -------
         coords : array, shape (2, N, C), float
             The coordinates of the profile along the scan line. The length of
             the profile is the ceil of the computed length of the scan line.
+
         Notes
         -----
-        This is a utility method meant to be used internally by skimage
-        functions. The destination point is included in the profile, in
-        contrast to standard numpy indexing.
+        This is a utility method meant to be used internally.
+        The destination point is included in the profile, in contrast to
+        standard numpy indexing.
 
         """
         src_row, src_col = src = np.asarray(src, dtype=float)

--- a/hyperspy/signal.py
+++ b/hyperspy/signal.py
@@ -4832,8 +4832,8 @@ class BaseSignal(
 
         Examples
         --------
-        >>> import skimage
-        >>> im = hs.signals.Signal2D(skimage.data.camera())
+        >>> import scipy
+        >>> im = hs.signals.Signal2D(scipy.datasets.face())
         >>> im.fft()
         <ComplexSignal2D, title: FFT of , dimensions: (|512, 512)>
 
@@ -4928,8 +4928,8 @@ class BaseSignal(
 
         Examples
         --------
-        >>> import skimage
-        >>> im = hs.signals.Signal2D(skimage.data.camera())
+        >>> import scipy
+        >>> im = hs.signals.Signal2D(scipy.datasets.face())
         >>> imfft = im.fft()
         >>> imfft.ifft()
         <Signal2D, title: real(iFFT of FFT of ), dimensions: (|512, 512)>

--- a/hyperspy/tests/drawing/test_markers.py
+++ b/hyperspy/tests/drawing/test_markers.py
@@ -236,6 +236,7 @@ class TestMarkers:
             _ = Points.from_signal(signal, sizes=(10,), signal_axes="test")
 
     def test_find_peaks(self):
+        pytest.importorskip("skimage")
         from skimage.draw import disk
         from skimage.morphology import disk as disk2
 
@@ -285,10 +286,9 @@ class TestMarkers:
         np.testing.assert_array_equal(col.get_current_kwargs()["offsets"], [marker_pos])
 
     def test_find_peaks0d(self):
-        from skimage.draw import disk
-        from skimage.morphology import disk as disk2
+        skimage = pytest.importorskip("skimage")
 
-        rr, cc = disk(
+        rr, cc = skimage.draw.disk(
             center=(10, 8),
             radius=4,
         )
@@ -302,7 +302,7 @@ class TestMarkers:
         pks = s.find_peaks(
             interactive=False,
             method="template_matching",
-            template=disk2(4),
+            template=skimage.morphology.disk(4),
         )
         col = Points.from_signal(
             pks, sizes=(0.3,), signal_axes=s.axes_manager.signal_axes

--- a/hyperspy/tests/misc/test_tv_denoise.py
+++ b/hyperspy/tests/misc/test_tv_denoise.py
@@ -18,7 +18,6 @@
 
 import numpy as np
 import pytest
-import skimage
 
 from hyperspy.misc.tv_denoise import tv_denoise
 
@@ -29,6 +28,7 @@ def test_tv_denoise_error():
 
 
 def test_2d_tv_denoise():
+    skimage = pytest.importorskip("skimage")
     rng = np.random.RandomState(123)
     data = skimage.data.camera().astype(float)
     data_noisy = data + data.std() * rng.randn(*data.shape)

--- a/hyperspy/tests/signals/test_2D_tools.py
+++ b/hyperspy/tests/signals/test_2D_tools.py
@@ -46,6 +46,7 @@ def _generate_parameters():
 @lazifyTestClass
 class TestSubPixelAlign:
     def setup_method(self, method):
+        pytest.importorskip("skimage")
         ref_image = ascent()
         center = np.array((256, 256))
         shifts = np.array(
@@ -77,6 +78,7 @@ class TestSubPixelAlign:
         self.shifts = shifts
 
     def test_align_subpix(self):
+        pytest.importorskip("skimage")
         # Align signal
         s = self.signal
         shifts = self.shifts

--- a/hyperspy/tests/signals/test_complex_signal.py
+++ b/hyperspy/tests/signals/test_complex_signal.py
@@ -115,6 +115,7 @@ class TestComplexProperties:
 
 @pytest.mark.parametrize("lazy", (True, False))
 def test_get_unwrapped_phase_1D(lazy):
+    pytest.importorskip("skimage")
     phase = 6 * (1 - abs(np.indices((9,)) - 4) / 4)
     s = hs.signals.ComplexSignal1D(np.ones_like(phase) * np.exp(1j * phase))
     if lazy:
@@ -126,6 +127,7 @@ def test_get_unwrapped_phase_1D(lazy):
 
 @pytest.mark.parametrize("lazy", (True, False))
 def test_get_unwrapped_phase_2D(lazy):
+    pytest.importorskip("skimage")
     phase = 5 * (1 - abs(np.indices((9, 9)) - 4).sum(axis=0) / 8)
     s = hs.signals.ComplexSignal(np.ones_like(phase) * np.exp(1j * phase))
     if lazy:
@@ -137,6 +139,7 @@ def test_get_unwrapped_phase_2D(lazy):
 
 @pytest.mark.parametrize("lazy", (True, False))
 def test_get_unwrapped_phase_3D(lazy):
+    pytest.importorskip("skimage")
     phase = 4 * (1 - abs(np.indices((9, 9, 9)) - 4).sum(axis=0) / 12)
     s = hs.signals.ComplexSignal(np.ones_like(phase) * np.exp(1j * phase))
     if lazy:

--- a/hyperspy/tests/signals/test_find_peaks2D.py
+++ b/hyperspy/tests/signals/test_find_peaks2D.py
@@ -26,6 +26,8 @@ from hyperspy.signal_tools import PeaksFinder2D
 from hyperspy.signals import BaseSignal, Signal1D, Signal2D
 from hyperspy.ui_registry import TOOLKIT_REGISTRY
 
+pytest.importorskip("skimage")
+
 
 def _generate_dataset():
     coefficients = np.array(

--- a/hyperspy/utils/markers.py
+++ b/hyperspy/utils/markers.py
@@ -21,8 +21,8 @@
 Examples
 --------
 
->>> import skimage
->>> im = hs.signals.Signal2D(skimage.data.camera())
+>>> import scipy
+>>> im = hs.signals.Signal2D(scipy.datasets.face())
 >>> m = hs.plot.markers.Rectangles(
 ...    offsets=[10, 15],
 ...    widths=(5,),

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,8 +32,7 @@ dependencies = [
     "pint>=0.10",
     "prettytable>=2.3",
     "pyyaml",
-    "rosettasciio[hdf5]",
-    "scikit-image>=0.18",
+    "rosettasciio[hdf5,image]",
     "scipy>=1.6.0",
     "sympy>=1.10",
     "tqdm>=4.59.0",
@@ -91,6 +90,7 @@ all = [
     "hyperspy[baseline]",
     "hyperspy[gui-jupyter]",
     "hyperspy[gui-traitsui]",
+    "hyperspy[image]",
     "hyperspy[ipython]",
     "hyperspy[learning]",
     "hyperspy[speed]",
@@ -120,6 +120,7 @@ doc = [
     "numpydoc",
     "pybaselines", # for docstring test
     "pydata_sphinx_theme",
+    "scikit-image",
     "setuptools_scm",
     "sphinx-copybutton",
     "sphinx-design",
@@ -136,6 +137,9 @@ gui-jupyter = [
 ]
 gui-traitsui = [
     "hyperspy_gui_traitsui>=2.0",
+]
+image = [
+    "scikit-image>=0.18",
 ]
 ipython = [
     "IPython>7.0,!=8.0",

--- a/upcoming_changes/3553.maintenance.rst
+++ b/upcoming_changes/3553.maintenance.rst
@@ -1,0 +1,1 @@
+Scikit-image is now an optional dependency.


### PR DESCRIPTION
### Description of the change
I am trying to test rosettasciio on python 3.14 and with free-threading with hyperspy and scikit-image is being problematic to install in that environment. Making scikit-image an optional dependency will be useful to use hyperspy on platform or python version where wheels are not available. I think that this is worth making it optional, considering it is used only in 3 places.
- subpixel Signal2D alignment
- phase unwrapping of complex signals
- Signal2D peak finding.

### Progress of the PR
- [x] Make scikit-image an optional dependency,
- [x] migrate macos intel runner form the deprecated `macos-13` to `macos-15-intel`: https://github.com/actions/runner-images/issues/13045
- [n/a] update docstring (if appropriate),
- [x] update user guide (if appropriate),
- [x] add an changelog entry in the `upcoming_changes` folder (see [`upcoming_changes/README.rst`](https://github.com/hyperspy/hyperspy/blob/RELEASE_next_minor/upcoming_changes/README.rst)),
- [x] Check formatting changelog entry in the `readthedocs` doc build of this PR (link in github checks)
- [x] update tests,
- [x] ready for review.


