### PR TITLE
Doc deploy improvement

### DIFF
--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -39,6 +39,9 @@ jobs:
     uses: hyperspy/.github/.github/workflows/push_doc.yml@main
     with:
       external_repository: 'hyperspy/hyperspy-doc'
-      output_path: 'current'
+      output_path: ${{ github.ref_name }}
+      # Update the current version.
+      create_stable_copy: true
+      persistent_name: current
     secrets:
       personal_token: ${{ secrets.PAT_DOCUMENTATION }}

--- a/doc/_static/switcher.json
+++ b/doc/_static/switcher.json
@@ -5,18 +5,21 @@
         "url": "https://hyperspy.org/hyperspy-doc/dev/"
     },
     {
-        "version": "2.2.x",
-        "name": "2.2",
-        "url": "https://hyperspy.org/hyperspy-doc/current/",
+        "version": "2.3.0",
+        "url": "https://hyperspy.org/hyperspy-doc/v2.3.0/",
         "preferred": true
     },
     {
-        "version": "2.1",
-        "url": "https://hyperspy.org/hyperspy-doc/v2.1/"
+        "version": "2.2.0",
+        "url": "https://hyperspy.org/hyperspy-doc/v2.2.0/"
     },
     {
-        "version": "2.0",
-        "url": "https://hyperspy.org/hyperspy-doc/v2.0/"
+        "version": "2.1.1",
+        "url": "https://hyperspy.org/hyperspy-doc/v2.1.1/"
+    },
+    {
+        "version": "2.0.1",
+        "url": "https://hyperspy.org/hyperspy-doc/v2.0.1/"
     },
     {
         "version": "1.7",

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -172,14 +172,8 @@ favicons = [
 
 # The old version banner used `release` to compare to the "prefered" version
 # using https://www.npmjs.com/package/compare-versions
-# To play well with our documentation structure (the preferred version point
-# to the latest minor or patch release without having to update on patch release),
-# we add a ".x".
 # See https://github.com/pydata/pydata-sphinx-theme/issues/1552 for more context
-# On a minor release, the version switcher json is updated.
-# In the version switcher json, version needs to be defined with a `x`, e.g. 2.1.x
-# in as it is done here to make sure that they match!
-version_match = "dev" if "dev" in release else ".".join(release.split(".")[:2] + ["x"])
+version_match = "dev" if "dev" in release else release
 
 print("version", release)
 print("version_match:", version_match)
@@ -215,7 +209,7 @@ html_theme_options = {
     "header_links_before_dropdown": 7,
     "show_version_warning_banner": True,
     "switcher": {
-        # Update when merged and released
+        # Updated when running `prepare_release.py` script before a new release
         "json_url": "https://hyperspy.org/hyperspy-doc/dev/_static/switcher.json",
         "version_match": version_match,
     },

--- a/prepare_release.py
+++ b/prepare_release.py
@@ -38,6 +38,35 @@ def update_fallback_version_in_pyproject(tag, fname="pyproject.toml"):
     )
 
 
+def update_doc_version_switcher_json(tag):
+    import json
+
+    tag = tag.lstrip("v")
+    json_file_path = "doc/_static/switcher.json"
+
+    with open(json_file_path, "r") as f:
+        data = json.load(f)
+
+    # Remove preferred entry
+    for entry in data:
+        entry.pop("preferred", None)
+
+    # Add new preferred version entry
+    new_entry = {
+        "version": tag,
+        "url": f"https://hyperspy.org/hyperspy-doc/v{tag}/",
+        "preferred": True,
+    }
+    data.insert(1, new_entry)
+
+    with open(json_file_path, "w") as f:
+        json.dump(data, f, indent=4)
+
+    print(
+        f"New preferred v{tag} version added to documentation version switcher (`switcher.json`).\n"
+    )
+
+
 if __name__ == "__main__":
     # Get tag argument
     parser = argparse.ArgumentParser()
@@ -50,3 +79,6 @@ if __name__ == "__main__":
 
     # Update fallback version for setuptools_scm
     update_fallback_version_in_pyproject(tag)
+
+    # Update doc version switcher
+    update_doc_version_switcher_json(tag)

--- a/releasing_guide.md
+++ b/releasing_guide.md
@@ -7,7 +7,8 @@ Create a PR to the `RELEASE_next_patch` branch and go through the following step
 **Preparation**
 - Prepare the release by running the `prepare_release.py` python script (e.g. `python prepare_release.py 2.0.1`) , which will do the following:
   - update the release notes in `CHANGES.rst` by running `towncrier`,
-  - update the `setuptools_scm` fallback version in `pyproject.toml`.
+  - update the `setuptools_scm` fallback version in `pyproject.toml`,
+  - update the documentation version switcher (`switcher.json`).
 - Check release notes
 - For a minor or major release, update the versioned documentation repository and documentation version switcher according to the instruction in the [developer guide](https://hyperspy.org/hyperspy-doc/current/dev_guide/writing_docs.html#hosting-versioned-documentation)
 - (optional) check conda-forge and wheels build. Pushing a tag to a fork will run the release workflow without uploading to pypi

--- a/upcoming_changes/3556.maintenance.rst
+++ b/upcoming_changes/3556.maintenance.rst
@@ -1,0 +1,1 @@
+Push versioned documentation automatically. 


### PR DESCRIPTION
Currently, the versioned documentation is managed as follow:
- documentation are pushing automically to `hyperspy/hyperspy-doc/current`
- on minor release, the documentation of the previous documentation is copied manually to a new folder (for example to folder `v2.2`, when version 2.3 was released).

With this PR, the documentation is push to the `hyperspy/hyperspy-doc/current` and a copy is made for the release version in the folder (the name is the version).

### Progress of the PR
- [x] Update release script and documentation push workflow to enable automatically deployment of versioned documentation,
- [n/a] update docstring (if appropriate),
- [n/a] update user guide (if appropriate),
- [x] add an changelog entry in the `upcoming_changes` folder (see [`upcoming_changes/README.rst`](https://github.com/hyperspy/hyperspy/blob/RELEASE_next_minor/upcoming_changes/README.rst)),
- [x] Check formatting changelog entry in the `readthedocs` doc build of this PR (link in github checks)
- [n/a] add tests,
- [x] ready for review.


