### PR TITLE
Fix using ipywidgets progress bar

### DIFF
--- a/hyperspy/external/progressbar.py
+++ b/hyperspy/external/progressbar.py
@@ -30,10 +30,13 @@ def progressbar(*args, **kwargs):
     %s
     """
     if preferences.General.nb_progressbar:
-        try:
-            return tqdm.notebook(*args, **kwargs)
-        except:
-            pass
+        # use tqdm.auto to use tqdm.std in terminal and
+        # tqdm.notebook in a jupyter environment.
+        from tqdm.auto import tqdm
+
+        return tqdm(*args, **kwargs)
+
+    # use tqdm.std all the time, even in a jupyter environment.
     return tqdm.tqdm(*args, **kwargs)
 
 progressbar.__doc__ %= (tqdm.__doc__, tqdm.__init__.__doc__)

--- a/upcoming_changes/3592.bugfix.rst
+++ b/upcoming_changes/3592.bugfix.rst
@@ -1,0 +1,1 @@
+Fix using ipywidgets progressbar, the standard tqdm progress was used instead. The regression was introduced in HyperSpy 2.4.0.


### PR DESCRIPTION
Fix regression introduced in https://github.com/hyperspy/hyperspy/pull/3566/changes#diff-ba595d298861f7c141ce8fc86c6969a5464ad36175dff7d35b8b52b1cf18771f, that prevents using the ipywidgets notebook progress bar - the standard tqdm progress bar was used instead.
The import was incorrect and it was caught by the try, except block.

### Progress of the PR
- [x] Fix using ipywidgets progress bar,
- [n/a] update docstring (if appropriate),
- [n/a] update user guide (if appropriate),
- [x] add an changelog entry in the `upcoming_changes` folder (see [`upcoming_changes/README.rst`](https://github.com/hyperspy/hyperspy/blob/RELEASE_next_minor/upcoming_changes/README.rst)),
- [x] Check formatting changelog entry in the `readthedocs` doc build of this PR (link in github checks)
- [n/a] add tests,
- [x] ready for review.


