### PR TITLE
ENH: Use PrettyTable consistently for all tabular data display

### DIFF
--- a/doc/user_guide/axes.rst
+++ b/doc/user_guide/axes.rst
@@ -291,10 +291,12 @@ Corresponding output of :class:`~.axes.AxesManager`:
 
     >>> s.axes_manager
     <Axes manager, axes: (|500)>
-                Name |   size |  index |  offset |   scale |  units 
-    ================ | ====== | ====== | ======= | ======= | ====== 
-    ---------------- | ------ | ------ | ------- | ------- | ------ 
-         <undefined> |    500 |      0 |   3e+02 |       1 | <undefined> 
+    Signal axes:
+    +-------------+------+--------+-------+-------------+
+    |     Name    | size | offset | scale |    units    |
+    +-------------+------+--------+-------+-------------+
+    | <undefined> | 500  | 300.0  |  1.0  | <undefined> |
+    +-------------+------+--------+-------+-------------+
 
 
 .. _functional-data-axis:
@@ -332,10 +334,12 @@ Corresponding output of :class:`~.axes.AxesManager`:
 
     >>> s.axes_manager
     <Axes manager, axes: (|500)>
-                Name |   size |  index |  offset |   scale |  units 
-    ================ | ====== | ====== | ======= | ======= | ====== 
-    ---------------- | ------ | ------ | ------- | ------- | ------ 
-         <undefined> |    500 |      0 | non-uniform axis | <undefined> 
+    Signal axes:
+    +-------------+------+-------------+-------------+-------------+
+    |     Name    | size |    offset   |    scale    |    units    |
+    +-------------+------+-------------+-------------+-------------+
+    | <undefined> | 500  | non-uniform | non-uniform | <undefined> |
+    +-------------+------+-------------+-------------+-------------+
 
 
 Initializing ``x`` with ``offset`` and ``scale``:
@@ -398,10 +402,12 @@ Corresponding output of :class:`~.axes.AxesManager`:
 
     >>> s.axes_manager
     <Axes manager, axes: (|12)>
-                Name |   size |  index |  offset |   scale |  units 
-    ================ | ====== | ====== | ======= | ======= | ====== 
-    ---------------- | ------ | ------ | ------- | ------- | ------ 
-         <undefined> |     12 |      0 | non-uniform axis | <undefined> 
+    Signal axes:
+    +-------------+------+-------------+-------------+-------------+
+    |     Name    | size |    offset   |    scale    |    units    |
+    +-------------+------+-------------+-------------+-------------+
+    | <undefined> |  12  | non-uniform | non-uniform | <undefined> |
+    +-------------+------+-------------+-------------+-------------+
 
 
 .. _defining-axes:

--- a/doc/user_guide/axes.rst
+++ b/doc/user_guide/axes.rst
@@ -67,12 +67,19 @@ the signal class. The individual axes can be accessed by indexing the
     <Signal1D, title: , dimensions: (20, 10|100)>
     >>> s.axes_manager
     <Axes manager, axes: (20, 10|100)>
-                Name |   size |  index |  offset |   scale |  units
-    ================ | ====== | ====== | ======= | ======= | ======
-         <undefined> |     20 |      0 |       0 |       1 | <undefined>
-         <undefined> |     10 |      0 |       0 |       1 | <undefined>
-    ---------------- | ------ | ------ | ------- | ------- | ------
-         <undefined> |    100 |      0 |       0 |       1 | <undefined>
+    Navigation axes:
+    +-------------+------+-------+--------+-------+-------------+
+    |     Name    | size | index | offset | scale |    units    |
+    +-------------+------+-------+--------+-------+-------------+
+    | <undefined> |  20  |   0   |  0.0   |  1.0  | <undefined> |
+    | <undefined> |  10  |   0   |  0.0   |  1.0  | <undefined> |
+    +-------------+------+-------+--------+-------+-------------+
+    Signal axes:
+    +-------------+------+--------+-------+-------------+
+    |     Name    | size | offset | scale |    units    |
+    +-------------+------+--------+-------+-------------+
+    | <undefined> | 100  |  0.0   |  1.0  | <undefined> |
+    +-------------+------+--------+-------+-------------+
     >>> s.axes_manager[0]
     <Unnamed 0th axis, size: 20, index: 0>
 

--- a/hyperspy/axes.py
+++ b/hyperspy/axes.py
@@ -2389,109 +2389,58 @@ class AxesManager(t.HasTraits):
         string += ")"
         return string
 
-    def __repr__(self):
-        text = "<Axes manager, axes: %s>\n" % self._get_dimension_str()
-        ax_signature_uniform = "% 16s | %6g | %6s | %7.2g | %7.2g | %6s "
-        ax_signature_non_uniform = "% 16s | %6g | %6s | non-uniform axis | %6s "
-        signature = "% 16s | %6s | %6s | %7s | %7s | %6s "
-        text += signature % ("Name", "size", "index", "offset", "scale", "units")
-        text += "\n"
-        text += signature % ("=" * 16, "=" * 6, "=" * 6, "=" * 7, "=" * 7, "=" * 6)
+    def _build_nav_table(self):
+        from prettytable import PrettyTable
 
-        def axis_repr(ax, ax_signature_uniform, ax_signature_non_uniform):
-            if ax.is_uniform:
-                return ax_signature_uniform % (
-                    str(ax.name)[:16],
-                    ax.size,
-                    str(ax.index),
-                    ax.offset,
-                    ax.scale,
-                    ax.units,
-                )
-            else:
-                return ax_signature_non_uniform % (
-                    str(ax.name)[:16],
-                    ax.size,
-                    str(ax.index),
-                    ax.units,
-                )
-
+        table = PrettyTable()
+        table.field_names = ["Name", "size", "index", "offset", "scale", "units"]
         for ax in self.navigation_axes:
-            text += "\n"
-            text += axis_repr(ax, ax_signature_uniform, ax_signature_non_uniform)
-        text += "\n"
-        text += signature % ("-" * 16, "-" * 6, "-" * 6, "-" * 7, "-" * 7, "-" * 6)
-        for ax in self.signal_axes:
-            text += "\n"
-            text += axis_repr(ax, ax_signature_uniform, ax_signature_non_uniform)
-        if self.ragged:
-            text += "\n"
-            text += "     Ragged axis |               Variable length"
+            if ax.is_uniform:
+                offset, scale = ax.offset, ax.scale
+            else:
+                offset, scale = "non-uniform", "non-uniform"
+            table.add_row([ax.name, ax.size, ax.index, offset, scale, ax.units])
+        return table
 
+    def _build_signal_table(self):
+        from prettytable import PrettyTable
+
+        table = PrettyTable()
+        table.field_names = ["Name", "size", "offset", "scale", "units"]
+        for ax in self.signal_axes:
+            if ax.is_uniform:
+                offset, scale = ax.offset, ax.scale
+            else:
+                offset, scale = "non-uniform", "non-uniform"
+            table.add_row([ax.name, ax.size, offset, scale, ax.units])
+        return table
+
+    def __repr__(self):
+        text = "<Axes manager, axes: %s>" % self._get_dimension_str()
+        if self.navigation_axes:
+            text += "\nNavigation axes:\n" + str(self._build_nav_table())
+        if self.signal_axes:
+            text += "\nSignal axes:\n" + str(self._build_signal_table())
+        if self.ragged:
+            text += "\nRagged axis | Variable length"
         return text
 
     def _repr_html_(self):
+        html_attrs = {
+            "style": "width:100%; border-collapse:collapse; text-align:center;",
+            "border": "1",
+        }
         text = (
-            "<style>\n"
-            "table, th, td {\n\t"
-            "border: 1px solid black;\n\t"
-            "border-collapse: collapse;\n}"
-            "\nth, td {\n\t"
-            "padding: 5px;\n}"
-            "\n</style>"
+            "<p><b>&lt; Axes manager, axes: %s &gt;</b></p>" % self._get_dimension_str()
         )
-        text += (
-            "\n<p><b>< Axes manager, axes: %s ></b></p>\n" % self._get_dimension_str()
-        )
-
-        def format_row(*args, tag="td", bold=False):
-            if bold:
-                signature = "\n<tr class='bolder_row'> "
-            else:
-                signature = "\n<tr> "
-            signature += " ".join(("{}" for _ in args)) + " </tr>"
-            return signature.format(
-                *map(lambda x: "\n<" + tag + ">{}</".format(x) + tag + ">", args)
-            )
-
-        def axis_repr(ax):
-            index = ax.index if ax.navigate else ""
-            if ax.is_uniform:
-                return format_row(
-                    ax.name, ax.size, index, ax.offset, ax.scale, ax.units
-                )
-            else:
-                return format_row(
-                    ax.name,
-                    ax.size,
-                    index,
-                    "non-uniform axis",
-                    "non-uniform axis",
-                    ax.units,
-                )
-
         if self.navigation_axes:
-            text += "<table style='width:100%'>\n"
-            text += format_row(
-                "Navigation axis name",
-                "size",
-                "index",
-                "offset",
-                "scale",
-                "units",
-                tag="th",
-            )
-            for ax in self.navigation_axes:
-                text += axis_repr(ax)
-            text += "</table>\n"
+            text += "<p><b>Navigation axes</b></p>"
+            text += self._build_nav_table().get_html_string(attributes=html_attrs)
         if self.signal_axes:
-            text += "<table style='width:100%'>\n"
-            text += format_row(
-                "Signal axis name", "size", "", "offset", "scale", "units", tag="th"
-            )
-            for ax in self.signal_axes:
-                text += axis_repr(ax)
-            text += "</table>\n"
+            text += "<p><b>Signal axes</b></p>"
+            text += self._build_signal_table().get_html_string(attributes=html_attrs)
+        if self.ragged:
+            text += "<p>Ragged axis | Variable length</p>"
         return text
 
     @property

--- a/hyperspy/misc/model_tools.py
+++ b/hyperspy/misc/model_tools.py
@@ -457,3 +457,48 @@ class ModelStatistics:
             )
             html += "<br>"
         return html
+
+
+class SummaryStatistics:
+    """
+    Display class for the five-number summary statistics of a signal.
+
+    Parameters
+    ----------
+    mean, std, min, q1, median, q3, max : float
+        The statistics to display.
+    formatter : str, optional
+        Printf-style format string for numeric values. Default is ``"%.3g"``.
+    """
+
+    def __init__(self, mean, std, min, q1, median, q3, max, formatter="%.3g"):
+        self.stats = [
+            ("mean", mean),
+            ("std", std),
+            ("min", min),
+            ("Q1", q1),
+            ("median", median),
+            ("Q3", q3),
+            ("max", max),
+        ]
+        self.formatter = formatter
+
+    def _build_table(self):
+        table = PrettyTable()
+        table.field_names = ["Statistic", "Value"]
+        table.align["Statistic"] = "r"
+        table.align["Value"] = "r"
+        for name, val in self.stats:
+            table.add_row([name, self.formatter % val])
+        return table
+
+    def __repr__(self):
+        return "Summary statistics\n" + str(self._build_table())
+
+    def _repr_html_(self):
+        return "<h4>Summary statistics</h4>" + self._build_table().get_html_string(
+            attributes={
+                "style": "width:100%; border-collapse:collapse; text-align:center;",
+                "border": "1",
+            }
+        )

--- a/hyperspy/signal.py
+++ b/hyperspy/signal.py
@@ -6667,18 +6667,17 @@ class BaseSignal(FancySlicing, MVA, MVATools):
         get_histogram
 
         """
+        from hyperspy.misc.model_tools import SummaryStatistics
+        from hyperspy.misc.utils import display
+
         _mean, _std, _min, _q1, _q2, _q3, _max = self._calculate_summary_statistics(
             rechunk=rechunk
         )
-        print(utils.underline("Summary statistics"))
-        print("mean:\t" + formatter % _mean)
-        print("std:\t" + formatter % _std)
-        print()
-        print("min:\t" + formatter % _min)
-        print("Q1:\t" + formatter % _q1)
-        print("median:\t" + formatter % _q2)
-        print("Q3:\t" + formatter % _q3)
-        print("max:\t" + formatter % _max)
+        display(
+            SummaryStatistics(
+                _mean, _std, _min, _q1, _q2, _q3, _max, formatter=formatter
+            )
+        )
 
     print_summary_statistics.__doc__ %= RECHUNK_ARG
 

--- a/hyperspy/tests/axes/test_axes_manager.py
+++ b/hyperspy/tests/axes/test_axes_manager.py
@@ -79,11 +79,21 @@ class TestAxesManager:
 
     def test_reprs(self):
         repr(self.am)
-        self.am._repr_html_
+        self.am._repr_html_()
         self.am[0].convert_to_non_uniform_axis()
         self.am[-1].convert_to_non_uniform_axis()
         repr(self.am)
-        self.am._repr_html_
+        self.am._repr_html_()
+
+    def test_reprs_signal_only(self):
+        """Test repr when there are no navigation axes (signal-only)."""
+        am = AxesManager([{"name": "x", "size": 5, "navigate": False}])
+        text = repr(am)
+        assert "Navigation axes" not in text
+        assert "Signal axes" in text
+        html = am._repr_html_()
+        assert "Navigation axes" not in html
+        assert "Signal axes" in html
 
     def test_update_from(self):
         am = self.am
@@ -598,7 +608,7 @@ def test_iterpath_function_serpentine():
             assert indices == (2, 1, 0)
 
 
-def TestAxesManagerRagged():
+class TestAxesManagerRagged:
     def setup_method(self, method):
         axes_list = [
             {
@@ -622,10 +632,8 @@ def TestAxesManagerRagged():
         assert not self.am.ragged
 
     def test_reprs(self):
-        expected_string = "<Axes manager, axes: (2|ragged)>\n"
-        "            Name |   size |  index |  offset |   scale |  units \n"
-        "================ | ====== | ====== | ======= | ======= | ====== \n"
-        "               a |      2 |      0 |       0 |     1.3 |     aa \n"
-        "---------------- | ------ | ------ | ------- | ------- | ------ \n"
-        "     Ragged axis |               Variable length"
-        assert self.am.__repr__() == expected_string
+        text = self.am.__repr__()
+        assert "<Axes manager, axes: (2|ragged)>" in text
+        assert "Ragged axis | Variable length" in text
+        html = self.am._repr_html_()
+        assert "Ragged axis | Variable length" in html

--- a/hyperspy/tests/signals/test_2D.py
+++ b/hyperspy/tests/signals/test_2D.py
@@ -359,6 +359,13 @@ class Test2D:
         if self.signal._lazy:
             self.signal.print_summary_statistics(rechunk=False)
 
+    def test_summary_statistics_repr(self):
+        from hyperspy.misc.model_tools import SummaryStatistics
+
+        s = SummaryStatistics(1.0, 0.5, 0.0, 0.25, 0.5, 0.75, 1.0)
+        assert "Summary statistics" in repr(s)
+        assert "<table" in s._repr_html_()
+
     def test_numpy_unfunc_one_arg_titled(self):
         self.signal.metadata.General.title = "yes"
         result = np.exp(self.signal)

--- a/upcoming_changes/3621.enhancements.rst
+++ b/upcoming_changes/3621.enhancements.rst
@@ -1,0 +1,6 @@
+Standardise tabular data display on PrettyTable throughout HyperSpy:
+:class:`~.axes.AxesManager` now uses PrettyTable for both terminal and
+HTML (notebook) output instead of manual string/HTML formatting; a new
+:class:`~.misc.model_tools.SummaryStatistics` display class gives
+:meth:`~.api.signals.BaseSignal.print_summary_statistics` a proper HTML
+table representation in Jupyter notebooks.

--- a/upcoming_changes/3621.enhancements.rst
+++ b/upcoming_changes/3621.enhancements.rst
@@ -1,6 +1,5 @@
 Standardise tabular data display on PrettyTable throughout HyperSpy:
 :class:`~.axes.AxesManager` now uses PrettyTable for both terminal and
-HTML (notebook) output instead of manual string/HTML formatting; a new
-:class:`~.misc.model_tools.SummaryStatistics` display class gives
-:meth:`~.api.signals.BaseSignal.print_summary_statistics` a proper HTML
-table representation in Jupyter notebooks.
+HTML (notebook) output instead of manual string/HTML formatting;
+:meth:`~.api.signals.BaseSignal.print_summary_statistics` now renders
+as a proper HTML table in Jupyter notebooks (previously text-only).


### PR DESCRIPTION
## Summary

HyperSpy displayed tabular data inconsistently: `AxesManager` used manual `%`-string formatting for terminal output and hand-crafted `<table>` HTML for notebooks, while `signal.print_summary_statistics` used bare `print()` with tab-separated text. Meanwhile, `model_tools.py` had established a clean pattern using PrettyTable with proper `__repr__` / `_repr_html_` for both contexts.

This PR standardises all tabular output on **PrettyTable** (already a declared dependency), following the `model_tools.py` pattern throughout:

- **`axes.py` (`AxesManager`)** — replace manual string/HTML construction with `_build_nav_table()` / `_build_signal_table()` helpers that return `PrettyTable` objects; navigation and signal axes remain in separate tables.
- **`misc/model_tools.py`** — add `SummaryStatistics` display class with `__repr__` and `_repr_html_`, so summary statistics render as a proper HTML table in Jupyter notebooks (previously text-only).
- **`signal.py` (`print_summary_statistics`)** — replace `print()` calls with `display(SummaryStatistics(...))` for notebook-aware rendering.
- **`doc/user_guide/axes.rst`** — update three code-block examples that showed the old `AxesManager` repr format.

## Test plan

- [x] `pytest hyperspy/tests/axes/test_axes_manager.py` — all pass
- [x] `pytest hyperspy/tests/signals/test_2D.py::Test2D::test_print_summary_statistics` — passes
- [x] `pytest hyperspy/tests/component/ hyperspy/tests/model/` — all pass (pre-existing unrelated failure in `test_lazy_compare_lstsq`)
- [ ] Visual check: `repr(s.axes_manager)` and `s.print_summary_statistics()` in terminal produce PrettyTable output
- [ ] Visual check: notebook cell shows HTML table for both `s.axes_manager` and `s.print_summary_statistics()`

🤖 Generated with [Claude Code](https://claude.com/claude-code)