### PR TITLE
Add support ipykernel subshells

### DIFF
--- a/hyperspy/drawing/mpl_he.py
+++ b/hyperspy/drawing/mpl_he.py
@@ -19,6 +19,7 @@
 import logging
 import warnings
 from functools import partial
+from threading import Lock
 
 import matplotlib
 from traits.api import Undefined
@@ -28,6 +29,7 @@ from hyperspy.drawing import image, signal1d, widgets
 from hyperspy.events import Event, Events
 
 _logger = logging.getLogger(__name__)
+_lock = Lock()
 
 
 def _is_widget_backend():
@@ -241,30 +243,33 @@ class MPL_HyperExplorer:
                 from IPython.display import display
                 from ipywidgets.widgets import HBox, VBox
 
-                if self.signal_plot is None and self.navigator_plot is not None:
-                    # in case the signal is navigation only
-                    display(self.navigator_plot.figure.canvas)
-                elif self.navigator_plot is None:
-                    # in case the signal is signal  only
-                    display(self.signal_plot.figure.canvas)
-                elif plot_style == "horizontal":
-                    display(
-                        HBox(
-                            [
-                                self.navigator_plot.figure.canvas,
-                                self.signal_plot.figure.canvas,
-                            ]
+                # lock to use IPython.display.display with kernel subshells
+                # See https://github.com/matplotlib/ipympl/pull/603
+                with _lock:
+                    if self.signal_plot is None and self.navigator_plot is not None:
+                        # in case the signal is navigation only
+                        display(self.navigator_plot.figure.canvas)
+                    elif self.navigator_plot is None:
+                        # in case the signal is signal  only
+                        display(self.signal_plot.figure.canvas)
+                    elif plot_style == "horizontal":
+                        display(
+                            HBox(
+                                [
+                                    self.navigator_plot.figure.canvas,
+                                    self.signal_plot.figure.canvas,
+                                ]
+                            )
                         )
-                    )
-                else:  # plot_style == "vertical":
-                    display(
-                        VBox(
-                            [
-                                self.navigator_plot.figure.canvas,
-                                self.signal_plot.figure.canvas,
-                            ]
+                    else:  # plot_style == "vertical":
+                        display(
+                            VBox(
+                                [
+                                    self.navigator_plot.figure.canvas,
+                                    self.signal_plot.figure.canvas,
+                                ]
+                            )
                         )
-                    )
 
         if _is_widget_backend() and "fig" not in kwargs:
             with matplotlib.pyplot.ioff():

--- a/upcoming_changes/3563.bugfix.rst
+++ b/upcoming_changes/3563.bugfix.rst
@@ -1,0 +1,1 @@
+Add support for ipykernels subshells when using ipympl matplotlib backend.


### PR DESCRIPTION
ipykernel 7 introduce [subshells ](https://github.com/ipython/ipykernel/releases/tag/v7.0.0) and this breaks the use of `IPython.display.display` when using the matplotlib backend ipympl.

to reproduce install ipykernel >=7 and run:
```python
%matplotlib widget
import hyperspy.api as hs
from scipy.datasets import ascent

img = hs.signals.Signal2D(ascent())
img.plot(cmap='RdYlBu_r')
```
in the jupyter lab/notebook: the plot will hang.

See https://github.com/hyperspy/hyperspy/discussions/3562 for context.
Similar fix as in https://github.com/matplotlib/ipympl/pull/603.


### Progress of the PR
- [x] Add lock to use global state, such as `IPython.display.display`,
- [n/a] update docstring (if appropriate),
- [n/a] update user guide (if appropriate),
- [x] add an changelog entry in the `upcoming_changes` folder (see [`upcoming_changes/README.rst`](https://github.com/hyperspy/hyperspy/blob/RELEASE_next_minor/upcoming_changes/README.rst)),
- [n/a] Check formatting changelog entry in the `readthedocs` doc build of this PR (link in github checks)
- [n/a] add tests,
- [x] ready for review.

