### PR TITLE
Fix for latest dask

### DIFF
--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -23,10 +23,10 @@ jobs:
     # Use the "reusable workflow" from the hyperspy organisation
     uses: hyperspy/.github/.github/workflows/push_doc.yml@main
     with:
-      repository: 'hyperspy/hyperspy-doc'
+      external_repository: 'hyperspy/hyperspy-doc'
       output_path: 'dev'
     secrets:
-      access_token: ${{ secrets.PAT_DOCUMENTATION }}
+      personal_token: ${{ secrets.PAT_DOCUMENTATION }}
 
   Push_tag:
     needs: Build
@@ -38,7 +38,7 @@ jobs:
     # Use the "reusable workflow" from the hyperspy organisation
     uses: hyperspy/.github/.github/workflows/push_doc.yml@main
     with:
-      repository: 'hyperspy/hyperspy-doc'
+      external_repository: 'hyperspy/hyperspy-doc'
       output_path: 'current'
     secrets:
-      access_token: ${{ secrets.PAT_DOCUMENTATION }}
+      personal_token: ${{ secrets.PAT_DOCUMENTATION }}

--- a/hyperspy/misc/model_tools.py
+++ b/hyperspy/misc/model_tools.py
@@ -229,7 +229,9 @@ def _calculate_covariance(
     # if target_signal shape is 1D, then fit_dot is 2D and numpy going to dask.linalg.inv is fine.
     # If target_signal shape is 2D, then dask.linalg.inv will fail because fit_dot is 3D.
     if lazy and target_signal.ndim > 1:
-        inv_fit_dot = da.map_blocks(np.linalg.inv, fit_dot, chunks=fit_dot.chunks)
+        inv_fit_dot = da.map_blocks(
+            np.linalg.inv, fit_dot, chunks=fit_dot.chunks, dtype=float, meta=fit_dot
+        )
     else:
         inv_fit_dot = np.linalg.inv(fit_dot)
 

--- a/upcoming_changes/3554.maintenance.rst
+++ b/upcoming_changes/3554.maintenance.rst
@@ -1,0 +1,1 @@
+Specify `dtype` and `meta` as parameters of `map_blocks` in the covariance calculation used in linear fitting.


### PR DESCRIPTION
Dask release of yesterday (https://pypi.org/project/dask/2025.10.0) breaks the covariance calculation used in linear fitting. From the dask release notes, it is not obvious what changes in dask to cause this failure, but setting `dtype` and `meta` in `map_blocks` is a good practice and fixes the failure.

### Progress of the PR
- [x] Specify `dtype` and `meta` as parameter of `map_blocks` in covariance calculation used in linear fitting,
- [x] Fix doc workflow following changes in reusable workflow (https://github.com/hyperspy/.github/commit/79a0eedb735803cca8337aa9a597c244dcb1392d)
- [n/a] update docstring (if appropriate),
- [n/a] update user guide (if appropriate),
- [x] add an changelog entry in the `upcoming_changes` folder (see [`upcoming_changes/README.rst`](https://github.com/hyperspy/hyperspy/blob/RELEASE_next_minor/upcoming_changes/README.rst)),
- [x] Check formatting changelog entry in the `readthedocs` doc build of this PR (link in github checks)
- [n/a] add tests,
- [x] ready for review.

### Example of failure:

```python
=================================== FAILURES ===================================
___________ TestMultiFitLinear.test_lazy_map_values_std_isset[False] ___________
[gw0] linux -- Python 3.12.12 /home/runner/work/hyperspy-bundle/hyperspy-bundle/new_distribution/bin/python3.12

self = <hyperspy.tests.model.test_linear_model.TestMultiFitLinear object at 0x7fa63c42b890>
weighted = False

    def test_map_values_std_isset(self, weighted):
        self._post_setup_method(weighted)
        m = self.m
        L = Gaussian(centre=15.0)
        L.centre.free = L.sigma.free = False
        m.append(L)
    
        m.multifit()
        nonlinear = L.A.map.copy()
    
        L.A.map["is_set"] = False
        cm = (
            pytest.warns(UserWarning)
            if weighted and not self.s._lazy
            else dummy_context_manager()
        )
        with cm:
>           m.multifit(optimizer="lstsq", calculate_errors=True)

new_distribution/lib/python3.12/site-packages/hyperspy/tests/model/test_linear_model.py:124: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
new_distribution/lib/python3.12/site-packages/hyperspy/model.py:2394: in multifit
    self.fit(**kwargs)
new_distribution/lib/python3.12/site-packages/hyperspy/model.py:2116: in fit
    fit_output = self._linear_fit(
new_distribution/lib/python3.12/site-packages/hyperspy/model.py:1627: in _linear_fit
    covariance = _calculate_covariance(
new_distribution/lib/python3.12/site-packages/hyperspy/misc/model_tools.py:232: in _calculate_covariance
    inv_fit_dot = da.map_blocks(np.linalg.inv, fit_dot, chunks=fit_dot.chunks)
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
new_distribution/lib/python3.12/site-packages/dask/array/core.py:844: in map_blocks
    dtype = apply_infer_dtype(func, args, original_kwargs, "map_blocks")
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

func = <function inv at 0x7fa65af3c930>, args = [array([[[0.]]])], kwargs = {}
funcname = 'map_blocks', suggest_dtype = 'dtype', nout = None

    def apply_infer_dtype(func, args, kwargs, funcname, suggest_dtype="dtype", nout=None):
        """
        Tries to infer output dtype of ``func`` for a small set of input arguments.
    
        Parameters
        ----------
        func: Callable
            Function for which output dtype is to be determined
    
        args: List of array like
            Arguments to the function, which would usually be used. Only attributes
            ``ndim`` and ``dtype`` are used.
    
        kwargs: dict
            Additional ``kwargs`` to the ``func``
    
        funcname: String
            Name of calling function to improve potential error messages
    
        suggest_dtype: None/False or String
            If not ``None`` adds suggestion to potential error message to specify a dtype
E           ValueError: `dtype` inference failed in `map_blocks`.
E           
E           Please specify the dtype explicitly using the `dtype` kwarg.
E           
E           Original error is below:
E           ------------------------
E           LinAlgError('Singular matrix')
E           
E           Traceback:
E           ---------
E             File "/home/runner/work/hyperspy-bundle/hyperspy-bundle/new_distribution/lib/python3.12/site-packages/dask/array/core.py", line 489, in apply_infer_dtype
E               o = func(*args, **kwargs)
E                   ^^^^^^^^^^^^^^^^^^^^^
E             File "/home/runner/work/hyperspy-bundle/hyperspy-bundle/new_distribution/lib/python3.12/site-packages/numpy/linalg/linalg.py", line 561, in inv
E               ainv = _umath_linalg.inv(a, signature=signature, extobj=extobj)
E                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
E             File "/home/runner/work/hyperspy-bundle/hyperspy-bundle/new_distribution/lib/python3.12/site-packages/numpy/linalg/linalg.py", line 112, in _raise_linalgerror_singular
E               raise LinAlgError("Singular matrix")

new_distribution/lib/python3.12/site-packages/dask/array/core.py:514: ValueError
```

