### PR TITLE
Align naming of azure pipeline instances with python version

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -25,27 +25,27 @@ resources:
 
 strategy:
   matrix:
-    Linux_Python39:
+    Linux_Python311:
       vmImage: 'ubuntu-latest'
       PYTHON_VERSION: '3.11'
       MINIFORGE_PATH: $(Agent.BuildDirectory)/miniforge3
-    Linux_Python310:
+    Linux_Python312:
       vmImage: 'ubuntu-latest'
       PYTHON_VERSION: '3.12'
       MINIFORGE_PATH: $(Agent.BuildDirectory)/miniforge3
-    MacOS_Python39:
+    MacOS_Python311:
       vmImage: 'macOS-latest'
       PYTHON_VERSION: '3.11'
       MINIFORGE_PATH: $(Agent.BuildDirectory)/miniforge3
-    MacOS_Python310:
+    MacOS_Python312:
       vmImage: 'macOS-latest'
       PYTHON_VERSION: '3.12'
       MINIFORGE_PATH: $(Agent.BuildDirectory)/miniforge3
-    Windows_Python39:
+    Windows_Python311:
       vmImage: 'windows-latest'
       PYTHON_VERSION: '3.11'
       MINIFORGE_PATH: $(Agent.BuildDirectory)\miniforge3
-    Windows_Python310:
+    Windows_Python312:
       vmImage: 'windows-latest'
       PYTHON_VERSION: '3.12'
       MINIFORGE_PATH: $(Agent.BuildDirectory)\miniforge3


### PR DESCRIPTION
Follow up to #3573. Fixes the naming of the azure pipeline instances, which should match the python version used.

### Progress of the PR
- [x] Change implemented (can be split into several points),
- [x] ready for review.
