### PR TITLE
Lazify docstring

### DIFF
--- a/hyperspy/io.py
+++ b/hyperspy/io.py
@@ -16,6 +16,7 @@
 # You should have received a copy of the GNU General Public License
 # along with HyperSpy. If not, see <https://www.gnu.org/licenses/#GPL>.
 
+import functools
 import glob
 import importlib
 import logging
@@ -47,17 +48,80 @@ _logger = logging.getLogger(__name__)
 # Utility string:
 f_error_fmt = "\tFile %d:\n\t\t%d signals\n\t\tPath: %s"
 
-# Support for zarr 2 and zarr 3
-ZARR_STORE_BASE_CLASS = MutableMapping
-try:
-    import zarr
 
-    if Version(zarr.__version__) >= Version("3.0.0"):  # pragma: no cover
-        ZARR_STORE_BASE_CLASS = zarr.abc.store.Store
-except ImportError:
-    # zarr is not installed, so we don't need to check for it
-    # keep MutableMapping as the default
-    pass
+def _is_zarr_store(obj):
+    ZARR_STORE_BASE_CLASS = MutableMapping
+    try:
+        import zarr
+
+        if Version(zarr.__version__) >= Version("3.0.0"):  # pragma: no cover
+            ZARR_STORE_BASE_CLASS = zarr.abc.store.Store
+    except ImportError:
+        # zarr is not installed, so we don't need to check for it
+        # keep MutableMapping as the default
+        pass
+
+    return isinstance(obj, ZARR_STORE_BASE_CLASS)
+
+
+class _LazyDocstring:
+    """Wrapper to lazily format a function/method's docstring on first access.
+
+    Works as both a callable wrapper (for functions) and a descriptor (for methods).
+
+    Parameters
+    ----------
+    func : callable
+        The function or method to wrap.
+    format_args_func : callable
+        A callable that returns the format arguments tuple.
+        This enables fully lazy evaluation (deferred until docstring access).
+    """
+
+    def __init__(self, func, format_args_func):
+        self._func = func
+        self._format_args_func = format_args_func
+        self._formatted_doc = None
+        # Exclude __doc__ from update_wrapper to preserve our lazy property
+        functools.update_wrapper(
+            self,
+            func,
+            assigned=(
+                "__module__",
+                "__name__",
+                "__qualname__",
+                "__annotations__",
+                "__wrapped__",
+            ),
+        )
+
+    def __call__(self, *args, **kwargs):
+        return self._func(*args, **kwargs)
+
+    def __get__(self, obj, objtype=None):
+        if obj is None:
+            return self
+        # Return a bound method that preserves our lazy docstring
+        bound_method = self._func.__get__(obj, objtype)
+
+        # Create a wrapper that has our lazy __doc__
+        @functools.wraps(bound_method)
+        def wrapper(*args, **kwargs):
+            return bound_method(*args, **kwargs)
+
+        # Replace the wrapper's __doc__ with our lazy-formatted docstring
+        wrapper.__doc__ = self.__doc__
+        return wrapper
+
+    @property
+    def __doc__(self):
+        if self._formatted_doc is None:
+            self._formatted_doc = self._func.__doc__ % self._format_args_func()
+        return self._formatted_doc
+
+    @__doc__.setter
+    def __doc__(self, value):
+        self._formatted_doc = value
 
 
 def _get_format_list_for_docstring(write_mode=False, style="bullet", indentation=8):
@@ -536,6 +600,7 @@ def load(
             "The 'reader' parameter is deprecated in HyperSpy 2.4 and"
             "will be removed in HyperSpy 3.0. Use 'file_format' instead.",
             VisibleDeprecationWarning,
+            stacklevel=3,  # Account for _LazyDocstring wrapper
         )
         # Use reader value as file_format for backward compatibility
         effective_file_format = reader
@@ -586,7 +651,9 @@ def load(
         filenames = list(filenames)
 
     # pathlib.Path.glob returns a map object in python 3.13
-    elif not isinstance(filenames, (list, tuple, ZARR_STORE_BASE_CLASS, map)):
+    elif not isinstance(filenames, (list, tuple, map)) and not _is_zarr_store(
+        filenames
+    ):
         raise ValueError(
             "The filenames parameter must be a list, tuple, "
             f"string or None, not {type(filenames)}"
@@ -596,7 +663,7 @@ def load(
         # in case, the file doesn't exist
         raise ValueError(f'No filename matches the pattern "{pattern}"')
 
-    if isinstance(filenames, ZARR_STORE_BASE_CLASS):
+    if _is_zarr_store(filenames):
         filenames = [filenames]
     else:
         # pathlib.Path not fully supported in io_plugins,
@@ -673,10 +740,13 @@ def load(
     return objects
 
 
-load.__doc__ %= (
-    STACK_METADATA_ARG,
-    SHOW_PROGRESSBAR_ARG,
-    _get_format_list_for_docstring(write_mode=False, style="bullet"),
+load = _LazyDocstring(
+    load,
+    lambda: (
+        STACK_METADATA_ARG,
+        SHOW_PROGRESSBAR_ARG,
+        _get_format_list_for_docstring(write_mode=False, style="bullet"),
+    ),
 )
 
 
@@ -802,6 +872,7 @@ def load_with_reader(
                     "axis.is_binned. Setting this attribute for all "
                     "signal axes instead.",
                     VisibleDeprecationWarning,
+                    stacklevel=4,  # Account for _LazyDocstring wrapper + load_single_file
                 )
             if convert_units:
                 signal.axes_manager.convert_units()
@@ -1071,7 +1142,7 @@ def save(filename, signal, overwrite=None, file_format=None, **kwds):
         )
 
     writer = None
-    if isinstance(filename, ZARR_STORE_BASE_CLASS):
+    if _is_zarr_store(filename):
         extension = ".zspy"
         writer = _infer_file_reader("ZSPY")
     else:
@@ -1122,7 +1193,7 @@ def save(filename, signal, overwrite=None, file_format=None, **kwds):
         )
 
     # Create the directory if it does not exist
-    if not isinstance(filename, ZARR_STORE_BASE_CLASS):
+    if not _is_zarr_store(filename):
         path.ensure_directory(filename.parent)
         is_file = filename.is_file() or (
             filename.is_dir() and os.path.splitext(filename)[1] == ".zspy"
@@ -1144,7 +1215,7 @@ def save(filename, signal, overwrite=None, file_format=None, **kwds):
         signal = _add_file_load_save_metadata("save", signal, writer)
         signal_dic = signal._to_dictionary(add_models=True)
         signal_dic["package_info"] = utils.get_object_package_info(signal)
-        if not isinstance(filename, ZARR_STORE_BASE_CLASS):
+        if not _is_zarr_store(filename):
             importlib.import_module(writer["api"]).file_writer(
                 str(filename), signal_dic, **kwds
             )
@@ -1163,8 +1234,11 @@ def save(filename, signal, overwrite=None, file_format=None, **kwds):
                 signal.tmp_parameters.set_item("extension", extension)
 
 
-save.__doc__ %= _get_format_list_for_docstring(write_mode=True).replace(
-    "loading", "saving"
+save = _LazyDocstring(
+    save,
+    lambda: (
+        _get_format_list_for_docstring(write_mode=True).replace("loading", "saving"),
+    ),
 )
 
 

--- a/hyperspy/signal.py
+++ b/hyperspy/signal.py
@@ -72,8 +72,9 @@ from hyperspy.exceptions import (
 from hyperspy.external.scipy.ndfilters import _get_footprint
 from hyperspy.interactive import interactive
 from hyperspy.io import (
-    ZARR_STORE_BASE_CLASS,
     _get_format_list_for_docstring,
+    _is_zarr_store,
+    _LazyDocstring,
     assign_signal_subclass,
 )
 from hyperspy.io import save as io_save
@@ -3395,7 +3396,7 @@ class BaseSignal(FancySlicing, MVA, MVATools):
                 "The 'extension' parameter is deprecated in HyperSpy 2.4 and will be removed in HyperSpy 3.0. "
                 "Please use 'file_format' instead.",
                 FutureWarning,
-                stacklevel=2,
+                stacklevel=3,  # Account for _LazyDocstring wrapper
             )
 
         if filename is None:
@@ -3432,7 +3433,7 @@ class BaseSignal(FancySlicing, MVA, MVATools):
             else:
                 raise ValueError("File name not defined")
 
-        if not isinstance(filename, (MutableMapping, ZARR_STORE_BASE_CLASS)):
+        if not _is_zarr_store(filename) and not isinstance(filename, MutableMapping):
             filename = Path(filename)
 
             # zspy can also be directory, make sure this is treated as a base directory
@@ -3482,11 +3483,20 @@ class BaseSignal(FancySlicing, MVA, MVATools):
 
         io_save(filename, self, overwrite=overwrite, file_format=file_format, **kwds)
 
-    # Format save method docstring with dynamic format list
-    save.__doc__ = save.__doc__ % (
-        _get_format_list_for_docstring(write_mode=True, style="bullet", indentation=8),
-        _get_format_list_for_docstring(write_mode=True, style="inline", indentation=8),
-        _get_format_list_for_docstring(write_mode=True, style="bullet", indentation=12),
+    # Lazily format save method docstring with dynamic format list
+    save = _LazyDocstring(
+        save,
+        lambda: (
+            _get_format_list_for_docstring(
+                write_mode=True, style="bullet", indentation=8
+            ),
+            _get_format_list_for_docstring(
+                write_mode=True, style="inline", indentation=8
+            ),
+            _get_format_list_for_docstring(
+                write_mode=True, style="bullet", indentation=12
+            ),
+        ),
     )
 
     def _replot(self):

--- a/hyperspy/tests/test_io.py
+++ b/hyperspy/tests/test_io.py
@@ -32,6 +32,7 @@ import hyperspy.api as hs
 from hyperspy import __version__ as hs_version
 from hyperspy.axes import DataAxis
 from hyperspy.exceptions import VisibleDeprecationWarning
+from hyperspy.io import _get_format_list_for_docstring
 
 PATH = Path(__file__).resolve()
 FULLFILENAME = PATH.parent.joinpath("test_io_overwriting.hspy")
@@ -671,8 +672,6 @@ def test_save_extension_parameter_overrides_tmp_parameters_extension(tmp_path):
 # Test coverage for _get_format_list_for_docstring function
 def test_get_format_list_for_docstring_bullet_style():
     """Test _get_format_list_for_docstring with bullet style."""
-    from hyperspy.io import _get_format_list_for_docstring
-
     # Test read mode with bullet style
     result = _get_format_list_for_docstring(write_mode=False, style="bullet")
     assert result.startswith("\n")
@@ -691,8 +690,6 @@ def test_get_format_list_for_docstring_bullet_style():
 
 def test_get_format_list_for_docstring_inline_style():
     """Test _get_format_list_for_docstring with inline style."""
-    from hyperspy.io import _get_format_list_for_docstring
-
     # Test read mode with inline style
     result = _get_format_list_for_docstring(write_mode=False, style="inline")
     assert "``'" in result
@@ -707,8 +704,6 @@ def test_get_format_list_for_docstring_inline_style():
 
 def test_get_format_list_for_docstring_extensions_style():
     """Test _get_format_list_for_docstring with extensions style."""
-    from hyperspy.io import _get_format_list_for_docstring
-
     # Test read mode with extensions style
     result = _get_format_list_for_docstring(write_mode=False, style="extensions")
     assert ", " in result
@@ -722,10 +717,16 @@ def test_get_format_list_for_docstring_extensions_style():
 
 def test_get_format_list_for_docstring_invalid_style():
     """Test _get_format_list_for_docstring with invalid style raises ValueError."""
-    from hyperspy.io import _get_format_list_for_docstring
-
     with pytest.raises(ValueError, match="Unknown style"):
         _get_format_list_for_docstring(style="invalid_style")
+
+
+def test_lazy_docstring_load():
+    """Test that the load function docstring includes format list."""
+    assert (
+        _get_format_list_for_docstring(write_mode=False, style="bullet")
+        in hs.load.__doc__
+    )
 
 
 def test_load_reader_parameter_deprecation_warning(tmp_path):
@@ -1126,8 +1127,6 @@ def test_parse_path():
 
 def test_get_format_list_for_docstring():
     """Test the _get_format_list_for_docstring function."""
-    from hyperspy.io import _get_format_list_for_docstring
-
     # Test bullet style
     bullet_list = _get_format_list_for_docstring(write_mode=False, style="bullet")
     assert isinstance(bullet_list, str)
@@ -1220,3 +1219,21 @@ def test_save_filename_none_without_tmp_parameters():
     # Should raise ValueError
     with pytest.raises(ValueError, match="File name not defined"):
         s.save(filename=None, file_format="HSPY")
+
+
+def test_lazy_docstring_save():
+    """Test that the save function docstring includes format list."""
+    s = hs.signals.Signal1D([1, 2, 3])
+
+    assert (
+        _get_format_list_for_docstring(write_mode=True, style="bullet", indentation=8)
+        in s.save.__doc__
+    )
+    assert (
+        _get_format_list_for_docstring(write_mode=True, style="inline", indentation=8)
+        in s.save.__doc__
+    )
+    assert (
+        _get_format_list_for_docstring(write_mode=True, style="bullet", indentation=12)
+        in s.save.__doc__
+    )

--- a/upcoming_changes/3586.enhancements.rst
+++ b/upcoming_changes/3586.enhancements.rst
@@ -1,0 +1,1 @@
+Lazify :func:`~.api.load` and :meth:`~.api.signals.BaseSignal.save` funtions to speed up import.


### PR DESCRIPTION
After merging https://github.com/hyperspy/hyperspy/pull/3525 with the lazy import, there is a speed import regression because of a function generating the `load` and `save` docstring. This PR lazify the generation of the docstring.

### Progress of the PR
- [x] Lazify `load` and `save` docstring,
- [x] update docstring (if appropriate),
- [n/a] update user guide (if appropriate),
- [x] add an changelog entry in the `upcoming_changes` folder (see [`upcoming_changes/README.rst`](https://github.com/hyperspy/hyperspy/blob/RELEASE_next_minor/upcoming_changes/README.rst)),
- [x] Check formatting changelog entry in the `readthedocs` doc build of this PR (link in github checks)
- [x] add tests,
- [x] ready for review.


