### PR TITLE
Add `lazy_output` to `get_decomposition_model` and `get_bss_model`

### DIFF
--- a/.github/instructions/tests.instructions.md
+++ b/.github/instructions/tests.instructions.md
@@ -18,6 +18,7 @@ Test data arrays must use ALL-DIFFERENT dimensions so axis reversals are visuall
 HyperSpy uses `numpy.testing` utilities, not `pytest.approx`:
 - ✅ `np.testing.assert_allclose(actual, expected, rtol=1e-4)`
 - ✅ `np.testing.assert_array_equal(actual, expected)` for exact/int comparisons
+- ❌ `assert np.array_equal(actual, expected)` — prefer `np.testing` for consistency and better failure messages
 - ❌ `assert actual == expected` — too fragile for floats
 - ❌ `assert actual == pytest.approx(expected)` — not the HyperSpy convention
 

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -401,6 +401,7 @@ numpydoc_xref_ignore = {
     "scheduler",
     "matplotlib",
     "color",
+    "length",
     "line",
     "style",
     "hyperspy",

--- a/hyperspy/learn/_mva.py
+++ b/hyperspy/learn/_mva.py
@@ -1362,7 +1362,7 @@ class MVA:
         return rec
 
     get_bss_model.__doc__ = get_bss_model.__doc__ % (CHUNKS_ARGS, LAZY_OUTPUT_ARG)
-        
+
     def get_scree_plot_data(self):
         """Return the scree plot data as a Signal1D.
 

--- a/hyperspy/learn/_mva.py
+++ b/hyperspy/learn/_mva.py
@@ -27,7 +27,7 @@ from rsciio.utils import path
 from hyperspy import learn, signals
 from hyperspy.decorators import deprecated
 from hyperspy.defaults_parser import preferences
-from hyperspy.docstrings.signal import SHOW_PROGRESSBAR_ARG
+from hyperspy.docstrings.signal import LAZY_OUTPUT_ARG, SHOW_PROGRESSBAR_ARG
 from hyperspy.external.progressbar import progressbar
 from hyperspy.misc import utils
 
@@ -35,6 +35,14 @@ MDP_INSTALLED = importlib.util.find_spec("mdp") is not None
 SKLEARN_INSTALLED = importlib.util.find_spec("sklearn") is not None
 
 _logger = logging.getLogger(__name__)
+
+
+CHUNKS_ARGS = """chunks : str, int, tuple of length 2, default "auto"
+            If lazy_output is True, determines the chunk size of the output dask array.
+            The chunking of the loadings and factors will be set to -1 for the first and
+            the last dimension respectively to optimise for the matrix multiplication
+            If tuple of length 2, the first element sets the chunk size for the factors
+            and the second element sets the chunk size for the loadings."""
 
 
 decomposition_algorithms = {
@@ -1192,7 +1200,13 @@ class MVA:
                     f"on the {reverse_component_criterion}"
                 )
 
-    def _calculate_recmatrix(self, components=None, mva_type="decomposition"):
+    def _calculate_recmatrix(
+        self,
+        components=None,
+        mva_type="decomposition",
+        chunks="auto",
+        lazy_output=None,
+    ):
         """Rebuilds data from selected components.
 
         Parameters
@@ -1203,6 +1217,8 @@ class MVA:
             * If list of ints, rebuilds signal instance from only components in given list
         mva_type : str {'decomposition', 'bss'}
             Decomposition type (not case sensitive)
+        %s
+        %s
 
         Returns
         -------
@@ -1221,7 +1237,6 @@ class MVA:
             loadings = target.bss_loadings.T
 
         if components is None:
-            a = factors @ loadings
             signal_name = f"model from {mva_type} with {factors.shape[1]} components"
         elif hasattr(components, "__iter__"):
             tfactors = np.zeros((factors.shape[0], len(components)))
@@ -1229,11 +1244,43 @@ class MVA:
             for i in range(len(components)):
                 tfactors[:, i] = factors[:, components[i]]
                 tloadings[i, :] = loadings[components[i], :]
-            a = tfactors @ tloadings
+            factors = tfactors
+            loadings = tloadings
             signal_name = f"model from {mva_type} with components {components}"
         else:
-            a = factors[:, :components] @ loadings[:components, :]
+            factors = factors[:, :components]
+            loadings = loadings[:components, :]
             signal_name = f"model from {mva_type} with {components} components"
+
+        if lazy_output is None:
+            lazy_output = self._lazy
+
+        if lazy_output:
+            import dask.array as da
+
+            if isinstance(chunks, (tuple, list)) and len(chunks) == 2:
+                factors_chunks, loadings_chunks = chunks
+            elif chunks == "auto" or isinstance(chunks, int):
+                # Scalar or "auto": use the same setting on both outer axes.
+                factors_chunks = loadings_chunks = chunks
+            else:
+                raise ValueError(
+                    "If provided, `chunks` must be a tuple of two elements, "
+                    "a scalar integer or 'auto'."
+                )
+
+            # For matrix multiplication (N, K) @ (K, M), keep K in one chunk.
+            if isinstance(factors, da.Array):
+                factors = factors.rechunk((factors_chunks, -1))
+            else:
+                factors = da.from_array(factors, chunks=(factors_chunks, -1))
+
+            if isinstance(loadings, da.Array):
+                loadings = loadings.rechunk((-1, loadings_chunks))
+            else:
+                loadings = da.from_array(loadings, chunks=(-1, loadings_chunks))
+
+        a = np.matmul(factors, loadings)
 
         self._unfolded4decomposition = self.unfold()
         try:
@@ -1248,9 +1295,19 @@ class MVA:
                 sc.fold()
                 self._unfolded4decomposition = False
 
+        if lazy_output and not sc._lazy:
+            sc = sc.as_lazy()
+        elif not lazy_output and sc._lazy:
+            sc.compute()
+
         return sc
 
-    def get_decomposition_model(self, components=None):
+    _calculate_recmatrix.__doc__ = _calculate_recmatrix.__doc__ % (
+        CHUNKS_ARGS,
+        LAZY_OUTPUT_ARG,
+    )
+
+    def get_decomposition_model(self, components=None, chunks="auto", lazy_output=None):
         """Generate model with the selected number of principal components.
 
         Parameters
@@ -1259,6 +1316,8 @@ class MVA:
             * If None, rebuilds signal instance from all components
             * If int, rebuilds signal instance from components in range 0-given int
             * If list of ints, rebuilds signal instance from only components in given list
+        %s
+        %s
 
         Returns
         -------
@@ -1266,10 +1325,20 @@ class MVA:
             A model built from the given components.
 
         """
-        rec = self._calculate_recmatrix(components=components, mva_type="decomposition")
+        rec = self._calculate_recmatrix(
+            components=components,
+            mva_type="decomposition",
+            chunks=chunks,
+            lazy_output=lazy_output,
+        )
         return rec
 
-    def get_bss_model(self, components=None, chunks="auto"):
+    get_decomposition_model.__doc__ = get_decomposition_model.__doc__ % (
+        CHUNKS_ARGS,
+        LAZY_OUTPUT_ARG,
+    )
+
+    def get_bss_model(self, components=None, chunks="auto", lazy_output=None):
         """Generate model with the selected number of independent components.
 
         Parameters
@@ -1278,6 +1347,8 @@ class MVA:
             If None, rebuilds signal instance from all components
             If int, rebuilds signal instance from components in range 0-given int
             If list of ints, rebuilds signal instance from only components in given list
+        %s
+        %s
 
         Returns
         -------
@@ -1290,24 +1361,38 @@ class MVA:
             import dask.array as da
 
             # Save originals because _calculate_recmatrix reads from
-            # lr.factors/lr.loadings.  We temporarily swap in dask-wrapped
+            # lr.bss_factors/lr.bss_loadings.  We temporarily swap in dask-wrapped
             # bss arrays so the computation stays lazy, then restore the
             # original decomposition results to avoid permanent corruption.
-            saved_factors = lr.factors
-            saved_loadings = lr.loadings
+            saved_factors = lr.bss_factors
+            saved_loadings = lr.bss_loadings
             try:
                 if isinstance(lr.bss_factors, np.ndarray):
-                    lr.factors = da.from_array(lr.bss_factors, chunks=chunks)
+                    lr.bss_factors = da.from_array(lr.bss_factors, chunks=chunks)
                 if isinstance(lr.bss_loadings, np.ndarray):
-                    lr.loadings = da.from_array(lr.bss_loadings, chunks=chunks)
-                rec = self._calculate_recmatrix(components=components, mva_type="bss")
+                    lr.bss_loadings = da.from_array(lr.bss_loadings, chunks=chunks)
+                rec = self._calculate_recmatrix(
+                    components=components,
+                    mva_type="bss",
+                    chunks=chunks,
+                    lazy_output=lazy_output,
+                )
             finally:
-                lr.factors = saved_factors
-                lr.loadings = saved_loadings
+                lr.bss_factors = saved_factors
+                lr.bss_loadings = saved_loadings
             return rec
-        rec = self._calculate_recmatrix(components=components, mva_type="bss")
+
+        rec = self._calculate_recmatrix(
+            components=components,
+            mva_type="bss",
+            chunks=chunks,
+            lazy_output=lazy_output,
+        )
+
         return rec
 
+    get_bss_model.__doc__ = get_bss_model.__doc__ % (CHUNKS_ARGS, LAZY_OUTPUT_ARG)
+        
     def get_scree_plot_data(self):
         """Return the scree plot data as a Signal1D.
 

--- a/hyperspy/learn/_mva.py
+++ b/hyperspy/learn/_mva.py
@@ -1239,13 +1239,9 @@ class MVA:
         if components is None:
             signal_name = f"model from {mva_type} with {factors.shape[1]} components"
         elif hasattr(components, "__iter__"):
-            tfactors = np.zeros((factors.shape[0], len(components)))
-            tloadings = np.zeros((len(components), loadings.shape[1]))
-            for i in range(len(components)):
-                tfactors[:, i] = factors[:, components[i]]
-                tloadings[i, :] = loadings[components[i], :]
-            factors = tfactors
-            loadings = tloadings
+            components = list(components)
+            factors = factors[:, components]
+            loadings = loadings[components, :]
             signal_name = f"model from {mva_type} with components {components}"
         else:
             factors = factors[:, :components]

--- a/hyperspy/learn/_mva.py
+++ b/hyperspy/learn/_mva.py
@@ -1251,19 +1251,19 @@ class MVA:
         if lazy_output is None:
             lazy_output = self._lazy
 
-        if lazy_output:
-            import dask.array as da
+        if isinstance(chunks, (tuple, list)) and len(chunks) == 2:
+            factors_chunks, loadings_chunks = chunks
+        elif chunks == "auto" or isinstance(chunks, int):
+            factors_chunks = loadings_chunks = chunks
+        else:
+            raise ValueError(
+                "If provided, `chunks` must be a tuple of two elements, "
+                "a scalar integer or 'auto'."
+            )
 
-            if isinstance(chunks, (tuple, list)) and len(chunks) == 2:
-                factors_chunks, loadings_chunks = chunks
-            elif chunks == "auto" or isinstance(chunks, int):
-                # Scalar or "auto": use the same setting on both outer axes.
-                factors_chunks = loadings_chunks = chunks
-            else:
-                raise ValueError(
-                    "If provided, `chunks` must be a tuple of two elements, "
-                    "a scalar integer or 'auto'."
-                )
+        # wrap numpy arrays as dask so intermediate computation stays lazy
+        if lazy_output or self._lazy:
+            import dask.array as da
 
             # For matrix multiplication (N, K) @ (K, M), keep K in one chunk.
             if isinstance(factors, da.Array):
@@ -1352,32 +1352,6 @@ class MVA:
             A model built from the given components.
 
         """
-        lr = self.learning_results
-        if self._lazy:
-            import dask.array as da
-
-            # Save originals because _calculate_recmatrix reads from
-            # lr.bss_factors/lr.bss_loadings.  We temporarily swap in dask-wrapped
-            # bss arrays so the computation stays lazy, then restore the
-            # original decomposition results to avoid permanent corruption.
-            saved_factors = lr.bss_factors
-            saved_loadings = lr.bss_loadings
-            try:
-                if isinstance(lr.bss_factors, np.ndarray):
-                    lr.bss_factors = da.from_array(lr.bss_factors, chunks=chunks)
-                if isinstance(lr.bss_loadings, np.ndarray):
-                    lr.bss_loadings = da.from_array(lr.bss_loadings, chunks=chunks)
-                rec = self._calculate_recmatrix(
-                    components=components,
-                    mva_type="bss",
-                    chunks=chunks,
-                    lazy_output=lazy_output,
-                )
-            finally:
-                lr.bss_factors = saved_factors
-                lr.bss_loadings = saved_loadings
-            return rec
-
         rec = self._calculate_recmatrix(
             components=components,
             mva_type="bss",

--- a/hyperspy/learn/_mva.py
+++ b/hyperspy/learn/_mva.py
@@ -37,12 +37,14 @@ SKLEARN_INSTALLED = importlib.util.find_spec("sklearn") is not None
 _logger = logging.getLogger(__name__)
 
 
-CHUNKS_ARGS = """chunks : str, int, tuple of length 2, default "auto"
-            If lazy_output is True, determines the chunk size of the output dask array.
-            The chunking of the loadings and factors will be set to -1 for the first and
-            the last dimension respectively to optimise for the matrix multiplication
-            If tuple of length 2, the first element sets the chunk size for the factors
-            and the second element sets the chunk size for the loadings."""
+CHUNKS_ARGS = """chunks : str, int, or tuple, default "auto"
+            Controls chunking of the reconstructed signal's signal dimension.
+            Navigation axes are always chunked with ``"auto"``.
+            If ``"auto"`` or ``"dask_auto"``, dask determines the chunk size.
+            If an int, the signal dimension is split into chunks of that size.
+            If a tuple, only the first element is used to set the signal
+            dimension chunking (the second element, formerly used for
+            navigation chunking, is silently ignored)."""
 
 
 decomposition_algorithms = {
@@ -1225,75 +1227,125 @@ class MVA:
         Signal instance
             Data built from the given components.
 
-        """
+        Notes
+        -----
+        For lazy output this method uses ``da.einsum`` instead of a
+        two-dimensional matmul followed by ``fold()``.  The fold path
+        requires a dask ``reshape`` from a flattened navigation dimension
+        back to the original multi-dimensional shape, which fails with
+        ``NotImplementedError`` (or materialises huge intermediate chunks)
+        when the chunk boundaries of the flattened dimension do not evenly
+        divide the navigation axis lengths.  ``da.einsum`` computes
+        directly into the target multi-dimensional shape and avoids the
+        reshape entirely.
 
+        """
         target = self.learning_results
 
+        # Load factors and loadings in their natural (numpy) shapes.
+        # factors:   (sig_size, n_comp)   — signal channels × components
+        # loadings:  (nav_size, n_comp)   — nav positions  × components
+        # We do NOT transpose loadings here; the transposition is handled
+        # differently in the lazy (einsum) and non-lazy (matmul) paths.
         if mva_type.lower() == "decomposition":
             factors = target.factors
-            loadings = target.loadings.T
+            loadings = target.loadings
         elif mva_type.lower() == "bss":
             factors = target.bss_factors
-            loadings = target.bss_loadings.T
+            loadings = target.bss_loadings
 
         if components is None:
             signal_name = f"model from {mva_type} with {factors.shape[1]} components"
         elif hasattr(components, "__iter__"):
             components = list(components)
             factors = factors[:, components]
-            loadings = loadings[components, :]
+            loadings = loadings[:, components]
             signal_name = f"model from {mva_type} with components {components}"
         else:
             factors = factors[:, :components]
-            loadings = loadings[:components, :]
+            loadings = loadings[:, :components]
             signal_name = f"model from {mva_type} with {components} components"
 
         if lazy_output is None:
             lazy_output = self._lazy
 
-        if isinstance(chunks, (tuple, list)) and len(chunks) == 2:
-            factors_chunks, loadings_chunks = chunks
-        elif chunks == "auto" or isinstance(chunks, int):
-            factors_chunks = loadings_chunks = chunks
+        # Parse the ``chunks`` parameter.  Only the signal-dimension chunking
+        # is configurable; navigation chunking is always ``"auto"`` because
+        # the einsum path wraps loadings into the multi-dimensional nav shape
+        # before da.from_array() and lets dask decide the nav block sizes.
+        if isinstance(chunks, (tuple, list)) and len(chunks) >= 1:
+            factors_chunks = chunks[0]
         else:
-            raise ValueError(
-                "If provided, `chunks` must be a tuple of two elements, "
-                "a scalar integer or 'auto'."
-            )
+            factors_chunks = chunks
 
-        # wrap numpy arrays as dask so intermediate computation stays lazy
+        nav_shape = self.axes_manager.navigation_shape[::-1]  # numpy order
+        n_comp = loadings.shape[1]
+
         if lazy_output or self._lazy:
             import dask.array as da
 
-            # For matrix multiplication (N, K) @ (K, M), keep K in one chunk.
-            if isinstance(factors, da.Array):
-                factors = factors.rechunk((factors_chunks, -1))
-            else:
-                factors = da.from_array(factors, chunks=(factors_chunks, -1))
-
+            # Reshape loadings *as numpy* from (nav_size, n_comp) into
+            # (ny, nx, ..., n_comp).  This is always safe because
+            # nav_size == product(nav_shape), and we avoid dask's reshape
+            # which is the source of the original bug.
             if isinstance(loadings, da.Array):
-                loadings = loadings.rechunk((-1, loadings_chunks))
+                loadings_np = loadings.compute()
             else:
-                loadings = da.from_array(loadings, chunks=(-1, loadings_chunks))
+                loadings_np = loadings
+            loadings_3d = loadings_np.reshape(nav_shape + (n_comp,))
 
-        a = np.matmul(factors, loadings)
+            # Wrap as dask arrays.  If factors/loadings are already dask
+            # (from a lazy decomposition), rechunk them; otherwise wrap
+            # the numpy arrays.  The contracted dimension (n_comp) is
+            # kept as a single chunk (-1) in both arrays so that dask's
+            # blockwise matmul does not need to aggregate across sub-chunks
+            # of the contraction axis.
+            if isinstance(factors, da.Array):
+                factors_da = factors.rechunk((factors_chunks, -1))
+            else:
+                factors_da = da.from_array(factors, chunks=(factors_chunks, -1))
+            loadings_da = da.from_array(
+                loadings_3d,
+                chunks=("auto",) * len(nav_shape) + (-1,),
+            )
 
-        self._unfolded4decomposition = self.unfold()
-        try:
-            sc = self.deepcopy()
-            sc.data = a.T.reshape(self.data.shape)
-            sc.metadata.General.title += " " + signal_name
-            if target.mean is not None:
-                sc.data += target.mean
-        finally:
-            if self._unfolded4decomposition:
-                self.fold()
-                sc.fold()
-                self._unfolded4decomposition = False
+            # einsum avoids a two-dimensional matmul + dask reshape because
+            # it computes each output block directly from the corresponding
+            # multi-dimensional input blocks.  The output already has the
+            # final multi-dimensional shape — no fold() needed.
+            #
+            # einsum('sc,…c->…s', …) is mathematically equivalent to
+            #   matmul(factors, loadings.T).T.reshape(nav_shape + sig_shape)
+            a = da.einsum("sc,...c->...s", factors_da, loadings_da)
+        else:
+            # Non-lazy path: standard matrix multiply with explicit
+            # transposition of loadings and numpy reshape (always safe).
+            loadings_T = loadings.T  # (n_comp, nav_size)
+            a = factors @ loadings_T  # (sig_size, nav_size)
+            a = a.T.reshape(
+                nav_shape + (factors.shape[0],)
+            )  # → (ny, nx, ..., sig_size)
 
-        if lazy_output and not sc._lazy:
-            sc = sc.as_lazy()
-        elif not lazy_output and sc._lazy:
+        sc = self.deepcopy()
+        sc.data = a
+        sc.metadata.General.title += " " + signal_name
+        if target.mean is not None:
+            # target.mean has shape (nav_size, 1) from the decomposition.
+            # Reshape to match the multi-dimensional nav axes so that
+            # broadcasting works regardless of whether sc.data is unfolded
+            # (non-lazy path) or already multi-dimensional (lazy path).
+            sc.data += target.mean.reshape(nav_shape + (-1,))
+
+        if lazy_output:
+            if not sc._lazy:
+                sc = sc.as_lazy()
+            # Enforce HyperSpy's chunking convention: nav axes chunked with
+            # "auto", signal axes kept as single chunks (-1).  The einsum
+            # may split the signal axis during blockwise alignment; this
+            # rechunk restores the convention followed by all other lazy
+            # operations in HyperSpy (see LazySignal.rechunk defaults).
+            sc.rechunk(nav_chunks="auto", sig_chunks=-1, inplace=True)
+        elif sc._lazy:
             sc.compute()
 
         return sc

--- a/hyperspy/learn/_mva.py
+++ b/hyperspy/learn/_mva.py
@@ -38,13 +38,15 @@ _logger = logging.getLogger(__name__)
 
 
 CHUNKS_ARGS = """chunks : str, int, or tuple, default "auto"
-            Controls chunking of the reconstructed signal's signal dimension.
-            Navigation axes are always chunked with ``"auto"``.
+            Controls chunking of the reconstructed signal when
+            ``lazy_output`` is active.
             If ``"auto"`` or ``"dask_auto"``, dask determines the chunk size.
-            If an int, the signal dimension is split into chunks of that size.
-            If a tuple, only the first element is used to set the signal
-            dimension chunking (the second element, formerly used for
-            navigation chunking, is silently ignored)."""
+            If an int, the signal dimension is split into chunks of that
+            size and navigation uses ``"auto"``.
+            If a tuple of length 2, the first element controls signal
+            dimension chunking and the second controls navigation
+            chunking (passed as ``nav_chunks`` to
+            :meth:`~._signals.lazy.LazySignal.rechunk`)."""
 
 
 decomposition_algorithms = {
@@ -1227,26 +1229,22 @@ class MVA:
         Signal instance
             Data built from the given components.
 
-        Notes
-        -----
-        For lazy output this method uses ``da.einsum`` instead of a
-        two-dimensional matmul followed by ``fold()``.  The fold path
-        requires a dask ``reshape`` from a flattened navigation dimension
-        back to the original multi-dimensional shape, which fails with
-        ``NotImplementedError`` (or materialises huge intermediate chunks)
-        when the chunk boundaries of the flattened dimension do not evenly
-        divide the navigation axis lengths.  ``da.einsum`` computes
-        directly into the target multi-dimensional shape and avoids the
-        reshape entirely.
-
         """
         target = self.learning_results
 
-        # Load factors and loadings in their natural (numpy) shapes.
-        # factors:   (sig_size, n_comp)   — signal channels × components
-        # loadings:  (nav_size, n_comp)   — nav positions  × components
-        # We do NOT transpose loadings here; the transposition is handled
-        # differently in the lazy (einsum) and non-lazy (matmul) paths.
+        # Load factors and loadings in the shapes used by the
+        # decomposition API (numpy order):
+        #   factors:  (sig_size, n_comp) — signal channels × components
+        #   loadings: (nav_size, n_comp) — nav positions  × components
+        #
+        # The lazy and non-lazy paths handle the transposition of
+        # loadings differently:
+        #   - lazy (einsum): loadings is reshaped as numpy into the
+        #     multi-dimensional nav shape and used directly — no
+        #     transpose needed.
+        #   - non-lazy (matmul): loadings is transposed just before
+        #     the matmul call (loadings.T), giving (n_comp, nav_size),
+        #     which is the standard [factors @ loadings.T] pattern.
         if mva_type.lower() == "decomposition":
             factors = target.factors
             loadings = target.loadings
@@ -1269,14 +1267,15 @@ class MVA:
         if lazy_output is None:
             lazy_output = self._lazy
 
-        # Parse the ``chunks`` parameter.  Only the signal-dimension chunking
-        # is configurable; navigation chunking is always ``"auto"`` because
-        # the einsum path wraps loadings into the multi-dimensional nav shape
-        # before da.from_array() and lets dask decide the nav block sizes.
-        if isinstance(chunks, (tuple, list)) and len(chunks) >= 1:
-            factors_chunks = chunks[0]
+        # Parse the ``chunks`` parameter into signal and navigation
+        # chunking.  The tuple form (sig, nav) mirrors the
+        # LazySignal.rechunk(nav_chunks, sig_chunks) convention.
+        if isinstance(chunks, (tuple, list)):
+            sig_chunks = chunks[0] if len(chunks) >= 1 else "auto"
+            nav_chunks = chunks[1] if len(chunks) >= 2 else "auto"
         else:
-            factors_chunks = chunks
+            sig_chunks = chunks
+            nav_chunks = "auto"
 
         nav_shape = self.axes_manager.navigation_shape[::-1]  # numpy order
         n_comp = loadings.shape[1]
@@ -1284,38 +1283,50 @@ class MVA:
         if lazy_output or self._lazy:
             import dask.array as da
 
-            # Reshape loadings *as numpy* from (nav_size, n_comp) into
-            # (ny, nx, ..., n_comp).  This is always safe because
-            # nav_size == product(nav_shape), and we avoid dask's reshape
-            # which is the source of the original bug.
+            # After a lazy decomposition learning_results.loadings may
+            # still be a dask array (shape nav_size × n_comp).
+            # Computing it to a numpy array is cheap because n_comp is
+            # typically < 100, limiting the total size to at most a few
+            # hundred MB.  We need a numpy array here so the subsequent
+            # reshape can be done safely without involving dask.
+            #
+            # The numpy reshape from (nav_size, n_comp) into
+            # (ny, nx, …, n_comp) is always valid because
+            # nav_size == product(nav_shape).  Doing this *before* wrapping
+            # as dask avoids the original problem: dask's reshape from a
+            # flattened (nav_size, sig_size) back to (ny, nx, sig_size)
+            # fails with NotImplementedError when chunk boundaries of the
+            # flattened dimension do not evenly divide the navigation axes,
+            # or with MemoryError when a single task tries to materialise
+            # a nav_chunk × sig_chunk intermediate array.
             if isinstance(loadings, da.Array):
                 loadings_np = loadings.compute()
             else:
                 loadings_np = loadings
             loadings_3d = loadings_np.reshape(nav_shape + (n_comp,))
 
-            # Wrap as dask arrays.  If factors/loadings are already dask
-            # (from a lazy decomposition), rechunk them; otherwise wrap
-            # the numpy arrays.  The contracted dimension (n_comp) is
+            # Wrap as dask arrays.  The contracted dimension (n_comp) is
             # kept as a single chunk (-1) in both arrays so that dask's
             # blockwise matmul does not need to aggregate across sub-chunks
             # of the contraction axis.
             if isinstance(factors, da.Array):
-                factors_da = factors.rechunk((factors_chunks, -1))
+                factors_da = factors.rechunk((sig_chunks, -1))
             else:
-                factors_da = da.from_array(factors, chunks=(factors_chunks, -1))
+                factors_da = da.from_array(factors, chunks=(sig_chunks, -1))
             loadings_da = da.from_array(
                 loadings_3d,
-                chunks=("auto",) * len(nav_shape) + (-1,),
+                chunks=(nav_chunks,) * len(nav_shape) + (-1,),
             )
 
-            # einsum avoids a two-dimensional matmul + dask reshape because
-            # it computes each output block directly from the corresponding
-            # multi-dimensional input blocks.  The output already has the
-            # final multi-dimensional shape — no fold() needed.
+            # da.einsum('sc,...c->...s', …) computes each output block
+            # directly from the corresponding multi-dimensional input
+            # blocks, avoiding the 2-D matmul (which would produce a flat
+            # (sig_size, nav_size) result) and the subsequent dask reshape
+            # to recover the multi-dimensional shape.
             #
-            # einsum('sc,…c->…s', …) is mathematically equivalent to
-            #   matmul(factors, loadings.T).T.reshape(nav_shape + sig_shape)
+            # Mathematically equivalent to:
+            #   a = factors @ loadings.T  # (sig_size, n_comp) @ (n_comp, nav_size)
+            #   a.T.reshape(nav_shape + (sig_size,))
             a = da.einsum("sc,...c->...s", factors_da, loadings_da)
         else:
             # Non-lazy path: standard matrix multiply with explicit
@@ -1339,12 +1350,11 @@ class MVA:
         if lazy_output:
             if not sc._lazy:
                 sc = sc.as_lazy()
-            # Enforce HyperSpy's chunking convention: nav axes chunked with
-            # "auto", signal axes kept as single chunks (-1).  The einsum
-            # may split the signal axis during blockwise alignment; this
-            # rechunk restores the convention followed by all other lazy
-            # operations in HyperSpy (see LazySignal.rechunk defaults).
-            sc.rechunk(nav_chunks="auto", sig_chunks=-1, inplace=True)
+            # Enforce HyperSpy's chunking convention by default.
+            # If the user passed explicit chunking via the ``chunks``
+            # parameter, the user's nav_chunks / sig_chunks override
+            # the defaults ("auto" / -1 respectively).
+            sc.rechunk(nav_chunks=nav_chunks, sig_chunks=sig_chunks, inplace=True)
         elif sc._lazy:
             sc.compute()
 

--- a/hyperspy/tests/learn/test_bss.py
+++ b/hyperspy/tests/learn/test_bss.py
@@ -552,6 +552,8 @@ class TestBSSModelCorruptionFix:
         saved_loadings = s.learning_results.loadings
         model = s.get_bss_model()
         assert model is not None
+        assert isinstance(model, hs.signals.LazySignal1D)
+        assert isinstance(model.data, da.Array)
         # learning_results must be unchanged
         assert s.learning_results.factors is saved_factors
         assert s.learning_results.loadings is saved_loadings

--- a/hyperspy/tests/learn/test_bss.py
+++ b/hyperspy/tests/learn/test_bss.py
@@ -535,7 +535,8 @@ class TestBSSModelCorruptionFix:
     """Regression test: get_bss_model() should not corrupt learning_results."""
 
     @skip_sklearn
-    def test_lazy_with_numpy_bss_arrays_preserves_decomposition(self):
+    @pytest.mark.parametrize("lazy_output", [True, False])
+    def test_lazy_with_numpy_bss_arrays_preserves_decomposition(self, lazy_output):
         """#3657: get_bss_model() on lazy signal with numpy bss arrays should
         wrap them as dask, compute, then restore original factors/loadings."""
         rng = np.random.default_rng(42)
@@ -550,16 +551,21 @@ class TestBSSModelCorruptionFix:
         assert isinstance(s.learning_results.bss_loadings, np.ndarray)
         saved_factors = s.learning_results.factors
         saved_loadings = s.learning_results.loadings
-        model = s.get_bss_model()
+        model = s.get_bss_model(lazy_output=lazy_output)
         assert model is not None
-        assert isinstance(model, hs.signals.LazySignal1D)
-        assert isinstance(model.data, da.Array)
+        if lazy_output:
+            assert isinstance(model, hs.signals.LazySignal1D)
+            assert isinstance(model.data, da.Array)
+        else:
+            assert isinstance(model, hs.signals.Signal1D)
+            assert isinstance(model.data, np.ndarray)
         # learning_results must be unchanged
         assert s.learning_results.factors is saved_factors
         assert s.learning_results.loadings is saved_loadings
 
     @skip_sklearn
-    def test_non_lazy_preserves_decomposition(self):
+    @pytest.mark.parametrize("lazy_output", [True, False])
+    def test_non_lazy_preserves_decomposition(self, lazy_output):
         """#3657: get_bss_model() on non-lazy signal should be a no-op
         for learning_results (takes the else return path)."""
         rng = np.random.default_rng(42)
@@ -568,7 +574,13 @@ class TestBSSModelCorruptionFix:
         s.blind_source_separation(3)
         saved_factors = s.learning_results.factors.copy()
         saved_loadings = s.learning_results.loadings.copy()
-        model = s.get_bss_model()
+        model = s.get_bss_model(lazy_output=lazy_output)
         assert model is not None
-        assert np.array_equal(s.learning_results.factors, saved_factors)
-        assert np.array_equal(s.learning_results.loadings, saved_loadings)
+        if lazy_output:
+            assert isinstance(model, hs.signals.LazySignal1D)
+            assert isinstance(model.data, da.Array)
+        else:
+            assert isinstance(model, hs.signals.Signal1D)
+            assert isinstance(model.data, np.ndarray)
+        np.testing.assert_array_equal(s.learning_results.factors, saved_factors)
+        np.testing.assert_array_equal(s.learning_results.loadings, saved_loadings)

--- a/hyperspy/tests/learn/test_decomposition.py
+++ b/hyperspy/tests/learn/test_decomposition.py
@@ -215,7 +215,7 @@ class TestGetModel:
         chunking convention: signal axes as single chunks (-1)."""
         s = self.s.deepcopy()
         s.decomposition(algorithm="SVD")
-        sc = s.get_decomposition_model(3, lazy_output=True)
+        sc = s.get_decomposition_model(3, lazy_output=True, chunks=-1)
         assert isinstance(sc.data, da.Array)
         sig_axes = sc.axes_manager.signal_dimension
         # Signal axes must be single chunks: (-1,) * sig_dim
@@ -254,8 +254,9 @@ class TestGetModel:
         s.learning_results.factors = rng.random((sig_len, n_comp))
         s.learning_results.loadings = rng.random((nav_size, n_comp))
 
-        # Exercise the einsum path.
-        sc = s.get_decomposition_model(components=3, lazy_output=True)
+        # Exercise the einsum path with HyperSpy's chunking convention.
+        # Passing chunks=-1 forces sig_chunks=-1 (signal axes whole).
+        sc = s.get_decomposition_model(components=3, lazy_output=True, chunks=-1)
         assert isinstance(sc.data, da.Array)
 
         # With the old code, even computing [0:3, 0:3, :] would

--- a/hyperspy/tests/learn/test_decomposition.py
+++ b/hyperspy/tests/learn/test_decomposition.py
@@ -210,6 +210,40 @@ class TestGetModel:
             rms = rms.compute()
         assert rms < 5e-7
 
+    def test_get_decomposition_model_lazy_output_chunks(self):
+        """lazy_output=True should produce signal with HyperSpy's
+        chunking convention: signal axes as single chunks (-1)."""
+        s = self.s.deepcopy()
+        s.decomposition(algorithm="SVD")
+        sc = s.get_decomposition_model(3, lazy_output=True)
+        assert isinstance(sc.data, da.Array)
+        sig_axes = sc.axes_manager.signal_dimension
+        # Signal axes must be single chunks: (-1,) * sig_dim
+        assert sc.data.chunks[-sig_axes:] == ((sc.axes_manager.signal_size,),)
+
+    def test_get_decomposition_model_large_signal_does_not_crash(self):
+        """Regression test: a signal large enough that dask chunks the
+        navigation dimension should not crash with MemoryError or
+        NotImplementedError during reconstruction."""
+        import dask.array as da
+
+        rng = np.random.default_rng(42)
+        # All-different dimensions: 30×20 nav, 500 energy channels.
+        data = rng.random((30, 20, 500))
+        s = signals.Signal1D(data)
+        s.decomposition(algorithm="SVD", output_dimension=5)
+        s.blind_source_separation(3)
+        # Force lazy output — this exercises the einsum path
+        sc = s.get_decomposition_model(components=3, lazy_output=True)
+        assert isinstance(sc.data, da.Array)
+        # Verify it can be computed without crashing
+        computed = sc.data.compute()
+        np.testing.assert_allclose(computed.sum(), s.data.sum(), rtol=1e-4)
+        # BSS model too
+        sc_bss = s.get_bss_model(lazy_output=True)
+        computed_bss = sc_bss.data.compute()
+        np.testing.assert_allclose(computed_bss.sum(), s.data.sum(), rtol=1e-4)
+
 
 @lazifyTestClass
 class TestGetScreePlotData:

--- a/hyperspy/tests/learn/test_decomposition.py
+++ b/hyperspy/tests/learn/test_decomposition.py
@@ -221,28 +221,51 @@ class TestGetModel:
         # Signal axes must be single chunks: (-1,) * sig_dim
         assert sc.data.chunks[-sig_axes:] == ((sc.axes_manager.signal_size,),)
 
-    def test_get_decomposition_model_large_signal_does_not_crash(self):
-        """Regression test: a signal large enough that dask chunks the
-        navigation dimension should not crash with MemoryError or
-        NotImplementedError during reconstruction."""
-        import dask.array as da
+    def test_lazy_output_einsum_avoids_dask_reshape_crash(self):
+        """Regression test for the old matmul+fold path that could
+        crash with MemoryError when dask chunked the flattened
+        navigation dimension.
 
+        The old path (``a.T.reshape(self.data.shape)`` inside
+        ``sc.fold()``) materialised a single chunk of up to
+        nav_chunk × sig_size elements.  Even computing a small
+        output slice would trigger the MemoryError because the
+        whole intermediate chunk had to be materialised first.
+
+        The new einsum path computes each output block directly
+        from the corresponding multi-dimensional input blocks,
+        avoiding this problem entirely.
+        """
         rng = np.random.default_rng(42)
-        # All-different dimensions: 30×20 nav, 500 energy channels.
-        data = rng.random((30, 20, 500))
-        s = signals.Signal1D(data)
-        s.decomposition(algorithm="SVD", output_dimension=5)
-        s.blind_source_separation(3)
-        # Force lazy output — this exercises the einsum path
+        # Signal size: 700×700 nav, 20000 energy channels.
+        # The loadings array (~157 MiB with 5 components) triggers
+        # dask chunking of the flattened nav dimension, which the
+        # old matmul+fold path cannot handle.
+        ny, nx, sig_len = 700, 700, 20000
+        n_comp = 5
+        nav_size = ny * nx
+
+        # Use a lazy-zeros signal: the full 78 GB reconstruction
+        # never needs to be materialised.
+        lazy_data = da.zeros((ny, nx, sig_len), chunks=(-1, -1, -1))
+        s = signals.Signal1D(lazy_data).as_lazy()
+
+        # Inject factors/loadings as if decomposition had run.
+        s.learning_results.factors = rng.random((sig_len, n_comp))
+        s.learning_results.loadings = rng.random((nav_size, n_comp))
+
+        # Exercise the einsum path.
         sc = s.get_decomposition_model(components=3, lazy_output=True)
         assert isinstance(sc.data, da.Array)
-        # Verify it can be computed without crashing
-        computed = sc.data.compute()
-        np.testing.assert_allclose(computed.sum(), s.data.sum(), rtol=1e-4)
-        # BSS model too
-        sc_bss = s.get_bss_model(lazy_output=True)
-        computed_bss = sc_bss.data.compute()
-        np.testing.assert_allclose(computed_bss.sum(), s.data.sum(), rtol=1e-4)
+
+        # With the old code, even computing [0:3, 0:3, :] would
+        # crash.  The einsum path should handle it fine.
+        sl = sc.data[0:3, 0:3, :].compute()
+        assert sl.shape == (3, 3, sig_len)
+        assert np.all(np.isfinite(sl))
+
+        # Check HyperSpy's chunking convention: signal axes whole.
+        assert sc.data.chunks[-1] == (sig_len,)
 
 
 @lazifyTestClass

--- a/hyperspy/tests/learn/test_decomposition.py
+++ b/hyperspy/tests/learn/test_decomposition.py
@@ -20,6 +20,7 @@ import importlib
 from pathlib import Path
 from tempfile import TemporaryDirectory
 
+import dask.array as da
 import numpy as np
 import pytest
 
@@ -174,20 +175,39 @@ class TestGetModel:
         )
 
     @pytest.mark.parametrize("centre", [None, "signal"])
-    def test_get_decomposition_model(self, centre):
+    def test_get_decomposition_model_centre(self, centre):
         s = self.s
         s.decomposition(algorithm="SVD", centre=centre)
         sc = self.s.get_decomposition_model(3)
         rms = np.sqrt(((sc.data - s.data) ** 2).sum())
+        if isinstance(rms, da.Array):
+            rms = rms.compute()
         assert rms < 5e-7
 
+    @pytest.mark.parametrize("lazy_output", [True, False, None])
+    def test_get_decomposition_model(self, lazy_output):
+        s = self.s
+        s.decomposition(algorithm="SVD")
+        sc = self.s.get_decomposition_model(3, lazy_output=lazy_output)
+        if lazy_output or (lazy_output is None and self.s._lazy):
+            assert isinstance(sc.data, da.Array)
+        else:
+            assert isinstance(sc.data, np.ndarray)
+
     @skip_sklearn
-    def test_get_bss_model(self):
+    @pytest.mark.parametrize("lazy_output", [True, False, None])
+    def test_get_bss_model(self, lazy_output):
         s = self.s
         s.decomposition(algorithm="SVD")
         s.blind_source_separation(3)
-        sc = self.s.get_bss_model()
+        sc = self.s.get_bss_model(lazy_output=lazy_output)
+        if lazy_output or (lazy_output is None and self.s._lazy):
+            assert isinstance(sc.data, da.Array)
+        else:
+            assert isinstance(sc.data, np.ndarray)
         rms = np.sqrt(((sc.data - s.data) ** 2).sum())
+        if isinstance(rms, da.Array):
+            rms = rms.compute()
         assert rms < 5e-7
 
 

--- a/upcoming_changes/3603.enhancements.rst
+++ b/upcoming_changes/3603.enhancements.rst
@@ -1,0 +1,1 @@
+Add ``lazy_output`` parameter to :meth:`~.signals.BaseSignal.get_decomposition_model` and :meth:`~.signals.BaseSignal.get_bss_model` methods.


### PR DESCRIPTION
As discussed in https://github.com/pyxem/kikuchipy/issues/769.

@hakonanes, what do you think about this approach? Does it do what the `get_decomposition_model_write` in kikuchipy do, but hopefully in a better way? 😅 

### Progress of the PR
- [x] Add `lazy_output` to `get_decomposition_model` and `get_bss_model`),
- [x] update docstring (if appropriate),
- [n/a] update user guide (if appropriate),
- [x] add an changelog entry in the `upcoming_changes` folder (see [`upcoming_changes/README.rst`](https://github.com/hyperspy/hyperspy/blob/RELEASE_next_minor/upcoming_changes/README.rst)),
- [x] Check formatting changelog entry in the `readthedocs` doc build of this PR (link in github checks)
- [x] add tests,
- [x] ready for review.

