### PR TITLE
Speed up hyperspy import part 1

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -30,7 +30,7 @@ jobs:
             PYTHON_VERSION: '3.10'
             PIP_SELECTOR: '[all, tests, coverage]'
             OLDEST_SUPPORTED_VERSION: true
-            DEPENDENCIES: dask[array]==2023.2.1 matplotlib==3.6.0 numba==0.56.0 numpy==1.22.0 scipy==1.8.0 sympy==1.10 scikit-image==0.19.0 scikit-learn==1.1.0 numexpr==2.8.0
+            DEPENDENCIES: dask[array]==2023.2.1 matplotlib==3.6.0 numba==0.56.0 numpy==1.22.0 scipy==1.8.0 sympy==1.10 scikit-image==0.19.0 scikit-learn==1.6.0 numexpr==2.8.0
             LABEL: -oldest
           # test minimum requirement
           - os: ubuntu

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -30,7 +30,7 @@ jobs:
             PYTHON_VERSION: '3.10'
             PIP_SELECTOR: '[all, tests, coverage]'
             OLDEST_SUPPORTED_VERSION: true
-            DEPENDENCIES: dask[array]==2022.9.2 matplotlib==3.6.0 numba==0.56.0 numpy==1.22.0 scipy==1.8.0 sympy==1.10 scikit-image==0.19.0 scikit-learn==1.1.0 numexpr==2.8.0
+            DEPENDENCIES: dask[array]==2023.2.1 matplotlib==3.6.0 numba==0.56.0 numpy==1.22.0 scipy==1.8.0 sympy==1.10 scikit-image==0.19.0 scikit-learn==1.1.0 numexpr==2.8.0
             LABEL: -oldest
           # test minimum requirement
           - os: ubuntu

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -25,27 +25,27 @@ resources:
 
 strategy:
   matrix:
-    Linux_Python39:
+    Linux_Python311:
       vmImage: 'ubuntu-latest'
       PYTHON_VERSION: '3.11'
       MINIFORGE_PATH: $(Agent.BuildDirectory)/miniforge3
-    Linux_Python310:
+    Linux_Python312:
       vmImage: 'ubuntu-latest'
       PYTHON_VERSION: '3.12'
       MINIFORGE_PATH: $(Agent.BuildDirectory)/miniforge3
-    MacOS_Python39:
+    MacOS_Python311:
       vmImage: 'macOS-latest'
       PYTHON_VERSION: '3.11'
       MINIFORGE_PATH: $(Agent.BuildDirectory)/miniforge3
-    MacOS_Python310:
+    MacOS_Python312:
       vmImage: 'macOS-latest'
       PYTHON_VERSION: '3.12'
       MINIFORGE_PATH: $(Agent.BuildDirectory)/miniforge3
-    Windows_Python39:
+    Windows_Python311:
       vmImage: 'windows-latest'
       PYTHON_VERSION: '3.11'
       MINIFORGE_PATH: $(Agent.BuildDirectory)\miniforge3
-    Windows_Python310:
+    Windows_Python312:
       vmImage: 'windows-latest'
       PYTHON_VERSION: '3.12'
       MINIFORGE_PATH: $(Agent.BuildDirectory)\miniforge3

--- a/conda_environment.yml
+++ b/conda_environment.yml
@@ -18,7 +18,7 @@ dependencies:
 - pyyaml
 - rosettasciio-base >=0.12.0
 - scikit-image >=0.19.0
-- scikit-learn >=1.1.0
+- scikit-learn >=1.6.0
 - scipy >=1.8.0
 - sympy >=1.10
 - tqdm >=4.59.0

--- a/conda_environment.yml
+++ b/conda_environment.yml
@@ -2,7 +2,7 @@ name: test_env
 channels:
 - conda-forge
 dependencies:
-- dask-core >=2022.9.2
+- dask-core >=2023.2.1
 - dill
 - importlib-metadata
 - h5py

--- a/conda_environment.yml
+++ b/conda_environment.yml
@@ -16,7 +16,7 @@ dependencies:
 - pint >=0.10
 - prettytable >=2.3
 - pyyaml
-- rosettasciio-base
+- rosettasciio-base >=0.12.0
 - scikit-image >=0.19.0
 - scikit-learn >=1.1.0
 - scipy >=1.8.0

--- a/conda_environment_dev.yml
+++ b/conda_environment_dev.yml
@@ -9,6 +9,7 @@ dependencies:
 - pytest
 - pytest-mpl
 # Regression introduced in https://github.com/pytest-dev/pytest-xdist/pull/778
+# doesn't play well with some plotting tests, most likely related to copying reference images.
 - pytest-xdist <3.5
 - pytest-rerunfailures
 - pytest-instafail

--- a/hyperspy/__init__.py
+++ b/hyperspy/__init__.py
@@ -16,39 +16,12 @@
 # You should have received a copy of the GNU General Public License
 # along with HyperSpy. If not, see <https://www.gnu.org/licenses/#GPL>.
 
+import functools
 import importlib
-import logging
 from importlib.metadata import version
 from pathlib import Path
 
 from hyperspy import docstrings
-
-_logger = logging.getLogger(__name__)
-
-__version__ = version("hyperspy")
-
-# For development version, `setuptools_scm` will be used at build time
-# to get the dev version, in case of missing vcs information (git archive,
-# shallow repository), the fallback version defined in pyproject.toml will
-# be used
-
-# if we have a editable install from a git repository try to use
-# `setuptools_scm` to find a more accurate version:
-# `importlib.metadata` will provide the version at installation
-# time and for editable version this may be different
-
-# we only do that if we have enough git history, e.g. not shallow checkout
-_root = Path(__file__).resolve().parents[1]
-if (_root / ".git").exists() and not (_root / ".git/shallow").exists():
-    try:
-        # setuptools_scm may not be installed
-        from setuptools_scm import get_version
-
-        __version__ = get_version(_root)
-    except ImportError:  # pragma: no cover
-        # setuptools_scm not install, we keep the existing __version__
-        pass
-
 
 __doc__ = (
     """
@@ -74,14 +47,46 @@ More details in the :mod:`~hyperspy.api` docstring.
 __all__ = ["api", "__version__"]
 
 
+@functools.cache
+def _get_version():
+    version_ = version("hyperspy")
+    # For development version, `setuptools_scm` will be used at build time
+    # to get the dev version, in case of missing vcs information (git archive,
+    # shallow repository), the fallback version defined in pyproject.toml will
+    # be used
+
+    # if we have a editable install from a git repository try to use
+    # `setuptools_scm` to find a more accurate version:
+    # `importlib.metadata` will provide the version at installation
+    # time and for editable version this may be different
+
+    # we only do that if we have enough git history, e.g. not shallow checkout
+    _root = Path(__file__).resolve().parents[1]
+    if (_root / ".git").exists() and not (_root / ".git/shallow").exists():
+        try:
+            # setuptools_scm may not be installed
+            from setuptools_scm import get_version
+
+            version_ = get_version(_root)
+        except ImportError:  # pragma: no cover
+            # setuptools_scm not install, we keep the existing __version__
+            pass
+
+    return version_
+
+
 def __dir__():
     return sorted(__all__)
 
 
 def __getattr__(name):
+    if name == "__version__":
+        return _get_version()
+
     if name in __all__:  # pragma: no cover
         # We can't get this block covered in the test suite because it is
         # already imported, when running the test suite.
         # If this is broken, a lot of things will be broken!
         return importlib.import_module("." + name, "hyperspy")
+
     raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/hyperspy/_components/gaussian.py
+++ b/hyperspy/_components/gaussian.py
@@ -18,11 +18,11 @@
 
 import math
 
-import dask.array as da
 import numpy as np
 
 from hyperspy._components.expression import Expression
 from hyperspy.component import _get_scaling_factor
+from hyperspy.misc.utils import is_dask_array
 
 sqrt2pi = math.sqrt(2 * math.pi)
 sigma2fwhm = 2 * math.sqrt(2 * math.log(2))
@@ -61,7 +61,9 @@ def _estimate_gaussian_parameters(signal, x1, x2, only_current):
     )
     height = data.max(i)
 
-    if isinstance(data, da.Array):
+    if is_dask_array(data):
+        import dask.array as da
+
         return da.compute(centre, height, sigma)
     else:
         return centre, height, sigma

--- a/hyperspy/_components/lorentzian.py
+++ b/hyperspy/_components/lorentzian.py
@@ -16,11 +16,11 @@
 # You should have received a copy of the GNU General Public License
 # along with HyperSpy. If not, see <https://www.gnu.org/licenses/#GPL>.
 
-import dask.array as da
 import numpy as np
 
 from hyperspy._components.expression import Expression
 from hyperspy.component import _get_scaling_factor
+from hyperspy.misc.utils import is_dask_array
 
 
 def _estimate_lorentzian_parameters(signal, x1, x2, only_current):
@@ -49,7 +49,9 @@ def _estimate_lorentzian_parameters(signal, x1, x2, only_current):
     igamma1 = np.argmin(abs(0.75 - cdfnorm), i)
     igamma2 = np.argmin(abs(0.25 - cdfnorm), i)
 
-    if isinstance(data, da.Array):
+    if is_dask_array(data):
+        import dask.array as da
+
         icentre, igamma1, igamma2 = da.compute(icentre, igamma1, igamma2)
 
     centre = X[icentre]

--- a/hyperspy/_components/scalable_fixed_pattern.py
+++ b/hyperspy/_components/scalable_fixed_pattern.py
@@ -17,7 +17,7 @@
 # along with HyperSpy. If not, see <https://www.gnu.org/licenses/#GPL>.
 
 import numpy as np
-from scipy.interpolate import make_interp_spline
+import scipy
 
 from hyperspy.component import Component
 from hyperspy.docstrings.parameters import FUNCTION_ND_DOCSTRING
@@ -119,7 +119,7 @@ class ScalableFixedPattern(Component):
             :func:`scipy.interpolate.make_interp_spline`
         """
 
-        self.f = make_interp_spline(
+        self.f = scipy.interpolate.make_interp_spline(
             self.signal.axes_manager.signal_axes[0].axis,
             self.signal.data.squeeze(),
             **kwargs,

--- a/hyperspy/_components/skew_normal.py
+++ b/hyperspy/_components/skew_normal.py
@@ -16,11 +16,11 @@
 # You should have received a copy of the GNU General Public License
 # along with HyperSpy. If not, see <https://www.gnu.org/licenses/#GPL>.
 
-import dask.array as da
 import numpy as np
 
 from hyperspy._components.expression import Expression
 from hyperspy.component import _get_scaling_factor
+from hyperspy.misc.utils import is_dask_array
 
 sqrt2pi = np.sqrt(2 * np.pi)
 
@@ -68,7 +68,9 @@ def _estimate_skewnormal_parameters(signal, x1, x2, only_current):
     iheight = np.argmin(abs(X.reshape(X_shape) - x0.reshape(x0_shape)), i)
     # height is the value of the function at x0, shich has to be computed
     # differently for dask array (lazy) and depending on the dimension
-    if isinstance(data, da.Array):
+    if is_dask_array(data):
+        import dask.array as da
+
         x0, iheight, scale, shape = da.compute(x0, iheight, scale, shape)
         if only_current is True or signal.axes_manager.navigation_dimension == 0:
             height = data.vindex[iheight].compute()

--- a/hyperspy/_signals/lazy.py
+++ b/hyperspy/_signals/lazy.py
@@ -34,14 +34,15 @@ from hyperspy.docstrings.signal import (
     SHOW_PROGRESSBAR_ARG,
 )
 from hyperspy.external.progressbar import progressbar
-from hyperspy.misc.array_tools import (
+from hyperspy.misc.array_tools import _requires_linear_rebin
+from hyperspy.misc.dask_utils import (
+    _compute,
     _get_navigation_dimension_chunk_slice,
-    _requires_linear_rebin,
     get_signal_chunk_slice,
 )
 from hyperspy.misc.hist_tools import _set_histogram_metadata, histogram_dask
 from hyperspy.misc.machine_learning import import_sklearn
-from hyperspy.misc.utils import _compute, isiterable, multiply
+from hyperspy.misc.utils import isiterable, multiply
 from hyperspy.signal import BaseSignal
 
 _logger = logging.getLogger(__name__)

--- a/hyperspy/_signals/lazy.py
+++ b/hyperspy/_signals/lazy.py
@@ -25,7 +25,7 @@ import dask
 import dask.array as da
 import numpy as np
 from dask.widgets import TEMPLATE_PATHS
-from rsciio.utils.tools import get_file_handle
+from rsciio.utils.file import get_file_handle
 
 from hyperspy.docstrings.signal import (
     LAZYSIGNAL_DOC,

--- a/hyperspy/_signals/lazy.py
+++ b/hyperspy/_signals/lazy.py
@@ -24,6 +24,7 @@ from itertools import product
 import dask
 import dask.array as da
 import numpy as np
+import scipy
 from dask.widgets import TEMPLATE_PATHS
 from rsciio.utils.file import get_file_handle
 
@@ -657,12 +658,11 @@ class LazySignal(BaseSignal):
 
     def integrate_simpson(self, axis, out=None, rechunk=False):
         axis = self.axes_manager[axis]
-        from scipy import integrate
 
         axis = self.axes_manager[axis]
         data = self._lazy_data(axis=axis, rechunk=rechunk)
         new_data = data.map_blocks(
-            integrate.simpson,
+            scipy.integrate.simpson,
             x=axis.axis,
             axis=axis.index_in_array,
             drop_axis=axis.index_in_array,

--- a/hyperspy/_signals/signal1d.py
+++ b/hyperspy/_signals/signal1d.py
@@ -21,7 +21,6 @@ import math
 import warnings
 
 import dask
-import dask.array as da
 import numpy as np
 import numpy.ma as ma
 from scipy import interpolate
@@ -51,6 +50,7 @@ from hyperspy.docstrings.signal1d import (
 )
 from hyperspy.misc.lowess_smooth import lowess
 from hyperspy.misc.tv_denoise import _tv_denoise_1d
+from hyperspy.misc.utils import is_dask_array
 from hyperspy.models.model1d import Model1D
 from hyperspy.signal import BaseSignal
 from hyperspy.signal_tools import (
@@ -496,6 +496,8 @@ class Signal1D(BaseSignal, CommonSignal1D):
             ilow = axis.low_index
         if expand:
             if self._lazy:
+                import dask.array as da
+
                 ind = axis.index_in_array
                 pre_shape = list(self.data.shape)
                 post_shape = list(self.data.shape)
@@ -703,9 +705,9 @@ class Signal1D(BaseSignal, CommonSignal1D):
             )
         self._check_navigation_mask(mask)
         # we compute for now
-        if isinstance(start, da.Array):
+        if is_dask_array(start):
             start = start.compute()
-        if isinstance(end, da.Array):
+        if is_dask_array(end):
             end = end.compute()
         i1, i2 = axis._get_index(start), axis._get_index(end)
         if reference_indices is None:
@@ -1139,6 +1141,8 @@ class Signal1D(BaseSignal, CommonSignal1D):
 
         if zero_fill:
             if self._lazy:
+                import dask.array as da
+
                 low_idx = result.axes_manager[-1].value2index(signal_range[0])
                 z = da.zeros(low_idx, chunks=(low_idx,))
                 cropped_da = result.data[low_idx:]
@@ -1475,6 +1479,8 @@ class Signal1D(BaseSignal, CommonSignal1D):
         SignalDimensionError
             If the signal dimension is not 1.
         """
+        import dask.array as da
+
         if not np.issubdtype(self.data.dtype, np.floating):
             raise TypeError(
                 "The data dtype should be `float`. It can be "

--- a/hyperspy/_signals/signal1d.py
+++ b/hyperspy/_signals/signal1d.py
@@ -23,9 +23,7 @@ import warnings
 import dask
 import numpy as np
 import numpy.ma as ma
-from scipy import interpolate
-from scipy.ndimage import gaussian_filter1d
-from scipy.signal import medfilt, savgol_filter
+import scipy
 
 from hyperspy._signals.common_signal1d import CommonSignal1D
 from hyperspy._signals.lazy import LazySignal
@@ -149,7 +147,7 @@ def find_peaks_ohaver(
         amp_thresh = 0.1 * y.max()
     peakgroup = np.round(peakgroup)
     if medfilt_radius:
-        d = np.gradient(medfilt(y, medfilt_radius))
+        d = np.gradient(scipy.signal.medfilt(y, medfilt_radius))
     else:
         d = np.gradient(y)
     n = np.round(peakgroup / 2 + 1)
@@ -241,7 +239,7 @@ def interpolate1D(number_of_interpolation_points, data):
     new_ax = np.linspace(0, 100, ch * ip - (ip - 1))
 
     data = ma.masked_invalid(data)
-    interpolator = interpolate.make_interp_spline(
+    interpolator = scipy.interpolate.make_interp_spline(
         old_ax,
         data,
         k=1,
@@ -278,7 +276,9 @@ def _shift1D(data, **kwargs):
 
     data = ma.masked_invalid(data)
     # #This is the interpolant function
-    si = interpolate.make_interp_spline(original_axis, data, k=1, check_finite=False)
+    si = scipy.interpolate.make_interp_spline(
+        original_axis, data, k=1, check_finite=False
+    )
 
     # Evaluate interpolated data at shifted positions
     return si(original_axis - shift)
@@ -615,7 +615,7 @@ class Signal1D(BaseSignal, CommonSignal1D):
             i3 = int(np.clip(i2 + delta, 0, axis.size))
 
         def interpolating_function(dat):
-            dat_int = interpolate.interp1d(
+            dat_int = scipy.interpolate.interp1d(
                 list(range(i0, i1)) + list(range(i2, i3)),
                 dat[i0:i1].tolist() + dat[i2:i3].tolist(),
                 **kwargs,
@@ -941,7 +941,7 @@ class Signal1D(BaseSignal, CommonSignal1D):
         if polynomial_order is not None and window_length is not None:
             axis = self.axes_manager.signal_axes[0]
             self.map(
-                savgol_filter,
+                scipy.signal.savgol_filter,
                 window_length=window_length,
                 polyorder=polynomial_order,
                 deriv=differential_order,
@@ -1456,7 +1456,7 @@ class Signal1D(BaseSignal, CommonSignal1D):
             raise ValueError("FWHM must be greater than zero")
         axis = self.axes_manager.signal_axes[0]
         FWHM *= 1 / axis.scale
-        self.map(gaussian_filter1d, sigma=FWHM / 2.35482, ragged=False)
+        self.map(scipy.ndimage.gaussian_filter1d, sigma=FWHM / 2.35482, ragged=False)
 
     def hanning_taper(self, side="both", channels=None, offset=0):
         """Apply a hanning taper to the data in place.
@@ -1679,7 +1679,7 @@ class Signal1D(BaseSignal, CommonSignal1D):
                 )
                 spectrum = spectrum[slices]
                 x = x[slices]
-            spline = interpolate.UnivariateSpline(
+            spline = scipy.interpolate.UnivariateSpline(
                 x, spectrum - factor * spectrum.max(), s=0
             )
             roots = spline.roots()

--- a/hyperspy/_signals/signal2d.py
+++ b/hyperspy/_signals/signal2d.py
@@ -21,7 +21,6 @@ import warnings
 from copy import deepcopy
 from functools import partial
 
-import dask.array as da
 import matplotlib.pyplot as plt
 import numpy as np
 import numpy.ma as ma
@@ -44,6 +43,7 @@ from hyperspy.docstrings.signal import (
 )
 from hyperspy.external.progressbar import progressbar
 from hyperspy.misc.math_tools import antisymmetrize, optimal_fft_size, symmetrize
+from hyperspy.misc.utils import is_dask_array
 from hyperspy.signal import BaseSignal
 from hyperspy.signal_tools import PeaksFinder2D, Signal2DCalibration
 from hyperspy.ui_registry import DISPLAY_DT, TOOLKIT_DT
@@ -206,8 +206,11 @@ def estimate_image_shift(
        Ultramicroscopy 102, no. 1 (December 2004): 27–36.
 
     """
+    if is_dask_array(ref) or is_dask_array(image):
+        import dask.array as da
 
-    ref, image = da.compute(ref, image)
+        ref, image = da.compute(ref, image)
+
     # Make a copy of the images to avoid modifying them
     ref = ref.copy().astype(dtype)
     image = image.copy().astype(dtype)
@@ -945,12 +948,7 @@ class Signal2D(BaseSignal, CommonSignal2D):
 
         """
         yy, xx = np.indices(self.axes_manager._signal_shape_in_array)
-        if self._lazy:
-            ramp = offset * da.ones(
-                self.data.shape, dtype=self.data.dtype, chunks=self.data.chunks
-            )
-        else:
-            ramp = offset * np.ones(self.data.shape, dtype=self.data.dtype)
+        ramp = offset * np.ones_like(self.data)
         ramp += ramp_x * xx
         ramp += ramp_y * yy
         self.data += ramp

--- a/hyperspy/_signals/signal2d.py
+++ b/hyperspy/_signals/signal2d.py
@@ -24,7 +24,7 @@ from functools import partial
 import matplotlib.pyplot as plt
 import numpy as np
 import numpy.ma as ma
-from scipy import ndimage
+import scipy
 
 from hyperspy._signals.common_signal2d import CommonSignal2D
 from hyperspy._signals.lazy import LazySignal
@@ -61,7 +61,7 @@ def shift_image(im, shift=0, interpolation_order=1, fill_value=np.nan):
         else:
             # Disable interpolation
             order = 0
-        return ndimage.shift(im, shift, cval=fill_value, order=order)
+        return scipy.ndimage.shift(im, shift, cval=fill_value, order=order)
 
 
 def triu_indices_minus_diag(n):
@@ -87,8 +87,8 @@ def hanning2d(M, N):
 
 
 def sobel_filter(im):
-    sx = ndimage.sobel(im, axis=0, mode="constant")
-    sy = ndimage.sobel(im, axis=1, mode="constant")
+    sx = scipy.ndimage.sobel(im, axis=0, mode="constant")
+    sy = scipy.ndimage.sobel(im, axis=1, mode="constant")
     sob = np.hypot(sx, sy)
     return sob
 
@@ -234,7 +234,7 @@ def estimate_image_shift(
             # which was the previous implementation.
             # The size is fixed at 3 to be consistent
             # with the previous implementation.
-            im[:] = ndimage.median_filter(im, size=3)
+            im[:] = scipy.ndimage.median_filter(im, size=3)
         if sobel is True:
             im[:] = sobel_filter(im)
 

--- a/hyperspy/api.py
+++ b/hyperspy/api.py
@@ -27,7 +27,6 @@ from hyperspy.logger import set_log_level
 _logger = logging.getLogger(__name__)
 set_log_level(preferences.General.logging_level)
 
-from hyperspy import __version__  # noqa: E402
 from hyperspy.docstrings import START_HSPY as _START_HSPY_DOCSTRING  # noqa: E402
 
 __doc__ = (
@@ -132,6 +131,7 @@ _import_mapping = {
     "samfire": ".utils",
     "stack": ".utils",
     "transpose": ".utils",
+    "__version__": "",
 }
 
 

--- a/hyperspy/axes.py
+++ b/hyperspy/axes.py
@@ -26,8 +26,8 @@ from contextlib import contextmanager
 
 import numpy as np
 import pint
+import sympy
 import traits.api as t
-from sympy.utilities.lambdify import lambdify
 from traits.trait_errors import TraitError
 
 from hyperspy._components.expression import _parse_substitutions
@@ -1064,7 +1064,7 @@ class FunctionalDataAxis(BaseDataAxis):
                 "The values of the following expression parameters "
                 f"must be given as keywords: {set(expr_parameters) - set(parameters)}"
             )
-        self._function = lambdify(
+        self._function = sympy.utilities.lambdify(
             variables + expr_parameters, expr.evalf(), dummify=False
         )
         for parameter in parameters.keys():

--- a/hyperspy/axes.py
+++ b/hyperspy/axes.py
@@ -24,7 +24,6 @@ import warnings
 from collections.abc import Iterable
 from contextlib import contextmanager
 
-import dask.array as da
 import numpy as np
 import pint
 import traits.api as t
@@ -43,7 +42,7 @@ from hyperspy.misc.array_tools import (
     round_half_towards_zero,
 )
 from hyperspy.misc.math_tools import isfloat
-from hyperspy.misc.utils import TupleSA, isiterable, ordinal
+from hyperspy.misc.utils import TupleSA, is_dask_array, isiterable, ordinal
 from hyperspy.ui_registry import add_gui_method, get_gui
 
 _logger = logging.getLogger(__name__)
@@ -569,7 +568,7 @@ class BaseDataAxis(t.HasTraits):
         return the same value."""
         if isinstance(value, str):
             value = self._parse_value_from_string(value)
-        elif isinstance(value, (list, tuple, np.ndarray, da.Array)):
+        elif isinstance(value, (list, tuple, np.ndarray)) or is_dask_array(value):
             value = np.asarray(value)
             if value.dtype.type is np.str_:
                 value = np.array([self._parse_value_from_string(v) for v in value])
@@ -643,7 +642,7 @@ class BaseDataAxis(t.HasTraits):
             )
 
     def index2value(self, index):
-        if isinstance(index, da.Array):
+        if is_dask_array(index):
             index = index.compute()
         if isinstance(index, np.ndarray):
             return self.axis[index.ravel()].reshape(index.shape)

--- a/hyperspy/component.py
+++ b/hyperspy/component.py
@@ -32,7 +32,12 @@ from hyperspy.misc.export_dictionary import (
     load_from_dictionary,
 )
 from hyperspy.misc.model_tools import CurrentComponentValues
-from hyperspy.misc.utils import display, get_object_package_info, slugify
+from hyperspy.misc.utils import (
+    display,
+    get_object_package_info,
+    is_dask_array,
+    slugify,
+)
 from hyperspy.ui_registry import add_gui_method
 
 _logger = logging.getLogger(__name__)
@@ -532,9 +537,9 @@ class Parameter(t.HasTraits):
         if self.map["is_set"][indices]:
             value = self.map["values"][indices]
             std = self.map["std"][indices]
-            if hasattr(value, "compute"):
+            if is_dask_array(value):
                 value = value.compute()
-            if hasattr(std, "compute"):
+            if is_dask_array(std):
                 std = std.compute()
             self.value = value
             self.std = std

--- a/hyperspy/component.py
+++ b/hyperspy/component.py
@@ -23,7 +23,7 @@ import numpy as np
 import sympy
 import traits.api as t
 from dask.array import Array as dArray
-from rsciio.utils.tools import append2pathname, incremental_filename
+from rsciio.utils.path import append2pathname, incremental_filename
 from sympy.utilities.lambdify import lambdify
 from traits.trait_numeric import Array
 

--- a/hyperspy/component.py
+++ b/hyperspy/component.py
@@ -22,7 +22,6 @@ from pathlib import Path
 import numpy as np
 import sympy
 import traits.api as t
-from dask.array import Array as dArray
 from rsciio.utils.path import append2pathname, incremental_filename
 from sympy.utilities.lambdify import lambdify
 from traits.trait_numeric import Array
@@ -533,9 +532,9 @@ class Parameter(t.HasTraits):
         if self.map["is_set"][indices]:
             value = self.map["values"][indices]
             std = self.map["std"][indices]
-            if isinstance(value, dArray):
+            if hasattr(value, "compute"):
                 value = value.compute()
-            if isinstance(std, dArray):
+            if hasattr(std, "compute"):
                 std = std.compute()
             self.value = value
             self.std = std

--- a/hyperspy/data/artificial_data.py
+++ b/hyperspy/data/artificial_data.py
@@ -23,6 +23,7 @@ For use in things like docstrings or to test HyperSpy functionalities.
 """
 
 import numpy as np
+import scipy
 
 from hyperspy import components1d, components2d, signals
 from hyperspy.axes import UniformDataAxis
@@ -130,9 +131,7 @@ def atomic_resolution_image(
     s = signals.Signal2D(array)
 
     if rotation_angle != 0:
-        from scipy.ndimage import rotate
-
-        s.map(rotate, angle=rotation_angle, reshape=False)
+        s.map(scipy.ndimage.rotate, angle=rotation_angle, reshape=False)
 
         w, h = s.axes_manager.signal_axes[0].size, s.axes_manager.signal_axes[1].size
         wr, hr = _get_largest_rectangle_from_rotation(w, h, rotation_angle)

--- a/hyperspy/drawing/image.py
+++ b/hyperspy/drawing/image.py
@@ -25,7 +25,7 @@ import matplotlib.pyplot as plt
 import numpy as np
 from matplotlib.colors import LogNorm, Normalize, PowerNorm, SymLogNorm
 from matplotlib.figure import SubFigure
-from rsciio.utils import rgb_tools
+from rsciio.utils import rgb
 from traits.api import Undefined
 
 from hyperspy.docstrings.plot import PLOT2D_DOCSTRING
@@ -433,9 +433,9 @@ class ImagePlot(BlittedFigure):
             _logger.debug("Updating image slowly because `data_changed=True`")
             self._update_data()
         data = self._current_data
-        if rgb_tools.is_rgbx(data):
+        if rgb.is_rgbx(data):
             self.colorbar = False
-            data = rgb_tools.rgbx2regular_array(data, plot_friendly=True)
+            data = rgb.rgbx2regular_array(data, plot_friendly=True)
             data = self._current_data = data
             self._is_rgb = True
 

--- a/hyperspy/drawing/markers.py
+++ b/hyperspy/drawing/markers.py
@@ -494,6 +494,7 @@ class Markers:
         Get the kwargs at some index.  If the index is cached return the cached value
         otherwise compute the kwargs and cache them.
         """
+
         chunks = {key: value.chunks for key, value in self.dask_kwargs.items()}
         chunk_slices = {
             key: _get_navigation_dimension_chunk_slice(indices, chunk)

--- a/hyperspy/drawing/markers.py
+++ b/hyperspy/drawing/markers.py
@@ -19,7 +19,6 @@
 import logging
 from copy import deepcopy
 
-import dask.array as da
 import matplotlib.collections as mpl_collections
 import numpy as np
 from matplotlib.patches import Patch
@@ -27,7 +26,7 @@ from matplotlib.transforms import IdentityTransform
 
 from hyperspy.events import Event, Events
 from hyperspy.misc.dask_utils import _get_navigation_dimension_chunk_slice
-from hyperspy.misc.utils import isiterable
+from hyperspy.misc.utils import is_dask_array, isiterable
 
 _logger = logging.getLogger(__name__)
 
@@ -201,9 +200,9 @@ class Markers:
                 self._iterable_argument_keys.append(key)
 
             # Handling dask arrays
-            if isinstance(value, da.Array) and value.dtype == object:
+            if is_dask_array(value) and value.dtype == object:
                 self.dask_kwargs[key] = self.kwargs[key]
-            elif isinstance(value, da.Array):  # and value.dtype != object:
+            elif is_dask_array(value):  # and value.dtype != object:
                 self.kwargs[key] = value.compute()
             # Patches or verts shouldn't be cast to array
             elif (
@@ -842,7 +841,7 @@ class Markers:
 
 
 def is_iterating(arg):
-    return isinstance(arg, (np.ndarray, da.Array)) and arg.dtype == object
+    return (isinstance(arg, np.ndarray) or is_dask_array(arg)) and arg.dtype == object
 
 
 def dict2vector(data, keys, return_size=True, dtype=float):

--- a/hyperspy/drawing/markers.py
+++ b/hyperspy/drawing/markers.py
@@ -26,7 +26,7 @@ from matplotlib.patches import Patch
 from matplotlib.transforms import IdentityTransform
 
 from hyperspy.events import Event, Events
-from hyperspy.misc.array_tools import _get_navigation_dimension_chunk_slice
+from hyperspy.misc.dask_utils import _get_navigation_dimension_chunk_slice
 from hyperspy.misc.utils import isiterable
 
 _logger = logging.getLogger(__name__)

--- a/hyperspy/drawing/utils.py
+++ b/hyperspy/drawing/utils.py
@@ -34,7 +34,7 @@ import traits.api as t
 from matplotlib.backend_bases import key_press_handler
 from mpl_toolkits.axes_grid1 import make_axes_locatable
 from packaging.version import Version
-from rsciio.utils import rgb_tools
+from rsciio.utils import rgb
 
 import hyperspy
 import hyperspy.api as hs
@@ -980,7 +980,7 @@ def plot_images(
     # Check to see if there are any rgb images in list
     # and tag them using the isrgb list
     for i, img in enumerate(images):
-        if rgb_tools.is_rgbx(img.data):
+        if rgb.is_rgbx(img.data):
             isrgb[i] = True
 
     # Determine how many non-rgb images there are
@@ -1171,8 +1171,8 @@ def plot_images(
                 data = _parse_array(im)
 
                 # Enable RGB plotting
-                if rgb_tools.is_rgbx(data):
-                    data = rgb_tools.rgbx2regular_array(data, plot_friendly=True)
+                if rgb.is_rgbx(data):
+                    data = rgb.rgbx2regular_array(data, plot_friendly=True)
                     _vmin, _vmax = None, None
                 elif colorbar != "single":
                     _vmin, _vmax = _parse_vmin_vmax(data, vmin, vmax, idx, centre)

--- a/hyperspy/drawing/utils.py
+++ b/hyperspy/drawing/utils.py
@@ -24,7 +24,6 @@ import textwrap
 import warnings
 from functools import partial
 
-import dask.array as da
 import matplotlib as mpl
 import matplotlib.colors as mcolors
 import matplotlib.patches as patches
@@ -40,7 +39,7 @@ import hyperspy
 import hyperspy.api as hs
 from hyperspy.defaults_parser import preferences
 from hyperspy.docstrings.signal import HISTOGRAM_BIN_ARGS, HISTOGRAM_RANGE_ARGS
-from hyperspy.misc.utils import isiterable, to_numpy
+from hyperspy.misc.utils import is_dask_array, isiterable, to_numpy
 
 _logger = logging.getLogger(__name__)
 
@@ -512,7 +511,7 @@ def _transpose_if_required(signal, expected_dimension):
 def _parse_array(signal, normalise=False):
     """Convenience function to parse array from a signal."""
     data = signal.data
-    if isinstance(data, da.Array):
+    if is_dask_array(data):
         data = data.compute()
     if normalise:
         data = (data - data.min()) / (data.max() - data.min())

--- a/hyperspy/external/astropy/histogram.py
+++ b/hyperspy/external/astropy/histogram.py
@@ -8,8 +8,7 @@ Tools for working with distributions
 import logging
 
 import numpy as np
-from scipy.optimize import fmin
-from scipy.special import gammaln
+import scipy
 
 from hyperspy.docstrings.signal import HISTOGRAM_MAX_BIN_ARGS
 
@@ -81,7 +80,7 @@ def knuth_bin_width(data, return_bins=False, quiet=True, max_num_bins=250):
         )
         bins0 = np.histogram_bin_edges(data, bins=max_num_bins)
 
-    M = fmin(knuthF, len(bins0), disp=not quiet)[0]
+    M = scipy.optimize.fmin(knuthF, len(bins0), disp=not quiet)[0]
     bins = knuthF.bins(M)
     dx = bins[1] - bins[0]
 
@@ -124,13 +123,8 @@ class _KnuthF:
         self.data.sort()
         self.n = self.data.size
 
-        # import here rather than globally: scipy is an optional dependency.
-        # Note that scipy is imported in the function which calls this,
-        # so there shouldn't be any issue importing here.
-        from scipy import special
-
         # create a reference to gammaln to use in self.eval()
-        self.gammaln = special.gammaln
+        self.gammaln = scipy.special.gammaln
 
     def bins(self, M):
         """Return the bin edges given a width dx"""
@@ -154,6 +148,8 @@ class _KnuthF:
             smaller values indicate a better fit.
 
         """
+        from scipy.special import gammaln
+
         if not np.isscalar(M):
             M = M[0]
         M = int(M)

--- a/hyperspy/external/progressbar.py
+++ b/hyperspy/external/progressbar.py
@@ -16,8 +16,6 @@
 # You should have received a copy of the GNU General Public License
 # along with HyperSpy. If not, see <https://www.gnu.org/licenses/#GPL>.
 
-from packaging.version import Version
-
 import tqdm
 
 from hyperspy.defaults_parser import preferences

--- a/hyperspy/external/progressbar.py
+++ b/hyperspy/external/progressbar.py
@@ -17,14 +17,8 @@
 # along with HyperSpy. If not, see <https://www.gnu.org/licenses/#GPL>.
 
 from packaging.version import Version
-from tqdm import __version__ as tqdm_version
 
-if Version(tqdm_version) >= Version("4.36.0"):
-    # API change for 5.0 https://github.com/tqdm/tqdm/pull/800
-    from tqdm import tqdm
-    from tqdm.notebook import tqdm as tqdm_notebook
-else:
-    from tqdm import tqdm, tqdm_notebook
+import tqdm
 
 from hyperspy.defaults_parser import preferences
 
@@ -39,8 +33,9 @@ def progressbar(*args, **kwargs):
     """
     if preferences.General.nb_progressbar:
         try:
-            return tqdm_notebook(*args, **kwargs)
+            return tqdm.notebook(*args, **kwargs)
         except:
             pass
-    return tqdm(*args, **kwargs)
+    return tqdm.tqdm(*args, **kwargs)
+
 progressbar.__doc__ %= (tqdm.__doc__, tqdm.__init__.__doc__)

--- a/hyperspy/io.py
+++ b/hyperspy/io.py
@@ -29,8 +29,8 @@ from pathlib import Path
 import numpy as np
 from natsort import natsorted
 from rsciio import IO_PLUGINS
-from rsciio.utils.tools import ensure_directory
-from rsciio.utils.tools import overwrite as overwrite_method
+from rsciio.utils.path import ensure_directory
+from rsciio.utils.path import overwrite as overwrite_method
 
 from hyperspy.api import __version__ as hs_version
 from hyperspy.docstrings.signal import SHOW_PROGRESSBAR_ARG

--- a/hyperspy/io.py
+++ b/hyperspy/io.py
@@ -32,7 +32,7 @@ from rsciio import IO_PLUGINS
 from rsciio.utils.path import ensure_directory
 from rsciio.utils.path import overwrite as overwrite_method
 
-from hyperspy.api import __version__ as hs_version
+import hyperspy
 from hyperspy.docstrings.signal import SHOW_PROGRESSBAR_ARG
 from hyperspy.docstrings.utils import STACK_METADATA_ARG
 from hyperspy.drawing.markers import markers_dict_to_markers
@@ -993,7 +993,7 @@ def _add_file_load_save_metadata(operation, signal, io_plugin):
         "io_plugin": io_plugin["api"]
         if isinstance(io_plugin, dict)
         else io_plugin.__loader__.name,
-        "hyperspy_version": hs_version,
+        "hyperspy_version": hyperspy.__version__,
         "timestamp": datetime.now().astimezone().isoformat(),
     }
     # get the largest integer key present under General.FileIO, returning 0

--- a/hyperspy/learn/mva.py
+++ b/hyperspy/learn/mva.py
@@ -16,7 +16,7 @@
 # You should have received a copy of the GNU General Public License
 # along with HyperSpy. If not, see <https://www.gnu.org/licenses/#GPL>.
 
-
+import importlib
 import logging
 import types
 import warnings
@@ -54,27 +54,53 @@ except ImportError:
 _logger = logging.getLogger(__name__)
 
 
-if import_sklearn.sklearn_installed:
-    decomposition_algorithms = {
-        "sklearn_pca": import_sklearn.sklearn.decomposition.PCA,
-        "NMF": import_sklearn.sklearn.decomposition.NMF,
-        "sparse_pca": import_sklearn.sklearn.decomposition.SparsePCA,
-        "mini_batch_sparse_pca": import_sklearn.sklearn.decomposition.MiniBatchSparsePCA,
-        "sklearn_fastica": import_sklearn.sklearn.decomposition.FastICA,
-    }
-    cluster_algorithms = {
-        None: import_sklearn.sklearn.cluster.KMeans,
-        "kmeans": import_sklearn.sklearn.cluster.KMeans,
-        "agglomerative": import_sklearn.sklearn.cluster.AgglomerativeClustering,
-        "minibatchkmeans": import_sklearn.sklearn.cluster.MiniBatchKMeans,
-        "spectralclustering": import_sklearn.sklearn.cluster.SpectralClustering,
-    }
-    cluster_preprocessing_algorithms = {
-        None: None,
-        "norm": import_sklearn.sklearn.preprocessing.Normalizer,
-        "standard": import_sklearn.sklearn.preprocessing.StandardScaler,
-        "minmax": import_sklearn.sklearn.preprocessing.MinMaxScaler,
-    }
+decomposition_algorithms = {
+    "sklearn_pca": "PCA",
+    "NMF": "NMF",
+    "sparse_pca": "SparsePCA",
+    "mini_batch_sparse_pca": "MiniBatchSparsePCA",
+    "sklearn_fastica": "FastICA",
+}
+
+
+cluster_algorithms = {
+    None: "KMeans",
+    "kmeans": "KMeans",
+    "agglomerative": "AgglomerativeClustering",
+    "minibatchkmeans": "MiniBatchKMeans",
+    "spectralclustering": "SpectralClustering",
+}
+
+
+preprocessing_algorithms = {
+    None: None,
+    "norm": "Normalizer",
+    "standard": "StandardScaler",
+    "minmax": "MinMaxScaler",
+}
+
+
+def _get_sklearn_algorithms(algorithm):
+    """Get the sklearn algorithms available for decomposition."""
+
+    module = importlib.import_module("sklearn.decomposition")
+    return getattr(module, decomposition_algorithms[algorithm])
+
+
+def _get_sklearn_clustering_algorithms(algorithm):
+    """Get the sklearn algorithms available for preprocessing."""
+
+    module = importlib.import_module("sklearn.cluster")
+    return getattr(module, cluster_algorithms[algorithm])
+
+
+def _get_sklearn_preprocessing_algorithms(algorithm):
+    """Get the sklearn algorithms available for preprocessing."""
+
+    module = importlib.import_module("sklearn.preprocessing")
+    return getattr(module, preprocessing_algorithms[algorithm])
+
+    return
 
 
 def _get_derivative(signal, diff_axes, diff_order):
@@ -292,7 +318,7 @@ class MVA:
 
             # Initialize the sklearn estimator
             is_sklearn_like = True
-            estim = decomposition_algorithms[algorithm](
+            estim = _get_sklearn_algorithms(algorithm)(
                 n_components=output_dimension, **kwargs
             )
 
@@ -847,7 +873,7 @@ class MVA:
 
             # Initialize the sklearn estimator
             is_sklearn_like = True
-            estim = decomposition_algorithms[algorithm](**kwargs)
+            estim = _get_sklearn_algorithms(algorithm)(**kwargs)
 
             # Check whiten argument
             if estim.whiten and whiten_method is not None:
@@ -2201,9 +2227,11 @@ class MVA:
             if algorithm in algorithms_sklearn:
                 if not import_sklearn.sklearn_installed:
                     raise ImportError(f"algorithm='{algorithm}' requires scikit-learn")
-                cluster_algorithm = cluster_algorithms[algorithm](**kwargs)
+                cluster_algorithm = _get_sklearn_clustering_algorithms(algorithm)(
+                    **kwargs
+                )
         elif algorithm is None:
-            cluster_algorithm = cluster_algorithms[None](**kwargs)
+            cluster_algorithm = _get_sklearn_clustering_algorithms(None)(**kwargs)
         elif hasattr(algorithm, "fit"):
             cluster_algorithm = algorithm
         else:
@@ -2218,12 +2246,12 @@ class MVA:
         """Convenience method to lookup method if algorithm is a string
         or if it's an object check that the object has a fit_transform method
         """
-        preprocessing_methods = list(cluster_preprocessing_algorithms.keys())
+        preprocessing_methods = list(preprocessing_algorithms.keys())
         if algorithm in preprocessing_methods:
             if algorithm is not None:
                 if not import_sklearn.sklearn_installed:
                     raise ImportError(f"algorithm='{algorithm}' requires scikit-learn")
-                process_algorithm = cluster_preprocessing_algorithms[algorithm](
+                process_algorithm = _get_sklearn_preprocessing_algorithms(algorithm)(
                     **kwargs
                 )
             else:
@@ -2395,7 +2423,7 @@ class MVA:
                 "Estimate number of clusters only works with "
                 "supported clustering algorithms"
             )
-        if preprocessing not in cluster_preprocessing_algorithms:
+        if preprocessing not in preprocessing_algorithms:
             raise ValueError(
                 "Estimate number of clusters only works with "
                 "supported preprocessing algorithms"

--- a/hyperspy/learn/mva.py
+++ b/hyperspy/learn/mva.py
@@ -21,7 +21,6 @@ import logging
 import types
 import warnings
 
-import dask.array as da
 import matplotlib.pyplot as plt
 import numpy as np
 import rsciio.utils.tools as io_tools
@@ -1284,9 +1283,11 @@ class MVA:
         """
         lr = self.learning_results
         if self._lazy:
+            import dask.array as da
+
             if isinstance(lr.bss_factors, np.ndarray):
                 lr.factors = da.from_array(lr.bss_factors, chunks=chunks)
-            if isinstance(lr.bss_factors, np.ndarray):
+            if isinstance(lr.bss_loadings, np.ndarray):
                 lr.loadings = da.from_array(lr.bss_loadings, chunks=chunks)
         rec = self._calculate_recmatrix(components=components, mva_type="bss")
         return rec

--- a/hyperspy/learn/ornmf.py
+++ b/hyperspy/learn/ornmf.py
@@ -20,7 +20,7 @@ import logging
 from itertools import chain
 
 import numpy as np
-from scipy.stats import halfnorm
+import scipy
 
 from hyperspy.external.progressbar import progressbar
 from hyperspy.misc.math_tools import check_random_state
@@ -209,7 +209,7 @@ class ORNMF:
         self.n_features = m
         self.iterating = iterating
 
-        self.W = halfnorm.rvs(
+        self.W = scipy.stats.halfnorm.rvs(
             size=(self.n_features, self.rank), random_state=self.random_state
         )
         self.W = abs(avg * self.W / np.sqrt(self.rank))

--- a/hyperspy/learn/svd_pca.py
+++ b/hyperspy/learn/svd_pca.py
@@ -142,7 +142,7 @@ def svd_solve(
             raise ImportError(
                 "svd_solver='randomized' requires scikit-learn to be installed"
             )
-        U, S, V = import_sklearn.randomized_svd(
+        U, S, V = import_sklearn.sklearn.utils.extmath.randomized_svd(
             data, n_components=output_dimension, **kwargs
         )
     elif svd_solver == "arpack":

--- a/hyperspy/learn/svd_pca.py
+++ b/hyperspy/learn/svd_pca.py
@@ -21,10 +21,7 @@ import logging
 import numpy as np
 from numpy.linalg import svd
 
-from hyperspy.misc.machine_learning.import_sklearn import (
-    randomized_svd,
-    sklearn_installed,
-)
+from hyperspy.misc.machine_learning import import_sklearn
 from hyperspy.misc.utils import is_cupy_array
 
 _logger = logging.getLogger(__name__)
@@ -134,18 +131,20 @@ def svd_solve(
         elif (
             output_dimension >= 1
             and output_dimension < 0.8 * min(m, n)
-            and sklearn_installed
+            and import_sklearn.sklearn_installed
         ):
             svd_solver = "randomized"
         else:
             svd_solver = "full"
 
     if svd_solver == "randomized":
-        if not sklearn_installed:  # pragma: no cover
+        if not import_sklearn.sklearn_installed:  # pragma: no cover
             raise ImportError(
                 "svd_solver='randomized' requires scikit-learn to be installed"
             )
-        U, S, V = randomized_svd(data, n_components=output_dimension, **kwargs)
+        U, S, V = import_sklearn.randomized_svd(
+            data, n_components=output_dimension, **kwargs
+        )
     elif svd_solver == "arpack":
         if output_dimension >= min(m, n):
             raise ValueError(

--- a/hyperspy/misc/array_tools.py
+++ b/hyperspy/misc/array_tools.py
@@ -19,7 +19,6 @@
 import logging
 import math
 
-import dask.array as da
 import numpy as np
 
 from hyperspy.decorators import jit_ifnumba
@@ -179,6 +178,8 @@ def rebin(a, new_shape=None, scale=None, crop=True, dtype=None):
             )
         else:
             try:
+                import dask.array as da
+
                 return da.coarsen(
                     np.sum, a, {i: int(f) for i, f in enumerate(scale)}, dtype=dtype
                 )
@@ -373,105 +374,6 @@ def _numba_histogram(data, bins, ranges):
     return hist
 
 
-def get_signal_chunk_slice(index, chunks):
-    """
-    Convenience function returning the chunk slice in signal space containing
-    the specified index.
-
-    Parameters
-    ----------
-    index : int or tuple of int
-        Index determining the wanted chunk.
-    chunks : tuple
-        Dask array chunks.
-
-    Returns
-    -------
-    slice
-        Slice containing the index x,y.
-
-    """
-    if not isinstance(index, (list, tuple)):
-        index = tuple(index)
-
-    chunk_slice_raw_list = da.core.slices_from_chunks(chunks[-len(index) :])
-    chunk_slice_list = []
-    for chunk_slice_raw in chunk_slice_raw_list:
-        chunk_slice_list.append(list(chunk_slice_raw)[::-1])
-
-    for chunk_slice in chunk_slice_list:
-        _slice = chunk_slice
-        if _slice[0].start <= index[0] < _slice[0].stop:
-            if len(_slice) == 1:
-                return chunk_slice
-            elif _slice[1].start <= index[1] < _slice[1].stop:
-                return chunk_slice
-    raise ValueError("Index out of signal range.")
-
-
-def get_chunk_slice(
-    shape,
-    signal_dimension,
-    chunks="auto",
-    block_size_limit=None,
-    dtype=None,
-):
-    """
-    Takes a shape and chunks and returns an array of the slices to be used with
-    :func:`dask.array.map_blocks`.
-
-    Parameters
-    ----------
-    shape : tuple
-        Shape of the data.
-    signal_dimension : int
-        The signal dimension of the signal.
-    chunks : "auto", "dask_auto" or tuple
-        If ``"auto"``, no chunking is created in the signal dimension. If ``"dask_auto"``, the
-        dask "auto" chunking is used - see :func:`dask.array.core.normalize_chunks` for more
-        information. The default is "auto".
-    block_size_limit : int, optional
-        Maximum size of a block in bytes. The default is None. This is passed
-        to the :func:`dask.array.core.normalize_chunks` function when chunks == "auto".
-    dtype : numpy.dtype, optional
-        Data type. The default is None. This is passed to the
-        :func:`dask.array.core.normalize_chunks` function when chunks == "auto".
-
-    Returns
-    -------
-    numpy.ndarray of slices
-        Dask array of the slices.
-    tuple
-        Tuple of the chunks.
-
-    Note
-    ----
-    Adapted from https://github.com/hyperspy/rosettasciio/blob/main/rsciio/utils/distributed.py
-    """
-    if chunks == "auto":
-        # no chunking along signal_dimension
-        chunks = ("auto",) * len(shape[:-signal_dimension]) + (-1,)
-    elif chunks == "dask_auto":
-        # Use dask auto
-        chunks = "auto"
-
-    chunks = da.core.normalize_chunks(
-        chunks=chunks, shape=shape, limit=block_size_limit, dtype=dtype
-    )
-    chunks_shape = tuple([len(c) for c in chunks])
-    slices = np.empty(
-        shape=chunks_shape + (len(chunks_shape), 2),
-        dtype=int,
-    )
-    for ind in np.ndindex(chunks_shape):
-        current_chunk = [chunk[i] for i, chunk in zip(ind, chunks)]
-        starts = [int(np.sum(chunk[:i])) for i, chunk in zip(ind, chunks)]
-        stops = [s + c for s, c in zip(starts, current_chunk)]
-        slices[ind] = [[start, stop] for start, stop in zip(starts, stops)]
-
-    return slices, chunks
-
-
 @jit_ifnumba(cache=True)
 def numba_closest_index_round(axis_array, value_array):
     """For each value in value_array, find the closest value in axis_array and
@@ -654,64 +556,3 @@ def round_half_away_from_zero(array, decimals=0):  # pragma: no cover
         np.floor(array * multiplier + 0.5) / multiplier,
         np.ceil(array * multiplier - 0.5) / multiplier,
     )
-
-
-def _get_navigation_dimension_chunk_slice(navigation_indices, chunks):
-    """Get the slice necessary to get the dask data chunk containing the
-    navigation indices.
-
-    Parameters
-    ----------
-    navigation_indices : iterable
-    chunks : iterable
-
-    Returns
-    -------
-    chunk_slice : list of slices
-
-    Examples
-    --------
-    Making all the variables
-
-
-    >>> from hyperspy._signals.lazy import _get_navigation_dimension_chunk_slice
-    >>> data = da.random.random((128, 128, 256, 256), chunks=(32, 32, 32, 32))
-    >>> s = hs.signals.Signal2D(data).as_lazy()
-
-    >>> sig_dim = s.axes_manager.signal_dimension
-    >>> nav_chunks = s.data.chunks[:-sig_dim]
-    >>> navigation_indices = s.axes_manager._getitem_tuple[:-sig_dim]
-
-    The navigation index here is (0, 0), giving us the slice which contains
-    this index.
-
-    >>> chunk_slice = _get_navigation_dimension_chunk_slice(navigation_indices, nav_chunks)
-    >>> print(chunk_slice)
-    (slice(0, 32, None), slice(0, 32, None))
-    >>> data_chunk = data[chunk_slice]
-
-    Moving the navigator to a new position, by directly setting the indices.
-    Normally, this is done by moving the navigator while plotting the data.
-    Note the "inversion" of the axes here: the indices is given in (x, y),
-    while the chunk_slice is given in (y, x).
-
-    >>> s.axes_manager.indices = (127, 70)
-    >>> navigation_indices = s.axes_manager._getitem_tuple[:-sig_dim]
-    >>> chunk_slice = _get_navigation_dimension_chunk_slice(navigation_indices, nav_chunks)
-    >>> print(chunk_slice)
-    (slice(64, 96, None), slice(96, 128, None))
-    >>> data_chunk = data[chunk_slice]
-
-    """
-    chunk_slice_list = da.core.slices_from_chunks(chunks)
-    for chunk_slice in chunk_slice_list:
-        is_slice = True
-        for index_nav in range(len(navigation_indices)):
-            temp_slice = chunk_slice[index_nav]
-            nav = navigation_indices[index_nav]
-            if not (temp_slice.start <= nav < temp_slice.stop):
-                is_slice = False
-                break
-        if is_slice:
-            return chunk_slice
-    return False

--- a/hyperspy/misc/axis_tools.py
+++ b/hyperspy/misc/axis_tools.py
@@ -18,8 +18,6 @@
 
 import numpy as np
 
-from hyperspy.api import _ureg
-
 
 def check_axes_calibration(ax1, ax2, rtol=1e-7):
     """Check if the calibration of two Axis objects matches.
@@ -42,6 +40,8 @@ def check_axes_calibration(ax1, ax2, rtol=1e-7):
         If the two axes have identical calibrations.
 
     """
+    from hyperspy.api import _ureg
+
     if ax1.size == ax2.size:
         try:
             unit1 = _ureg.Unit(ax1.units)

--- a/hyperspy/misc/dask_utils.py
+++ b/hyperspy/misc/dask_utils.py
@@ -44,10 +44,10 @@ def process_function_blockwise(
     data : np.ndarray
         The data for one chunk
     *args : tuple
-        Any signal the is iterated alongside the data in. In the form
+        Any signal that is iterated alongside the input data. In the form
         ((key1, value1), (key2, value2))
     function : function
-        The function to applied to the signal axis
+        The function to be applied to the signal axis
     nav_indexes : tuple
         The indexes of the navigation axes for the dataset.
     output_signal_size: tuple
@@ -95,7 +95,7 @@ def process_function_blockwise(
 
 def _get_block_pattern(args, output_shape):
     """Returns the block pattern used by the `blockwise` function for a
-    set of arguments give a resulting output_shape
+    set of arguments given a resulting output_shape
 
     Parameters
     ----------

--- a/hyperspy/misc/dask_utils.py
+++ b/hyperspy/misc/dask_utils.py
@@ -160,7 +160,25 @@ def guess_output_signal_size(test_data, function, ragged, **kwargs):
     return output_signal_size, output_dtype
 
 
-def _compute(array, store_to=None, show_progressbar=None, **kwargs):
+def _compute(arrays, store_to=None, show_progressbar=None, **kwargs):
+    """Compute a dask array with optional progressbar and storing to disk.
+
+    Parameters
+    ----------
+    arrays : dask.array or list of dask.array
+        The dask array(s) to compute.
+    store_to : str or list of str or None
+        If not None, the location to store the dask array to disk.
+    show_progressbar : bool or None
+        Whether to show a progressbar during computation. If None, the value
+        from preferences.General.show_progressbar is used.
+    **kwargs : dict
+        Additional keyword arguments passed to dask.array.compute or
+
+    Returns
+    -------
+    computed_array : numpy.ndarray or list of numpy.ndarray
+    """
     if show_progressbar is None:
         show_progressbar = preferences.General.show_progressbar
     # this isn't compatible with distributed scheduler
@@ -169,11 +187,9 @@ def _compute(array, store_to=None, show_progressbar=None, **kwargs):
 
     with cm():
         if store_to is not None:
-            da.store(
-                array, store_to, dtype=array.dtype, compute=True, lock=False, **kwargs
-            )
+            da.store(arrays, store_to, compute=True, lock=False, **kwargs)
         else:
-            return array.compute(**kwargs)
+            return da.compute(arrays, **kwargs)[0]
 
 
 def _get_navigation_dimension_chunk_slice(navigation_indices, chunks):

--- a/hyperspy/misc/dask_utils.py
+++ b/hyperspy/misc/dask_utils.py
@@ -1,0 +1,337 @@
+# -*- coding: utf-8 -*-
+# Copyright 2007-2025 The HyperSpy developers
+#
+# This file is part of HyperSpy.
+#
+# HyperSpy is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# HyperSpy is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with HyperSpy. If not, see <https://www.gnu.org/licenses/#GPL>.
+
+import dask.array as da
+import numpy as np
+from tqdm.dask import TqdmCallback
+
+from hyperspy.defaults_parser import preferences
+from hyperspy.misc.utils import dummy_context_manager
+
+
+def process_function_blockwise(
+    data,
+    *args,
+    function,
+    nav_indexes=None,
+    output_signal_size=None,
+    output_dtype=None,
+    arg_keys=None,
+    **kwargs,
+):
+    """
+    Convenience function for processing a function blockwise. By design, its
+    output is used as an argument of the dask ``map_blocks`` so that the
+    function only gets applied to the signal axes.
+
+    Parameters
+    ----------
+    data : np.ndarray
+        The data for one chunk
+    *args : tuple
+        Any signal the is iterated alongside the data in. In the form
+        ((key1, value1), (key2, value2))
+    function : function
+        The function to applied to the signal axis
+    nav_indexes : tuple
+        The indexes of the navigation axes for the dataset.
+    output_signal_size: tuple
+        The shape of the output signal. For a ragged signal, this is equal to 1
+    output_dtype : dtype
+        The data type for the output.
+    arg_keys : tuple
+        The list of keys for the passed arguments (args).  Together this makes
+        a set of key:value pairs to be passed to the function.
+    **kwargs : dict
+        Any additional key value pairs to be used by the function
+        (Note that these are the constants that are applied.)
+
+    """
+    # Both of these values need to be passed in
+    dtype = output_dtype
+    chunk_nav_shape = tuple([data.shape[i] for i in sorted(nav_indexes)])
+    output_shape = chunk_nav_shape + tuple(output_signal_size)
+    # Pre-allocating the output array
+    output_array = np.empty(output_shape, dtype=dtype, like=data)
+    if len(args) == 0:
+        # There aren't any BaseSignals for iterating
+        for nav_index in np.ndindex(chunk_nav_shape):
+            islice = np.s_[nav_index]
+            output_array[islice] = function(data[islice], **kwargs)
+    else:
+        # There are BaseSignals which iterate alongside the data
+        for index in np.ndindex(chunk_nav_shape):
+            islice = np.s_[index]
+            iter_dict = {}
+            for key, a in zip(arg_keys, args):
+                arg_i = np.squeeze(a[islice])
+                # Some functions do not handle 0-dimension NumPy arrays
+                if hasattr(arg_i, "shape") and arg_i.shape == ():
+                    arg_i = arg_i[()]
+                iter_dict[key] = arg_i
+            output_array[islice] = function(data[islice], **iter_dict, **kwargs)
+    if not (chunk_nav_shape == output_array.shape):
+        try:
+            output_array = output_array.squeeze(-1)
+        except ValueError:
+            pass
+    return output_array
+
+
+def _get_block_pattern(args, output_shape):
+    """Returns the block pattern used by the `blockwise` function for a
+    set of arguments give a resulting output_shape
+
+    Parameters
+    ----------
+    args: list
+        A list of all the arguments which are used for `da.blockwise`
+    output_shape: tuple
+        The output shape for the function passed to `da.blockwise` given args
+    """
+    arg_patterns = tuple(tuple(range(a.ndim)) for a in args)
+    arg_shapes = tuple(a.shape for a in args)
+    output_pattern = tuple(range(len(output_shape)))
+    all_ind = arg_shapes + (output_shape,)
+    max_len = max((len(i) for i in all_ind))  # max number of dimensions
+    max_arg_len = max((len(i) for i in arg_shapes))
+    adjust_chunks = {}
+    new_axis = {}
+    output_shape = output_shape + (0,) * (max_len - len(output_shape))
+    for i in range(max_len):
+        shapes = np.array(
+            [s[i] if len(s) > i else -1 for s in (output_shape,) + arg_shapes]
+        )
+        is_equal_shape = shapes == shapes[0]  # if in shapes == output shapes
+        if not all(is_equal_shape):
+            if i > max_arg_len - 1:  # output shape is a new axis
+                new_axis[i] = output_shape[i]
+            else:  # output shape is an existing axis
+                adjust_chunks[i] = output_shape[i]  # adjusting chunks based on output
+    arg_pairs = [(a, p) for a, p in zip(args, arg_patterns)]
+    return arg_pairs, adjust_chunks, new_axis, output_pattern
+
+
+def guess_output_signal_size(test_data, function, ragged, **kwargs):
+    """This function is for guessing the output signal shape and size.
+    It will attempt to apply the function to some test data and then output
+    the resulting signal shape and datatype.
+
+    Parameters
+    ----------
+    test_data : NumPy array
+        Data from a test signal for the function to be applied to.
+        The data must be from a signal with 0 navigation dimensions.
+    function : function
+        The function to be applied to the data
+    ragged : bool
+        If the data is ragged then the output signal size is () and the
+        data type is 'object'
+    **kwargs : dict
+        Any other keyword arguments passed to the function.
+    """
+    if ragged:
+        output_dtype = object
+        output_signal_size = ()
+    else:
+        output = function(test_data, **kwargs)
+        try:
+            output_dtype = output.dtype
+            output_signal_size = output.shape
+        except AttributeError:
+            output = np.asarray(output)
+            output_dtype = output.dtype
+            output_signal_size = output.shape
+    return output_signal_size, output_dtype
+
+
+def _compute(array, store_to=None, show_progressbar=None, **kwargs):
+    if show_progressbar is None:
+        show_progressbar = preferences.General.show_progressbar
+    # this isn't compatible with distributed scheduler
+    # https://docs.dask.org/en/stable/diagnostics-distributed.html#progress-bar
+    cm = TqdmCallback if show_progressbar else dummy_context_manager
+
+    with cm():
+        if store_to is not None:
+            da.store(
+                array, store_to, dtype=array.dtype, compute=True, lock=False, **kwargs
+            )
+        else:
+            return array.compute(**kwargs)
+
+
+def _get_navigation_dimension_chunk_slice(navigation_indices, chunks):
+    """Get the slice necessary to get the dask data chunk containing the
+    navigation indices.
+
+    Parameters
+    ----------
+    navigation_indices : iterable
+    chunks : iterable
+
+    Returns
+    -------
+    chunk_slice : list of slices
+
+    Examples
+    --------
+    Making all the variables
+
+
+    >>> from hyperspy._signals.lazy import _get_navigation_dimension_chunk_slice
+    >>> data = da.random.random((128, 128, 256, 256), chunks=(32, 32, 32, 32))
+    >>> s = hs.signals.Signal2D(data).as_lazy()
+
+    >>> sig_dim = s.axes_manager.signal_dimension
+    >>> nav_chunks = s.data.chunks[:-sig_dim]
+    >>> navigation_indices = s.axes_manager._getitem_tuple[:-sig_dim]
+
+    The navigation index here is (0, 0), giving us the slice which contains
+    this index.
+
+    >>> chunk_slice = _get_navigation_dimension_chunk_slice(navigation_indices, nav_chunks)
+    >>> print(chunk_slice)
+    (slice(0, 32, None), slice(0, 32, None))
+    >>> data_chunk = data[chunk_slice]
+
+    Moving the navigator to a new position, by directly setting the indices.
+    Normally, this is done by moving the navigator while plotting the data.
+    Note the "inversion" of the axes here: the indices is given in (x, y),
+    while the chunk_slice is given in (y, x).
+
+    >>> s.axes_manager.indices = (127, 70)
+    >>> navigation_indices = s.axes_manager._getitem_tuple[:-sig_dim]
+    >>> chunk_slice = _get_navigation_dimension_chunk_slice(navigation_indices, nav_chunks)
+    >>> print(chunk_slice)
+    (slice(64, 96, None), slice(96, 128, None))
+    >>> data_chunk = data[chunk_slice]
+
+    """
+    chunk_slice_list = da.core.slices_from_chunks(chunks)
+    for chunk_slice in chunk_slice_list:
+        is_slice = True
+        for index_nav in range(len(navigation_indices)):
+            temp_slice = chunk_slice[index_nav]
+            nav = navigation_indices[index_nav]
+            if not (temp_slice.start <= nav < temp_slice.stop):
+                is_slice = False
+                break
+        if is_slice:
+            return chunk_slice
+
+    return False
+
+
+def get_signal_chunk_slice(index, chunks):
+    """
+    Convenience function returning the chunk slice in signal space containing
+    the specified index.
+
+    Parameters
+    ----------
+    index : int or tuple of int
+        Index determining the wanted chunk.
+    chunks : tuple
+        Dask array chunks.
+
+    Returns
+    -------
+    slice
+        Slice containing the index x,y.
+
+    """
+    if not isinstance(index, (list, tuple)):
+        index = tuple(index)
+
+    chunk_slice_raw_list = da.core.slices_from_chunks(chunks[-len(index) :])
+    chunk_slice_list = []
+    for chunk_slice_raw in chunk_slice_raw_list:
+        chunk_slice_list.append(list(chunk_slice_raw)[::-1])
+
+    for chunk_slice in chunk_slice_list:
+        _slice = chunk_slice
+        if _slice[0].start <= index[0] < _slice[0].stop:
+            if len(_slice) == 1:
+                return chunk_slice
+            elif _slice[1].start <= index[1] < _slice[1].stop:
+                return chunk_slice
+    raise ValueError("Index out of signal range.")
+
+
+def get_chunk_slice(
+    shape,
+    signal_dimension,
+    chunks="auto",
+    block_size_limit=None,
+    dtype=None,
+):
+    """
+    Takes a shape and chunks and returns an array of the slices to be used with
+    :func:`dask.array.map_blocks`.
+
+    Parameters
+    ----------
+    shape : tuple
+        Shape of the data.
+    signal_dimension : int
+        The signal dimension of the signal.
+    chunks : "auto", "dask_auto" or tuple
+        If ``"auto"``, no chunking is created in the signal dimension. If ``"dask_auto"``, the
+        dask "auto" chunking is used - see :func:`dask.array.core.normalize_chunks` for more
+        information. The default is "auto".
+    block_size_limit : int, optional
+        Maximum size of a block in bytes. The default is None. This is passed
+        to the :func:`dask.array.core.normalize_chunks` function when chunks == "auto".
+    dtype : numpy.dtype, optional
+        Data type. The default is None. This is passed to the
+        :func:`dask.array.core.normalize_chunks` function when chunks == "auto".
+
+    Returns
+    -------
+    numpy.ndarray of slices
+        Dask array of the slices.
+    tuple
+        Tuple of the chunks.
+
+    Note
+    ----
+    Adapted from https://github.com/hyperspy/rosettasciio/blob/main/rsciio/utils/distributed.py
+    """
+    if chunks == "auto":
+        # no chunking along signal_dimension
+        chunks = ("auto",) * len(shape[:-signal_dimension]) + (-1,)
+    elif chunks == "dask_auto":
+        # Use dask auto
+        chunks = "auto"
+
+    chunks = da.core.normalize_chunks(
+        chunks=chunks, shape=shape, limit=block_size_limit, dtype=dtype
+    )
+    chunks_shape = tuple([len(c) for c in chunks])
+    slices = np.empty(
+        shape=chunks_shape + (len(chunks_shape), 2),
+        dtype=int,
+    )
+    for ind in np.ndindex(chunks_shape):
+        current_chunk = [chunk[i] for i, chunk in zip(ind, chunks)]
+        starts = [int(np.sum(chunk[:i])) for i, chunk in zip(ind, chunks)]
+        stops = [s + c for s, c in zip(starts, current_chunk)]
+        slices[ind] = [[start, stop] for start, stop in zip(starts, stops)]
+
+    return slices, chunks

--- a/hyperspy/misc/export_dictionary.py
+++ b/hyperspy/misc/export_dictionary.py
@@ -20,7 +20,6 @@ from copy import deepcopy
 from operator import attrgetter
 
 import cloudpickle
-from dask.array import Array
 
 from hyperspy.misc.utils import attrsetter
 
@@ -206,6 +205,6 @@ def reconstruct_object(flags, value):
             return cloudpickle.loads(thing)
         # should not be reached
         raise ValueError("The object format is not recognized")
-    if isinstance(value, Array):
+    if hasattr(value, "compute"):
         value = value.compute()
     return value

--- a/hyperspy/misc/export_dictionary.py
+++ b/hyperspy/misc/export_dictionary.py
@@ -21,7 +21,7 @@ from operator import attrgetter
 
 import cloudpickle
 
-from hyperspy.misc.utils import attrsetter
+from hyperspy.misc.utils import attrsetter, is_dask_array
 
 
 def check_that_flags_make_sense(flags):
@@ -205,6 +205,6 @@ def reconstruct_object(flags, value):
             return cloudpickle.loads(thing)
         # should not be reached
         raise ValueError("The object format is not recognized")
-    if hasattr(value, "compute"):
+    if is_dask_array(value):
         value = value.compute()
     return value

--- a/hyperspy/misc/hist_tools.py
+++ b/hyperspy/misc/hist_tools.py
@@ -18,7 +18,6 @@
 
 import warnings
 
-import dask.array as da
 import numpy as np
 import traits.api as t
 
@@ -30,6 +29,7 @@ from hyperspy.docstrings.signal import (
 )
 from hyperspy.external.astropy.bayesian_blocks import bayesian_blocks
 from hyperspy.external.astropy.histogram import knuth_bin_width
+from hyperspy.misc.utils import is_dask_array
 
 
 def _set_histogram_metadata(signal, histogram, **kwargs):
@@ -77,7 +77,7 @@ def histogram(a, bins="fd", range=None, max_num_bins=250, weights=None, **kwargs
     * :func:`numpy.histogram`
 
     """
-    if isinstance(a, da.Array):
+    if is_dask_array(a):
         return histogram_dask(
             a,
             bins=bins,
@@ -173,7 +173,9 @@ def histogram_dask(a, bins="fd", range=None, max_num_bins=250, weights=None, **k
     * :func:`numpy.histogram`
 
     """
-    if not isinstance(a, da.Array):
+    import dask.array as da
+
+    if not is_dask_array(a):
         raise TypeError("Expected a dask array")
 
     if a.ndim != 1:
@@ -254,7 +256,9 @@ def _scott_bw_dask(data, return_bins=True):
     :math:`n` is the number of data points.
 
     """
-    if not isinstance(data, da.Array):
+    import dask.array as da
+
+    if not is_dask_array(data):
         raise TypeError("Expected a dask array")
 
     if data.ndim != 1:
@@ -302,7 +306,9 @@ def _freedman_bw_dask(data, return_bins=True):
     :math:`n` is the number of data points.
 
     """
-    if not isinstance(data, da.Array):
+    import dask.array as da
+
+    if not is_dask_array(data):
         raise TypeError("Expected a dask array")
 
     if data.ndim != 1:

--- a/hyperspy/misc/machine_learning/import_sklearn.py
+++ b/hyperspy/misc/machine_learning/import_sklearn.py
@@ -17,21 +17,15 @@
 # along with HyperSpy. If not, see <https://www.gnu.org/licenses/#GPL>.
 
 """
-Import sklearn.* and randomized_svd from scikit-learn
+Import sklearn if installed.
 """
 
 import importlib
 
-sklearn_spec = importlib.util.find_spec("sklearn")
-sklearn_installed = False if sklearn_spec is None else True
+sklearn_installed = False if importlib.util.find_spec("sklearn") is None else True
 
 
 def __getattr__(name):
     if name == "sklearn":
         return importlib.import_module("sklearn")
-    elif name == "randomized_svd":
-        if sklearn_installed:
-            return importlib.import_module("sklearn.utils.extmath").randomized_svd
-        else:
-            return
     raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/hyperspy/misc/machine_learning/import_sklearn.py
+++ b/hyperspy/misc/machine_learning/import_sklearn.py
@@ -21,21 +21,17 @@ Import sklearn.* and randomized_svd from scikit-learn
 """
 
 import importlib
-import warnings
 
 sklearn_spec = importlib.util.find_spec("sklearn")
+sklearn_installed = False if sklearn_spec is None else True
 
-if sklearn_spec is None:  # pragma: no cover
-    randomized_svd = None
-    sklearn_installed = False
-else:
-    with warnings.catch_warnings():
-        warnings.simplefilter("ignore")
-        import sklearn  # noqa: F401
-        import sklearn.cluster  # noqa: F401
-        import sklearn.decomposition  # noqa: F401
-        import sklearn.metrics  # noqa: F401
-        import sklearn.preprocessing  # noqa: F401
-        from sklearn.utils.extmath import randomized_svd  # noqa: F401
 
-        sklearn_installed = True
+def __getattr__(name):
+    if name == "sklearn":
+        return importlib.import_module("sklearn")
+    elif name == "randomized_svd":
+        if sklearn_installed:
+            return importlib.import_module("sklearn.utils.extmath").randomized_svd
+        else:
+            return
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/hyperspy/misc/math_tools.py
+++ b/hyperspy/misc/math_tools.py
@@ -21,8 +21,6 @@ import numbers
 import warnings
 from functools import reduce
 
-import dask
-import dask.array as da
 import numpy as np
 from packaging.version import Version
 
@@ -206,6 +204,9 @@ def check_random_state(seed, lazy=False):
     np.random.Generator instance or dask.array.random.Generator
 
     """
+    import dask
+    import dask.array as da
+
     # Derived from `sklearn.utils.check_random_state`.
     # Copyright (c) 2007-2020 The scikit-learn developers.
     # All rights reserved.

--- a/hyperspy/misc/math_tools.py
+++ b/hyperspy/misc/math_tools.py
@@ -17,12 +17,9 @@
 # along with HyperSpy. If not, see <https://www.gnu.org/licenses/#GPL>.
 
 import math
-import numbers
-import warnings
 from functools import reduce
 
 import numpy as np
-from packaging.version import Version
 
 
 def symmetrize(a):
@@ -182,73 +179,23 @@ def optimal_fft_size(target, real=False):
 
 
 def check_random_state(seed, lazy=False):
-    """Turn a random seed into a RandomState or Generator instance.
+    """
+    Turn a random seed into a RandomState or Generator instance.
 
     Parameters
     ----------
-    seed : None or int or numpy.random.RandomState or numpy.random.Generator or \
-        dask.array.random.RandomState or dask.array.random.Generator
-
-        - If None, returns the random state singleton used by numpy.random or
-          dask.array.random
-        - If int, returns a new random state instance seeded with ``seed``.
-        - If numpy.random.RandomState, numpy.random.Generator or
-          dask.array.random.RandomState, returns seed, `i.e.` the input.
+    seed : None or int or numpy.random.Generator or dask.array.random.Generator
+        Parameter passed to numpy.random.default_rng or dask.array.random.default_rng
+        when lazy=True to create a new Generator instance.
     lazy : bool, default False
-        If True, and seed is ``None`` or ``int``, return
-        a dask.array.random.RandomState instance instead for dask < 2023.2.1,
-        otherwise returns a dask.array.random.Generator instance
+        If True, and seed is ``None`` or ``int``, return a
+        dask.array.random.Generator instance.
 
     Returns
     -------
-    np.random.Generator instance or dask.array.random.Generator
-
+    np.random.Generator or dask.array.random.Generator instance
     """
-    import dask
     import dask.array as da
 
-    # Derived from `sklearn.utils.check_random_state`.
-    # Copyright (c) 2007-2020 The scikit-learn developers.
-    # All rights reserved.
-    dask_version = Version(dask.__version__)
-    if seed is None:
-        if lazy:
-            if dask_version < Version("2022.10.0"):
-                return da.random._state
-            elif dask_version < Version("2023.2.1"):
-                backend = da.backends.array_creation_dispatch.backend
-                if backend not in da.random._cached_random_states.keys():
-                    # Need to initialise the backend
-                    da.random.seed()
-                return da.random._cached_random_states[backend]
-            else:
-                return da.random.default_rng()
-        else:
-            return np.random.default_rng()
-
-    if isinstance(seed, numbers.Integral):
-        if lazy:
-            try:
-                return da.random.default_rng(seed)
-            except AttributeError:
-                return da.random.RandomState(seed)
-        else:
-            return np.random.default_rng(seed)
-
-    if isinstance(seed, (np.random.RandomState, da.random.RandomState)):
-        warnings.warn(
-            "Support for RandomState generators have been deprecated and will be removed "
-            " in HyperSpy 2.0, use `default_rng` instead.",
-            DeprecationWarning,
-        )
-        return seed
-
-    if isinstance(seed, np.random.Generator):
-        return seed
-
-    if dask_version >= Version("2023.2.1") and isinstance(seed, da.random.Generator):
-        return seed
-
-    raise ValueError(
-        f"{seed} cannot be used to seed a RandomState or a Generator instance"
-    )
+    xp = da if lazy else np
+    return xp.random.default_rng(seed)

--- a/hyperspy/misc/model_tools.py
+++ b/hyperspy/misc/model_tools.py
@@ -19,7 +19,6 @@
 import numbers
 from collections.abc import Iterable
 
-import dask.array as da
 import numpy as np
 
 
@@ -266,6 +265,8 @@ def _calculate_covariance(
     # if target_signal shape is 1D, then fit_dot is 2D and numpy going to dask.linalg.inv is fine.
     # If target_signal shape is 2D, then dask.linalg.inv will fail because fit_dot is 3D.
     if lazy and target_signal.ndim > 1:
+        import dask.array as da
+
         inv_fit_dot = da.map_blocks(
             np.linalg.inv, fit_dot, chunks=fit_dot.chunks, dtype=float, meta=fit_dot
         )

--- a/hyperspy/misc/slicing.py
+++ b/hyperspy/misc/slicing.py
@@ -18,12 +18,11 @@
 
 from operator import attrgetter
 
-import dask.array as da
 import numpy as np
 
 from hyperspy import roi
 from hyperspy.misc.export_dictionary import parse_flag_string
-from hyperspy.misc.utils import attrsetter
+from hyperspy.misc.utils import attrsetter, is_dask_array
 
 
 def _slice_target(target, dims, both_slices, slice_nav=None, issignal=False):
@@ -56,7 +55,7 @@ def _slice_target(target, dims, both_slices, slice_nav=None, issignal=False):
         sl = tuple(array_slices[:nav_dims])
         if isinstance(target, np.ndarray):
             return np.atleast_1d(target[sl])
-        if isinstance(target, da.Array):
+        if is_dask_array(target):
             return target[sl]
         raise ValueError(
             "tried to slice with navigation dimensions, but was neither a "
@@ -68,7 +67,7 @@ def _slice_target(target, dims, both_slices, slice_nav=None, issignal=False):
         sl = tuple(array_slices[-sig_dims:])
         if isinstance(target, np.ndarray):
             return np.atleast_1d(target[sl])
-        if isinstance(target, da.Array):
+        if is_dask_array(target):
             return target[sl]
         raise ValueError(
             "tried to slice with navigation dimensions, but was neither a "

--- a/hyperspy/misc/utils.py
+++ b/hyperspy/misc/utils.py
@@ -28,9 +28,7 @@ from contextlib import contextmanager
 from io import StringIO
 from operator import attrgetter
 
-import dask.array as da
 import numpy as np
-from tqdm.dask import TqdmCallback
 
 from hyperspy.defaults_parser import preferences
 from hyperspy.docstrings.signal import SHOW_PROGRESSBAR_ARG
@@ -293,7 +291,6 @@ class DictionaryTreeBrowser:
 
     def _get_print_items(self, padding="", max_len=78):
         """Prints only the attributes that are not methods"""
-        from hyperspy.defaults_parser import preferences
 
         string = ""
         eoi = len(self)
@@ -349,7 +346,6 @@ class DictionaryTreeBrowser:
         of metadata.
         """
         recursive_level += 1
-        from hyperspy.defaults_parser import preferences
 
         string = ""  # Final return string
 
@@ -1108,6 +1104,8 @@ def stack(
     """
     from numbers import Number
 
+    import dask.array as da
+
     from hyperspy.axes import DataAxis, FunctionalDataAxis, UniformDataAxis
     from hyperspy.signals import BaseSignal
 
@@ -1311,158 +1309,6 @@ def transpose(*args, signal_axes=None, navigation_axes=None, optimize=False):
     ]
 
 
-def process_function_blockwise(
-    data,
-    *args,
-    function,
-    nav_indexes=None,
-    output_signal_size=None,
-    output_dtype=None,
-    arg_keys=None,
-    **kwargs,
-):
-    """
-    Convenience function for processing a function blockwise. By design, its
-    output is used as an argument of the dask ``map_blocks`` so that the
-    function only gets applied to the signal axes.
-
-    Parameters
-    ----------
-    data : np.ndarray
-        The data for one chunk
-    *args : tuple
-        Any signal the is iterated alongside the data in. In the form
-        ((key1, value1), (key2, value2))
-    function : function
-        The function to applied to the signal axis
-    nav_indexes : tuple
-        The indexes of the navigation axes for the dataset.
-    output_signal_size: tuple
-        The shape of the output signal. For a ragged signal, this is equal to 1
-    output_dtype : dtype
-        The data type for the output.
-    arg_keys : tuple
-        The list of keys for the passed arguments (args).  Together this makes
-        a set of key:value pairs to be passed to the function.
-    **kwargs : dict
-        Any additional key value pairs to be used by the function
-        (Note that these are the constants that are applied.)
-
-    """
-    # Both of these values need to be passed in
-    dtype = output_dtype
-    chunk_nav_shape = tuple([data.shape[i] for i in sorted(nav_indexes)])
-    output_shape = chunk_nav_shape + tuple(output_signal_size)
-    # Pre-allocating the output array
-    output_array = np.empty(output_shape, dtype=dtype, like=data)
-    if len(args) == 0:
-        # There aren't any BaseSignals for iterating
-        for nav_index in np.ndindex(chunk_nav_shape):
-            islice = np.s_[nav_index]
-            output_array[islice] = function(data[islice], **kwargs)
-    else:
-        # There are BaseSignals which iterate alongside the data
-        for index in np.ndindex(chunk_nav_shape):
-            islice = np.s_[index]
-            iter_dict = {}
-            for key, a in zip(arg_keys, args):
-                arg_i = np.squeeze(a[islice])
-                # Some functions do not handle 0-dimension NumPy arrays
-                if hasattr(arg_i, "shape") and arg_i.shape == ():
-                    arg_i = arg_i[()]
-                iter_dict[key] = arg_i
-            output_array[islice] = function(data[islice], **iter_dict, **kwargs)
-    if not (chunk_nav_shape == output_array.shape):
-        try:
-            output_array = output_array.squeeze(-1)
-        except ValueError:
-            pass
-    return output_array
-
-
-def _get_block_pattern(args, output_shape):
-    """Returns the block pattern used by the `blockwise` function for a
-    set of arguments give a resulting output_shape
-
-    Parameters
-    ----------
-    args: list
-        A list of all the arguments which are used for `da.blockwise`
-    output_shape: tuple
-        The output shape for the function passed to `da.blockwise` given args
-    """
-    arg_patterns = tuple(tuple(range(a.ndim)) for a in args)
-    arg_shapes = tuple(a.shape for a in args)
-    output_pattern = tuple(range(len(output_shape)))
-    all_ind = arg_shapes + (output_shape,)
-    max_len = max((len(i) for i in all_ind))  # max number of dimensions
-    max_arg_len = max((len(i) for i in arg_shapes))
-    adjust_chunks = {}
-    new_axis = {}
-    output_shape = output_shape + (0,) * (max_len - len(output_shape))
-    for i in range(max_len):
-        shapes = np.array(
-            [s[i] if len(s) > i else -1 for s in (output_shape,) + arg_shapes]
-        )
-        is_equal_shape = shapes == shapes[0]  # if in shapes == output shapes
-        if not all(is_equal_shape):
-            if i > max_arg_len - 1:  # output shape is a new axis
-                new_axis[i] = output_shape[i]
-            else:  # output shape is an existing axis
-                adjust_chunks[i] = output_shape[i]  # adjusting chunks based on output
-    arg_pairs = [(a, p) for a, p in zip(args, arg_patterns)]
-    return arg_pairs, adjust_chunks, new_axis, output_pattern
-
-
-def guess_output_signal_size(test_data, function, ragged, **kwargs):
-    """This function is for guessing the output signal shape and size.
-    It will attempt to apply the function to some test data and then output
-    the resulting signal shape and datatype.
-
-    Parameters
-    ----------
-    test_data : NumPy array
-        Data from a test signal for the function to be applied to.
-        The data must be from a signal with 0 navigation dimensions.
-    function : function
-        The function to be applied to the data
-    ragged : bool
-        If the data is ragged then the output signal size is () and the
-        data type is 'object'
-    **kwargs : dict
-        Any other keyword arguments passed to the function.
-    """
-    if ragged:
-        output_dtype = object
-        output_signal_size = ()
-    else:
-        output = function(test_data, **kwargs)
-        try:
-            output_dtype = output.dtype
-            output_signal_size = output.shape
-        except AttributeError:
-            output = np.asarray(output)
-            output_dtype = output.dtype
-            output_signal_size = output.shape
-    return output_signal_size, output_dtype
-
-
-def _compute(array, store_to=None, show_progressbar=None, **kwargs):
-    if show_progressbar is None:
-        show_progressbar = preferences.General.show_progressbar
-    # this isn't compatible with distributed scheduler
-    # https://docs.dask.org/en/stable/diagnostics-distributed.html#progress-bar
-    cm = TqdmCallback if show_progressbar else dummy_context_manager
-
-    with cm():
-        if store_to is not None:
-            da.store(
-                array, store_to, dtype=array.dtype, compute=True, lock=False, **kwargs
-            )
-        else:
-            return array.compute(**kwargs)
-
-
 def multiply(iterable):
     """Return product of sequence of numbers.
 
@@ -1602,7 +1448,7 @@ def to_numpy(array):
     """
     if isinstance(array, np.ndarray):
         return array
-    elif isinstance(array, da.Array):
+    elif hasattr(array, "compute"):
         raise TypeError(
             "Implicit conversion of dask array to numpy array is not "
             "supported, conversion needs to be done explicitely."

--- a/hyperspy/misc/utils.py
+++ b/hyperspy/misc/utils.py
@@ -38,6 +38,27 @@ from hyperspy.misc.signal_tools import broadcast_signals
 _logger = logging.getLogger(__name__)
 
 
+def is_dask_array(x):
+    """Check if x is a dask array.
+
+    Parameters
+    ----------
+    x : any
+        The input to check.
+
+    Returns
+    -------
+    bool
+        True if x is a dask array, False otherwise.
+    """
+    try:
+        from dask.base import is_dask_collection
+
+        return is_dask_collection(x)
+    except ImportError:
+        return hasattr(x, "__dask_keys__")
+
+
 def attrsetter(target, attrs, value):
     """
     Sets attribute of the target to specified value, supports nested
@@ -1448,7 +1469,7 @@ def to_numpy(array):
     """
     if isinstance(array, np.ndarray):
         return array
-    elif hasattr(array, "compute"):
+    elif is_dask_array(array):
         raise TypeError(
             "Implicit conversion of dask array to numpy array is not "
             "supported, conversion needs to be done explicitely."

--- a/hyperspy/model.py
+++ b/hyperspy/model.py
@@ -52,7 +52,7 @@ from hyperspy.extensions import ALL_EXTENSIONS
 from hyperspy.external.mpfit.mpfit import mpfit
 from hyperspy.external.progressbar import progressbar
 from hyperspy.io import assign_signal_subclass
-from hyperspy.misc.array_tools import get_chunk_slice
+from hyperspy.misc.dask_utils import get_chunk_slice
 from hyperspy.misc.export_dictionary import (
     export_to_dictionary,
     load_from_dictionary,

--- a/hyperspy/model.py
+++ b/hyperspy/model.py
@@ -28,17 +28,8 @@ from functools import partial
 import cloudpickle
 import dask
 import numpy as np
-from dask.diagnostics import ProgressBar
+import scipy
 from packaging.version import Version
-from scipy.linalg import svd
-from scipy.optimize import (
-    OptimizeResult,
-    differential_evolution,
-    least_squares,
-    leastsq,
-    minimize,
-)
-from scipy.signal import fftconvolve
 
 from hyperspy.component import Component
 from hyperspy.components1d import Expression
@@ -250,7 +241,7 @@ def _get_model_data_function_nd(
                 )
             # add all components, take the convolution for components that need
             # to be convolved, do it here only once instead of each component individually
-            data_ = sum_ + fftconvolve(
+            data_ = sum_ + scipy.signal.fftconvolve(
                 sum_convolved,
                 model._signal_to_convolve.inav[nav_slices].data,
                 mode="valid",
@@ -1614,14 +1605,6 @@ class BaseModel(list):
 
         fit_output = {"x": coefficient_array}
 
-        # TODO: reorganise to do lazy computation (coeff and error together)
-        if self.signal._lazy:
-            cm = (
-                ProgressBar if kwargs.get("show_progressbar") else dummy_context_manager
-            )
-            with cm():
-                fit_output["x"] = fit_output["x"].compute()
-
         # Calculate errors
         # We only do this if going pixel-by-pixel or if `calculate_errors=True`
         # is specified in multifit. This is because it is a very large
@@ -1638,6 +1621,20 @@ class BaseModel(list):
             fit_output["covar"] = covariance
             fit_output["perror"] = abs(fit_output["x"]) * std_error
 
+        # TODO: reorganise to do lazy computation (coeff and error together)
+        if self.signal._lazy:
+            from hyperspy.misc.dask_utils import _compute
+
+            fit_output["x"] = _compute(
+                fit_output["x"], show_progressbar=kwargs.get("show_progressbar")
+            )
+
+            if calculate_errors:
+                fit_output["perror"] = _compute(
+                    fit_output["perror"],
+                    show_progressbar=kwargs.get("show_progressbar"),
+                )
+
         if not only_current:
             # The nav shape will have been flattened. We reshape it here.
             fit_output["x"] = fit_output["x"].reshape(nav_shape + (n_parameters,))
@@ -1649,10 +1646,6 @@ class BaseModel(list):
                 fit_output["perror"] = fit_output["perror"].reshape(
                     nav_shape + (n_parameters,)
                 )
-
-        if self.signal._lazy and calculate_errors:
-            with cm():
-                fit_output["perror"] = fit_output["perror"].compute()
 
         fit_output["success"] = True
 
@@ -1819,13 +1812,16 @@ class BaseModel(list):
 
         # Supported losses and optimizers
         _supported_global = {
-            "Differential Evolution": differential_evolution,
+            "Differential Evolution": scipy.optimize.differential_evolution,
         }
 
         if optimizer in ["Dual Annealing", "SHGO"]:
-            from scipy.optimize import dual_annealing, shgo
-
-            _supported_global.update({"Dual Annealing": dual_annealing, "SHGO": shgo})
+            _supported_global.update(
+                {
+                    "Dual Annealing": scipy.optimize.dual_annealing,
+                    "SHGO": scipy.optimize.shgo,
+                }
+            )
 
         _supported_fd_schemes = ["2-point", "3-point", "cs"]
         _supported_losses = ["ls", "ML-poisson", "huber"]
@@ -2014,7 +2010,7 @@ class BaseModel(list):
                     # Dfun=None means the gradient is always estimated here.
                     grad = self._jacobian if grad == "analytical" else None
 
-                    res = leastsq(
+                    res = scipy.optimize.leastsq(
                         self._errfunc,
                         self.p0[:],
                         Dfun=grad,
@@ -2024,7 +2020,7 @@ class BaseModel(list):
                         **kwargs,
                     )
 
-                    self.fit_output = OptimizeResult(
+                    self.fit_output = scipy.optimize.OptimizeResult(
                         x=res[0],
                         covar=res[1],
                         fun=res[2]["fvec"],
@@ -2052,7 +2048,7 @@ class BaseModel(list):
 
                 grad = _wrap_jac if grad == "analytical" else grad
 
-                self.fit_output = least_squares(
+                self.fit_output = scipy.optimize.least_squares(
                     self._errfunc,
                     self.p0[:],
                     args=args,
@@ -2069,7 +2065,7 @@ class BaseModel(list):
 
                 # Do Moore-Penrose inverse, discarding zero singular values
                 # to get pcov (as per scipy.optimize.curve_fit())
-                _, s, VT = svd(jac, full_matrices=False)
+                _, s, VT = scipy.linalg.svd(jac, full_matrices=False)
                 threshold = np.finfo(float).eps * max(jac.shape) * s[0]
                 s = s[s > threshold]
                 VT = VT[: s.size]
@@ -2121,7 +2117,7 @@ class BaseModel(list):
                     # Note that a value of 5 means maximum iterations reached
                     dd["success"] = (res.info >= 0) and (res.info < 4)
 
-                self.fit_output = OptimizeResult(**dd)
+                self.fit_output = scipy.optimize.OptimizeResult(**dd)
                 self.p0 = self.fit_output.x
                 self.p_std = self.fit_output.perror
 
@@ -2135,7 +2131,7 @@ class BaseModel(list):
                 fit_output = self._linear_fit(
                     optimizer=optimizer, weights=weights, **kwargs
                 )
-                self.fit_output = OptimizeResult(**fit_output)
+                self.fit_output = scipy.optimize.OptimizeResult(**fit_output)
 
                 if only_current:
                     # fit_output will have only one entry
@@ -2184,7 +2180,7 @@ class BaseModel(list):
                     )
 
                 else:
-                    self.fit_output = minimize(
+                    self.fit_output = scipy.optimize.minimize(
                         f_min,
                         self.p0,
                         jac=f_der,

--- a/hyperspy/model.py
+++ b/hyperspy/model.py
@@ -27,7 +27,6 @@ from functools import partial
 
 import cloudpickle
 import dask
-import dask.array as da
 import numpy as np
 from dask.diagnostics import ProgressBar
 from packaging.version import Version
@@ -65,6 +64,7 @@ from hyperspy.misc.slicing import copy_slice_from_whitelist
 from hyperspy.misc.utils import (
     display,
     dummy_context_manager,
+    is_dask_array,
     shorten_name,
     slugify,
     stash_active_state,
@@ -354,6 +354,8 @@ def _model_as_signal_lazy_data(
     data : dask array
         The calculated model data
     """
+    import dask.array as da
+
     _, data_chunks = get_chunk_slice(
         shape=model.signal.data.shape,
         chunks=chunks,
@@ -877,6 +879,8 @@ class BaseModel(list):
                     self, components_with_function_nd, out_of_range_to_nan
                 )
         else:
+            import dask.array as da
+
             xp = da if lazy_output else np
             # Make the placeholder array
             data_ = xp.full_like(self.signal.data, np.nan, dtype=float)
@@ -933,7 +937,7 @@ class BaseModel(list):
         # position for a thread-friendly bars. Otherwise race conditions are
         # ugly...
 
-        if out_of_range_to_nan and isinstance(data_, da.Array):
+        if out_of_range_to_nan and is_dask_array(data_):
             # requires array assignment which is not compatible with
             # dask array since dask 2024.12.0
             raise ValueError(
@@ -1570,16 +1574,12 @@ class BaseModel(list):
             )
 
         if optimizer == "lstsq":
-            if self.signal._lazy:
-                xp = da
-                kw = {}
-            else:
-                xp = np
-                kw = kwargs
-                kw.setdefault("rcond", None)
+            kwargs = {"rcond": None} if not self.signal._lazy else {}
 
             result, residual, *_ = np.linalg.lstsq(
-                xp.asanyarray(comp_values.T), target_signal.T, **kw
+                np.asanyarray(comp_values.T, like=self.signal.data),
+                target_signal.T,
+                **kwargs,
             )
             if len(residual) == 0:
                 # can be empty array, see np.linalg.lstsq docstring

--- a/hyperspy/model.py
+++ b/hyperspy/model.py
@@ -1621,19 +1621,18 @@ class BaseModel(list):
             fit_output["covar"] = covariance
             fit_output["perror"] = abs(fit_output["x"]) * std_error
 
-        # TODO: reorganise to do lazy computation (coeff and error together)
         if self.signal._lazy:
             from hyperspy.misc.dask_utils import _compute
 
-            fit_output["x"] = _compute(
-                fit_output["x"], show_progressbar=kwargs.get("show_progressbar")
-            )
-
+            arrays = [fit_output["x"]]
             if calculate_errors:
-                fit_output["perror"] = _compute(
-                    fit_output["perror"],
-                    show_progressbar=kwargs.get("show_progressbar"),
-                )
+                arrays.append(fit_output["perror"])
+
+            outputs = _compute(arrays, show_progressbar=kwargs.get("show_progressbar"))
+
+            fit_output["x"] = outputs[0]
+            if calculate_errors:
+                fit_output["perror"] = outputs[1]
 
         if not only_current:
             # The nav shape will have been flattened. We reshape it here.

--- a/hyperspy/models/model1d.py
+++ b/hyperspy/models/model1d.py
@@ -19,8 +19,8 @@
 import copy
 
 import numpy as np
+import scipy
 import traits.api as t
-from scipy.special import huber
 
 import hyperspy.drawing.signal1d
 from hyperspy.decorators import interactive_range_selector
@@ -622,7 +622,7 @@ class Model1D(BaseModel):
             weights = 1.0
         if huber_delta is None:
             huber_delta = 1.0
-        return huber(huber_delta, weights * self._errfunc(param, y)).sum()
+        return scipy.special.huber(huber_delta, weights * self._errfunc(param, y)).sum()
 
     def _gradient_huber(self, param, y, weights=None, huber_delta=None):
         if huber_delta is None:

--- a/hyperspy/samfire_utils/samfire_pool.py
+++ b/hyperspy/samfire_utils/samfire_pool.py
@@ -22,8 +22,8 @@ import time
 from multiprocessing import Manager
 
 import numpy as np
-from dask.array import Array as dar
 
+from hyperspy.misc.utils import is_dask_array
 from hyperspy.samfire_utils.samfire_worker import create_worker
 from hyperspy.utils.parallel_pool import ParallelPool
 
@@ -34,7 +34,7 @@ def _walk_compute(athing):
     if isinstance(athing, dict):
         this = {}
         for key, val in athing.items():
-            if isinstance(key, dar):
+            if is_dask_array(key):
                 raise ValueError("Dask arrays should not be used as keys")
             value = _walk_compute(val)
             this[key] = value
@@ -43,7 +43,7 @@ def _walk_compute(athing):
         return [_walk_compute(val) for val in athing]
     elif isinstance(athing, tuple):
         return tuple(_walk_compute(val) for val in athing)
-    elif isinstance(athing, dar):
+    elif is_dask_array(athing):
         _logger.debug("found a dask array!")
         return athing.compute()
     else:

--- a/hyperspy/samfire_utils/segmenters/histogram.py
+++ b/hyperspy/samfire_utils/segmenters/histogram.py
@@ -17,7 +17,7 @@
 # along with HyperSpy. If not, see <https://www.gnu.org/licenses/#GPL>.
 
 import numpy as np
-from scipy.signal import argrelextrema
+import scipy
 
 from hyperspy.misc.hist_tools import histogram
 
@@ -43,7 +43,7 @@ class HistogramSegmenter(object):
             comp_dict = {}
             for p_n, (hist, bin_edges) in comp.items():
                 # calculate frequent values
-                maxima_hist_ind = argrelextrema(
+                maxima_hist_ind = scipy.signal.argrelextrema(
                     np.append(0, hist), np.greater, mode="wrap"
                 )
                 middles_of_maxima = 0.5 * (

--- a/hyperspy/signal.py
+++ b/hyperspy/signal.py
@@ -5725,7 +5725,7 @@ class BaseSignal(
             ):
                 # use `store_to` to minmize memory usage
                 _compute(
-                    array=mapped,
+                    arrays=mapped,
                     store_to=self.data,
                     show_progressbar=show_progressbar,
                     num_workers=num_workers,

--- a/hyperspy/signal.py
+++ b/hyperspy/signal.py
@@ -84,20 +84,22 @@ from hyperspy.io import assign_signal_subclass
 from hyperspy.io import save as io_save
 from hyperspy.learn.mva import MVA, LearningResults
 from hyperspy.misc.array_tools import rebin as array_rebin
+from hyperspy.misc.dask_utils import (
+    _compute,
+    _get_block_pattern,
+    guess_output_signal_size,
+    process_function_blockwise,
+)
 from hyperspy.misc.hist_tools import _set_histogram_metadata, histogram
 from hyperspy.misc.math_tools import check_random_state, hann_window_nth_order, outer_nd
 from hyperspy.misc.signal_tools import are_signals_aligned, broadcast_signals
 from hyperspy.misc.slicing import FancySlicing, SpecialSlicers
 from hyperspy.misc.utils import (
     DictionaryTreeBrowser,
-    _compute,
-    _get_block_pattern,
     add_scalar_axis,
-    guess_output_signal_size,
     is_cupy_array,
     isiterable,
     iterable_not_string,
-    process_function_blockwise,
     rollelem,
     slugify,
     to_numpy,

--- a/hyperspy/signal.py
+++ b/hyperspy/signal.py
@@ -31,17 +31,15 @@ from pathlib import Path
 
 import dask
 import numpy as np
+import scipy
 import traits.api as t
 from matplotlib import pyplot as plt
 from pint import UndefinedUnitError
 from rsciio.utils import rgb
 from rsciio.utils.path import ensure_directory
-from scipy import integrate
-from scipy import signal as sp_signal
-from scipy.interpolate import make_interp_spline
 from tlz import concat
 
-from hyperspy.api import _ureg
+import hyperspy
 from hyperspy.axes import AxesManager, create_axis
 from hyperspy.docstrings.plot import (
     BASE_PLOT_DOCSTRING,
@@ -3511,7 +3509,7 @@ class BaseSignal(
         """
         old_axis = self.axes_manager[axis]
         axis_idx = old_axis.index_in_array
-        interpolator = make_interp_spline(
+        interpolator = scipy.interpolate.make_interp_spline(
             old_axis.axis,
             self.data,
             axis=axis_idx,
@@ -4786,7 +4784,9 @@ class BaseSignal(
         """
         axis = self.axes_manager[axis]
         s = out or self._deepcopy_with_new_data(None)
-        data = integrate.simpson(y=self.data, x=axis.axis, axis=axis.index_in_array)
+        data = scipy.integrate.simpson(
+            y=self.data, x=axis.axis, axis=axis.index_in_array
+        )
         if out is not None:
             out.data[:] = data
             out.events.data_changed.trigger(obj=out)
@@ -4888,7 +4888,7 @@ class BaseSignal(
             axis.scale = 1.0 / axis.size / axis.scale
             axis.offset = 0.0
             try:
-                units = _ureg.parse_expression(str(axis.units)) ** (-1)
+                units = hyperspy.api._ureg.parse_expression(str(axis.units)) ** (-1)
                 axis.units = "{:~}".format(units.units)
             except UndefinedUnitError:
                 _logger.warning("Units are not set or cannot be recognized")
@@ -4975,7 +4975,7 @@ class BaseSignal(
         for axis in im_ifft.axes_manager.signal_axes:
             axis.scale = 1.0 / axis.size / axis.scale
             try:
-                units = _ureg.parse_expression(str(axis.units)) ** (-1)
+                units = hyperspy.api._ureg.parse_expression(str(axis.units)) ** (-1)
                 axis.units = "{:~}".format(units.units)
             except UndefinedUnitError:
                 _logger.warning("Units are not set or cannot be recognized")
@@ -7065,7 +7065,7 @@ class BaseSignal(
         elif window == "tukey":
 
             def window_function(m):
-                return sp_signal.windows.tukey(m, tukey_alpha)
+                return scipy.signal.windows.tukey(m, tukey_alpha)
         else:
             raise ValueError("Wrong type parameter value.")
 

--- a/hyperspy/signal.py
+++ b/hyperspy/signal.py
@@ -35,8 +35,8 @@ import numpy as np
 import traits.api as t
 from matplotlib import pyplot as plt
 from pint import UndefinedUnitError
-from rsciio.utils import rgb_tools
-from rsciio.utils.tools import ensure_directory
+from rsciio.utils import rgb
+from rsciio.utils.path import ensure_directory
 from scipy import integrate
 from scipy import signal as sp_signal
 from scipy.interpolate import make_interp_spline
@@ -5874,7 +5874,7 @@ class BaseSignal(
         if rechunk is True:
             rechunk = "dask_auto"
         if not isinstance(dtype, np.dtype):
-            if dtype in rgb_tools.rgb_dtypes:
+            if dtype in rgb.RGB_DTYPES.keys():
                 if self.axes_manager.signal_dimension != 1:
                     raise AttributeError(
                         "Only 1D signals can be converted to RGB images."
@@ -5892,7 +5892,7 @@ class BaseSignal(
                 if replot:
                     # Close the figure to avoid error with events
                     self._plot.close()
-                self.data = rgb_tools.regular_array2rgbx(self.data)
+                self.data = rgb.regular_array2rgbx(self.data)
                 self.axes_manager.remove(-1)
                 self.axes_manager._set_signal_dimension(2)
                 self._assign_subclass(chunks=rechunk)
@@ -5901,7 +5901,7 @@ class BaseSignal(
                 return
             else:
                 dtype = np.dtype(dtype)
-        if rgb_tools.is_rgbx(self.data) is True:
+        if rgb.is_rgbx(self.data) is True:
             ddtype = self.data.dtype.fields["B"][0]
 
             if ddtype != dtype:
@@ -5910,7 +5910,7 @@ class BaseSignal(
             if replot:
                 # Close the figure to avoid error with events
                 self._plot.close()
-            self.data = rgb_tools.rgbx2regular_array(self.data)
+            self.data = rgb.rgbx2regular_array(self.data)
             self.axes_manager._append_axis(
                 size=self.data.shape[-1],
                 scale=1,
@@ -6572,14 +6572,14 @@ class BaseSignal(
         """
         Whether or not this signal is an RGB + alpha channel `dtype`.
         """
-        return rgb_tools.is_rgba(self.data)
+        return rgb.is_rgba(self.data)
 
     @property
     def is_rgb(self):
         """
         Whether or not this signal is an RGB `dtype`.
         """
-        return rgb_tools.is_rgb(self.data)
+        return rgb.is_rgb(self.data)
 
     @property
     def is_rgbx(self):
@@ -6587,7 +6587,7 @@ class BaseSignal(
         Whether or not this signal is either an RGB or RGB + alpha channel
         `dtype`.
         """
-        return rgb_tools.is_rgbx(self.data)
+        return rgb.is_rgbx(self.data)
 
     def add_marker(
         self,

--- a/hyperspy/signal.py
+++ b/hyperspy/signal.py
@@ -30,7 +30,6 @@ from itertools import product
 from pathlib import Path
 
 import dask
-import dask.array as da
 import numpy as np
 import traits.api as t
 from matplotlib import pyplot as plt
@@ -98,6 +97,7 @@ from hyperspy.misc.utils import (
     DictionaryTreeBrowser,
     add_scalar_axis,
     is_cupy_array,
+    is_dask_array,
     isiterable,
     iterable_not_string,
     rollelem,
@@ -2696,6 +2696,7 @@ class BaseSignal(
         res : :class:`~hyperspy._signals.lazy.LazySignal`
             The same signal, converted to be lazy
         """
+
         res = self._deepcopy_with_new_data(
             self.data,
             copy_variance=copy_variance,
@@ -2705,8 +2706,8 @@ class BaseSignal(
         res._lazy = True
         if chunks is None:
             # Set default values
-            chunks = False if isinstance(res.data, da.Array) else "auto"
-        elif isinstance(chunks, str) and isinstance(res.data, da.Array):
+            chunks = False if is_dask_array(res.data) else "auto"
+        elif isinstance(chunks, str) and is_dask_array(res.data):
             chunks = False
             _logger.warning(
                 "Ignoring `chunks` argument because data is already a dask array."
@@ -5600,6 +5601,8 @@ class BaseSignal(
         navigation_chunks="auto",
         **kwargs,
     ):
+        import dask.array as da
+
         if lazy_output is None:
             lazy_output = self._lazy
 
@@ -6231,7 +6234,7 @@ class BaseSignal(
             s = Signal2D(data, axes=self.axes_manager._get_navigation_axes_dicts())
         else:
             s = BaseSignal(data, axes=self.axes_manager._get_navigation_axes_dicts()).T
-        if isinstance(data, da.Array):
+        if is_dask_array(data):
             s = s.as_lazy()
         return s
 
@@ -6279,7 +6282,7 @@ class BaseSignal(
             s.set_signal_type(self.metadata.Signal.signal_type)
         else:
             s = self.__class__(data, axes=self.axes_manager._get_signal_axes_dicts())
-        if isinstance(data, da.Array):
+        if is_dask_array(data):
             s = s.as_lazy()
         return s
 
@@ -7046,7 +7049,6 @@ class BaseSignal(
         >>> wave = hs.data.wave_image()
         >>> wave.apply_apodization('tukey', tukey_alpha=0.1).plot()
         """
-
         if window == "hanning" or window == "hann":
             if hann_order:
 
@@ -7072,7 +7074,9 @@ class BaseSignal(
         axes = np.array(self.axes_manager.signal_indices_in_array)
 
         for axis, axis_index in zip(self.axes_manager.signal_axes, axes):
-            if isinstance(self.data, da.Array):
+            if is_dask_array(self.data):
+                import dask.array as da
+
                 chunks = self.data.chunks[axis_index]
                 window_da = da.from_array(window_function(axis.size), chunks=(chunks,))
                 windows_1d.append(window_da)

--- a/hyperspy/signal_tools.py
+++ b/hyperspy/signal_tools.py
@@ -24,9 +24,8 @@ import matplotlib
 import matplotlib.colors
 import matplotlib.text as mpl_text
 import numpy as np
+import scipy
 import traits.api as t
-from scipy import interpolate
-from scipy import signal as sp_signal
 
 from hyperspy import components1d, drawing
 from hyperspy.axes import AxesManager, UniformDataAxis
@@ -741,13 +740,13 @@ class ButterworthFilter(Smoothing):
         self.update_lines()
 
     def model2plot(self, axes_manager=None):
-        b, a = sp_signal.butter(self.order, self.cutoff_frequency_ratio, self.type)
-        smoothed = sp_signal.filtfilt(b, a, self.signal._get_current_data())
+        b, a = scipy.signal.butter(self.order, self.cutoff_frequency_ratio, self.type)
+        smoothed = scipy.signal.filtfilt(b, a, self.signal._get_current_data())
         return smoothed
 
     def apply(self):
-        b, a = sp_signal.butter(self.order, self.cutoff_frequency_ratio, self.type)
-        f = functools.partial(sp_signal.filtfilt, b, a)
+        b, a = scipy.signal.butter(self.order, self.cutoff_frequency_ratio, self.type)
+        f = functools.partial(scipy.signal.filtfilt, b, a)
         self.signal.map(f)
 
 
@@ -1682,7 +1681,7 @@ class SpikesRemoval:
             # Interpolate
             x = np.hstack((axis.axis[ileft:left], axis.axis[right:iright]))
             y = np.hstack((data[ileft:left], data[right:iright]))
-            intp = interpolate.make_interp_spline(x, y, k=self.spline_order)
+            intp = scipy.interpolate.make_interp_spline(x, y, k=self.spline_order)
             data[left:right] = intp(axis.axis[left:right])
 
         # Add noise

--- a/hyperspy/tests/learn/test_bss.py
+++ b/hyperspy/tests/learn/test_bss.py
@@ -16,7 +16,7 @@
 # You should have received a copy of the GNU General Public License
 # along with HyperSpy. If not, see <https://www.gnu.org/licenses/#GPL>.
 
-
+import dask.array as da
 import numpy as np
 import pytest
 
@@ -475,7 +475,7 @@ class TestBSS2D:
     def test_mask_diff_order_1_on_loadings(self):
         s = self.s.to_signal1D()
         s.decomposition()
-        if hasattr(s.learning_results.loadings, "compute"):
+        if isinstance(s.learning_results.loadings, da.Array):
             s.learning_results.loadings = s.learning_results.loadings.compute()
         s.learning_results.loadings[5, :] = np.nan
         s.blind_source_separation(3, diff_order=1, mask=self.mask_sig, on_loadings=True)
@@ -483,7 +483,7 @@ class TestBSS2D:
     def test_mask_diff_order_1_on_loadings_diff_axes(self):
         s = self.s.to_signal1D()
         s.decomposition()
-        if hasattr(s.learning_results.loadings, "compute"):
+        if isinstance(s.learning_results.loadings, da.Array):
             s.learning_results.loadings = s.learning_results.loadings.compute()
         s.learning_results.loadings[5, :] = np.nan
         s.blind_source_separation(

--- a/hyperspy/tests/learn/test_lazy_decomposition.py
+++ b/hyperspy/tests/learn/test_lazy_decomposition.py
@@ -16,6 +16,7 @@
 # You should have received a copy of the GNU General Public License
 # along with HyperSpy. If not, see <https://www.gnu.org/licenses/#GPL>.
 
+import dask.array as da
 import numpy as np
 import pytest
 
@@ -57,9 +58,9 @@ class TestLazyDecomposition:
         factors = self.s.learning_results.factors
         loadings = self.s.learning_results.loadings
 
-        if hasattr(factors, "compute"):
+        if isinstance(factors, da.Array):
             factors = factors.compute()
-        if hasattr(loadings, "compute"):
+        if isinstance(loadings, da.Array):
             loadings = loadings.compute()
 
         explained_variance = self.s.learning_results.explained_variance
@@ -86,9 +87,9 @@ class TestLazyDecomposition:
         factors = self.s.learning_results.factors
         loadings = self.s.learning_results.loadings
 
-        if hasattr(factors, "compute"):
+        if isinstance(factors, da.Array):
             factors = factors.compute()
-        if hasattr(loadings, "compute"):
+        if isinstance(loadings, da.Array):
             loadings = loadings.compute()
 
         explained_variance = self.s.learning_results.explained_variance
@@ -145,9 +146,9 @@ class TestLazyDecomposition:
         factors = self.s.learning_results.factors
         loadings = self.s.learning_results.loadings
 
-        if hasattr(factors, "compute"):
+        if isinstance(factors, da.Array):
             factors = factors.compute()
-        if hasattr(loadings, "compute"):
+        if isinstance(loadings, da.Array):
             loadings = loadings.compute()
 
         explained_variance = self.s.learning_results.explained_variance
@@ -170,9 +171,9 @@ class TestLazyDecomposition:
         factors = self.s.learning_results.factors
         loadings = self.s.learning_results.loadings
 
-        if hasattr(factors, "compute"):
+        if isinstance(factors, da.Array):
             factors = factors.compute()
-        if hasattr(loadings, "compute"):
+        if isinstance(loadings, da.Array):
             loadings = loadings.compute()
 
         explained_variance = self.s.learning_results.explained_variance

--- a/hyperspy/tests/misc/test_array_tools.py
+++ b/hyperspy/tests/misc/test_array_tools.py
@@ -23,13 +23,12 @@ import pytest
 
 from hyperspy.misc.array_tools import (
     get_array_memory_size_in_GiB,
-    get_chunk_slice,
-    get_signal_chunk_slice,
     get_value_at_index,
     numba_histogram,
     round_half_away_from_zero,
     round_half_towards_zero,
 )
+from hyperspy.misc.dask_utils import get_chunk_slice, get_signal_chunk_slice
 
 dt = [("x", np.uint8), ("y", np.uint16), ("text", (bytes, 6))]
 

--- a/hyperspy/tests/misc/test_math_tools.py
+++ b/hyperspy/tests/misc/test_math_tools.py
@@ -16,11 +16,9 @@
 # You should have received a copy of the GNU General Public License
 # along with HyperSpy. If not, see <https://www.gnu.org/licenses/#GPL>.
 
-import dask
 import dask.array as da
 import numpy as np
 import pytest
-from packaging.version import Version
 
 from hyperspy.misc import math_tools
 
@@ -46,36 +44,14 @@ def test_random_state(seed):
     assert isinstance(math_tools.check_random_state(seed), np.random.Generator)
 
 
-def test_random_state_deprecated():
-    with pytest.warns(DeprecationWarning):
-        assert isinstance(
-            math_tools.check_random_state(np.random.RandomState(123)),
-            np.random.RandomState,
-        )
-
-
 @pytest.mark.parametrize("seed", [None, 123, "dask_supported"])
 def test_random_state_lazy(seed):
-    if Version(dask.__version__) < Version("2023.2.1"):
-        if seed == "dask_supported":
-            seed = da.random.RandomState(123)
-        out = math_tools.check_random_state(seed, lazy=True)
-        assert isinstance(out, da.random.RandomState)
-    else:
-        if seed == "dask_supported":
-            seed = da.random.default_rng(123)
-        out = math_tools.check_random_state(seed, lazy=True)
-        assert isinstance(out, da.random.Generator)
-
-
-def test_random_state_lazy_deprecated():
-    with pytest.warns(DeprecationWarning):
-        assert isinstance(
-            math_tools.check_random_state(da.random.RandomState(123)),
-            da.random.RandomState,
-        )
+    if seed == "dask_supported":
+        seed = da.random.default_rng(123)
+    out = math_tools.check_random_state(seed, lazy=True)
+    assert isinstance(out, da.random.Generator)
 
 
 def test_random_state_error():
-    with pytest.raises(ValueError, match="RandomState"):
+    with pytest.raises(TypeError, match="SeedSequence expects"):
         math_tools.check_random_state("string")

--- a/hyperspy/tests/signals/test_2D.py
+++ b/hyperspy/tests/signals/test_2D.py
@@ -18,10 +18,8 @@
 
 from unittest import mock
 
-import dask
 import numpy as np
 import pytest
-from packaging.version import Version
 
 from hyperspy.decorators import lazifyTestClass
 from hyperspy.exceptions import VisibleDeprecationWarning
@@ -398,8 +396,6 @@ class Test2D:
         s.change_dtype("float64")
         kwargs = {}
         if s._lazy:
-            if Version(dask.__version__) < Version("2023.2.1"):
-                pytest.skip("dask.array.random.default_rng added in 2023.2.1")
             data = s.data.compute()
             from dask.array.random import default_rng
 
@@ -429,14 +425,12 @@ class Test2D:
         s = self.signal
         kwargs = {}
         if s._lazy:
-            if Version(dask.__version__) < Version("2023.2.1"):
-                pytest.skip("dask.array.random.default_rng added in 2023.2.1")
             data = s.data.compute()
-            from dask.array.random import default_rng
+            import dask.array as da
 
             kwargs["chunks"] = s.data.chunks
-            rng1 = default_rng(123)
-            rng2 = default_rng(123)
+            rng1 = da.random.default_rng(123)
+            rng2 = da.random.default_rng(123)
         else:
             data = s.data.copy()
             rng1 = np.random.default_rng(123)
@@ -444,20 +438,8 @@ class Test2D:
 
         original_data = s.data
         s.add_poissonian_noise(random_state=rng1)
-        assert s.data is original_data
-
-        if s._lazy:
-            s.compute()
-
+        assert s.data is original_data  # check in-place
         np.testing.assert_array_almost_equal(s.data, rng2.poisson(lam=data, **kwargs))
-        s.change_dtype("float64")
-        original_data = s.data
-        s.add_poissonian_noise(random_state=rng1)
-        if s._lazy:
-            s.compute()
-        assert s.data is original_data
-
-        assert s.data.dtype == np.dtype("float64")
 
     def test_add_poisson_noise_warning(self, caplog):
         s = self.signal

--- a/hyperspy/tests/signals/test_lazy.py
+++ b/hyperspy/tests/signals/test_lazy.py
@@ -24,10 +24,10 @@ from dask.threaded import get
 import hyperspy.api as hs
 from hyperspy import _lazy_signals
 from hyperspy._signals.lazy import (
-    _get_navigation_dimension_chunk_slice,
     _reshuffle_mixed_blocks,
     to_array,
 )
+from hyperspy.misc.dask_utils import _get_navigation_dimension_chunk_slice
 
 
 def _signal():

--- a/hyperspy/tests/signals/test_map_method.py
+++ b/hyperspy/tests/signals/test_map_method.py
@@ -28,7 +28,8 @@ from scipy.ndimage import gaussian_filter, gaussian_filter1d, rotate
 import hyperspy.api as hs
 from hyperspy._signals.lazy import LazySignal
 from hyperspy.decorators import lazifyTestClass
-from hyperspy.misc.utils import _get_block_pattern, dummy_context_manager
+from hyperspy.misc.dask_utils import _get_block_pattern
+from hyperspy.misc.utils import dummy_context_manager
 
 
 def identify_function(x):

--- a/hyperspy/tests/signals/test_map_method.py
+++ b/hyperspy/tests/signals/test_map_method.py
@@ -1121,9 +1121,9 @@ class TestLazyInputMapAll:
             lazy_output=False,
         )
         assert not s_rot._lazy
-        assert not hasattr(s_rot.data, "compute")
+        assert not isinstance(s_rot.data, da.Array)
         assert s._lazy
-        assert hasattr(s.data, "compute")
+        assert isinstance(s.data, da.Array)
         assert s_rot.data[0, 0] == 0.0
         assert s_rot.data[0, -1] == 0.0
         assert s_rot.data[-1, 0] == 0.0
@@ -1144,7 +1144,7 @@ class TestLazyInputMapAll:
             lazy_output=False,
         )
         assert not s._lazy
-        assert not hasattr(s.data, "compute")
+        assert not isinstance(s.data, da.Array)
         assert s.data[0, 0] == 0.0
         assert s.data[0, -1] == 0.0
         assert s.data[-1, 0] == 0.0

--- a/hyperspy/tests/signals/test_rgb.py
+++ b/hyperspy/tests/signals/test_rgb.py
@@ -18,7 +18,7 @@
 
 import numpy as np
 import pytest
-from rsciio.utils import rgb_tools
+from rsciio.utils import rgb
 
 import hyperspy.api as hs
 
@@ -34,7 +34,7 @@ class TestRGBA8:
         self.im = hs.signals.Signal1D(
             np.array(
                 [[(1, 1, 1, 0), (2, 2, 2, 0)], [(3, 3, 3, 0), (4, 4, 4, 0)]],
-                dtype=rgb_tools.rgba8,
+                dtype=rgb.RGB_DTYPES["rgba8"],
             )
         )
 
@@ -79,7 +79,7 @@ class TestRGBA16:
         self.im = hs.signals.Signal1D(
             np.array(
                 [[(1, 1, 1, 0), (2, 2, 2, 0)], [(3, 3, 3, 0), (4, 4, 4, 0)]],
-                dtype=rgb_tools.rgba16,
+                dtype=rgb.RGB_DTYPES["rgba16"],
             )
         )
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ classifiers = [
 ]
 dependencies = [
     "cloudpickle",
-    "dask[array]>=2022.9.2",
+    "dask[array]>=2023.2.1",
     "importlib-metadata>=3.6",
     "jinja2", # improves representation of lazy signals by dask
     "matplotlib>=3.6",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ dependencies = [
     "pint>=0.10",
     "prettytable>=2.3",
     "pyyaml",
-    "rosettasciio[hdf5,image]",
+    "rosettasciio[hdf5,image]>=0.12.0",
     "scipy>=1.8.0",
     "sympy>=1.10",
     "tqdm>=4.59.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -147,7 +147,7 @@ ipython = [
     "ipyparallel",
 ]
 learning = [
-    "scikit-learn>=1.1.0",
+    "scikit-learn>=1.6.0",
 ]
 odr = [
     "odrpack>=0.3.1",

--- a/upcoming_changes/3566.enhancements.rst
+++ b/upcoming_changes/3566.enhancements.rst
@@ -1,0 +1,1 @@
+Speed up import of hyperspy modules.


### PR DESCRIPTION
On windows, it is particularly bad, it takes 6-8 s to import `hyperspy.signal` and with this PR is reduced to 2 s. This is mostly done by defering costly import, such as scikit-learn, dask array, scipy. On linux, it is about 2x faster than on windows.

A new feature of python 3.15 will be lazy import that will be better than putting import in functions and method, but it will take a couple of years until it can be used in hyperspy!

### Progress of the PR
- [x] Fix deprecation from https://github.com/hyperspy/rosettasciio/pull/424,
- [x] defer `dask.array` import,
- [x] defer most of scipy import - see https://docs.scipy.org/doc/scipy/reference/#guidelines-for-importing-functions-from-scipy for more explanation,
- [n/a] update docstring (if appropriate),
- [n/a] update user guide (if appropriate),
- [ ] add an changelog entry in the `upcoming_changes` folder (see [`upcoming_changes/README.rst`](https://github.com/hyperspy/hyperspy/blob/RELEASE_next_minor/upcoming_changes/README.rst)),
- [ ] Check formatting changelog entry in the `readthedocs` doc build of this PR (link in github checks)
- [n/a] add tests,
- [ ] ready for review.

### Minimal example of the bug fix or the new feature

To measure the import time of some modules using ipython:
```python
%time from hyperspy.signals import BaseSignal
```
```python
%time from hyperspy.signals import Signal1D
```
```python
%time from hyperspy.signals import Signal2D
```
```python
%time from hyperspy.model import BaseModel
```

