### PR TITLE
Fix readthedocs build on tags

### DIFF
--- a/readthedocs.yaml
+++ b/readthedocs.yaml
@@ -12,6 +12,9 @@ build:
     python: "3.11"
   apt_packages:
     - optipng
+  jobs:
+    post_checkout:
+      - git fetch origin --tags
 
 # Build documentation in the docs/ directory with Sphinx
 sphinx:

--- a/readthedocs.yaml
+++ b/readthedocs.yaml
@@ -7,7 +7,7 @@ version: 2
 
 # Set the version of Python and other tools you might need
 build:
-  os: ubuntu-22.04
+  os: ubuntu-24.04
   tools:
     python: "3.11"
   apt_packages:

--- a/upcoming_changes/3575.maintenance.rst
+++ b/upcoming_changes/3575.maintenance.rst
@@ -1,0 +1,1 @@
+Fix readthedocs documentation build on tag.


### PR DESCRIPTION
The readthedocs build are failing on tag: https://app.readthedocs.org/projects/hyperspy/builds/?version__slug=stable because the git repository in the readthedocs build doesn't have the tags and the hyperspy version is incorrect.

### Progress of the PR
- [x] Fetch tags on readthedocs build to avoid failure of the build,
- [x] update the ubuntu version to the latest, 
- [n/a] update docstring (if appropriate),
- [n/a] update user guide (if appropriate),
- [x] add an changelog entry in the `upcoming_changes` folder (see [`upcoming_changes/README.rst`](https://github.com/hyperspy/hyperspy/blob/RELEASE_next_minor/upcoming_changes/README.rst)),
- [x] Check formatting changelog entry in the `readthedocs` doc build of this PR (link in github checks)
- [n/a] add tests,
- [x] ready for review.

