### PR TITLE
Fix flyiter for numpy 2.4.0rc1

### DIFF
--- a/hyperspy/axes.py
+++ b/hyperspy/axes.py
@@ -1487,8 +1487,7 @@ def _flyback_iter(shape):
 
     class ndindex_reversed(np.ndindex):
         def __next__(self):
-            next(self._it)
-            return self._it.multi_index[::-1]
+            return super().__next__()[::-1]
 
     return ndindex_reversed(shape)
 

--- a/upcoming_changes/3571.bugfix.rst
+++ b/upcoming_changes/3571.bugfix.rst
@@ -1,0 +1,1 @@
+Fix compatibility of `'flyback'` axes iterator with numpy 2.4.0.


### PR DESCRIPTION
The [package and test workflow](https://github.com/hyperspy/hyperspy/actions/workflows/package_and_test.yml) started to fails since numpy [2.4.0rc1](https://pypi.org/project/numpy/2.4.0rc1/) is available in on pypi. This is due to https://github.com/numpy/numpy/pull/29165.
This is caught in that build and not elsewhere because other testing build that test against dev or pre-release of dependencies have numba installed that must be pinning numpy to an older version.

### Progress of the PR
- [x] Avoid using numpy private API that is changing in numpy 2.4.0,
- [n/a] update docstring (if appropriate),
- [n/a] update user guide (if appropriate),
- [x] add an changelog entry in the `upcoming_changes` folder (see [`upcoming_changes/README.rst`](https://github.com/hyperspy/hyperspy/blob/RELEASE_next_minor/upcoming_changes/README.rst)),
- [x] Check formatting changelog entry in the `readthedocs` doc build of this PR (link in github checks)
- [n/a] add tests,
- [x] ready for review.


