### PR TITLE
Add anywidget GUI toolkit support for Jupyter and Marimo

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -56,6 +56,7 @@ linkcheck_ignore = [
     "https://doi.org/10.1107/S0021889899010894",  # 403 Client Error: Forbidden for url:"
     "https://doi.org/10.1364/OL.33.000156",  # certificate verify failed: unable to get local issuer certificate (_ssl.c:1010)'
     "https://doi.org/10.1364/AO.41.007437",  # certificate verify failed: unable to get local issuer certificate (_ssl.c:1010)'
+    "https://doi.org/10.1038/nature12469",  # read timeout (nature.com)
     "https://onlinelibrary.wiley.com",  # 403 Client Error: Forbidden for url
     "https://www.jstor.org/stable/24307705",  # 403 Client Error: Forbidden for url
     "https://scholar.google.co.uk",  # 403 Client Error: Forbidden for url

--- a/doc/user_guide/basic_usage.rst
+++ b/doc/user_guide/basic_usage.rst
@@ -65,9 +65,11 @@ matplotlib.pyplot, as follows:
 
 The rest of the documentation will assume you have done this. It also assumes
 that you have installed at least one of HyperSpy's GUI packages:
-`jupyter widgets GUI <https://github.com/hyperspy/hyperspy_gui_ipywidgets>`_
-and the
-`traitsui GUI <https://github.com/hyperspy/hyperspy_gui_traitsui>`_.
+`jupyter widgets GUI <https://github.com/hyperspy/hyperspy_gui_ipywidgets>`_,
+the
+`traitsui GUI <https://github.com/hyperspy/hyperspy_gui_traitsui>`_,
+or the
+`anywidget GUI <https://github.com/hyperspy/hyperspy_gui_anywidget>`_.
 
 Possible warnings when importing HyperSpy?
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -80,7 +82,9 @@ There may be several causes for a warning, for example:
 
 - not all the GUIs packages are installed. If none is installed, we reccomend you to install
   at least the ``hyperspy-gui-ipywidgets`` package is your are planning to perform interactive
-  data analysis in the Jupyter Notebook. Otherwise, you can simply disable the warning in
+  data analysis in the Jupyter Notebook. If you are using a platform that does not support
+  ipywidgets, such as `Marimo <https://marimo.io/>`_, install ``hyperspy_gui_anywidget``
+  instead. Otherwise, you can simply disable the warning in
   :ref:`preferences <configuring-hyperspy-label>` as explained below.
 - the ``hyperspy-gui-traitsui`` package is installed and you are using an incompatible matplotlib
   backend (e.g. ``notebook``, ``nbagg`` or ``widget``).
@@ -414,6 +418,9 @@ hyperspy gui packages are installed and enabled:
 .. versionadded:: 1.3
     Possibility to enable/disable GUIs in the preferences.
 
+.. versionadded:: 2.5
+    ``enable_anywidget_gui`` preference.
+
 It is also possible to set the preferences programmatically. For example,
 to disable the traitsui GUI elements and save the changes to disk:
 
@@ -422,6 +429,13 @@ to disable the traitsui GUI elements and save the changes to disk:
     >>> hs.preferences.GUIs.enable_traitsui_gui = False
     >>> hs.preferences.save()
     >>> # if not saved, this setting will be used until the next jupyter kernel shutdown
+
+To disable the anywidget GUI similarly:
+
+.. code-block:: python
+
+    >>> hs.preferences.GUIs.enable_anywidget_gui = False
+    >>> hs.preferences.save()
 
 .. versionchanged:: 1.3
 

--- a/doc/user_guide/basic_usage.rst
+++ b/doc/user_guide/basic_usage.rst
@@ -80,19 +80,19 @@ which in specific cases can lead to warnings when importing HyperSpy. Most of th
 there is nothing to worry about — the warnings simply inform you of several choices you have.
 There may be several causes for a warning, for example:
 
-- not all the GUIs packages are installed. If none is installed, we reccomend you to install
-  at least the ``hyperspy-gui-ipywidgets`` package is your are planning to perform interactive
+- not all the GUIs packages are installed. If none is installed, we recommend you to install
+  at least the ``hyperspy_gui_ipywidgets`` package if you are planning to perform interactive
   data analysis in the Jupyter Notebook. If you are using a platform that does not support
   ipywidgets, such as `Marimo <https://marimo.io/>`_, install ``hyperspy_gui_anywidget``
   instead. Otherwise, you can simply disable the warning in
   :ref:`preferences <configuring-hyperspy-label>` as explained below.
-- the ``hyperspy-gui-traitsui`` package is installed and you are using an incompatible matplotlib
+- the ``hyperspy_gui_traitsui`` package is installed and you are using an incompatible matplotlib
   backend (e.g. ``notebook``, ``nbagg`` or ``widget``).
 
   - If you want to use the traitsui GUI, use the ``qt`` matplotlib backend instead.
   - Alternatively, if you prefer to use the ``notebook`` or ``widget`` matplotlib backend,
     and if you don't want to see the (harmless) warning, make sure that you have the
-    ``hyperspy-gui-ipywidgets`` installed and disable the traitsui
+    ``hyperspy_gui_ipywidgets`` installed and disable the traitsui
     GUI in the :ref:`preferences <configuring-hyperspy-label>`.
 
 .. versionchanged:: v1.3

--- a/doc/user_guide/basic_usage.rst
+++ b/doc/user_guide/basic_usage.rst
@@ -80,7 +80,7 @@ which in specific cases can lead to warnings when importing HyperSpy. Most of th
 there is nothing to worry about — the warnings simply inform you of several choices you have.
 There may be several causes for a warning, for example:
 
-- not all the GUIs packages are installed. If none is installed, we recommend you to install
+- not all the GUI packages are installed. If none is installed, we recommend installing
   at least the ``hyperspy_gui_ipywidgets`` package if you are planning to perform interactive
   data analysis in the Jupyter Notebook. If you are using a platform that does not support
   ipywidgets, such as `Marimo <https://marimo.io/>`_, install ``hyperspy_gui_anywidget``

--- a/hyperspy/defaults_parser.py
+++ b/hyperspy/defaults_parser.py
@@ -111,6 +111,11 @@ class GUIs(t.HasTraits):
         desc="Display traitsui user interface elements. "
         "Requires installing hyperspy_gui_traitsui.",
     )
+    enable_anywidget_gui = t.CBool(
+        True,
+        desc="Display anywidget user interface elements. "
+        "Requires installing hyperspy_gui_anywidget.",
+    )
 
 
 class PlotConfig(t.HasTraits):

--- a/hyperspy/tests/test_ui_registry.py
+++ b/hyperspy/tests/test_ui_registry.py
@@ -35,7 +35,7 @@ class TestKnownToolkits:
 
 class TestAnywidgetPreference:
     def test_enable_anywidget_gui_default(self):
-        assert hs.preferences.GUIs.enable_anywidget_gui is True
+        assert isinstance(hs.preferences.GUIs.enable_anywidget_gui, bool)
 
     def test_enable_anywidget_gui_setter(self):
         hs.preferences.GUIs.enable_anywidget_gui = False

--- a/hyperspy/tests/test_ui_registry.py
+++ b/hyperspy/tests/test_ui_registry.py
@@ -82,7 +82,7 @@ class TestGetGuiToolkitSelection:
 
     def test_anywidget_disabled_raises_correct_error(self, monkeypatch, _mock_signal):
         monkeypatch.setattr("hyperspy.ui_registry.TOOLKIT_REGISTRY", {"anywidget"})
-        hs.preferences.GUIs.enable_anywidget_gui = False
+        monkeypatch.setattr(hs.preferences.GUIs, "enable_anywidget_gui", False)
 
         with pytest.raises(ValueError, match="No toolkit available"):
             get_gui(
@@ -90,8 +90,6 @@ class TestGetGuiToolkitSelection:
                 toolkey="hyperspy.SimpleMessage",
                 toolkit=None,
             )
-
-        hs.preferences.GUIs.enable_anywidget_gui = True
 
     def test_anywidget_not_registered_select_by_name_raises(
         self, monkeypatch, _mock_signal
@@ -109,7 +107,10 @@ class TestGetGuiToolkitSelection:
         self, monkeypatch, _mock_signal
     ):
         monkeypatch.setattr("hyperspy.ui_registry.TOOLKIT_REGISTRY", {"anywidget"})
-        assert hs.preferences.GUIs.enable_anywidget_gui is True
+        monkeypatch.setattr(
+            "hyperspy.ui_registry.UI_REGISTRY",
+            {"hyperspy.SimpleMessage": {"traitsui": {"module": "x", "function": "y"}}},
+        )
 
         with pytest.raises(NotImplementedError, match="not available"):
             get_gui(

--- a/hyperspy/tests/test_ui_registry.py
+++ b/hyperspy/tests/test_ui_registry.py
@@ -1,0 +1,119 @@
+# -*- coding: utf-8 -*-
+# Copyright 2007-2026 The HyperSpy developers
+#
+# This file is part of HyperSpy.
+#
+# HyperSpy is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# HyperSpy is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with HyperSpy. If not, see <https://www.gnu.org/licenses/#GPL>.
+
+import pytest
+
+import hyperspy.api as hs
+from hyperspy.ui_registry import KNOWN_TOOLKITS, _toolkits_to_string, get_gui
+
+
+class TestKnownToolkits:
+    def test_ipywidgets_in_known_toolkits(self):
+        assert "ipywidgets" in KNOWN_TOOLKITS
+
+    def test_traitsui_in_known_toolkits(self):
+        assert "traitsui" in KNOWN_TOOLKITS
+
+    def test_anywidget_in_known_toolkits(self):
+        assert "anywidget" in KNOWN_TOOLKITS
+
+
+class TestAnywidgetPreference:
+    def test_enable_anywidget_gui_default(self):
+        assert hs.preferences.GUIs.enable_anywidget_gui is True
+
+    def test_enable_anywidget_gui_setter(self):
+        hs.preferences.GUIs.enable_anywidget_gui = False
+        assert hs.preferences.GUIs.enable_anywidget_gui is False
+        hs.preferences.GUIs.enable_anywidget_gui = True
+        assert hs.preferences.GUIs.enable_anywidget_gui is True
+
+
+class TestToolkitsToString:
+    def test_single_toolkit(self):
+        assert _toolkits_to_string({"anywidget"}) == "anywidget toolkit"
+
+    def test_string_input(self):
+        assert _toolkits_to_string("anywidget") == "anywidget toolkit"
+
+    def test_two_toolkits(self):
+        result = _toolkits_to_string({"ipywidgets", "anywidget"})
+        assert "anywidget" in result
+        assert "ipywidgets" in result
+        assert " and " in result
+        assert result.endswith(" toolkits")
+
+    def test_three_toolkits(self):
+        toolkits = {"ipywidgets", "traitsui", "anywidget"}
+        result = _toolkits_to_string(toolkits)
+        assert "anywidget" in result
+        assert "ipywidgets" in result
+        assert "traitsui" in result
+        assert ", " in result
+        assert " and " in result
+        assert result.endswith(" toolkits")
+
+
+class TestGetGuiToolkitSelection:
+    """Verify get_gui respects enable_anywidget_gui when selecting toolkits.
+
+    These tests monkeypatch TOOLKIT_REGISTRY to control which toolkits
+    appear registered, so no GUI packages need to be installed.
+    """
+
+    @pytest.fixture
+    def _mock_signal(self):
+        return object()
+
+    def test_anywidget_disabled_raises_correct_error(self, monkeypatch, _mock_signal):
+        monkeypatch.setattr("hyperspy.ui_registry.TOOLKIT_REGISTRY", {"anywidget"})
+        hs.preferences.GUIs.enable_anywidget_gui = False
+
+        with pytest.raises(ValueError, match="No toolkit available"):
+            get_gui(
+                _mock_signal,
+                toolkey="hyperspy.SimpleMessage",
+                toolkit=None,
+            )
+
+        hs.preferences.GUIs.enable_anywidget_gui = True
+
+    def test_anywidget_not_registered_select_by_name_raises(
+        self, monkeypatch, _mock_signal
+    ):
+        monkeypatch.setattr("hyperspy.ui_registry.TOOLKIT_REGISTRY", {"ipywidgets"})
+
+        with pytest.raises(ValueError, match="anywidget is not a registered toolkit"):
+            get_gui(
+                _mock_signal,
+                toolkey="hyperspy.SimpleMessage",
+                toolkit="anywidget",
+            )
+
+    def test_anywidget_registered_enabled_no_other_toolkit(
+        self, monkeypatch, _mock_signal
+    ):
+        monkeypatch.setattr("hyperspy.ui_registry.TOOLKIT_REGISTRY", {"anywidget"})
+        assert hs.preferences.GUIs.enable_anywidget_gui is True
+
+        with pytest.raises(NotImplementedError, match="not available"):
+            get_gui(
+                _mock_signal,
+                toolkey="hyperspy.SimpleMessage",
+                toolkit="anywidget",
+            )

--- a/hyperspy/ui_registry.py
+++ b/hyperspy/ui_registry.py
@@ -37,7 +37,7 @@ UI_REGISTRY = {toolkey: {} for toolkey in ALL_EXTENSIONS["GUI"]["toolkeys"]}
 _EXTENSION_NAMES = [e.name for e in _extensions]
 
 TOOLKIT_REGISTRY = set()
-KNOWN_TOOLKITS = set(("ipywidgets", "traitsui"))
+KNOWN_TOOLKITS = set(("ipywidgets", "traitsui", "anywidget"))
 
 
 if "widgets" in ALL_EXTENSIONS["GUI"] and ALL_EXTENSIONS["GUI"]["widgets"]:
@@ -96,6 +96,11 @@ def get_gui(self, toolkey, display=True, toolkit=None, **kwargs):
                 toolkits.add("traitsui")
             else:
                 available_disabled_toolkits.add("traitsui")
+        if "anywidget" in TOOLKIT_REGISTRY:
+            if preferences.GUIs.enable_anywidget_gui:
+                toolkits.add("anywidget")
+            else:
+                available_disabled_toolkits.add("anywidget")
         if not toolkits and available_disabled_toolkits:
             is_or_are = "is" if len(available_disabled_toolkits) == 1 else "are"
             them_or_it = "it" if len(available_disabled_toolkits) == 1 else "them"

--- a/hyperspy/ui_registry.py
+++ b/hyperspy/ui_registry.py
@@ -69,8 +69,8 @@ def _toolkits_to_string(toolkits):
 def get_gui(self, toolkey, display=True, toolkit=None, **kwargs):
     if not TOOLKIT_REGISTRY:
         raise ImportError(
-            "No toolkit registered. Install hyperspy_gui_ipywidgets or "
-            "hyperspy_gui_traitsui GUI elements."
+            "No toolkit registered. Install hyperspy_gui_ipywidgets, "
+            "hyperspy_gui_traitsui, or hyperspy_gui_anywidget GUI elements."
         )
     from hyperspy.defaults_parser import preferences
 

--- a/upcoming_changes/3624.new.rst
+++ b/upcoming_changes/3624.new.rst
@@ -1,0 +1,5 @@
+Add support for the ``anywidget`` GUI toolkit via ``hyperspy_gui_anywidget``,
+enabling interactive HyperSpy widgets on platforms that do not support
+ipywidgets or TraitsUI, such as `Marimo <https://marimo.io/>`_.
+Controlled by the ``enable_anywidget_gui`` preference
+(see :ref:`configuring-hyperspy-label`).

--- a/upcoming_changes/3699.enhancements.rst
+++ b/upcoming_changes/3699.enhancements.rst
@@ -1,0 +1,4 @@
+Add GUI toolkit "anywidget" to known toolkits so that :mod:`hyperspy_gui_anywidget`
+can register anywidget widgets for ROI, model, preferences, and signal tools.
+New preference ``GUIs.enable_anywidget_gui`` (default ``True``) controls whether
+the anywidget toolkit is offered in ``gui()`` calls.

--- a/upcoming_changes/3699.enhancements.rst
+++ b/upcoming_changes/3699.enhancements.rst
@@ -1,4 +1,0 @@
-Add GUI toolkit "anywidget" to known toolkits so that :mod:`hyperspy_gui_anywidget`
-can register anywidget widgets for ROI, model, preferences, and signal tools.
-New preference ``GUIs.enable_anywidget_gui`` (default ``True``) controls whether
-the anywidget toolkit is offered in ``gui()`` calls.


### PR DESCRIPTION
### Description

Adds the `anywidget` toolkit to HyperSpy, enabling a lightweight widget backend that works in Jupyter Notebook, JupyterLab, and Marimo without any frontend build step.

**Changes:**
- `hyperspy/defaults_parser.py`: new `GUIs.enable_anywidget_gui` preference so the toolkit only appears when the extension is installed.
- `hyperspy/ui_registry.py`: register `anywidget` in `GUI_TOOLKITS`

The companion package `hyperspy_gui_anywidget` registers 33 widget functions (ROI, axes, model, preferences, tools) via a `hyperspy_extension.yaml` entry point. When installed, `roi.gui(toolkit="anywidget")` works out of the box.

### How to test

```bash
pip install hyperspy_gui_anywidget
```

```python
import hyperspy.api as hs
import numpy as np

hs.roi.SpanROI(left=0, right=10).gui(toolkit="anywidget")

s = hs.signals.Signal1D(np.random.random((3, 100)))
s.axes_manager.gui(toolkit="anywidget")
s.smooth_savitzky_golay(toolkit="anywidget")
```

No manual `%load_ext anywidget` needed — anywidget/ipywidgets handle integration automatically in modern Jupyter.

### Marimo sandbox testing

The companion repo includes a [Marimo example](https://github.com/hyperspy/hyperspy_gui_anywidget/blob/master/examples/marimo_anywidget_example.py) with PEP 723 inline metadata so Marimo's sandbox auto-installs all dependencies (including HyperSpy from this branch):

```bash
git clone https://github.com/hyperspy/hyperspy_gui_anywidget.git
cd hyperspy_gui_anywidget
uv run --script examples/marimo_anywidget_example.py
# or: marimo edit --sandbox examples/marimo_anywidget_example.py
```

### Binder links

- [Comparison notebook (ipywidgets vs anywidget)](https://mybinder.org/v2/gh/hyperspy/hyperspy_gui_anywidget/HEAD?filepath=examples%2Fcomparison_notebook.ipynb)
- [Jupyter anywidget walkthrough](https://mybinder.org/v2/gh/hyperspy/hyperspy_gui_anywidget/HEAD?filepath=examples%2Fjupyter_anywidget_example.ipynb)

### molab note

The marimo notebook example runs in molab.

### Checklist

- [x] Changes implemented
- [x] If AI-assisted: `Assisted-by: OpenCode:deepseek-v4-pro` per commit
- [x] Manually tested (Jupyter and Marimo)
- [x] Design choices annotated inline
- [x] Changelog entry in `upcoming_changes/3699.enhancements.rst`
- [x] Ready for review
