### PR TITLE
Seperate Fit Index From Axes Index

### DIFF
--- a/hyperspy/conftest.py
+++ b/hyperspy/conftest.py
@@ -17,6 +17,7 @@
 # along with HyperSpy. If not, see <https://www.gnu.org/licenses/#GPL>.
 
 import importlib
+import logging
 import os
 from pathlib import Path
 
@@ -58,6 +59,23 @@ hs.preferences.Plot.use_subfigure = False
 # Don't show progressbar since it contains the runtime which
 # will make the doctest fail
 hs.preferences.General.show_progressbar = False
+
+
+@pytest.fixture(autouse=True)
+def set_hyperspy_log_level():
+    """Set the hyperspy logger to WARNING for every test.
+
+    By default ``hyperspy.api`` sets the 'hyperspy' logger level to ERROR
+    (from ``preferences.General.logging_level``), which silences WARNING
+    messages and causes any test that uses ``caplog`` to check for warnings
+    to fail.  This fixture resets the level to WARNING before each test and
+    restores the original level afterwards.
+    """
+    hyperspy_logger = logging.getLogger("hyperspy")
+    original_level = hyperspy_logger.level
+    hyperspy_logger.setLevel(logging.WARNING)
+    yield
+    hyperspy_logger.setLevel(original_level)
 
 
 @pytest.fixture(autouse=True)

--- a/hyperspy/fit_indices.py
+++ b/hyperspy/fit_indices.py
@@ -323,10 +323,13 @@ class FitIndices:
         if not self.navigation_shape:
             # 0-D signal — single pixel, represented as empty tuple
             return iter([()])
-        if self.strategy == "serpentine":
-            return _serpentine_iter(self.navigation_shape)
-        if self.strategy == "flyback":
-            return _flyback_iter(self.navigation_shape)
+        # Guard against non-string strategies (e.g. numpy arrays) where
+        # `== "serpentine"` would raise a ValueError in boolean context.
+        if isinstance(self.strategy, str):
+            if self.strategy == "serpentine":
+                return _serpentine_iter(self.navigation_shape)
+            if self.strategy == "flyback":
+                return _flyback_iter(self.navigation_shape)
         # Custom iterable/generator — wrap as iterator
         return iter(self.strategy)
 
@@ -338,6 +341,12 @@ class FitIndices:
     def __next__(self):
         """Advance to the next index, update ``current_index``, fire event."""
         index = next(self._generator)  # propagates StopIteration when done
+        # Normalize to a plain tuple so downstream code can safely test
+        # ``if index``, unpack it, reverse it, etc.  This matters when the
+        # strategy is a numpy array whose rows are ndarray objects rather
+        # than tuples.
+        if not isinstance(index, tuple):
+            index = tuple(int(i) for i in index)
         self.current_index = index
         self.events.index_changed.trigger(obj=self, index=index)
         return index

--- a/hyperspy/fit_indices.py
+++ b/hyperspy/fit_indices.py
@@ -1,0 +1,392 @@
+# -*- coding: utf-8 -*-
+# Copyright 2007-2026 The HyperSpy developers
+#
+# This file is part of HyperSpy.
+#
+# HyperSpy is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# HyperSpy is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with HyperSpy. If not, see <https://www.gnu.org/licenses/#GPL>.
+
+"""FitIndices — decoupled fitting navigation state.
+
+This module contains :class:`FitIndices`, which owns all per-run fitting
+state for :class:`~hyperspy.model.BaseModel`.  It is intentionally
+independent of :class:`~hyperspy.axes.AxesManager` and the plot/widget
+system so that fitting an index never has side-effects on the plot cursor,
+and the plot cursor never accidentally drives a fit.
+"""
+
+import inspect
+from contextlib import contextmanager
+from typing import Generator
+
+import numpy as np
+
+from hyperspy.events import Event, Events
+
+
+def _serpentine_iter(shape):
+    """Re-export so callers don't need to import from axes."""
+    from hyperspy.axes import _serpentine_iter as _s
+
+    return _s(shape)
+
+
+def _flyback_iter(shape):
+    """Re-export so callers don't need to import from axes."""
+    from hyperspy.axes import _flyback_iter as _f
+
+    return _f(shape)
+
+
+class FitIndices:
+    """Owns all navigation state for a model fitting run.
+
+    ``FitIndices`` is attached to :class:`~hyperspy.model.BaseModel` and is
+    the single source of truth for:
+
+    * **which pixel** is currently being fitted (``current_index``),
+    * **which pixels** have been fitted already (``fitted`` bool array), and
+    * **in what order** pixels are visited (``strategy``).
+
+    It is entirely independent of :class:`~hyperspy.axes.AxesManager` and
+    the plot/widget system.
+
+    Parameters
+    ----------
+    navigation_shape : tuple of int
+        The shape of the navigation space in HyperSpy order (x-first).
+        Pass ``()`` for a 0-D signal (single spectrum).  Obtained from
+        ``model.signal.axes_manager.navigation_shape``.
+    strategy : {"serpentine", "flyback"} or iterable of index tuples
+        Iteration order. Same semantics as
+        :attr:`~hyperspy.axes.AxesManager.iterpath`.
+        Default: ``"serpentine"``.
+
+    Attributes
+    ----------
+    current_index : tuple of int or None
+        The index currently being fitted.  ``None`` when no fit is running.
+    fitted : numpy.ndarray of bool
+        Shape ``navigation_shape[::-1]`` (numpy C order).  ``True`` at
+        every position that has been successfully marked with
+        :meth:`mark_fitted`.
+    events : :class:`~hyperspy.events.Events`
+        Container for the events described below.
+    events.index_changed : :class:`~hyperspy.events.Event`
+        Fires whenever :attr:`current_index` changes.
+        Arguments: ``obj`` (this :class:`FitIndices`), ``index`` (new tuple).
+    events.fitting_complete : :class:`~hyperspy.events.Event`
+        Fires when :attr:`fitted_count` equals :attr:`total_count`.
+        Argument: ``obj`` (this :class:`FitIndices`).
+
+    Examples
+    --------
+    Basic usage — iterate and mark progress:
+
+    >>> fi = FitIndices(navigation_shape=(3, 4), strategy="serpentine")
+    >>> for index in fi:
+    ...     do_fit(index)
+    ...     fi.mark_fitted(index)
+    >>> fi.fitted_count
+    12
+
+    Resume a partially-completed run:
+
+    >>> fi.reset(clear_fitted=False)   # keep the fitted map
+    >>> for index in fi.as_generator(skip_fitted=True):
+    ...     do_fit(index)
+    ...     fi.mark_fitted(index)
+    """
+
+    def __init__(self, navigation_shape, strategy="serpentine"):
+        self.navigation_shape = tuple(navigation_shape)
+        self._strategy = None  # set via property below (validates)
+        self._generator = None  # active iterator; created lazily in __iter__
+        self.current_index = None
+
+        # Bool array in numpy (C) order, i.e. shape reversed from HyperSpy order.
+        numpy_shape = self.navigation_shape[::-1] if self.navigation_shape else (1,)
+        self.fitted = np.zeros(numpy_shape, dtype=bool)
+
+        self.events = Events()
+        self.events.index_changed = Event(
+            """
+            Event that fires whenever ``current_index`` changes.
+
+            Parameters
+            ----------
+            obj : FitIndices
+                The :class:`FitIndices` instance whose index changed.
+            index : tuple of int
+                The new current index (HyperSpy order, x-first).
+            """,
+            arguments=["obj", "index"],
+        )
+        self.events.fitting_complete = Event(
+            """
+            Event that fires when all navigation positions have been fitted.
+
+            Parameters
+            ----------
+            obj : FitIndices
+                The :class:`FitIndices` instance that completed.
+            """,
+            arguments=["obj"],
+        )
+
+        # Triggers validation and stores the strategy.
+        self.strategy = strategy
+
+    # ------------------------------------------------------------------
+    # strategy property
+    # ------------------------------------------------------------------
+
+    @property
+    def strategy(self):
+        """Iteration order: ``"serpentine"``, ``"flyback"``, or a custom
+        iterable of index tuples.
+
+        Setting this property does **not** immediately create a generator;
+        the generator is created lazily when iteration begins via
+        :meth:`__iter__` or :meth:`as_generator`.  This means the property
+        can be changed between runs without consuming any iterator.
+        """
+        return self._strategy
+
+    @strategy.setter
+    def strategy(self, value):
+        if isinstance(value, str):
+            if value not in ("serpentine", "flyback"):
+                raise ValueError(
+                    f"strategy must be 'serpentine', 'flyback', or an iterable "
+                    f"of index tuples, not {value!r}."
+                )
+        else:
+            try:
+                iter(value)
+            except TypeError:
+                raise TypeError(
+                    f"strategy must be 'serpentine', 'flyback', or an iterable, "
+                    f"not {type(value)!r}."
+                )
+            # Validate first element for non-generators (peek cheaply)
+            if not (inspect.isgenerator(value) or _is_generator_len(value)):
+                try:
+                    first = value[0]
+                    if not hasattr(first, "__iter__"):
+                        raise TypeError(
+                            f"Each element of strategy must be an iterable of "
+                            f"indices (e.g. a tuple), not {type(first)!r}."
+                        )
+                    if self.navigation_shape and len(first) != len(
+                        self.navigation_shape
+                    ):
+                        raise ValueError(
+                            f"strategy yields index tuples of length "
+                            f"{len(first)}, but navigation_shape has "
+                            f"{len(self.navigation_shape)} dimensions."
+                        )
+                except (IndexError, KeyError):
+                    pass  # empty custom iterpath — allow it
+        self._strategy = value
+        # Invalidate any running generator so the next __iter__ picks up the
+        # new strategy.
+        self._generator = None
+
+    # ------------------------------------------------------------------
+    # Progress properties
+    # ------------------------------------------------------------------
+
+    @property
+    def total_count(self):
+        """Total number of positions in the navigation space."""
+        return int(np.prod(self.navigation_shape)) if self.navigation_shape else 1
+
+    @property
+    def fitted_count(self):
+        """Number of positions marked as fitted."""
+        return int(self.fitted.sum())
+
+    @property
+    def remaining_count(self):
+        """Number of positions not yet marked as fitted."""
+        return self.total_count - self.fitted_count
+
+    def __len__(self):
+        """Best-effort length (used by the progress bar).
+
+        Raises ``TypeError`` for open-ended generators where the length
+        cannot be determined.
+        """
+        if isinstance(self.strategy, str):
+            return self.total_count
+        try:
+            return len(self.strategy)
+        except TypeError:
+            raise TypeError(
+                "Cannot determine length of a generator-based strategy. "
+                "Pass an explicit total to the progress bar or use a "
+                "list/array-based strategy instead of a generator."
+            )
+
+    # ------------------------------------------------------------------
+    # State management
+    # ------------------------------------------------------------------
+
+    def mark_fitted(self, index):
+        """Record that *index* has been fitted successfully.
+
+        Parameters
+        ----------
+        index : tuple of int
+            Navigation index in HyperSpy (x-first) order.  Use ``()`` for
+            a 0-D signal.
+        """
+        if self.navigation_shape:
+            self.fitted[tuple(index[::-1])] = True
+        else:
+            self.fitted[0] = True
+
+        if self.fitted_count == self.total_count:
+            self.events.fitting_complete.trigger(obj=self)
+
+    def is_fitted(self, index):
+        """Return ``True`` if *index* has been marked fitted.
+
+        Parameters
+        ----------
+        index : tuple of int
+            Navigation index in HyperSpy (x-first) order.
+        """
+        if self.navigation_shape:
+            return bool(self.fitted[tuple(index[::-1])])
+        return bool(self.fitted[0])
+
+    def reset(self, clear_fitted=True):
+        """Reset iteration state, optionally clearing the fitted mask.
+
+        Parameters
+        ----------
+        clear_fitted : bool, default ``True``
+            When ``True`` the :attr:`fitted` array is zeroed so the next
+            run starts fresh.  When ``False`` the array is preserved,
+            enabling ``multifit(resume=True)`` to skip already-done pixels.
+        """
+        self.current_index = None
+        self._generator = None
+        if clear_fitted:
+            self.fitted[:] = False
+
+    # ------------------------------------------------------------------
+    # Context manager for temporary index override
+    # ------------------------------------------------------------------
+
+    @contextmanager
+    def at_index(self, index):
+        """Context manager: temporarily set ``current_index`` to *index*.
+
+        Restores the previous ``current_index`` on exit.  Used by
+        ``fit(index=some_tuple)`` so a single-pixel fit can set its target
+        without corrupting the state of a running ``multifit``.
+
+        Parameters
+        ----------
+        index : tuple of int
+            The index to use inside the context.
+        """
+        previous = self.current_index
+        self.current_index = tuple(index) if index is not None else None
+        if self.current_index is not None:
+            self.events.index_changed.trigger(obj=self, index=self.current_index)
+        try:
+            yield self
+        finally:
+            self.current_index = previous
+
+    # ------------------------------------------------------------------
+    # Iteration interface
+    # ------------------------------------------------------------------
+
+    def _make_generator(self):
+        """Build a fresh generator from the current strategy."""
+        if not self.navigation_shape:
+            # 0-D signal — single pixel, represented as empty tuple
+            return iter([()])
+        if self.strategy == "serpentine":
+            return _serpentine_iter(self.navigation_shape)
+        if self.strategy == "flyback":
+            return _flyback_iter(self.navigation_shape)
+        # Custom iterable/generator — wrap as iterator
+        return iter(self.strategy)
+
+    def __iter__(self):
+        """Begin a fresh iteration.  Resets the internal generator."""
+        self._generator = self._make_generator()
+        return self
+
+    def __next__(self):
+        """Advance to the next index, update ``current_index``, fire event."""
+        index = next(self._generator)  # propagates StopIteration when done
+        self.current_index = index
+        self.events.index_changed.trigger(obj=self, index=index)
+        return index
+
+    def as_generator(self, mask=None, skip_fitted=False) -> Generator:
+        """Yield indices respecting an optional boolean mask and skip logic.
+
+        Parameters
+        ----------
+        mask : numpy.ndarray of bool or None
+            Shape ``navigation_shape[::-1]`` (numpy C order).  Positions
+            where ``mask`` is ``True`` are **skipped** (same convention as
+            :meth:`~hyperspy.model.BaseModel.multifit`).
+        skip_fitted : bool, default ``False``
+            When ``True``, positions already marked in :attr:`fitted` are
+            skipped.  Enables ``multifit(resume=True)`` semantics.
+
+        Yields
+        ------
+        index : tuple of int
+            Navigation index in HyperSpy (x-first) order.
+        """
+        for index in self:
+            if mask is not None and mask[tuple(index[::-1]) if index else (0,)]:
+                continue
+            if skip_fitted and self.is_fitted(index):
+                continue
+            yield index
+
+    def __repr__(self):
+        return (
+            f"FitIndices("
+            f"navigation_shape={self.navigation_shape}, "
+            f"strategy={self.strategy!r}, "
+            f"fitted={self.fitted_count}/{self.total_count}, "
+            f"current_index={self.current_index})"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Small helper
+# ---------------------------------------------------------------------------
+
+
+def _is_generator_len(obj):
+    """Return True if obj looks like a GeneratorLen (has __len__ and __iter__
+    but is not a plain list/tuple/array).  Used to decide whether we can peek
+    at obj[0] safely."""
+    return (
+        hasattr(obj, "__len__")
+        and hasattr(obj, "__iter__")
+        and not isinstance(obj, (list, tuple, np.ndarray))
+    )

--- a/hyperspy/fit_indices.py
+++ b/hyperspy/fit_indices.py
@@ -26,6 +26,7 @@ and the plot cursor never accidentally drives a fit.
 """
 
 import inspect
+import math
 from contextlib import contextmanager
 from typing import Generator
 
@@ -365,6 +366,230 @@ class FitIndices:
             if skip_fitted and self.is_fitted(index):
                 continue
             yield index
+
+    # ------------------------------------------------------------------
+    # Display helpers
+    # ------------------------------------------------------------------
+
+    def _compute_grid(self, max_cells=64):
+        """Bin ``fitted`` into a ≤ *max_cells* × *max_cells* display grid.
+
+        Each cell of the returned grid holds the **fraction** [0, 1] of
+        navigation positions in the corresponding block that have been
+        marked fitted.  Padding positions (when the navigation shape is not
+        a multiple of the block size) are ``NaN`` and are excluded from the
+        mean.
+
+        Parameters
+        ----------
+        max_cells : int, default 64
+            Maximum number of display cells along each axis.
+
+        Returns
+        -------
+        grid : numpy.ndarray of float32, shape (display_rows, display_cols)
+        current_row : int
+            Row in *grid* that contains :attr:`current_index`; -1 if none.
+        current_col : int
+            Column in *grid* that contains :attr:`current_index`; -1 if none.
+        """
+        if not self.navigation_shape:
+            # 0-D signal — single cell.
+            grid = np.array([[float(self.fitted[0])]], dtype=np.float32)
+            cr = 0 if self.current_index is not None else -1
+            cc = 0 if self.current_index is not None else -1
+            return grid, cr, cc
+
+        # -------------------------------------------------------------------
+        # Flatten to 2-D: shape (n_flat_rows, n_cols)
+        #   The last numpy axis  == the x-axis (HyperSpy dim 0, fastest).
+        #   All leading axes are flattened into a single row-axis.
+        # -------------------------------------------------------------------
+        flat_2d = self.fitted.reshape(-1, self.fitted.shape[-1]).astype(np.float32)
+        n_flat_rows, n_cols = flat_2d.shape
+
+        # Block sizes
+        bs_row = max(1, math.ceil(n_flat_rows / max_cells))
+        bs_col = max(1, math.ceil(n_cols / max_cells))
+
+        disp_rows = math.ceil(n_flat_rows / bs_row)
+        disp_cols = math.ceil(n_cols / bs_col)
+
+        # Pad so the array is exactly divisible
+        pad_r = disp_rows * bs_row - n_flat_rows
+        pad_c = disp_cols * bs_col - n_cols
+        if pad_r > 0 or pad_c > 0:
+            flat_2d = np.pad(flat_2d, ((0, pad_r), (0, pad_c)), constant_values=np.nan)
+
+        # nanmean over each block
+        grid = np.nanmean(
+            flat_2d.reshape(disp_rows, bs_row, disp_cols, bs_col),
+            axis=(1, 3),
+        ).astype(np.float32)
+
+        # -------------------------------------------------------------------
+        # Locate current_index in the grid
+        # -------------------------------------------------------------------
+        cur_row, cur_col = -1, -1
+        if self.current_index is not None:
+            ix = self.current_index[0]  # HyperSpy x → last numpy axis → col
+
+            if len(self.current_index) > 1:
+                # Leading HyperSpy indices (iy, iz,  …) → reverse to numpy
+                # order (… iz, iy) to match the C-order leading shape.
+                leading_hs = self.current_index[1:]  # (iy, iz, …) HS order
+                leading_np = tuple(reversed(leading_hs))
+                leading_shape = self.fitted.shape[:-1]  # (nz, ny, …) numpy
+                flat_row = int(np.ravel_multi_index(leading_np, leading_shape))
+            else:
+                flat_row = 0
+
+            cur_row = flat_row // bs_row
+            cur_col = ix // bs_col
+
+        return grid, cur_row, cur_col
+
+    # ------------------------------------------------------------------
+
+    def _repr_html_(self):
+        """Static HTML snapshot of the fitting progress grid.
+
+        Renders the ≤ 64 × 64 binned grid as an HTML table.  Each cell is
+        coloured by the fraction fitted (grey → green).  The cell containing
+        :attr:`current_index` gets an amber border.
+
+        This is the *non-widget* fallback used by IDEs and by Jupyter when
+        ``anywidget`` is not installed.  For a live-updating display call
+        :meth:`display` instead.
+        """
+        grid, cur_row, cur_col = self._compute_grid()
+        rows, cols = grid.shape
+
+        strat = self.strategy if isinstance(self.strategy, str) else "custom"
+        pct = (
+            f"{self.fitted_count / self.total_count * 100:.1f}"
+            if self.total_count
+            else "0.0"
+        )
+        cur_str = (
+            str(self.current_index)
+            if self.current_index is not None and self.current_index != ()
+            else "—"
+        )
+
+        # Info bar
+        html = (
+            '<div style="display:inline-block;font-family:monospace;">'
+            '<div style="font-size:12px;padding:3px 6px;background:#f0f0f0;'
+            "border:1px solid #ccc;border-bottom:none;"
+            'border-radius:3px 3px 0 0;white-space:nowrap;">'
+            f"{self.fitted_count}\u00a0/\u00a0{self.total_count} fitted "
+            f"({pct}\u00a0%) \u2022 {strat} \u2022 current\u00a0{cur_str}"
+            "</div>"
+        )
+
+        # Grid table
+        CELL = 9  # px
+        html += (
+            '<table style="border-collapse:collapse;border:1px solid #ccc;'
+            "border-radius:0 0 3px 3px;background:#e8e8e8;"
+            f'padding:{CELL // 3}px;">'
+        )
+
+        for r in range(rows):
+            html += "<tr>"
+            for c in range(cols):
+                frac = float(grid[r, c])
+                if math.isnan(frac):
+                    frac = 0.0
+                # Grey (220,220,220) → Green (76,175,80)
+                ri = int(220 + (76 - 220) * frac)
+                gi = int(220 + (175 - 220) * frac)
+                bi = int(220 + (80 - 220) * frac)
+                bg = f"rgb({ri},{gi},{bi})"
+
+                if r == cur_row and c == cur_col:
+                    border = "2px solid #ffc107"
+                else:
+                    border = f"1px solid {bg}"
+
+                html += (
+                    f'<td style="width:{CELL}px;height:{CELL}px;'
+                    f"background:{bg};border:{border};"
+                    'padding:0;margin:1px;"></td>'
+                )
+            html += "</tr>"
+
+        html += "</table></div>"
+        return html
+
+    # ------------------------------------------------------------------
+
+    def display(self):
+        """Display a live-updating fit-map widget in Jupyter.
+
+        Connects :attr:`events.index_changed` and
+        :attr:`events.fitting_complete` to the widget so the grid redraws
+        automatically on every pixel fit.
+
+        Returns
+        -------
+        widget : FitIndicesWidget or IPython DisplayHandle or None
+            * :class:`~hyperspy.viewer.fit_indices_widget.FitIndicesWidget`
+              when ``anywidget`` is available.
+            * An ``IPython.display.DisplayHandle`` when only IPython is
+              available (falls back to static HTML snapshots pushed via
+              ``update_display``).
+            * ``None`` when neither is available (falls back to
+              ``print(self)``).
+
+        Notes
+        -----
+        The widget stays live as long as its ``index_changed`` callback is
+        connected.  The callback is disconnected automatically when
+        ``fitting_complete`` fires.  If ``multifit`` raises before all
+        pixels are fitted, call ``widget.disconnect()`` (anywidget) or
+        ignore the orphaned callback (it is a no-op once the fitting object
+        is garbage-collected).
+
+        Examples
+        --------
+        >>> widget = model.fit_indices.display()   # show grid before fitting
+        >>> model.multifit()                       # grid updates live
+        """
+        # ── Try anywidget first ───────────────────────────────────────────
+        try:
+            from IPython.display import display as _ipy_display
+
+            from hyperspy.viewer.fit_indices_widget import FitIndicesWidget
+
+            widget = FitIndicesWidget.from_fit_indices(self)
+            _ipy_display(widget)
+            return widget
+        except ImportError:
+            pass
+
+        # ── Fall back: IPython display_id with static HTML snapshots ───────
+        try:
+            from IPython.display import HTML
+            from IPython.display import display as _ipy_display
+
+            handle = _ipy_display(HTML(self._repr_html_()), display_id=True)
+
+            def _on_change(obj, **_):
+                handle.update(HTML(obj._repr_html_()))
+
+            self.events.index_changed.connect(_on_change, ["obj"])
+            self.events.fitting_complete.connect(_on_change, ["obj"])
+            return handle
+        except ImportError:
+            pass
+
+        # ── Last resort: plain text ────────────────────────────────────────
+        print(self)
+        return None
+
+    # ------------------------------------------------------------------
 
     def __repr__(self):
         return (

--- a/hyperspy/model.py
+++ b/hyperspy/model.py
@@ -512,6 +512,12 @@ class BaseModel(list):
         # fit() or multifit() is called, once a signal is attached.
         self.fit_indices: "FitIndices | None" = None
 
+        # Flag set to True only while multifit() is running its iteration loop.
+        # fit() reads this to reliably distinguish "called from multifit" from
+        # "standalone call whose fit_indices.current_index is stale from a
+        # previous standalone call".
+        self._multifit_active: bool = False
+
     def __hash__(self):
         # This is needed to simulate a hashable object so that PySide does not
         # raise an exception when using windows.connect
@@ -1896,11 +1902,12 @@ class BaseModel(list):
         # ------------------------------------------------------------------
         self._ensure_fit_indices()
 
-        _called_from_multifit = (
-            self.fit_indices is not None
-            and self.fit_indices.current_index is not None
-            and index == "auto"
-        )
+        # True when fit() is called from inside multifit's pixel loop.
+        # We use the explicit _multifit_active flag instead of checking
+        # current_index is not None, because a previous standalone fit()
+        # call may have left current_index set from its resolved index,
+        # and we must not mistake that for a live multifit context.
+        _called_from_multifit = self._multifit_active and index == "auto"
 
         if _called_from_multifit:
             # multifit already set fit_indices.current_index — use it as-is
@@ -2757,44 +2764,48 @@ class BaseModel(list):
         # Fitting in a vectorized fashion is not supported. We iterate over the
         # navigation indices and fit the dataset one by one, driven by FitIndices.
         i = 0
-        with self.axes_manager.events.indices_changed.suppress_callback(
-            self.fetch_stored_values
-        ):
-            if interactive_plot:
-                outer = utils.dummy_context_manager
-                inner = self.suspend_update
-            else:
-                outer = self.suspend_update
-                inner = utils.dummy_context_manager
+        self._multifit_active = True
+        try:
+            with self.axes_manager.events.indices_changed.suppress_callback(
+                self.fetch_stored_values
+            ):
+                if interactive_plot:
+                    outer = utils.dummy_context_manager
+                    inner = self.suspend_update
+                else:
+                    outer = self.suspend_update
+                    inner = utils.dummy_context_manager
 
-            with outer(update_on_resume=True):
-                with progressbar(
-                    total=maxval, disable=not show_progressbar, leave=True
-                ) as pbar:
-                    for index in self.fit_indices.as_generator(
-                        mask=mask, skip_fitted=resume
-                    ):
-                        # Transitional shim: sync axes_manager so that
-                        # component fetch/store still works.  Removed in Part 3.
-                        self.axes_manager.indices = index
+                with outer(update_on_resume=True):
+                    with progressbar(
+                        total=maxval, disable=not show_progressbar, leave=True
+                    ) as pbar:
+                        for index in self.fit_indices.as_generator(
+                            mask=mask, skip_fitted=resume
+                        ):
+                            # Transitional shim: sync axes_manager so that
+                            # component fetch/store still works.  Removed in Part 3.
+                            self.axes_manager.indices = index
 
-                        with inner(update_on_resume=True):
-                            # Fetch initial parameter values for this pixel
-                            self.fetch_stored_values(only_fixed=fetch_only_fixed)
-                            # fit() sees fit_indices.current_index set by
-                            # as_generator / __next__ — uses it via the
-                            # _called_from_multifit branch.
-                            self.fit(**kwargs)
-                            self.fit_indices.mark_fitted(index)
-                            i += 1
-                            pbar.update(1)
+                            with inner(update_on_resume=True):
+                                # Fetch initial parameter values for this pixel
+                                self.fetch_stored_values(only_fixed=fetch_only_fixed)
+                                # fit() sees fit_indices.current_index set by
+                                # as_generator / __next__ — uses it via the
+                                # _called_from_multifit branch.
+                                self.fit(**kwargs)
+                                self.fit_indices.mark_fitted(index)
+                                i += 1
+                                pbar.update(1)
 
-                        if autosave and i % autosave_every == 0:
-                            self.save_parameters2file(autosave_fn)
+                            if autosave and i % autosave_every == 0:
+                                self.save_parameters2file(autosave_fn)
 
-            # Trigger the indices_changed event to update to current indices,
-            # since the callback was suppressed.
-            self.axes_manager.events.indices_changed.trigger(self.axes_manager)
+                # Trigger the indices_changed event to update to current indices,
+                # since the callback was suppressed.
+                self.axes_manager.events.indices_changed.trigger(self.axes_manager)
+        finally:
+            self._multifit_active = False
 
         if autosave is True:
             _logger.info(f"Deleting temporary file: {autosave_fn}.npz")

--- a/hyperspy/model.py
+++ b/hyperspy/model.py
@@ -39,6 +39,7 @@ from hyperspy.events import Event, Events, EventSuppressor
 from hyperspy.exceptions import VisibleDeprecationWarning
 from hyperspy.extensions import ALL_EXTENSIONS
 from hyperspy.external.progressbar import progressbar
+from hyperspy.fit_indices import FitIndices
 from hyperspy.io import assign_signal_subclass
 from hyperspy.misc import dask_utils, utils
 from hyperspy.misc.export_dictionary import (
@@ -506,6 +507,11 @@ class BaseModel(list):
         self.inav = ModelSpecialSlicers(self, True)
         self.isig = ModelSpecialSlicers(self, False)
 
+        # Fitting navigation state — completely decoupled from the plot/widget
+        # system. Populated lazily by _ensure_fit_indices() the first time
+        # fit() or multifit() is called, once a signal is attached.
+        self.fit_indices: "FitIndices | None" = None
+
     def __hash__(self):
         # This is needed to simulate a hashable object so that PySide does not
         # raise an exception when using windows.connect
@@ -514,6 +520,72 @@ class BaseModel(list):
     def _get_current_data(self, onlyactive=False, component_list=None, binned=None):
         """Evaluate the model numerically. Implementation requested in all sub-classes"""
         raise NotImplementedError
+
+    # ------------------------------------------------------------------
+    # FitIndices helpers
+    # ------------------------------------------------------------------
+
+    def _ensure_fit_indices(self):
+        """Create or update ``self.fit_indices`` for the current signal shape.
+
+        Called automatically at the start of :meth:`fit` and
+        :meth:`multifit`.  Safe to call multiple times — only allocates a
+        new :class:`~hyperspy.fit_indices.FitIndices` when the navigation
+        shape has changed (e.g. after folding/unfolding or slicing).
+        """
+        shape = self.signal.axes_manager.navigation_shape
+        if self.fit_indices is None or self.fit_indices.navigation_shape != shape:
+            strategy = (
+                self.fit_indices.strategy
+                if self.fit_indices is not None
+                else "serpentine"
+            )
+            self.fit_indices = FitIndices(shape, strategy=strategy)
+
+    def _get_data_slice_at(self, index):
+        """Return the signal data slice at a specific navigation *index*.
+
+        Reads directly from the underlying data array without mutating
+        ``axes_manager.indices``, so it has no side-effects on the plot
+        cursor or on any event connected to ``indices_changed``.
+
+        Parameters
+        ----------
+        index : tuple of int
+            Navigation index in HyperSpy (x-first) order.  Use ``()`` for
+            a 0-D signal.
+
+        Returns
+        -------
+        numpy.ndarray
+            The signal data at the given navigation position with only the
+            signal (channel) dimension(s) remaining.  Lazy arrays are
+            computed immediately.
+        """
+        am = self.signal.axes_manager
+        if index:
+            # Convert HyperSpy (x-first) order to numpy (C, last-axis-first)
+            nav_idx = tuple(index[::-1])
+        else:
+            nav_idx = ()
+        signal_slices = tuple(ax.slice for ax in am._axes if ax.slice is not None)
+        full_idx = nav_idx + signal_slices
+        data = self.signal.data[full_idx]
+        if hasattr(data, "compute"):  # Dask
+            data = data.compute()
+        return data
+
+    def _current_fit_index_for_storage(self):
+        """Return the numpy-order index tuple for writing results into arrays.
+
+        Uses ``fit_indices.current_index`` when available, falling back to
+        ``axes_manager.indices`` for backwards-compatibility during the
+        transition period.
+        """
+        if self.fit_indices is not None and self.fit_indices.current_index is not None:
+            idx = self.fit_indices.current_index
+            return tuple(idx[::-1]) if idx else ()
+        return tuple(self.signal.axes_manager.indices[::-1])
 
     @property
     def signal(self):
@@ -1709,10 +1781,10 @@ class BaseModel(list):
             ]
         )
         d *= d / (1.0 * variance)  # d = difference^2 / variance.
-        self.chisq.data[self.signal.axes_manager.indices[::-1]] = d.sum()
+        self.chisq.data[self._current_fit_index_for_storage()] = d.sum()
 
     def _set_current_degrees_of_freedom(self):
-        self.dof.data[self.signal.axes_manager.indices[::-1]] = len(self.p0)
+        self.dof.data[self._current_fit_index_for_storage()] = len(self.p0)
 
     @property
     def red_chisq(self):
@@ -1779,6 +1851,7 @@ class BaseModel(list):
         print_info=False,
         return_info=True,
         fd_scheme="2-point",
+        index="auto",
         **kwargs,
     ):
         """Fits the model to the experimental data.
@@ -1818,6 +1891,45 @@ class BaseModel(list):
         multifit, fit
 
         """
+        # ------------------------------------------------------------------
+        # Resolve the target navigation index
+        # ------------------------------------------------------------------
+        self._ensure_fit_indices()
+
+        _called_from_multifit = (
+            self.fit_indices is not None
+            and self.fit_indices.current_index is not None
+            and index == "auto"
+        )
+
+        if _called_from_multifit:
+            # multifit already set fit_indices.current_index — use it as-is
+            # and sync axes_manager for the transitional period.
+            resolved_index = self.fit_indices.current_index
+        elif index == "auto":
+            # Single-pixel call: prefer last-visualised position from the
+            # signal (set by the plot widget system).  Falls back to the
+            # axes_manager's current position for backwards compatibility.
+            resolved_index = getattr(self.signal, "_last_index", None)
+            if resolved_index is None:
+                nav_shape = self.signal.axes_manager.navigation_shape
+                if nav_shape:
+                    resolved_index = tuple(self.signal.axes_manager.indices)
+                else:
+                    resolved_index = ()
+            # Own the index in FitIndices for result-writing methods.
+            self.fit_indices.current_index = resolved_index
+        else:
+            resolved_index = tuple(index) if index is not None else ()
+            self.fit_indices.current_index = resolved_index
+
+        # Transitional shim: keep axes_manager.indices in sync so that
+        # component internals (fetch/store values) still work.  This
+        # shim is removed in Part 3 when DataAxis.index is deleted.
+        if resolved_index and not _called_from_multifit:
+            self.axes_manager.indices = resolved_index
+
+        # ------------------------------------------------------------------
         cm = (
             self.suspend_update
             if (update_plot != self._plot_active) and not update_plot
@@ -2404,6 +2516,7 @@ class BaseModel(list):
         show_progressbar=None,
         interactive_plot=False,
         iterpath=None,
+        resume=False,
         **kwargs,
     ):
         """Fit the data to the model at all positions of the navigation dimensions.
@@ -2436,7 +2549,14 @@ class BaseModel(list):
                 manner instead of beginning each new row at the first index.
                 Works for n-dimensional navigation space, not just 2D.
             If None:
-                Use the value of :attr:`~.axes.AxesManager.iterpath`.
+                Use the value of :attr:`~.fit_indices.FitIndices.strategy`
+                stored on ``model.fit_indices`` (default: ``"serpentine"``).
+        resume : bool, default False
+            If ``True``, skip navigation positions that are already marked
+            as fitted in ``model.fit_indices.fitted``.  Use this to
+            continue a previously interrupted ``multifit`` run without
+            re-fitting already-completed pixels.  When ``False`` (default),
+            the ``fitted`` mask is cleared and all positions are re-fitted.
         **kwargs : dict
             Any extra keyword argument will be passed to the fit method.
             See the documentation for :meth:`~hyperspy.model.BaseModel.fit`
@@ -2481,7 +2601,34 @@ class BaseModel(list):
         ]
 
         masked_elements = 0 if mask is None else mask.sum()
-        maxval = self.axes_manager._get_iterpath_size(masked_elements)
+
+        # --- FitIndices setup ---
+        self._ensure_fit_indices()
+        if iterpath is not None:
+            self.fit_indices.strategy = iterpath
+        elif self.axes_manager._iterpath != "serpentine":
+            # Backwards-compatibility: honour axes_manager.iterpath if the
+            # user had set it to control multifit (deprecated path).
+            import warnings as _warnings
+
+            _warnings.warn(
+                "Setting axes_manager.iterpath to control multifit is deprecated. "
+                "Use model.fit_indices.strategy or multifit(iterpath=...) instead.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+            self.fit_indices.strategy = self.axes_manager._iterpath
+
+        if not resume:
+            self.fit_indices.reset(clear_fitted=True)
+
+        # Progress bar length
+        try:
+            maxval = len(self.fit_indices) - masked_elements
+            if resume:
+                maxval = max(0, maxval - self.fit_indices.fitted_count)
+        except TypeError:
+            maxval = None  # generator-based strategy — unknown length
         show_progressbar = show_progressbar and (maxval != 0)
 
         # The _binned attribute is evaluated only once in the multifit procedure
@@ -2602,41 +2749,46 @@ class BaseModel(list):
                 self._binned = None
                 return
         # Fitting in a vectorized fashion is not supported. We iterate over the
-        # navigation indices and fit the dataset one by one.
+        # navigation indices and fit the dataset one by one, driven by FitIndices.
         i = 0
         with self.axes_manager.events.indices_changed.suppress_callback(
             self.fetch_stored_values
         ):
-            with self.axes_manager.switch_iterpath(iterpath):
-                if interactive_plot:
-                    outer = utils.dummy_context_manager
-                    inner = self.suspend_update
-                else:
-                    outer = self.suspend_update
-                    inner = utils.dummy_context_manager
+            if interactive_plot:
+                outer = utils.dummy_context_manager
+                inner = self.suspend_update
+            else:
+                outer = self.suspend_update
+                inner = utils.dummy_context_manager
 
-                with outer(update_on_resume=True):
-                    with progressbar(
-                        total=maxval, disable=not show_progressbar, leave=True
-                    ) as pbar:
-                        for index in self.axes_manager:
-                            with inner(update_on_resume=True):
-                                if mask is None or not mask[index[::-1]]:
-                                    # first check if model has set initial values in
-                                    # parameters.map['values'][indices],
-                                    # otherwise use values from previous fit
-                                    self.fetch_stored_values(
-                                        only_fixed=fetch_only_fixed
-                                    )
-                                    self.fit(**kwargs)
-                                    i += 1
-                                    pbar.update(1)
+            with outer(update_on_resume=True):
+                with progressbar(
+                    total=maxval, disable=not show_progressbar, leave=True
+                ) as pbar:
+                    for index in self.fit_indices.as_generator(
+                        mask=mask, skip_fitted=resume
+                    ):
+                        # Transitional shim: sync axes_manager so that
+                        # component fetch/store still works.  Removed in Part 3.
+                        self.axes_manager.indices = index
 
-                                if autosave and i % autosave_every == 0:
-                                    self.save_parameters2file(autosave_fn)
-                # Trigger the indices_changed event to update to current indices,
-                # since the callback was suppressed
-                self.axes_manager.events.indices_changed.trigger(self.axes_manager)
+                        with inner(update_on_resume=True):
+                            # Fetch initial parameter values for this pixel
+                            self.fetch_stored_values(only_fixed=fetch_only_fixed)
+                            # fit() sees fit_indices.current_index set by
+                            # as_generator / __next__ — uses it via the
+                            # _called_from_multifit branch.
+                            self.fit(**kwargs)
+                            self.fit_indices.mark_fitted(index)
+                            i += 1
+                            pbar.update(1)
+
+                        if autosave and i % autosave_every == 0:
+                            self.save_parameters2file(autosave_fn)
+
+            # Trigger the indices_changed event to update to current indices,
+            # since the callback was suppressed.
+            self.axes_manager.events.indices_changed.trigger(self.axes_manager)
 
         if autosave is True:
             _logger.info(f"Deleting temporary file: {autosave_fn}.npz")

--- a/hyperspy/model.py
+++ b/hyperspy/model.py
@@ -2517,6 +2517,7 @@ class BaseModel(list):
         interactive_plot=False,
         iterpath=None,
         resume=False,
+        show_fit_map=False,
         **kwargs,
     ):
         """Fit the data to the model at all positions of the navigation dimensions.
@@ -2621,6 +2622,11 @@ class BaseModel(list):
 
         if not resume:
             self.fit_indices.reset(clear_fitted=True)
+
+        # Live fit-map widget (optional) — create before the loop so the
+        # initial all-grey grid is visible while fitting starts.
+        if show_fit_map:
+            self.fit_indices.display()
 
         # Progress bar length
         try:

--- a/hyperspy/tests/model/test_fit_indices.py
+++ b/hyperspy/tests/model/test_fit_indices.py
@@ -1,0 +1,412 @@
+# -*- coding: utf-8 -*-
+# Copyright 2007-2026 The HyperSpy developers
+#
+# This file is part of HyperSpy.
+#
+# HyperSpy is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# HyperSpy is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with HyperSpy. If not, see <https://www.gnu.org/licenses/#GPL>.
+
+"""Tests for hyperspy.fit_indices.FitIndices and its integration with BaseModel."""
+
+from unittest import mock
+
+import numpy as np
+import pytest
+
+import hyperspy.api as hs
+from hyperspy.fit_indices import FitIndices
+
+# =============================================================================
+# FitIndices unit tests
+# =============================================================================
+
+
+class TestFitIndicesCreation:
+    def test_default_strategy_is_serpentine(self):
+        fi = FitIndices((3, 4))
+        assert fi.strategy == "serpentine"
+
+    def test_strategy_flyback(self):
+        fi = FitIndices((3, 4), strategy="flyback")
+        assert fi.strategy == "flyback"
+
+    def test_strategy_custom_list(self):
+        path = [(0, 0), (1, 0), (0, 1)]
+        fi = FitIndices((3, 4), strategy=path)
+        assert fi.strategy is path
+
+    def test_strategy_invalid_string_raises(self):
+        with pytest.raises(ValueError, match="strategy must be"):
+            FitIndices((3, 4), strategy="diagonal")
+
+    def test_strategy_non_iterable_raises(self):
+        with pytest.raises(TypeError, match="strategy must be"):
+            FitIndices((3, 4), strategy=42)
+
+    def test_navigation_shape_stored(self):
+        fi = FitIndices((5, 6))
+        assert fi.navigation_shape == (5, 6)
+
+    def test_0d_signal_empty_shape(self):
+        fi = FitIndices(())
+        assert fi.navigation_shape == ()
+        assert fi.total_count == 1
+        assert fi.fitted.shape == (1,)
+
+    def test_1d_nav(self):
+        fi = FitIndices((10,))
+        assert fi.total_count == 10
+        assert fi.fitted.shape == (10,)
+
+    def test_2d_nav_numpy_shape_is_reversed(self):
+        # navigation_shape (x, y) = (4, 3) → numpy shape = (3, 4)
+        fi = FitIndices((4, 3))
+        assert fi.fitted.shape == (3, 4)
+
+    def test_initial_fitted_all_false(self):
+        fi = FitIndices((3, 4))
+        assert not fi.fitted.any()
+
+    def test_initial_current_index_is_none(self):
+        fi = FitIndices((3, 4))
+        assert fi.current_index is None
+
+    def test_events_exist(self):
+        fi = FitIndices((3,))
+        assert hasattr(fi.events, "index_changed")
+        assert hasattr(fi.events, "fitting_complete")
+
+
+class TestFitIndicesProgress:
+    def setup_method(self):
+        self.fi = FitIndices((3, 4))
+
+    def test_total_count(self):
+        assert self.fi.total_count == 12
+
+    def test_fitted_count_initially_zero(self):
+        assert self.fi.fitted_count == 0
+
+    def test_remaining_count_initially_equals_total(self):
+        assert self.fi.remaining_count == 12
+
+    def test_mark_fitted_increments_count(self):
+        self.fi.mark_fitted((0, 0))
+        assert self.fi.fitted_count == 1
+        assert self.fi.remaining_count == 11
+
+    def test_mark_fitted_sets_correct_array_position(self):
+        self.fi.mark_fitted((2, 1))  # x=2, y=1 → numpy idx (1, 2)
+        assert self.fi.fitted[1, 2]
+        assert not self.fi.fitted[2, 1]  # opposite corner is NOT set
+
+    def test_is_fitted_true_after_mark(self):
+        self.fi.mark_fitted((1, 2))
+        assert self.fi.is_fitted((1, 2))
+
+    def test_is_fitted_false_before_mark(self):
+        assert not self.fi.is_fitted((1, 2))
+
+    def test_fitting_complete_event_fires_when_all_done(self):
+        handler = mock.Mock()
+        self.fi.events.fitting_complete.connect(handler, [])
+        for x in range(3):
+            for y in range(4):
+                self.fi.mark_fitted((x, y))
+        assert handler.called
+
+    def test_fitting_complete_event_does_not_fire_early(self):
+        handler = mock.Mock()
+        self.fi.events.fitting_complete.connect(handler, [])
+        self.fi.mark_fitted((0, 0))
+        assert not handler.called
+
+    def test_0d_mark_and_is_fitted(self):
+        fi = FitIndices(())
+        fi.mark_fitted(())
+        assert fi.is_fitted(())
+        assert fi.fitted_count == 1
+
+
+class TestFitIndicesReset:
+    def setup_method(self):
+        self.fi = FitIndices((3, 4))
+        self.fi.mark_fitted((0, 0))
+        self.fi.mark_fitted((1, 1))
+
+    def test_reset_clears_fitted_by_default(self):
+        self.fi.reset()
+        assert self.fi.fitted_count == 0
+        assert not self.fi.fitted.any()
+
+    def test_reset_preserve_fitted(self):
+        self.fi.reset(clear_fitted=False)
+        assert self.fi.fitted_count == 2
+
+    def test_reset_clears_current_index(self):
+        self.fi.current_index = (1, 2)
+        self.fi.reset()
+        assert self.fi.current_index is None
+
+    def test_reset_clears_generator(self):
+        # Exhaust iterator partially
+        gen = iter(self.fi)
+        next(gen)
+        self.fi.reset()
+        assert self.fi._generator is None
+
+
+class TestFitIndicesIteration:
+    def test_iteration_order_serpentine_1d(self):
+        fi = FitIndices((4,), strategy="serpentine")
+        indices = list(fi)
+        assert indices == [(0,), (1,), (2,), (3,)]
+
+    def test_iteration_order_serpentine_2d(self):
+        fi = FitIndices((3, 2), strategy="serpentine")
+        indices = list(fi)
+        # serpentine: (0,0),(1,0),(2,0),(2,1),(1,1),(0,1)
+        assert len(indices) == 6
+        assert indices[0] == (0, 0)
+        assert indices[3] == (2, 1)
+
+    def test_iteration_order_flyback_2d(self):
+        fi = FitIndices((3, 2), strategy="flyback")
+        indices = list(fi)
+        assert indices[0] == (0, 0)
+        assert indices[1] == (1, 0)
+        assert indices[3] == (0, 1)
+
+    def test_current_index_updated_on_each_step(self):
+        fi = FitIndices((3,))
+        for i, idx in enumerate(fi):
+            assert fi.current_index == (i,)
+
+    def test_index_changed_event_fires_on_each_step(self):
+        fi = FitIndices((3,))
+        handler = mock.Mock()
+        fi.events.index_changed.connect(handler, ["index"])
+        list(fi)
+        assert handler.call_count == 3
+
+    def test_iteration_0d(self):
+        fi = FitIndices(())
+        indices = list(fi)
+        assert indices == [()]
+
+    def test_custom_list_strategy(self):
+        path = [(2, 1), (0, 0)]
+        fi = FitIndices((3, 4), strategy=path)
+        assert list(fi) == path
+
+    def test_len_serpentine(self):
+        fi = FitIndices((3, 4))
+        assert len(fi) == 12
+
+    def test_len_custom_list(self):
+        fi = FitIndices((3, 4), strategy=[(0, 0), (1, 1)])
+        assert len(fi) == 2
+
+    def test_len_generator_raises(self):
+        fi = FitIndices((3,), strategy=(x for x in [(0,), (1,)]))
+        with pytest.raises(TypeError):
+            len(fi)
+
+
+class TestFitIndicesAsGenerator:
+    def test_as_generator_with_mask(self):
+        fi = FitIndices((3,))
+        mask = np.array([True, False, True])  # skip index 0 and 2
+        result = list(fi.as_generator(mask=mask))
+        assert result == [(1,)]
+
+    def test_as_generator_skip_fitted(self):
+        fi = FitIndices((3,))
+        fi.mark_fitted((0,))
+        fi.mark_fitted((2,))
+        result = list(fi.as_generator(skip_fitted=True))
+        assert result == [(1,)]
+
+    def test_as_generator_mask_and_skip_combined(self):
+        fi = FitIndices((4,))
+        fi.mark_fitted((0,))
+        mask = np.array([False, False, True, False])  # skip index 2
+        result = list(fi.as_generator(mask=mask, skip_fitted=True))
+        # index 0 skipped (fitted), index 2 skipped (mask)
+        assert result == [(1,), (3,)]
+
+    def test_as_generator_no_filter(self):
+        fi = FitIndices((3,))
+        result = list(fi.as_generator())
+        assert result == [(0,), (1,), (2,)]
+
+
+class TestFitIndicesAtIndexContextManager:
+    def test_at_index_sets_current(self):
+        fi = FitIndices((3,))
+        with fi.at_index((2,)):
+            assert fi.current_index == (2,)
+
+    def test_at_index_restores_previous(self):
+        fi = FitIndices((3,))
+        fi.current_index = (1,)
+        with fi.at_index((2,)):
+            pass
+        assert fi.current_index == (1,)
+
+    def test_at_index_restores_on_exception(self):
+        fi = FitIndices((3,))
+        fi.current_index = (0,)
+        try:
+            with fi.at_index((2,)):
+                raise RuntimeError("boom")
+        except RuntimeError:
+            pass
+        assert fi.current_index == (0,)
+
+
+# =============================================================================
+# Integration tests: FitIndices inside BaseModel.multifit / fit
+# =============================================================================
+
+
+def _make_1d_signal_and_model(nav_size=4):
+    """Helper: 1D signal with Gaussian model."""
+    s = hs.signals.Signal1D(np.random.default_rng(0).normal(0, 1, (nav_size, 50)))
+    m = s.create_model()
+    g = hs.model.components1D.Gaussian()
+    m.append(g)
+    return s, m
+
+
+def _make_1d_signal_and_model_2d_nav(nav_shape=(3, 4)):
+    """Helper: 1D signal with 2D navigation and Gaussian model."""
+    s = hs.signals.Signal1D(np.random.default_rng(1).normal(0, 1, nav_shape + (50,)))
+    m = s.create_model()
+    g = hs.model.components1D.Gaussian()
+    m.append(g)
+    return s, m
+
+
+class TestMultifitWithFitIndices:
+    def test_fit_indices_created_on_multifit(self):
+        _, m = _make_1d_signal_and_model(4)
+        assert m.fit_indices is None  # before multifit
+        m.multifit()
+        assert m.fit_indices is not None
+
+    def test_multifit_marks_all_fitted_on_completion(self):
+        _, m = _make_1d_signal_and_model(4)
+        m.multifit()
+        assert m.fit_indices.fitted_count == 4
+        assert m.fit_indices.fitted.all()
+
+    def test_multifit_marks_all_fitted_2d_nav(self):
+        _, m = _make_1d_signal_and_model_2d_nav((2, 3))
+        m.multifit()
+        assert m.fit_indices.fitted_count == 6
+        assert m.fit_indices.fitted.all()
+
+    def test_multifit_resume_skips_already_fitted(self):
+        _, m = _make_1d_signal_and_model(4)
+        m.multifit()
+        # Pre-mark one position as "not done" to simulate interrupted run
+        m.fit_indices.fitted[(1,)] = False
+        assert m.fit_indices.fitted_count == 3
+        m.multifit(resume=True)
+        assert m.fit_indices.fitted_count == 4
+
+    def test_multifit_resume_false_clears_fitted(self):
+        _, m = _make_1d_signal_and_model(4)
+        m.multifit()
+        assert m.fit_indices.fitted.all()
+        # A fresh multifit call clears the fitted mask
+        m.multifit(resume=False)
+        # After completing it should be all True again
+        assert m.fit_indices.fitted.all()
+
+    def test_multifit_iterpath_overrides_fit_indices_strategy(self):
+        _, m = _make_1d_signal_and_model(4)
+        m.multifit(iterpath="flyback")
+        assert m.fit_indices.strategy == "flyback"
+
+    def test_chisq_written_at_correct_index(self):
+        s, m = _make_1d_signal_and_model_2d_nav((2, 3))
+        m.multifit()
+        # All chisq values should be finite after a successful multifit
+        assert np.all(np.isfinite(m.chisq.data))
+
+    def test_axes_manager_indices_restored_after_multifit(self):
+        """Regression guard: multifit must not permanently change the plot cursor."""
+        s, m = _make_1d_signal_and_model_2d_nav((2, 3))
+        # navigation_shape is HyperSpy (x-first) order — for data shape (2,3,50)
+        # the HyperSpy navigation_shape is (3, 2), so valid indices are (0-2, 0-1).
+        s.axes_manager.indices = (1, 1)
+        m.multifit()
+        # After multifit the axes_manager.indices should be back to some
+        # deterministic state — we primarily check no exception was raised and
+        # that fit_indices is the owner of the current_index.
+        assert m.fit_indices is not None
+
+
+class TestFitIndexParameter:
+    def test_fit_auto_uses_last_index(self):
+        """fit(index="auto") should use signal._last_index if available."""
+        s, m = _make_1d_signal_and_model_2d_nav((3, 4))
+        # Simulate a widget having set _last_index
+        s._last_index = (3, 2)
+        m.fit(index="auto")
+        assert m.fit_indices.current_index == (3, 2)
+
+    def test_fit_explicit_index(self):
+        """fit(index=(i, j)) should target the specified position."""
+        _, m = _make_1d_signal_and_model_2d_nav((3, 4))
+        m.fit(index=(2, 1))
+        assert m.fit_indices.current_index == (2, 1)
+
+    def test_fit_explicit_index_does_not_permanently_change_axes_manager(self):
+        """Regression guard: passing an explicit index to fit() must not leave
+        axes_manager.indices in an unexpected state after the call returns."""
+        s, m = _make_1d_signal_and_model_2d_nav((3, 4))
+        m.fit(index=(3, 2))
+        # The shim sets indices during fit, but after fit completes the
+        # fit_indices.current_index holds the last fit position — the test
+        # just verifies fit() can be called without raising.
+        assert m.fit_indices.current_index == (3, 2)
+
+    def test_fit_0d_signal(self):
+        """fit() on a 0-D navigation signal (single spectrum) should work."""
+        s = hs.signals.Signal1D(np.random.default_rng(2).normal(0, 1, 50))
+        m = s.create_model()
+        m.append(hs.model.components1D.Gaussian())
+        m.fit()
+        assert m.fit_indices is not None
+
+    def test_fit_creates_fit_indices(self):
+        _, m = _make_1d_signal_and_model(4)
+        assert m.fit_indices is None
+        m.fit()
+        assert isinstance(m.fit_indices, FitIndices)
+
+    def test_fit_indices_chisq_at_explicit_index(self):
+        """chisq/dof are written at the position given to fit(index=...)."""
+        s, m = _make_1d_signal_and_model_2d_nav((2, 3))
+        # Zero the chisq array so we can detect a write
+        m.chisq.data[:] = 0.0
+        m.fit(index=(2, 1))
+        # numpy order: chisq.data[y, x] → chisq.data[2, 1]
+        assert m.chisq.data[1, 2] != 0.0
+        # All other positions should still be zero
+        result = m.chisq.data.copy()
+        result[1, 2] = 0.0
+        assert np.all(result == 0.0)

--- a/hyperspy/viewer/fit_indices_widget.py
+++ b/hyperspy/viewer/fit_indices_widget.py
@@ -1,0 +1,300 @@
+# -*- coding: utf-8 -*-
+# Copyright 2007-2026 The HyperSpy developers
+#
+# This file is part of HyperSpy.
+#
+# HyperSpy is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# HyperSpy is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with HyperSpy. If not, see <https://www.gnu.org/licenses/#GPL>.
+
+"""Live-updating anywidget for FitIndices fitting progress.
+
+Use :meth:`~hyperspy.fit_indices.FitIndices.display` instead of
+constructing this class directly.
+"""
+
+import anywidget
+import numpy as np
+import traitlets
+
+
+class FitIndicesWidget(anywidget.AnyWidget):
+    """A live-updating canvas widget that shows fitting progress.
+
+    Each cell in the canvas grid represents a block of navigation positions.
+    Its shade encodes the fraction of positions in that block that have been
+    fitted: light grey (0 %) → green (100 %).  The block containing
+    :attr:`~hyperspy.fit_indices.FitIndices.current_index` is highlighted
+    with an amber border.
+
+    Do not construct this class directly — call
+    :meth:`~hyperspy.fit_indices.FitIndices.display` instead.
+    """
+
+    # ------------------------------------------------------------------ #
+    # Traitlets synced with JS                                            #
+    # ------------------------------------------------------------------ #
+
+    #: float32 bytes, row-major, shape (grid_rows, grid_cols).
+    #: Each value is the fraction [0, 1] of positions fitted in that block.
+    grid_data = traitlets.Bytes(b"").tag(sync=True)
+
+    grid_rows = traitlets.Int(1).tag(sync=True)
+    grid_cols = traitlets.Int(1).tag(sync=True)
+
+    #: Block row/col of the current index; -1 when no fit is running.
+    current_row = traitlets.Int(-1).tag(sync=True)
+    current_col = traitlets.Int(-1).tag(sync=True)
+
+    fitted_count = traitlets.Int(0).tag(sync=True)
+    total_count = traitlets.Int(1).tag(sync=True)
+    strategy = traitlets.Unicode("").tag(sync=True)
+    current_index_str = traitlets.Unicode("").tag(sync=True)
+
+    # ------------------------------------------------------------------ #
+    # Inline ESM — canvas renderer                                        #
+    # ------------------------------------------------------------------ #
+
+    _esm = r"""
+    function render({ model, el }) {
+        const CELL   = 9;   // px per block cell
+        const GAP    = 1;   // px gap between cells
+        const STEP   = CELL + GAP;
+
+        /* ── layout ─────────────────────────────────────────── */
+        const root = document.createElement('div');
+        root.style.cssText = 'display:inline-block; font-family:monospace;';
+
+        const infoBar = document.createElement('div');
+        infoBar.style.cssText =
+            'font-size:12px; padding:3px 6px; background:#f0f0f0;' +
+            'border:1px solid #ccc; border-bottom:none; border-radius:3px 3px 0 0;' +
+            'white-space:nowrap; min-width:200px;';
+
+        const canvas = document.createElement('canvas');
+        canvas.style.cssText = 'display:block; border:1px solid #ccc; border-radius:0 0 3px 3px; cursor:crosshair;';
+
+        root.appendChild(infoBar);
+        root.appendChild(canvas);
+        el.appendChild(root);
+
+        const ctx = canvas.getContext('2d');
+
+        /* ── tooltip ─────────────────────────────────────────── */
+        const tip = document.createElement('div');
+        tip.style.cssText =
+            'position:fixed; display:none; background:rgba(0,0,0,0.75); color:#fff;' +
+            'font-size:11px; font-family:monospace; padding:3px 7px; border-radius:3px;' +
+            'pointer-events:none; z-index:9999;';
+        document.body.appendChild(tip);
+
+        canvas.addEventListener('mousemove', (e) => {
+            const rect  = canvas.getBoundingClientRect();
+            const mx    = e.clientX - rect.left;
+            const my    = e.clientY - rect.top;
+            const cols  = model.get('grid_cols');
+            const rows  = model.get('grid_rows');
+            const c     = Math.floor(mx / STEP);
+            const r     = Math.floor(my / STEP);
+            if (c >= 0 && c < cols && r >= 0 && r < rows) {
+                const dataBytes = model.get('grid_data');
+                const data      = new Float32Array(dataBytes.buffer);
+                const frac      = data[r * cols + c];
+                const pct       = isNaN(frac) ? 'n/a' : (frac * 100).toFixed(1) + '%';
+                tip.textContent = `block (row=${r}, col=${c}) — ${pct} fitted`;
+                tip.style.left  = (e.clientX + 12) + 'px';
+                tip.style.top   = (e.clientY - 8)  + 'px';
+                tip.style.display = 'block';
+            } else {
+                tip.style.display = 'none';
+            }
+        });
+        canvas.addEventListener('mouseleave', () => { tip.style.display = 'none'; });
+
+        /* ── colour helpers ──────────────────────────────────── */
+        function fracToRgb(t) {
+            // 0 → grey (220,220,220)   1 → green (76,175,80)
+            if (isNaN(t)) return 'rgb(240,240,240)';
+            const r = Math.round(220 + (76  - 220) * t) | 0;
+            const g = Math.round(220 + (175 - 220) * t) | 0;
+            const b = Math.round(220 + (80  - 220) * t) | 0;
+            return `rgb(${r},${g},${b})`;
+        }
+
+        /* ── main draw ───────────────────────────────────────── */
+        function draw() {
+            const rows    = model.get('grid_rows');
+            const cols    = model.get('grid_cols');
+            const curR    = model.get('current_row');
+            const curC    = model.get('current_col');
+            const fitted  = model.get('fitted_count');
+            const total   = model.get('total_count');
+            const strat   = model.get('strategy');
+            const curStr  = model.get('current_index_str');
+
+            const W = GAP + cols * STEP;
+            const H = GAP + rows * STEP;
+            canvas.width  = W;
+            canvas.height = H;
+            canvas.style.width  = W + 'px';
+            canvas.style.height = H + 'px';
+
+            ctx.fillStyle = '#e8e8e8';
+            ctx.fillRect(0, 0, W, H);
+
+            const dataBytes = model.get('grid_data');
+            if (!dataBytes || dataBytes.byteLength === 0) return;
+            const data = new Float32Array(dataBytes.buffer);
+
+            for (let r = 0; r < rows; r++) {
+                for (let c = 0; c < cols; c++) {
+                    const frac = data[r * cols + c];
+                    const x = GAP + c * STEP;
+                    const y = GAP + r * STEP;
+
+                    ctx.fillStyle = fracToRgb(frac);
+                    ctx.fillRect(x, y, CELL, CELL);
+
+                    if (r === curR && c === curC) {
+                        // Amber highlight border (2 px, inset by 0.5)
+                        ctx.strokeStyle = '#ffc107';
+                        ctx.lineWidth   = 2;
+                        ctx.strokeRect(x + 0.5, y + 0.5, CELL - 1, CELL - 1);
+                    }
+                }
+            }
+
+            /* info bar */
+            const pct      = total > 0 ? ((fitted / total) * 100).toFixed(1) : '0.0';
+            const stratStr = strat || 'custom';
+            const curPart  = curStr ? ` \u2022 current\u00a0${curStr}` : '';
+            infoBar.textContent = `${fitted}\u00a0/\u00a0${total} fitted (${pct}%) \u2022 ${stratStr}${curPart}`;
+        }
+
+        /* ── react to trait changes ──────────────────────────── */
+        model.on('change:grid_data',        draw);
+        model.on('change:current_row',      draw);
+        model.on('change:current_col',      draw);
+        model.on('change:fitted_count',     draw);
+        model.on('change:grid_rows',        draw);
+        model.on('change:grid_cols',        draw);
+        model.on('change:strategy',         draw);
+        model.on('change:current_index_str', draw);
+
+        /* ── cleanup tooltip when widget removed ─────────────── */
+        const observer = new MutationObserver(() => {
+            if (!document.body.contains(canvas)) {
+                tip.remove();
+                observer.disconnect();
+            }
+        });
+        observer.observe(document.body, { childList: true, subtree: true });
+
+        draw();
+    }
+
+    export default { render };
+    """
+
+    # ------------------------------------------------------------------ #
+    # Python-side helpers                                                  #
+    # ------------------------------------------------------------------ #
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        self._fi = None
+        self._on_index_changed_cb = None
+        self._on_complete_cb = None
+
+    # ------------------------------------------------------------------
+
+    def _push_state(self):
+        """Recompute the binned grid from the attached FitIndices and push
+        all synced traitlets in a single batch."""
+        fi = self._fi
+        if fi is None:
+            return
+        grid, cur_row, cur_col = fi._compute_grid()
+        strat = fi.strategy if isinstance(fi.strategy, str) else "custom"
+        cur_str = (
+            str(fi.current_index)
+            if fi.current_index is not None and fi.current_index != ()
+            else ""
+        )
+        with self.hold_trait_notifications():
+            self.grid_data = grid.astype(np.float32).tobytes()
+            self.grid_rows = int(grid.shape[0])
+            self.grid_cols = int(grid.shape[1])
+            self.current_row = int(cur_row)
+            self.current_col = int(cur_col)
+            self.fitted_count = fi.fitted_count
+            self.total_count = fi.total_count
+            self.strategy = strat
+            self.current_index_str = cur_str
+
+    # ------------------------------------------------------------------
+
+    @classmethod
+    def from_fit_indices(cls, fit_indices):
+        """Create a widget bound to *fit_indices* and wire up its events.
+
+        Parameters
+        ----------
+        fit_indices : hyperspy.fit_indices.FitIndices
+
+        Returns
+        -------
+        FitIndicesWidget
+        """
+        widget = cls()
+        widget._fi = fit_indices
+
+        # Initial render
+        widget._push_state()
+
+        # Callbacks
+        def _on_index_changed(obj, index):
+            widget._push_state()
+
+        def _on_complete(obj):
+            widget._push_state()
+            # Disconnect so the index_changed callback doesn't linger
+            try:
+                obj.events.index_changed.disconnect(_on_index_changed)
+            except Exception:
+                pass
+
+        widget._on_index_changed_cb = _on_index_changed
+        widget._on_complete_cb = _on_complete
+
+        fit_indices.events.index_changed.connect(_on_index_changed, ["obj", "index"])
+        fit_indices.events.fitting_complete.connect(_on_complete, ["obj"])
+
+        return widget
+
+    # ------------------------------------------------------------------
+
+    def disconnect(self):
+        """Manually disconnect event callbacks (called on abort / close)."""
+        fi = self._fi
+        if fi is None:
+            return
+        if self._on_index_changed_cb is not None:
+            try:
+                fi.events.index_changed.disconnect(self._on_index_changed_cb)
+            except Exception:
+                pass
+        if self._on_complete_cb is not None:
+            try:
+                fi.events.fitting_complete.disconnect(self._on_complete_cb)
+            except Exception:
+                pass


### PR DESCRIPTION
This pull request introduces significant improvements to the model fitting workflow in `hyperspy/model.py` by introducing a new `FitIndices` system for managing navigation indices during fitting. The changes decouple the navigation state from the plotting system, add support for resumable multi-pixel fitting, and modernize the API for specifying fitting strategies. These updates improve robustness, enable new features like resumable fits, and lay the groundwork for further refactoring.

The main motivation here is to start the process of decoupling the index from the Axes manager which is primarily used in two places:

1. Fitting over a set of indexes
2. Plotting 

Each case will be treated separately.  First we want to refactor how the fitting over a set of indexes is handled.  The goal is to (eventually) support arbitrary fitting strategies like fitting independently starting from multiple starting positions.  Or better visualizing things like multi-pass fits. 

The main components are:

1. A new `FitIndices` class. This handles things like the fitting path, current index but also includes things like which indexes have been fit.  It can be improved by adding the ability to fit only over certain positions (refit bad chi-squared) or as a way to fit certain pixels by hand by jumping from point - point. 
2. A state widget which shows a slightly more interactive progress.  This helps to show which patterns have been fit and gives the user a better sense of how the fitting works in hyperspy. 