### PR TITLE
Fix ylimits in `spikes_removal_tool` when moving to the next spike

### DIFF
--- a/hyperspy/signal_tools/_spikes_removal.py
+++ b/hyperspy/signal_tools/_spikes_removal.py
@@ -339,7 +339,7 @@ class SpikesRemovalInteractive(SpikesRemoval, signal_tools.SpanSelectorInSignal1
 
     def update_spectrum_line(self):
         self.line.auto_update = True
-        self.line.update()
+        self.line.update(update_ylimits=True)
         self.line.auto_update = False
 
     def on_disabling_span_selector(self):

--- a/hyperspy/tests/signals/test_spike_removal_tool.py
+++ b/hyperspy/tests/signals/test_spike_removal_tool.py
@@ -35,14 +35,19 @@ def test_spikes_removal_tool():
     s.data[1, 2, 14] += 1
 
     sr = SpikesRemovalInteractive(s, random_state=1)
+    ax = s._plot.signal_plot.ax
     sr._show_derivative_histogram_fired()
     sr.threshold = 1.5
     sr.find()
     assert s.axes_manager.indices == (0, 1)
+    # check that the y limits of the plot have been updated to show the spike
+    assert ax.get_ylim()[1] > 2.5
     sr.threshold = 0.5
     assert s.axes_manager.indices == (0, 0)
     sr.find()
     assert s.axes_manager.indices == (2, 0)
+    # check that the y limits of the plot have been updated to show the spike
+    assert ax.get_ylim()[1] < 2.5
     sr.find()
     assert s.axes_manager.indices == (0, 1)
     sr.find(back=True)

--- a/upcoming_changes/3593.bugfix.rst
+++ b/upcoming_changes/3593.bugfix.rst
@@ -1,0 +1,1 @@
+:meth:`~.api.signals.Signal1D.spikes_removal_tool`: fix updating y-limits when moving to the next detected spike.


### PR DESCRIPTION
The y-limits wasn't updated when moving to the next detected spike. 

### Progress of the PR
- [x] Fix updating y-limits when moving to the next detected spike,
- [n/a] update docstring (if appropriate),
- [n/a] update user guide (if appropriate),
- [x] add an changelog entry in the `upcoming_changes` folder (see [`upcoming_changes/README.rst`](https://github.com/hyperspy/hyperspy/blob/RELEASE_next_minor/upcoming_changes/README.rst)),
- [x] Check formatting changelog entry in the `readthedocs` doc build of this PR (link in github checks)
- [x] add tests,
- [x] ready for review.

### Minimal example of the bug fix or the new feature
```python
import hyperspy.api as hs
import numpy as np

s = hs.signals.Signal1D(np.ones((2, 3, 30)))
s.add_gaussian_noise(1e-5, random_state=1)
# Add three spikes
s.data[1, 0, 1] += 2
s.data[0, 2, 29] += 1
s.data[1, 2, 14] += 1
s.metadata.Signal.set_item("Noise_properties.variance", 1e-5)

sr = s.spikes_removal_tool()
```

