### PR TITLE
Improve error message in `remove_baseline` when pybaseline is not installed

### DIFF
--- a/hyperspy/_signals/_signal1d_tool.py
+++ b/hyperspy/_signals/_signal1d_tool.py
@@ -1,7 +1,22 @@
-try:
-    from pybaselines import Baseline
-except ImportError:
-    pass
+# -*- coding: utf-8 -*-
+# Copyright 2007-2025 The HyperSpy developers
+#
+# This file is part of HyperSpy.
+#
+# HyperSpy is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# HyperSpy is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with HyperSpy. If not, see <https://www.gnu.org/licenses/#GPL>.
+
+from pybaselines import Baseline
 
 
 def _remove_baseline(data, method, x, **kwargs):

--- a/hyperspy/drawing/markers.py
+++ b/hyperspy/drawing/markers.py
@@ -25,7 +25,6 @@ import numpy as np
 from matplotlib.patches import Patch
 from matplotlib.transforms import IdentityTransform
 
-import hyperspy
 from hyperspy.events import Event, Events
 from hyperspy.misc.array_tools import _get_navigation_dimension_chunk_slice
 from hyperspy.misc.utils import isiterable
@@ -1071,4 +1070,6 @@ def markers_dict_to_markers(marker_dict):
     if "size" in kwargs:
         kwargs["sizes"] = kwargs.pop("size")
 
-    return getattr(hyperspy.utils.markers, markers_class)(**marker_dict, **kwargs)
+    from hyperspy.utils import markers
+
+    return getattr(markers, markers_class)(**marker_dict, **kwargs)

--- a/hyperspy/tests/signals/test_remove_baseline.py
+++ b/hyperspy/tests/signals/test_remove_baseline.py
@@ -28,9 +28,23 @@ from hyperspy.utils.baseline_removal_tool import (
     BaselineRemoval,
 )
 
-pytest.importorskip("pybaselines")
+try:
+    from pybaselines import Baseline  # noqa: F401
+
+    PYBASELINES_INSTALLED = True
+except (ImportError, ModuleNotFoundError):
+    PYBASELINES_INSTALLED = False
 
 
+@pytest.mark.skipif(PYBASELINES_INSTALLED, reason="pybaselines is installed")
+def test_pybaselines_not_installed():
+    """Test that an ImportError is raised when pybaselines is not installed."""
+    s = hs.data.two_gaussians().inav[:2, :2]
+    with pytest.raises(ImportError):
+        s.remove_baseline(method="aspls", lam=1e7)
+
+
+@pytest.mark.skipif(not PYBASELINES_INSTALLED, reason="pybaselines is not installed")
 @pytest.mark.parametrize("single", (True, False))
 def test_remove_baseline(single):
     # 100 navigation size with 16 workers
@@ -49,6 +63,7 @@ def test_remove_baseline(single):
     assert s.isig[:10].data.mean() < 5
 
 
+@pytest.mark.skipif(not PYBASELINES_INSTALLED, reason="pybaselines is not installed")
 def test_remove_baseline_apply_close():
     s = hs.data.two_gaussians().inav[:2, :4]
     assert s.isig[:10].data.mean() > 20
@@ -71,6 +86,7 @@ def test_remove_baseline_apply_close():
     assert s.isig[:10].data.mean() < 5
 
 
+@pytest.mark.skipif(not PYBASELINES_INSTALLED, reason="pybaselines is not installed")
 def test_baseline_removal_tool_enable():
     s = hs.data.two_gaussians().inav[:4, :2]
 
@@ -129,6 +145,7 @@ def test_baseline_removal_tool_enable():
         assert br._enable_penalized_spline is False
 
 
+@pytest.mark.skipif(not PYBASELINES_INSTALLED, reason="pybaselines is not installed")
 def test_remove_baseline_warning(caplog):
     s = hs.data.two_gaussians().inav[:2, :2]
 

--- a/upcoming_changes/3565.bugfix.rst
+++ b/upcoming_changes/3565.bugfix.rst
@@ -1,0 +1,1 @@
+Improve error message in :meth:`~.api.signals.Signal1D.remove_baseline` when pybaseline is not installed. Fix markers import.


### PR DESCRIPTION
### Progress of the PR
- [x] Raise the error early instead with a clear import error,
- [x] Fix markers that seems to fail with recent python version (?),
- [n/a] update docstring (if appropriate),
- [n/a] update user guide (if appropriate),
- [x] add an changelog entry in the `upcoming_changes` folder (see [`upcoming_changes/README.rst`](https://github.com/hyperspy/hyperspy/blob/RELEASE_next_minor/upcoming_changes/README.rst)),
- x ] Check formatting changelog entry in the `readthedocs` doc build of this PR (link in github checks)
- [x] update tests,
- [x] ready for review.


