### PR TITLE
Migrate from deprecated `scipy.odr` to `odrpack`

### DIFF
--- a/doc/user_guide/install.rst
+++ b/doc/user_guide/install.rst
@@ -179,6 +179,8 @@ dependencies required by specific functionalities:
   :meth:`~hyperspy.api.signals.ComplexSignal.unwrapped_phase`.
 * ``ipython`` for integration with the `ipython` terminal and parallel processing using `ipyparallel`,
 * ``learning`` for some machine learning features,
+* ``odr`` for weighted orthogonal distance regression (ODR) fitting using the `odrpack95 <https://hugomvale.github.io/odrpack-python/>`_
+  library,
 * ``gui-jupyter`` to use the `Jupyter widgets <https://ipywidgets.readthedocs.io/en/stable/>`_
   GUI elements,
 * ``gui-traitsui`` to use the GUI elements based on `traitsui <https://docs.enthought.com/traitsui/>`_,

--- a/doc/user_guide/model/fitting_model.rst
+++ b/doc/user_guide/model/fitting_model.rst
@@ -39,36 +39,38 @@ whether the optimizers find a local or global optima.
     +---------------------------------+----------+-----------+----------+---------------+--------+--------+
     | ``"dogbox"``                    |  Yes     | Yes       | Yes      | Only ``"ls"`` | local  | No     |
     +---------------------------------+----------+-----------+----------+---------------+--------+--------+
-    | ``"odr"``                       |  No      | Yes       | Yes      | Only ``"ls"`` | local  | No     |
+    | ``"odr"`` [1]_                  |  Yes     | Yes       | Yes      | Only ``"ls"`` | local  | No     |
     +---------------------------------+----------+-----------+----------+---------------+--------+--------+
-    | ``"lstsq"``                     |  No      | No        | Yes [1]_ | Only ``"ls"`` | global | Yes    |
+    | ``"lstsq"``                     |  No      | No        | Yes [2]_ | Only ``"ls"`` | global | Yes    |
     +---------------------------------+----------+-----------+----------+---------------+--------+--------+
-    | ``"ols"``                       |  No      | No        | Yes [1]_ | Only ``"ls"`` | global | Yes    |
+    | ``"ols"``                       |  No      | No        | Yes [2]_ | Only ``"ls"`` | global | Yes    |
     +---------------------------------+----------+-----------+----------+---------------+--------+--------+
-    | ``"nnls"``                      |  No      | No        | Yes [1]_ | Only ``"ls"`` | global | Yes    |
+    | ``"nnls"``                      |  No      | No        | Yes [2]_ | Only ``"ls"`` | global | Yes    |
     +---------------------------------+----------+-----------+----------+---------------+--------+--------+
-    | ``"ridge"``                     |  No      | No        | Yes [1]_ | Only ``"ls"`` | global | Yes    |
+    | ``"ridge"``                     |  No      | No        | Yes [2]_ | Only ``"ls"`` | global | Yes    |
     +---------------------------------+----------+-----------+----------+---------------+--------+--------+
-    | :func:`scipy.optimize.minimize` | Yes [2]_ | Yes [2]_  | No       | All           | local  | No     |
+    | :func:`scipy.optimize.minimize` | Yes [3]_ | Yes [3]_  | No       | All           | local  | No     |
     +---------------------------------+----------+-----------+----------+---------------+--------+--------+
     | ``"Differential Evolution"``    |  Yes     | No        | No       | All           | global | No     |
     +---------------------------------+----------+-----------+----------+---------------+--------+--------+
-    | ``"Dual Annealing"`` [3]_       |  Yes     | No        | No       | All           | global | No     |
+    | ``"Dual Annealing"`` [4]_       |  Yes     | No        | No       | All           | global | No     |
     +---------------------------------+----------+-----------+----------+---------------+--------+--------+
-    | ``"SHGO"`` [3]_                 |  Yes     | No        | No       | All           | global | No     |
+    | ``"SHGO"`` [4]_                 |  Yes     | No        | No       | All           | global | No     |
     +---------------------------------+----------+-----------+----------+---------------+--------+--------+
 
 .. rubric:: Footnotes
 
-.. [1] Requires the :meth:`~hyperspy.model.BaseModel.multifit` ``calculate_errors = True`` argument
+.. [1] Requires the ``odrpack`` library to be installed.
+
+.. [2] Requires the :meth:`~hyperspy.model.BaseModel.multifit` ``calculate_errors = True`` argument
        in most cases. See the documentation below on :ref:`linear least square fitting <linear_fitting-label>`
        for more info.
 
-.. [2] **All** of the fitting algorithms available in :func:`scipy.optimize.minimize` are currently
+.. [3] **All** of the fitting algorithms available in :func:`scipy.optimize.minimize` are currently
        supported by HyperSpy; however, only some of them support bounds and/or gradients. For more information,
        please see the `SciPy documentation <https://docs.scipy.org/doc/scipy/reference/optimize.html>`_.
 
-.. [3] Requires ``scipy >= 1.2.0``.
+.. [4] Requires ``scipy >= 1.2.0``.
 
 
 

--- a/hyperspy/model.py
+++ b/hyperspy/model.py
@@ -1152,7 +1152,7 @@ class BaseModel(list):
                     else:
                         self.free_parameters_boundaries.extend((param._bounds))
 
-    def _bounds_as_tuple(self, transpose):
+    def _bounds_as_tuple(self, transpose, as_array=False):
         """
         Converts parameter bounds to tuples for scipy optimizer. For scipy
         ``least_squares``, ``transpose=True`` needs to be used, as the order of the
@@ -1166,9 +1166,13 @@ class BaseModel(list):
             for a, b in self.free_parameters_boundaries
         )
         if transpose:
-            return tuple(zip(*bounds))
-        else:
-            return bounds
+            bounds = tuple(zip(*bounds))
+
+        if as_array:
+            # odrpack needs numpy arrays
+            bounds = tuple(np.array(bounds_) for bounds_ in bounds)
+
+        return bounds
 
     def _set_mpfit_parameters_info(self, bounded=True):
         """Generate the boundary list for mpfit.
@@ -1829,6 +1833,7 @@ class BaseModel(list):
             "lm",
             "trf",
             "dogbox",
+            "odr",
             "Powell",
             "TNC",
             "L-BFGS-B",
@@ -1846,6 +1851,7 @@ class BaseModel(list):
             in [
                 "trf",  # Use least_squares
                 "dogbox",  # Use least_squares
+                "odr",  # Use odrpack
             ]
             else False
         )
@@ -2073,6 +2079,7 @@ class BaseModel(list):
                 self.p_std = self._calculate_parameter_std(pcov, cost, ysize)
 
             elif optimizer == "odr":
+                self._set_boundaries(bounded=bounded)
                 try:
                     import odrpack
                 except ModuleNotFoundError:  # pragma: no cover
@@ -2085,8 +2092,10 @@ class BaseModel(list):
                         "`optimizer='odr'` is not implemented for Model2D"
                     )
 
-                odr_jacobian = self._jacobian4odr if grad == "analytical" else None
-
+                kwargs.setdefault("task", "OLS")
+                bounds = self._bounds_as_tuple(
+                    transpose=_transpose_bounds, as_array=True
+                )
                 res = odrpack.odr_fit(
                     self._function4odr,
                     xdata=self.axis.axis[np.where(self._channel_switches)],
@@ -2096,8 +2105,8 @@ class BaseModel(list):
                     beta0=np.array(self.p0[:]),
                     weight_x=None,
                     weight_y=(1.0 / weights if weights is not None else None),
-                    jac_beta=odr_jacobian,
-                    task="OLS",
+                    jac_beta=self._jacobian4odr if grad == "analytical" else None,
+                    bounds=bounds if bounded else None,
                     **kwargs,
                 )
 

--- a/hyperspy/model.py
+++ b/hyperspy/model.py
@@ -29,7 +29,6 @@ import cloudpickle
 import dask
 import dask.array as da
 import numpy as np
-import scipy.odr as odr
 from dask.diagnostics import ProgressBar
 from packaging.version import Version
 from scipy.linalg import svd
@@ -2074,6 +2073,13 @@ class BaseModel(list):
                 self.p_std = self._calculate_parameter_std(pcov, cost, ysize)
 
             elif optimizer == "odr":
+                try:
+                    import odrpack
+                except ModuleNotFoundError:  # pragma: no cover
+                    raise ImportError(
+                        "The 'odrpack' package is required for optimizer='odr'."
+                    )
+
                 if not hasattr(self, "axis"):
                     raise NotImplementedError(
                         "`optimizer='odr'` is not implemented for Model2D"
@@ -2081,15 +2087,19 @@ class BaseModel(list):
 
                 odr_jacobian = self._jacobian4odr if grad == "analytical" else None
 
-                modelo = odr.Model(fcn=self._function4odr, fjacb=odr_jacobian)
-                mydata = odr.RealData(
-                    self.axis.axis[np.where(self._channel_switches)],
-                    self.signal._get_current_data()[np.where(self._channel_switches)],
-                    sx=None,
-                    sy=(1.0 / weights if weights is not None else None),
+                res = odrpack.odr_fit(
+                    self._function4odr,
+                    xdata=self.axis.axis[np.where(self._channel_switches)],
+                    ydata=self.signal._get_current_data()[
+                        np.where(self._channel_switches)
+                    ],
+                    beta0=np.array(self.p0[:]),
+                    weight_x=None,
+                    weight_y=(1.0 / weights if weights is not None else None),
+                    jac_beta=odr_jacobian,
+                    task="OLS",
+                    **kwargs,
                 )
-                myodr = odr.ODR(mydata, modelo, beta0=self.p0[:], **kwargs)
-                res = myodr.run()
 
                 dd = {
                     "x": res.beta,
@@ -2098,7 +2108,7 @@ class BaseModel(list):
                 }
                 if hasattr(res, "info"):
                     dd["status"] = res.info
-                    dd["message"] = ", ".join(res.stopreason)
+                    dd["message"] = res.stopreason
                     # Note that a value of 5 means maximum iterations reached
                     dd["success"] = (res.info >= 0) and (res.info < 4)
 

--- a/hyperspy/models/model1d.py
+++ b/hyperspy/models/model1d.py
@@ -595,10 +595,10 @@ class Model1D(BaseModel):
 
         return to_return
 
-    def _function4odr(self, param, x):
+    def _function4odr(self, x, param):
         return self._model_function(param)
 
-    def _jacobian4odr(self, param, x):
+    def _jacobian4odr(self, x, param):
         return self._jacobian(param, x)
 
     def _poisson_likelihood_function(self, param, y, weights=None):

--- a/hyperspy/models/model2d.py
+++ b/hyperspy/models/model2d.py
@@ -322,10 +322,10 @@ class Model2D(BaseModel):
     def _jacobian(self, param, y, weights=None):
         raise NotImplementedError
 
-    def _function4odr(self, param, x):
+    def _function4odr(self, x, param):
         raise NotImplementedError
 
-    def _jacobian4odr(self, param, x):
+    def _jacobian4odr(self, x, param):
         raise NotImplementedError
 
     def _poisson_likelihood_function(self, param, y, weights=None):

--- a/hyperspy/tests/model/test_fitting.py
+++ b/hyperspy/tests/model/test_fitting.py
@@ -145,6 +145,16 @@ class TestModelFitBinnedLeastSquares:
         assert len(self.m.p_std) == 3
         assert np.all(~np.isnan(self.m.p_std))
 
+    def test_fit_odr_bounded(self):
+        pytest.importorskip("odrpack", reason="odrpack not installed")
+        self.m.fit(optimizer="odr", bounded=True)
+        self._check_model_values(self.m[0], (250.66282746, 50.0, 5.0), rtol=TOL)
+
+        assert isinstance(self.m.fit_output, OptimizeResult)
+        assert self.m.p_std is not None
+        assert len(self.m.p_std) == 3
+        assert np.all(~np.isnan(self.m.p_std))
+
     def test_fit_bounded_bad_starting_values(self):
         self.m[0].centre.bmin = 0.5
         self.m[0].centre.value = -1
@@ -481,10 +491,6 @@ class TestFitErrorsAndWarnings:
             NotImplementedError, match=r".* only supports least-squares fitting"
         ):
             self.m.fit(loss_function="ML-poisson", optimizer="lm")
-
-    def test_not_support_bounds(self):
-        with pytest.raises(ValueError, match="Bounded optimization is only supported"):
-            self.m.fit(optimizer="odr", bounded=True)
 
     def test_wrong_grad(self):
         with pytest.raises(ValueError, match="`grad` must be one of"):

--- a/hyperspy/tests/model/test_fitting.py
+++ b/hyperspy/tests/model/test_fitting.py
@@ -136,6 +136,7 @@ class TestModelFitBinnedLeastSquares:
         ],
     )
     def test_fit_odr(self, grad, expected):
+        pytest.importorskip("odrpack", reason="odrpack not installed")
         self.m.fit(optimizer="odr", grad=grad)
         self._check_model_values(self.m[0], expected, rtol=TOL)
 
@@ -362,12 +363,14 @@ class TestModelWeighted:
         [
             ("lm", True, True, (267.851451, 50.284446, 5.220067)),
             ("lm", True, False, (267.851451, 50.284446, 5.220067)),
-            ("odr", True, False, (267.851451, 50.284446, 5.220067)),
+            ("odr", True, False, (268.262884, 50.285163, 5.236098)),
             ("lm", False, False, (26.785102, 50.284446, 5.220067)),
-            ("odr", False, False, (26.785102, 50.284446, 5.220067)),
+            ("odr", False, False, (26.826236, 50.285163, 5.236098)),
         ],
     )
     def test_fit(self, non_uniform_axis, optimizer, binned, expected):
+        if optimizer == "odr":
+            pytest.importorskip("odrpack", reason="odrpack not installed")
         axis = self.m.signal.axes_manager[-1]
         axis.is_binned = binned
         if non_uniform_axis:
@@ -421,6 +424,8 @@ class TestFitPrintReturnInfo:
 
     @pytest.mark.parametrize("optimizer", ["odr", "Nelder-Mead", "L-BFGS-B"])
     def test_print_info(self, optimizer, capfd):
+        if optimizer == "odr":
+            pytest.importorskip("odrpack", reason="odrpack not installed")
         self.m.fit(optimizer=optimizer, print_info=True)
         captured = capfd.readouterr()
         assert "Fit info:" in captured.out
@@ -443,6 +448,8 @@ class TestFitPrintReturnInfo:
     @pytest.mark.parametrize("optimizer", ["odr", "Nelder-Mead", "L-BFGS-B"])
     def test_return_info(self, optimizer):
         # Default is return_info=True
+        if optimizer == "odr":
+            pytest.importorskip("odrpack", reason="odrpack not installed")
         res = self.m.fit(optimizer=optimizer)
         assert isinstance(res, OptimizeResult)
 

--- a/hyperspy/tests/model/test_model2d.py
+++ b/hyperspy/tests/model/test_model2d.py
@@ -99,6 +99,7 @@ class TestModel2D:
             self.m.fit(optimizer="L-BFGS-B", grad="analytical")
 
     def test_fit_no_odr_error(self):
+        pytest.importorskip("odrpack", reason="odrpack not installed")
         with pytest.raises(NotImplementedError, match="is not implemented for Model2D"):
             self.m.fit(optimizer="odr")
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -93,6 +93,7 @@ all = [
     "hyperspy[image]",
     "hyperspy[ipython]",
     "hyperspy[learning]",
+    "hyperspy[odr]",
     "hyperspy[speed]",
 ]
 baseline = [
@@ -147,6 +148,9 @@ ipython = [
 ]
 learning = [
     "scikit-learn>=1.1.0",
+]
+odr = [
+    "odrpack>=0.3.1",
 ]
 speed = [
     "numba>=0.56.0",

--- a/upcoming_changes/3574.maintenance.rst
+++ b/upcoming_changes/3574.maintenance.rst
@@ -1,0 +1,1 @@
+Migrate from deprecated ``scipy.odr`` to ``odrpack`` in the implementation of weighted orthogonal distance regression (ODR) fitting, which now needs the optional dependency `odrpack <https://pypi.org/project/odrpack/>`_.


### PR DESCRIPTION
The package and test workflow is failing because `scipy` has a pre-release on pypi with the `scipy.odr` deprecation.

`odrpack` is not on conda-forge yet, but hopefully, it will be soon: https://github.com/HugoMVale/odrpack-python/issues/6

### Progress of the PR
- [x] Migrate from deprecated `scipy.odr` to `odrpack`,
- [x] add bounds support in when using `odrpack`, 
- [x] update docstring (if appropriate),
- [x] update user guide (if appropriate),
- [x] add an changelog entry in the `upcoming_changes` folder (see [`upcoming_changes/README.rst`](https://github.com/hyperspy/hyperspy/blob/RELEASE_next_minor/upcoming_changes/README.rst)),
- [x] Check formatting changelog entry in the `readthedocs` doc build of this PR (link in github checks)
- [x] update tests,
- [x] ready for review.


