### PR TITLE
Use `ruff` consistently for avoid settings conflict with `black` linter

### DIFF
--- a/doc/dev_guide/coding_style.rst
+++ b/doc/dev_guide/coding_style.rst
@@ -9,7 +9,7 @@ for code consistency that you can read all about in the `Python Style Guide
 <https://www.python.org/dev/peps/pep-0008/>`_. You can use the `ruff`_ code
 formatter to automatically fix the style of your code using pre-commit hooks.
 
-Linting error can be suppressed in the code using the ``# noqa`` marker,
+Linting errors can be suppressed in the code using the ``# noqa`` marker,
 more information in the `ruff documentation <https://docs.astral.sh/ruff/linter/#error-suppression>`_.
 
 Pre-commit hooks

--- a/doc/dev_guide/coding_style.rst
+++ b/doc/dev_guide/coding_style.rst
@@ -6,9 +6,8 @@ Coding style
 
 HyperSpy follows the Style Guide for Python Code - these are rules
 for code consistency that you can read all about in the `Python Style Guide
-<https://www.python.org/dev/peps/pep-0008/>`_. You can use the
-`black <https://github.com/psf/black>`_ or `ruff`_ code formatter to automatically
-fix the style of your code using pre-commit hooks.
+<https://www.python.org/dev/peps/pep-0008/>`_. You can use the `ruff`_ code
+formatter to automatically fix the style of your code using pre-commit hooks.
 
 Linting error can be suppressed in the code using the ``# noqa`` marker,
 more information in the `ruff documentation <https://docs.astral.sh/ruff/linter/#error-suppression>`_.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -105,7 +105,7 @@ dask-image = [
     "dask-image",
 ]
 dev = [
-    "black",
+    "ruff",
     "hyperspy[all]",
     "hyperspy[coverage]",
     "hyperspy[doc]",

--- a/upcoming_changes/3567.bugfix.rst
+++ b/upcoming_changes/3567.bugfix.rst
@@ -1,0 +1,1 @@
+Remove mention of ``black`` in the contributor guide in favour of ``ruff`` to avoid settings conflict between ``ruff`` and ``black``.


### PR DESCRIPTION
### Progress of the PR
- [x] Remove mention of `black` in the contributor guide,
- [x] Replace `black` dev dependency with `ruff`, 
- [n/a] update docstring (if appropriate),
- [n/a] update user guide (if appropriate),
- [x] add an changelog entry in the `upcoming_changes` folder (see [`upcoming_changes/README.rst`](https://github.com/hyperspy/hyperspy/blob/RELEASE_next_minor/upcoming_changes/README.rst)),
- [x] Check formatting changelog entry in the `readthedocs` doc build of this PR (link in github checks)
- [n/a] add tests,
- [x] ready for review.


