### PR TITLE
Fix formatting print model

### DIFF
--- a/hyperspy/misc/model_tools.py
+++ b/hyperspy/misc/model_tools.py
@@ -23,7 +23,7 @@ import dask.array as da
 import numpy as np
 
 
-def _format_string(val, format_string=".5g"):
+def _format_string(val, format_string=".5g", max_length=None, add_ellipsis=True):
     """
     Returns formatted string for a value unless it equals None,
     then empty string is returned.
@@ -34,6 +34,12 @@ def _format_string(val, format_string=".5g"):
         Value to format
     format_string : str, optional
         For numeric types only: the format string to use. Default is ".5g".
+    max_length : int or None, optional
+        Maximum length of the returned string. If None, no maximum length
+        is applied. Default is None.
+    add_ellipsis : bool, optional
+        Whether to add ellipsis when truncating the string.
+        Default is True.
     """
     if val is None:
         to_return = ""
@@ -47,6 +53,13 @@ def _format_string(val, format_string=".5g"):
         to_return = f"({to_return})"
     else:
         to_return = f"{val:{format_string}}"
+
+    if max_length is not None and len(to_return) > max_length:
+        if add_ellipsis:
+            # Add ellipsis to indicate truncation
+            to_return = to_return[: max_length - 3] + "..."
+        else:
+            to_return = to_return[:max_length]
 
     return to_return
 
@@ -117,13 +130,13 @@ class CurrentComponentValues:
                 free = para.free if para.twin is None else "Twinned"
                 ln = para._linear
                 text += signature.format(
-                    para.name[: size["name"]],
-                    str(free)[: size["free"]],
-                    _format_string(para.value)[: size["value"]],
-                    _format_string(para.std)[: size["std"]],
-                    _format_string(para.bmin)[: size["bmin"]],
-                    _format_string(para.bmax)[: size["bmax"]],
-                    _format_string(str(ln))[: size["linear"]],
+                    _format_string(para.name, max_length=size["name"]),
+                    _format_string(str(free), max_length=size["free"]),
+                    _format_string(para.value, max_length=size["value"]),
+                    _format_string(para.std, max_length=size["std"]),
+                    _format_string(para.bmin, max_length=size["bmin"]),
+                    _format_string(para.bmax, max_length=size["bmax"]),
+                    _format_string(str(ln), max_length=size["linear"]),
                 )
                 text += "\n"
         return text

--- a/hyperspy/misc/model_tools.py
+++ b/hyperspy/misc/model_tools.py
@@ -16,6 +16,8 @@
 # You should have received a copy of the GNU General Public License
 # along with HyperSpy. If not, see <https://www.gnu.org/licenses/#GPL>.
 
+from collections.abc import Iterable
+
 import dask.array as da
 import numpy as np
 
@@ -24,7 +26,17 @@ def _format_string(val):
     """
     Returns formatted string for a value unless it equals None, then blank
     """
-    return "{:6g}".format(val) if val is not None else ""
+    if val is None:
+        to_return = ""
+    elif isinstance(val, str):
+        to_return = val
+    elif isinstance(val, Iterable):
+        to_return = ", ".join(f"{v:.6g}" for v in val)
+        to_return = f"({to_return})"
+    else:
+        to_return = f"{val:.6g}"
+
+    return to_return
 
 
 class CurrentComponentValues:
@@ -95,11 +107,11 @@ class CurrentComponentValues:
                 text += signature.format(
                     para.name[: size["name"]],
                     str(free)[: size["free"]],
-                    str(para.value)[: size["value"]],
-                    str(para.std)[: size["std"]],
-                    str(para.bmin)[: size["bmin"]],
-                    str(para.bmax)[: size["bmax"]],
-                    str(ln)[: size["linear"]],
+                    _format_string(para.value)[: size["value"]],
+                    _format_string(para.std)[: size["std"]],
+                    _format_string(para.bmin)[: size["bmin"]],
+                    _format_string(para.bmax)[: size["bmax"]],
+                    _format_string(str(ln))[: size["linear"]],
                 )
                 text += "\n"
         return text

--- a/hyperspy/misc/model_tools.py
+++ b/hyperspy/misc/model_tools.py
@@ -16,25 +16,37 @@
 # You should have received a copy of the GNU General Public License
 # along with HyperSpy. If not, see <https://www.gnu.org/licenses/#GPL>.
 
+import numbers
 from collections.abc import Iterable
 
 import dask.array as da
 import numpy as np
 
 
-def _format_string(val):
+def _format_string(val, format_string=".5g"):
     """
-    Returns formatted string for a value unless it equals None, then blank
+    Returns formatted string for a value unless it equals None,
+    then empty string is returned.
+
+    Parameters
+    ----------
+    val : any
+        Value to format
+    format_string : str, optional
+        For numeric types only: the format string to use. Default is ".5g".
     """
     if val is None:
         to_return = ""
     elif isinstance(val, str):
         to_return = val
     elif isinstance(val, Iterable):
-        to_return = ", ".join(f"{v:.6g}" for v in val)
+        to_return = ", ".join(
+            f"{v:{format_string}}" if isinstance(v, numbers.Number) else str(v)
+            for v in val
+        )
         to_return = f"({to_return})"
     else:
-        to_return = f"{val:.6g}"
+        to_return = f"{val:{format_string}}"
 
     return to_return
 

--- a/hyperspy/tests/component/test_component_print_current.py
+++ b/hyperspy/tests/component/test_component_print_current.py
@@ -166,3 +166,6 @@ def test_format_string():
     assert (
         _format_string((0.123, 1.234, 2.345), format_string=".2g") == "(0.12, 1.2, 2.3)"
     )
+    assert _format_string("Hello, World!") == "Hello, World!"
+    assert _format_string("Hello, World!", max_length=5) == "He..."
+    assert _format_string("Hello, World!", max_length=5, add_ellipsis=False) == "Hello"

--- a/hyperspy/tests/component/test_component_print_current.py
+++ b/hyperspy/tests/component/test_component_print_current.py
@@ -160,5 +160,9 @@ class TestSetParameters:
 def test_format_string():
     assert _format_string(None) == ""
     assert _format_string(5) == "5"
-    assert _format_string(5.123456789) == "5.12346"
+    assert _format_string(5.123456789) == "5.1235"
+    assert _format_string(5.123456789, format_string=".6g") == "5.12346"
     assert _format_string((0, 1, 2)) == "(0, 1, 2)"
+    assert (
+        _format_string((0.123, 1.234, 2.345), format_string=".2g") == "(0.12, 1.2, 2.3)"
+    )

--- a/hyperspy/tests/component/test_component_print_current.py
+++ b/hyperspy/tests/component/test_component_print_current.py
@@ -140,7 +140,7 @@ class TestSetParameters:
     def test_zero_in_html_print(self):
         """Ensure parameters with value=0 are printed too"""
         assert (
-            "<td>a1</td><td>True</td><td>     0</td>"
+            "<td>a1</td><td>True</td><td>0</td>"
             in CurrentComponentValues(self.model[0])._repr_html_()
         )
 
@@ -156,7 +156,9 @@ class TestSetParameters:
             in str(CurrentComponentValues(self.model[2]).__repr__()).split("\n")[4]
         )
 
-    def test_related_tools(self):
-        assert _format_string(None) == ""
-        assert _format_string(5) == "     5"
-        assert _format_string(5.123456789) == "5.12346"
+
+def test_format_string():
+    assert _format_string(None) == ""
+    assert _format_string(5) == "5"
+    assert _format_string(5.123456789) == "5.12346"
+    assert _format_string((0, 1, 2)) == "(0, 1, 2)"

--- a/upcoming_changes/3558.bugfix.rst
+++ b/upcoming_changes/3558.bugfix.rst
@@ -1,0 +1,1 @@
+Fix generating html code when printing iterable components values and improve string representation of components. 


### PR DESCRIPTION
Fix bug reported in https://github.com/hyperspy/hyperspy/discussions/3540.

### Progress of the PR
- [x] Fix generating html code when printing values of components with iterable values,
- [x] Improve string representation of components
- [x] update docstring (if appropriate),
- [n/a] update user guide (if appropriate),
- [x] add an changelog entry in the `upcoming_changes` folder (see [`upcoming_changes/README.rst`](https://github.com/hyperspy/hyperspy/blob/RELEASE_next_minor/upcoming_changes/README.rst)),
- [x] Check formatting changelog entry in the `readthedocs` doc build of this PR (link in github checks)
- [x] add tests,
- [x] ready for review.

### Minimal example of the bug fix or the new feature
```python
import hyperspy.api as hs
import numpy as np

s = hs.signals.Signal1D(np.arange(200))
s.set_signal_type("EELS")
s.add_elements(("Li",))
s.set_microscope_parameters(beam_energy=200, convergence_angle=20, collection_angle=40)

m = s.create_model()
m.print_current_values()
```
Raise an error when creating the html code, because it doesn't support components with iterable values (`number_of_elements`>1).

```python
---------------------------------------------------------------------------
TypeError                                 Traceback (most recent call last)
File ~\miniforge3\Lib\site-packages\IPython\core\formatters.py:406, in BaseFormatter.__call__(self, obj)
    404     method = get_real_method(obj, self.print_method)
    405     if method is not None:
--> 406         return method()
    407     return None
    408 else:

File ~\Dev\hyperspy\hyperspy\misc\model_tools.py:184, in CurrentModelValues._repr_html_(self)
    178     if not self.only_active or self.only_active and comp.active:
    179         if not self.only_free or comp.free_parameters and self.only_free:
    180             html += CurrentComponentValues(
    181                 component=comp,
    182                 only_free=self.only_free,
    183                 only_active=self.only_active,
--> 184             )._repr_html_()
    185 return html

File ~\Dev\hyperspy\hyperspy\misc\model_tools.py:122, in CurrentComponentValues._repr_html_(self)
    120 free = para.free if para.twin is None else "Twinned"
    121 linear = para._linear
--> 122 value = _format_string(para.value)
    123 std = _format_string(para.std)
    124 bmin = _format_string(para.bmin)

File ~\Dev\hyperspy\hyperspy\misc\model_tools.py:27, in _format_string(val)
     23 def _format_string(val):
     24     """
     25     Returns formatted string for a value unless it equals None, then blank
     26     """
---> 27     return "{:6g}".format(val) if val is not None else ""

TypeError: unsupported format string passed to tuple.__format__
```
