### PR TITLE
Fix deprecation warning when building package using `python -m build`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,6 @@ classifiers = [
     "Framework :: Matplotlib",
     "Intended Audience :: Developers",
     "Intended Audience :: Science/Research",
-    "License :: OSI Approved :: GNU General Public License v3 (GPLv3)",
     "Operating System :: OS Independent",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
@@ -77,12 +76,11 @@ keywords = [
     "spectroscopy",
     "spectrum image",
 ]
+license = "GPL-3.0-or-later"
+license-files = ["COPYING.txt"]
 name = "hyperspy"
 readme = "README.md"
 requires-python = ">=3.10"
-
-[project.license]
-file = "COPYING.txt"
 
 [project.optional-dependencies]
 all = [

--- a/upcoming_changes/3594.enhancements.rst
+++ b/upcoming_changes/3594.enhancements.rst
@@ -1,0 +1,1 @@
+Fix deprecation warning about license specification when building package using ``python -m build``.


### PR DESCRIPTION
### Progress of the PR
- [x] Fix deprecation warning when building package using `python -m build`,
- [n/a] update docstring (if appropriate),
- [n/a] update user guide (if appropriate),
- [x] add an changelog entry in the `upcoming_changes` folder (see [`upcoming_changes/README.rst`](https://github.com/hyperspy/hyperspy/blob/RELEASE_next_minor/upcoming_changes/README.rst)),
- [x] Check formatting changelog entry in the `readthedocs` doc build of this PR (link in github checks)
- [n/a] add tests,
- [x] ready for review.

### Minimal example of the bug fix or the new feature
```python
python -m build
```
Give the following warnings (from https://github.com/hyperspy/hyperspy/actions/runs/22259666885/job/64395884240):
```python
* Creating isolated environment: venv+pip...
* Installing packages in isolated environment:
  - setuptools>=64
  - setuptools_scm>=8
  - wheel
* Getting build dependencies for sdist...
/tmp/build-env-41txb74e/lib/python3.11/site-packages/setuptools_scm/_integration/version_inference.py:51: UserWarning: version of None already set
  warnings.warn(self.message)
/tmp/build-env-41txb74e/lib/python3.11/site-packages/setuptools/config/_apply_pyprojecttoml.py:82: SetuptoolsDeprecationWarning: `project.license` as a TOML table is deprecated
!!

        ********************************************************************************
        Please use a simple string containing a SPDX expression for `project.license`. You can also use `project.license-files`. (Both options available on setuptools>=77.0.0).

        By 2027-Feb-18, you need to update your project and remove deprecated calls
        or your builds will no longer be supported.

        See https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#license for details.
        ********************************************************************************

!!
  corresp(dist, value, root_dir)
/tmp/build-env-41txb74e/lib/python3.11/site-packages/setuptools/config/_apply_pyprojecttoml.py:61: SetuptoolsDeprecationWarning: License classifiers are deprecated.
!!

        ********************************************************************************
        Please consider removing the following classifiers in favor of a SPDX license expression:

        License :: OSI Approved :: GNU General Public License v3 (GPLv3)

        See https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#license for details.
        ********************************************************************************

!!
  dist._finalize_license_expression()
/tmp/build-env-41txb74e/lib/python3.11/site-packages/setuptools/dist.py:765: SetuptoolsDeprecationWarning: License classifiers are deprecated.
!!

        ********************************************************************************
        Please consider removing the following classifiers in favor of a SPDX license expression:

        License :: OSI Approved :: GNU General Public License v3 (GPLv3)

        See https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#license for details.
        ********************************************************************************

!!
  self._finalize_license_expression()
running egg_info
creating hyperspy.egg-info
```
