### PR TITLE
Use PrettyTable for formatting output tables

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,3 +50,7 @@ jsconfig.json
 *__pycache__*
 
 *sg_execution_times.rst
+
+# virtual environments
+venv/
+

--- a/hyperspy/misc/model_tools.py
+++ b/hyperspy/misc/model_tools.py
@@ -446,7 +446,7 @@ class ModelStatistics:
     def _repr_html_(self):
         html = ""
         for comp_type, params in self.stats.items():
-            html += f"<h4>Component type: {comp_type}</h4>"
+            html += f"<h4>{comp_type}</h4>"
             table = self._build_table(params)
             html += table.get_html_string(
                 attributes={

--- a/hyperspy/misc/model_tools.py
+++ b/hyperspy/misc/model_tools.py
@@ -105,7 +105,7 @@ class CurrentComponentValues:
         # Create table
         table = PrettyTable()
         table.field_names = [
-            "Parameter Name",
+            "Parameter",
             "Free",
             "Value",
             "Std",
@@ -113,7 +113,7 @@ class CurrentComponentValues:
             "Max",
             "Linear",
         ]
-        table.align["Parameter Name"] = "r"
+        table.align["Parameter"] = "r"
         table.align["Free"] = "r"
         table.align["Value"] = "r"
         table.align["Std"] = "r"
@@ -436,11 +436,19 @@ class ModelStatistics:
             for pname, stats in params.items():
                 table.add_row(
                     [
-                        pname[:14],  # Truncate to 14 chars
-                        f"{stats['mean']:.3e}",
-                        f"{stats['std']:.3e}",
-                        f"{stats['min']:.3e}",
-                        f"{stats['max']:.3e}",
+                        _format_string(pname, max_length=14),
+                        _format_string(
+                            stats["mean"], format_string=".3e", max_length=12
+                        ),
+                        _format_string(
+                            stats["std"], format_string=".3e", max_length=12
+                        ),
+                        _format_string(
+                            stats["min"], format_string=".3e", max_length=12
+                        ),
+                        _format_string(
+                            stats["max"], format_string=".3e", max_length=12
+                        ),
                     ]
                 )
 

--- a/hyperspy/misc/model_tools.py
+++ b/hyperspy/misc/model_tools.py
@@ -23,6 +23,7 @@ from collections.abc import Iterable
 
 import dask.array as da
 import numpy as np
+from prettytable import PrettyTable
 
 from hyperspy.misc.utils import _parse_percentile_value
 
@@ -93,57 +94,51 @@ class CurrentComponentValues:
         self.only_active = only_active
 
     def __repr__(self):
-        # Number of digits for each label for the terminal-style view.
-        size = {
-            "name": 14,
-            "free": 7,
-            "value": 10,
-            "std": 10,
-            "bmin": 10,
-            "bmax": 10,
-            "linear": 6,
-        }
-        # Using nested string formatting for flexibility in future updates
-        signature = "{{:>{name}}} | {{:>{free}}} | {{:>{value}}} | {{:>{std}}} | {{:>{bmin}}} | {{:>{bmax}}} | {{:>{linear}}}".format(
-            **size
-        )
-
+        # Create header text
         if self.only_active:
-            text = "{0}: {1}".format(self.__class__.__name__, self.name)
+            header = "{0}: {1}".format(self.__class__.__name__, self.name)
         else:
-            text = "{0}: {1}\nActive: {2}".format(
+            header = "{0}: {1}\nActive: {2}".format(
                 self.__class__.__name__, self.name, self.active
             )
-        text += "\n"
-        text += signature.format(
-            "Parameter Name", "Free", "Value", "Std", "Min", "Max", "Linear"
-        )
-        text += "\n"
-        text += signature.format(
-            "=" * size["name"],
-            "=" * size["free"],
-            "=" * size["value"],
-            "=" * size["std"],
-            "=" * size["bmin"],
-            "=" * size["bmax"],
-            "=" * size["linear"],
-        )
-        text += "\n"
+
+        # Create table
+        table = PrettyTable()
+        table.field_names = [
+            "Parameter Name",
+            "Free",
+            "Value",
+            "Std",
+            "Min",
+            "Max",
+            "Linear",
+        ]
+        table.align["Parameter Name"] = "r"
+        table.align["Free"] = "r"
+        table.align["Value"] = "r"
+        table.align["Std"] = "r"
+        table.align["Min"] = "r"
+        table.align["Max"] = "r"
+        table.align["Linear"] = "r"
+
+        # Add rows
         for para in self.parameters:
             if not self.only_free or self.only_free and para.free:
                 free = para.free if para.twin is None else "Twinned"
                 ln = para._linear
-                text += signature.format(
-                    _format_string(para.name, max_length=size["name"]),
-                    _format_string(str(free), max_length=size["free"]),
-                    _format_string(para.value, max_length=size["value"]),
-                    _format_string(para.std, max_length=size["std"]),
-                    _format_string(para.bmin, max_length=size["bmin"]),
-                    _format_string(para.bmax, max_length=size["bmax"]),
-                    _format_string(str(ln), max_length=size["linear"]),
+                table.add_row(
+                    [
+                        _format_string(para.name, max_length=14),
+                        _format_string(str(free), max_length=7),
+                        _format_string(para.value, max_length=10),
+                        _format_string(para.std, max_length=10),
+                        _format_string(para.bmin, max_length=10),
+                        _format_string(para.bmax, max_length=10),
+                        _format_string(str(ln), max_length=6),
+                    ]
                 )
-                text += "\n"
-        return text
+
+        return header + "\n" + str(table)
 
     def _repr_html_(self):
         if self.only_active:

--- a/hyperspy/misc/model_tools.py
+++ b/hyperspy/misc/model_tools.py
@@ -93,16 +93,9 @@ class CurrentComponentValues:
         self.only_free = only_free
         self.only_active = only_active
 
-    def __repr__(self):
-        # Create header text
-        if self.only_active:
-            header = "{0}: {1}".format(self.__class__.__name__, self.name)
-        else:
-            header = "{0}: {1}\nActive: {2}".format(
-                self.__class__.__name__, self.name, self.active
-            )
+    def _build_table(self):
+        """Build and return a PrettyTable with parameter data."""
 
-        # Create table
         table = PrettyTable()
         table.field_names = [
             "Parameter",
@@ -137,35 +130,36 @@ class CurrentComponentValues:
                         _format_string(str(ln), max_length=6),
                     ]
                 )
+        return table
 
+    def __repr__(self):
+        if self.only_active:
+            header = "{0}: {1}".format(self.__class__.__name__, self.name)
+        else:
+            header = "{0}: {1}\nActive: {2}".format(
+                self.__class__.__name__, self.name, self.active
+            )
+
+        table = self._build_table()
         return header + "\n" + str(table)
 
     def _repr_html_(self):
         if self.only_active:
-            text = "<p><b>{0}: {1}</b></p>".format(self.__class__.__name__, self.name)
+            header = "<p><b>{0}: {1}</b></p>".format(self.__class__.__name__, self.name)
         else:
-            text = "<p><b>{0}: {1}</b><br />Active: {2}</p>".format(
+            header = "<p><b>{0}: {1}</b><br />Active: {2}</p>".format(
                 self.__class__.__name__, self.name, self.active
             )
 
-        para_head = """<table style="width:100%"><tr><th>Parameter Name</th><th>Free</th>
-            <th>Value</th><th>Std</th><th>Min</th><th>Max</th><th>Linear</th></tr>"""
-        text += para_head
-        for para in self.parameters:
-            if not self.only_free or self.only_free and para.free:
-                free = para.free if para.twin is None else "Twinned"
-                linear = para._linear
-                value = _format_string(para.value)
-                std = _format_string(para.std)
-                bmin = _format_string(para.bmin)
-                bmax = _format_string(para.bmax)
+        table = self._build_table()
+        table_html = table.get_html_string(
+            attributes={
+                "style": "width:100%; border-collapse:collapse; text-align:center;",
+                "border": "1",
+            }
+        )
 
-                text += """<tr><td>{0}</td><td>{1}</td><td>{2}</td>
-                    <td>{3}</td><td>{4}</td><td>{5}</td><td>{6}</td></tr>""".format(
-                    para.name, free, value, std, bmin, bmax, linear
-                )
-        text += "</table>"
-        return text
+        return header + table_html
 
 
 class CurrentModelValues:
@@ -418,60 +412,47 @@ class ModelStatistics:
                     }
         return statistics
 
-    # --- Text output (repr) ---
+    # --- Table Output ---
+    def _build_table(self, params):
+        """Build and return a PrettyTable for a component type's statistics."""
+        table = PrettyTable()
+        table.field_names = ["Parameter", "Mean", "Std", "Min", "Max"]
+        table.align["Parameter"] = "l"
+        table.align["Mean"] = "r"
+        table.align["Std"] = "r"
+        table.align["Min"] = "r"
+        table.align["Max"] = "r"
+
+        for pname, stats in params.items():
+            table.add_row(
+                [
+                    _format_string(pname, max_length=14),
+                    _format_string(stats["mean"], format_string=".3e", max_length=12),
+                    _format_string(stats["std"], format_string=".3e", max_length=12),
+                    _format_string(stats["min"], format_string=".3e", max_length=12),
+                    _format_string(stats["max"], format_string=".3e", max_length=12),
+                ]
+            )
+        return table
+
     def __repr__(self):
         text = ""
         for comp_type, params in self.stats.items():
             text += f"{comp_type}:\n"
-
-            # create a table for this component type
-            table = PrettyTable()
-            table.field_names = ["Parameter", "Mean", "Std", "Min", "Max"]
-            table.align["Parameter"] = "l"
-            table.align["Mean"] = "r"
-            table.align["Std"] = "r"
-            table.align["Min"] = "r"
-            table.align["Max"] = "r"
-
-            for pname, stats in params.items():
-                table.add_row(
-                    [
-                        _format_string(pname, max_length=14),
-                        _format_string(
-                            stats["mean"], format_string=".3e", max_length=12
-                        ),
-                        _format_string(
-                            stats["std"], format_string=".3e", max_length=12
-                        ),
-                        _format_string(
-                            stats["min"], format_string=".3e", max_length=12
-                        ),
-                        _format_string(
-                            stats["max"], format_string=".3e", max_length=12
-                        ),
-                    ]
-                )
-
+            table = self._build_table(params)
             text += str(table) + "\n\n"
-
         return text
 
-    # --- HTML output (repr_html) ---
     def _repr_html_(self):
         html = ""
         for comp_type, params in self.stats.items():
             html += f"<h4>Component type: {comp_type}</h4>"
-            html += (
-                "<table style='width:100%; border-collapse:collapse; text-align:center;'>"
-                "<tr><th>Parameter</th><th>Mean</th><th>Std</th><th>Min</th><th>Max</th></tr>"
+            table = self._build_table(params)
+            html += table.get_html_string(
+                attributes={
+                    "style": "width:100%; border-collapse:collapse; text-align:center;",
+                    "border": "1",
+                }
             )
-            for pname, stats in params.items():
-                html += (
-                    f"<tr><td>{pname}</td>"
-                    f"<td>{stats['mean']:.3e}</td>"
-                    f"<td>{stats['std']:.3e}</td>"
-                    f"<td>{stats['min']:.3e}</td>"
-                    f"<td>{stats['max']:.3e}</td></tr>"
-                )
-            html += "</table><br>"
+            html += "<br>"
         return html

--- a/hyperspy/misc/model_tools.py
+++ b/hyperspy/misc/model_tools.py
@@ -420,46 +420,32 @@ class ModelStatistics:
 
     # --- Text output (repr) ---
     def __repr__(self):
-        # Spaltengrößen für Terminal-Layout
-        size = {
-            "param": 14,
-            "mean": 12,
-            "std": 12,
-            "min": 12,
-            "max": 12,
-        }
-
-        signature = "{{:<{param}}} | {{:>{mean}}} | {{:>{std}}} | {{:>{min}}} | {{:>{max}}}".format(
-            **size
-        )
-
         text = ""
         for comp_type, params in self.stats.items():
             text += f"{comp_type}:\n"
-            text += signature.format("Parameter", "Mean", "Std", "Min", "Max") + "\n"
-            text += (
-                signature.format(
-                    "=" * size["param"],
-                    "=" * size["mean"],
-                    "=" * size["std"],
-                    "=" * size["min"],
-                    "=" * size["max"],
-                )
-                + "\n"
-            )
+
+            # create a table for this component type
+            table = PrettyTable()
+            table.field_names = ["Parameter", "Mean", "Std", "Min", "Max"]
+            table.align["Parameter"] = "l"
+            table.align["Mean"] = "r"
+            table.align["Std"] = "r"
+            table.align["Min"] = "r"
+            table.align["Max"] = "r"
 
             for pname, stats in params.items():
-                text += (
-                    signature.format(
-                        pname[: size["param"]],
+                table.add_row(
+                    [
+                        pname[:14],  # Truncate to 14 chars
                         f"{stats['mean']:.3e}",
                         f"{stats['std']:.3e}",
                         f"{stats['min']:.3e}",
                         f"{stats['max']:.3e}",
-                    )
-                    + "\n"
+                    ]
                 )
-            text += "\n"
+
+            text += str(table) + "\n\n"
+
         return text
 
     # --- HTML output (repr_html) ---

--- a/hyperspy/misc/model_tools.py
+++ b/hyperspy/misc/model_tools.py
@@ -87,6 +87,7 @@ class CurrentComponentValues:
 
     def __init__(self, component, only_free=False, only_active=False):
         self.name = component.name
+        self.component_type = component.__class__.__name__
         self.active = component.active
         self.parameters = component.parameters
         self._id_name = component._id_name
@@ -134,10 +135,10 @@ class CurrentComponentValues:
 
     def __repr__(self):
         if self.only_active:
-            header = "{0}: {1}".format(self.__class__.__name__, self.name)
+            header = "{0}: {1}".format(self.component_type, self.name)
         else:
             header = "{0}: {1}\nActive: {2}".format(
-                self.__class__.__name__, self.name, self.active
+                self.component_type, self.name, self.active
             )
 
         table = self._build_table()
@@ -145,10 +146,10 @@ class CurrentComponentValues:
 
     def _repr_html_(self):
         if self.only_active:
-            header = "<p><b>{0}: {1}</b></p>".format(self.__class__.__name__, self.name)
+            header = "<p><b>{0}: {1}</b></p>".format(self.component_type, self.name)
         else:
             header = "<p><b>{0}: {1}</b><br />Active: {2}</p>".format(
-                self.__class__.__name__, self.name, self.active
+                self.component_type, self.name, self.active
             )
 
         table = self._build_table()
@@ -181,11 +182,10 @@ class CurrentModelValues:
         self.only_free = only_free
         self.only_active = only_active
         self.component_list = model if component_list is None else component_list
-        self.model_type = str(self.model.__class__).split("'")[1].split(".")[-1]
 
     def __repr__(self):
         text = "{}: {}\n".format(
-            self.model_type, self.model.signal.metadata.General.title
+            self.model.__class__.__name__, self.model.signal.metadata.General.title
         )
         for comp in self.component_list:
             if not self.only_active or self.only_active and comp.active:
@@ -202,7 +202,7 @@ class CurrentModelValues:
 
     def _repr_html_(self):
         html = "<h4>{}: {}</h4>".format(
-            self.model_type, self.model.signal.metadata.General.title
+            self.model.__class__.__name__, self.model.signal.metadata.General.title
         )
         for comp in self.component_list:
             if not self.only_active or self.only_active and comp.active:

--- a/hyperspy/tests/component/test_component_print_current.py
+++ b/hyperspy/tests/component/test_component_print_current.py
@@ -146,15 +146,15 @@ class TestSetParameters:
 
     def test_zero_in_normal_print(self):
         """Ensure parameters with value=0 are printed too"""
-        assert "            a0 |    True |          0 |" in str(
-            CurrentComponentValues(self.model[0]).__repr__
-        )
+        table = str(CurrentComponentValues(self.model[0]))
+        assert "a0" in table
+        assert "True" in table
+        assert "0" in table
 
     def test_twinned_in_print(self):
-        assert (
-            "             A | Twinned |"
-            in str(CurrentComponentValues(self.model[2]).__repr__()).split("\n")[4]
-        )
+        table = str(CurrentComponentValues(self.model[2]))
+        assert "A" in table
+        assert "Twinned" in table
 
 
 def test_format_string():

--- a/hyperspy/tests/component/test_component_print_current.py
+++ b/hyperspy/tests/component/test_component_print_current.py
@@ -139,10 +139,11 @@ class TestSetParameters:
 
     def test_zero_in_html_print(self):
         """Ensure parameters with value=0 are printed too"""
-        assert (
-            "<td>a1</td><td>True</td><td>0</td>"
-            in CurrentComponentValues(self.model[0])._repr_html_()
-        )
+        html = CurrentComponentValues(self.model[0])._repr_html_()
+        assert "<table" in html
+        assert "a1" in html
+        assert "True" in html
+        assert "0" in html
 
     def test_zero_in_normal_print(self):
         """Ensure parameters with value=0 are printed too"""

--- a/upcoming_changes/3579.enhancements.rst
+++ b/upcoming_changes/3579.enhancements.rst
@@ -1,0 +1,3 @@
+The `print_current_values` and `print_model_statistics` display classes now use
+PrettyTable to render terminal and notebook HTML outputs consistently and
+with improved readability.


### PR DESCRIPTION

### Description of the change
The PR tries to fix the issue #3579 
- Changes the __repr__ method in model_tools.py to use PrettyTable 
- Updates the tests for prettytable format.

### Progress of the PR
- [ ] Change implemented (can be split into several points),
- [ ] update docstring (if appropriate),
- [ ] update user guide (if appropriate),
- [ ] add an changelog entry in the `upcoming_changes` folder (see [`upcoming_changes/README.rst`](https://github.com/hyperspy/hyperspy/blob/RELEASE_next_minor/upcoming_changes/README.rst)),
- [ ] Check formatting changelog entry in the `readthedocs` doc build of this PR (link in github checks)
- [ ] add tests,
- [ ] ready for review.

### Minimal example of the bug fix or the new feature
```python
#!/usr/bin/env python3
import numpy as np
import hyperspy.api as hs

x = np.linspace(0, 20, 200)
y = (
    3 * np.exp(-((x - 5) ** 2) / (2 * 0.5 ** 2))
    + 2 * np.exp(-((x - 10) ** 2) / (2 * 1.0 ** 2))
    + 4 * np.exp(-((x - 15) ** 2) / (2 * 0.8 ** 2))
)

s = hs.signals.Signal1D(y)
m = s.create_model()

gauss1 = hs.model.components1D.Gaussian()
gauss2 = hs.model.components1D.Gaussian()
gauss3 = hs.model.components1D.Gaussian()
lorenz1 = hs.model.components1D.Lorentzian()
lorenz2 = hs.model.components1D.Lorentzian()

m.extend([gauss1, gauss2, gauss3, lorenz1, lorenz2])
m.multifit()
m.print_model_statistics()
```
#### Output of prettytable after changes.
<img width="526" height="578" alt="output_prettytable" src="https://github.com/user-attachments/assets/9fb1829c-85c0-4cc5-bf3c-dec5922d21f3" />

Note that this example can be useful to update the user guide.

