### PR TITLE
Add navigators

### DIFF
--- a/doc/user_guide/visualisation.rst
+++ b/doc/user_guide/visualisation.rst
@@ -445,7 +445,7 @@ Named navigators (``navigators``)
 
 Every signal carries a dict-like :attr:`~.api.signals.BaseSignal.navigators`
 proxy that stores **named navigator signals**. Unlike the singular
-:attr:`~.api.signals.BaseSignal.navigator`, named navigators:
+``navigator`` attribute, named navigators:
 
 * survive :ref:`inav slicing <signal.indexing>` — each navigator is
   automatically sliced to match the parent signal;
@@ -480,10 +480,9 @@ An invalid key raises a :exc:`ValueError` listing valid keys. When
 
 **Promoting a navigator to the default**
 
-:meth:`~hyperspy.signal.NavigatorsProxy.set_default` copies a named navigator
-to the singular :attr:`~.api.signals.BaseSignal.navigator` slot, making it the
-priority navigator for all subsequent :meth:`~.api.signals.BaseSignal.plot`
-calls:
+``navigators.set_default()`` copies a named navigator to the singular
+``navigator`` slot, making it the priority navigator for all subsequent
+:meth:`~.api.signals.BaseSignal.plot` calls:
 
 .. code-block:: python
 
@@ -523,8 +522,8 @@ navigator's navigation or signal space.
 .. note::
     Named navigators are cleared when a signal is transposed
     (:attr:`~.api.signals.BaseSignal.T`), because the navigation space changes.
-    Use :meth:`~hyperspy.signal.NavigatorsProxy.set_default` on the transposed
-    signal to attach a new navigator.
+    Use ``navigators.set_default()`` on the transposed signal to attach a new
+    navigator.
 
 .. seealso::
 

--- a/doc/user_guide/visualisation.rst
+++ b/doc/user_guide/visualisation.rst
@@ -436,6 +436,101 @@ the "maximum spectrum" for which each channel is the maximum of all pixels.
 
 Lastly, if no navigator is needed, "navigator=None" can be used.
 
+.. _plot.named_navigators:
+
+Named navigators (``navigators``)
+==================================
+
+.. versionadded:: 2.5.0
+
+Every signal carries a dict-like :attr:`~.api.signals.BaseSignal.navigators`
+proxy that stores **named navigator signals**. Unlike the singular
+:attr:`~.api.signals.BaseSignal.navigator`, named navigators:
+
+* survive :ref:`inav slicing <signal.indexing>` — each navigator is
+  automatically sliced to match the parent signal;
+* are preserved by :meth:`~.api.signals.BaseSignal.map` (both ``inplace=True``
+  and ``inplace=False``);
+* can be selected by name when calling :meth:`~.api.signals.BaseSignal.plot`.
+
+**Assigning a named navigator**
+
+The navigator must have the same total number of dimensions as the signal's
+navigation space, and the same sizes (in any order):
+
+.. code-block:: python
+
+    >>> import numpy as np
+    >>> import hyperspy.api as hs
+    >>> s = hs.signals.Signal2D(np.random.rand(10, 15, 64, 64))
+    >>> vbf = hs.signals.Signal2D(np.random.rand(10, 15))  # nav shape matches
+    >>> s.navigators["Virtual Bright Field"] = vbf
+
+**Plotting with a named navigator**
+
+Pass the key string to ``plot()``:
+
+.. code-block:: python
+
+    >>> s.plot(navigator="Virtual Bright Field")  # doctest: +SKIP
+
+An invalid key raises a :exc:`ValueError` listing valid keys. When
+``navigator="auto"`` and no singular navigator is set, the first entry in
+``navigators`` is used automatically.
+
+**Promoting a navigator to the default**
+
+:meth:`~hyperspy.signal.NavigatorsProxy.set_default` copies a named navigator
+to the singular :attr:`~.api.signals.BaseSignal.navigator` slot, making it the
+priority navigator for all subsequent :meth:`~.api.signals.BaseSignal.plot`
+calls:
+
+.. code-block:: python
+
+    >>> s.navigators.set_default("Virtual Bright Field")
+    >>> s.plot()  # uses the Virtual Bright Field navigator  # doctest: +SKIP
+
+**Computing and storing a sum navigator**
+
+:meth:`~.api.signals.BaseSignal.compute_navigator` sums over all signal axes
+once, stores the result as ``navigators["Signal Sum Image"]``, and sets it as
+the default navigator:
+
+.. code-block:: python
+
+    >>> s.compute_navigator()
+    >>> "Signal Sum Image" in s.navigators
+    True
+
+For lazy signals, the existing chunk-based computation is used.
+
+**Slicing propagation**
+
+Named navigators are sliced automatically when ``inav`` is used:
+
+.. code-block:: python
+
+    >>> s.navigators["VBF"] = vbf
+    >>> sliced = s.inav[0:5, 0:8]
+    >>> sliced.navigators["VBF"].data.shape
+    (8, 5)
+
+For complex multi-dimensional datasets (e.g. a 5D signal with mixed nav/signal
+navigator), axes are matched by calibration properties (size, units, scale,
+offset), so the correct slices propagate whether those axes live in the
+navigator's navigation or signal space.
+
+.. note::
+    Named navigators are cleared when a signal is transposed
+    (:attr:`~.api.signals.BaseSignal.T`), because the navigation space changes.
+    Use :meth:`~hyperspy.signal.NavigatorsProxy.set_default` on the transposed
+    signal to attach a new navigator.
+
+.. seealso::
+
+    :ref:`Sphinx Gallery example <sphx_glr_auto_examples_plotting_named_navigators.py>`
+    for a complete runnable demonstration.
+
 .. _visualization_3D_EDS-label:
 
 Using Mayavi to visualize 3D data

--- a/examples/plotting/named_navigators.py
+++ b/examples/plotting/named_navigators.py
@@ -1,0 +1,80 @@
+"""
+================
+Named Navigators
+================
+
+This example demonstrates ``signal.navigators``, a dict-like proxy that stores
+named navigator signals. Named navigators survive ``inav`` slicing and ``map``
+operations, and can be selected by name when calling ``plot()``.
+"""
+
+import matplotlib.pyplot as plt
+import numpy as np
+
+import hyperspy.api as hs
+
+# %%
+# Create a synthetic 4D-STEM-like dataset: navigation (10, 15), signal (64, 64)
+rng = np.random.default_rng(0)
+s = hs.signals.Signal2D(rng.random((10, 15, 64, 64)))
+s.axes_manager.navigation_axes[0].name = "x"
+s.axes_manager.navigation_axes[0].scale = 0.5
+s.axes_manager.navigation_axes[0].units = "nm"
+s.axes_manager.navigation_axes[1].name = "y"
+s.axes_manager.navigation_axes[1].scale = 0.5
+s.axes_manager.navigation_axes[1].units = "nm"
+
+# %%
+# Build a "Virtual Bright Field" navigator by summing signal pixels near the
+# centre (a stand-in for a real VBF aperture).
+centre = s.isig[24:40, 24:40].sum(axis=(2, 3)).T
+centre.metadata.General.title = "Virtual Bright Field"
+
+# %%
+# Assign it to the navigators dict.  The proxy validates that the total shape
+# matches the signal's navigation space.
+s.navigators["Virtual Bright Field"] = centre
+
+# %%
+# A second named navigator: annular dark field using an outer ring.
+adf = s.isig[:12, :].sum(axis=(2, 3)).T
+adf.metadata.General.title = "ADF"
+s.navigators["ADF"] = adf
+
+print("Stored navigators:", list(s.navigators.keys()))
+
+# %%
+# Use ``navigators.set_default`` to promote one to the singular navigator so
+# ``plot()`` uses it by default.
+s.navigators.set_default("Virtual Bright Field")
+
+# %%
+# inav slicing propagates to all named navigators automatically.
+sliced = s.inav[2:8, 3:12]
+print("Original nav shape :", s.axes_manager.navigation_shape)
+print("Sliced   nav shape :", sliced.axes_manager.navigation_shape)
+print("Navigator shape    :", sliced.navigators["Virtual Bright Field"].data.shape)
+
+# %%
+# Plot the VBF and ADF navigators side-by-side using plain matplotlib to show
+# what the navigator images look like.
+fig, axes = plt.subplots(1, 2, figsize=(6, 3))
+axes[0].imshow(s.navigators["Virtual Bright Field"].data.T, origin="lower")
+axes[0].set_title("Virtual Bright Field")
+axes[0].set_xlabel("x (nm)")
+axes[0].set_ylabel("y (nm)")
+
+axes[1].imshow(s.navigators["ADF"].data.T, origin="lower")
+axes[1].set_title("ADF")
+axes[1].set_xlabel("x (nm)")
+axes[1].set_ylabel("y (nm)")
+
+fig.tight_layout()
+
+# %%
+# ``compute_navigator()`` sums over all signal axes, saves the result as
+# ``navigators["Signal Sum Image"]``, and sets it as the default navigator.
+s2 = hs.signals.Signal2D(rng.random((5, 7, 32, 32)))
+s2.compute_navigator()
+print("After compute_navigator:", list(s2.navigators.keys()))
+print("Navigator is set      :", s2.navigator is not None)

--- a/hyperspy/_signals/lazy.py
+++ b/hyperspy/_signals/lazy.py
@@ -1221,8 +1221,14 @@ class LazySignal(signals.BaseSignal):
                 navigator = "auto"
             if navigator == "auto":
                 if self.navigator is None:
-                    self.compute_navigator()
-                navigator = self.navigator
+                    _nav_dict = getattr(self, "_navigators_dict", {})
+                    if _nav_dict:
+                        navigator = next(iter(_nav_dict.values()))
+                    else:
+                        self.compute_navigator()
+                        navigator = self.navigator
+                else:
+                    navigator = self.navigator
         super().plot(navigator=navigator, **kwargs)
 
     def compute_navigator(self, index=None, chunks_number=None, show_progressbar=None):
@@ -1304,6 +1310,9 @@ class LazySignal(signals.BaseSignal):
         navigator.original_metadata.set_item("sum_from", str(isig_slice))
 
         self.navigator = navigator.T
+        if not hasattr(self, "_navigators_dict"):
+            self._navigators_dict = {}
+        self._navigators_dict["Signal Sum Image"] = self.navigator
 
     compute_navigator.__doc__ %= SHOW_PROGRESSBAR_ARG
 

--- a/hyperspy/signal.py
+++ b/hyperspy/signal.py
@@ -2374,6 +2374,78 @@ class BaseSetMetadataItems(t.HasTraits):
                 self.signal.metadata.set_item(key, getattr(self, value))
 
 
+def _axis_matches(axis_a, axis_b):
+    """Return True if two axes have identical calibration properties."""
+    if axis_a.size != axis_b.size:
+        return False
+    units_a = axis_a.units if axis_a.units is not None else ""
+    units_b = axis_b.units if axis_b.units is not None else ""
+    if units_a != units_b:
+        return False
+    try:
+        scale_match = np.isclose(
+            float(axis_a.scale), float(axis_b.scale), rtol=1e-5, atol=0
+        )
+        offset_match = np.isclose(
+            float(axis_a.offset), float(axis_b.offset), rtol=1e-5, atol=1e-10
+        )
+        return bool(scale_match and offset_match)
+    except (TypeError, ValueError):
+        return axis_a.scale == axis_b.scale and axis_a.offset == axis_b.offset
+
+
+def _slice_navigator_for_inav(navigator, parent_nav_axes, parent_array_slices):
+    """Slice a navigator signal to match a parent's ``inav`` operation.
+
+    Matches each navigator axis to the corresponding parent navigation axis
+    by calibration properties (size, units, scale, offset), then applies the
+    parent's array-level slices via ``inav`` and/or ``isig`` on the navigator.
+
+    Parameters
+    ----------
+    navigator : BaseSignal
+        The navigator signal to slice.
+    parent_nav_axes : tuple of BaseDataAxis
+        The parent's ``navigation_axes`` in display order (innermost first).
+    parent_array_slices : tuple
+        Per-array-index slices from ``_get_array_slices``; index with
+        ``parent_axis.index_in_array``.
+
+    Returns
+    -------
+    BaseSignal
+        Sliced copy of the navigator.
+    """
+    used_parent = set()
+    axis_slice_map = {}
+
+    for nav_ax in navigator.axes_manager._axes:
+        for parent_ax in parent_nav_axes:
+            pid = id(parent_ax)
+            if pid not in used_parent and _axis_matches(nav_ax, parent_ax):
+                axis_slice_map[id(nav_ax)] = parent_array_slices[
+                    parent_ax.index_in_array
+                ]
+                used_parent.add(pid)
+                break
+
+    inav_tuple = tuple(
+        axis_slice_map.get(id(ax), slice(None))
+        for ax in navigator.axes_manager.navigation_axes
+    )
+    isig_tuple = tuple(
+        axis_slice_map.get(id(ax), slice(None))
+        for ax in navigator.axes_manager.signal_axes
+    )
+
+    result = navigator
+    if any(s != slice(None) for s in inav_tuple):
+        result = result.inav[inav_tuple]
+    if any(s != slice(None) for s in isig_tuple):
+        result = result.isig[isig_tuple]
+    return result
+
+
 class NavigatorsProxy:
     """Dict-like proxy for a signal's named navigators.
 
@@ -3115,6 +3187,28 @@ class BaseSignal(FancySlicing, MVA, MVATools):
         >>> s.navigators.set_default("Virtual Bright Field")
         """
         return NavigatorsProxy(self)
+
+    def _slicer(self, slices, isNavigation=None, out=None):
+        result = super()._slicer(slices, isNavigation, out)
+        if isNavigation is True and out is None:
+            nav_dict = getattr(self, "_navigators_dict", None)
+            if nav_dict:
+                array_slices = self._get_array_slices(slices, isNavigation)
+                parent_nav_axes = self.axes_manager.navigation_axes
+                sliced = {}
+                for key, nav in nav_dict.items():
+                    try:
+                        sliced[key] = _slice_navigator_for_inav(
+                            nav, parent_nav_axes, array_slices
+                        )
+                    except Exception as e:
+                        warnings.warn(
+                            f"Could not slice navigator '{key}': {e}. "
+                            "Dropping it from result.",
+                            stacklevel=2,
+                        )
+                result._navigators_dict = sliced
+        return result
 
     def plot(self, navigator="auto", axes_manager=None, plot_markers=True, **kwargs):
         """%s

--- a/hyperspy/signal.py
+++ b/hyperspy/signal.py
@@ -2374,6 +2374,95 @@ class BaseSetMetadataItems(t.HasTraits):
                 self.signal.metadata.set_item(key, getattr(self, value))
 
 
+class NavigatorsProxy:
+    """Dict-like proxy for a signal's named navigators.
+
+    Wraps ``signal._navigators_dict`` (a plain Python dict on the signal
+    instance). Validates shape and type on ``__setitem__``.
+    """
+
+    def __init__(self, signal):
+        self._signal = signal
+
+    @property
+    def _dict(self):
+        if not hasattr(self._signal, "_navigators_dict"):
+            self._signal._navigators_dict = {}
+        return self._signal._navigators_dict
+
+    def __setitem__(self, key, value):
+        if not isinstance(value, BaseSignal):
+            raise TypeError(
+                f"Navigator must be a BaseSignal, got {type(value).__name__}"
+            )
+        parent_nav_shape = self._signal.axes_manager.navigation_shape
+        parent_nav_ndim = len(parent_nav_shape)
+        nav_total_ndim = (
+            value.axes_manager.navigation_dimension
+            + value.axes_manager.signal_dimension
+        )
+        if nav_total_ndim != parent_nav_ndim:
+            raise ValueError(
+                f"Navigator must have {parent_nav_ndim} total dimensions "
+                f"(matching the signal's {parent_nav_ndim} navigation "
+                f"dimensions), got {nav_total_ndim}"
+            )
+        nav_total_shape = tuple(
+            sorted(
+                list(value.axes_manager.navigation_shape)
+                + list(value.axes_manager.signal_shape)
+            )
+        )
+        if nav_total_shape != tuple(sorted(parent_nav_shape)):
+            raise ValueError(
+                f"Navigator shape "
+                f"{value.axes_manager.navigation_shape + value.axes_manager.signal_shape}"
+                f" is not compatible with the signal's navigation shape "
+                f"{parent_nav_shape}"
+            )
+        self._dict[key] = value
+
+    def __getitem__(self, key):
+        return self._dict[key]
+
+    def __delitem__(self, key):
+        del self._dict[key]
+
+    def __contains__(self, key):
+        return key in self._dict
+
+    def __iter__(self):
+        return iter(self._dict)
+
+    def __len__(self):
+        return len(self._dict)
+
+    def __repr__(self):
+        return repr(self._dict)
+
+    def keys(self):
+        return self._dict.keys()
+
+    def values(self):
+        return self._dict.values()
+
+    def items(self):
+        return self._dict.items()
+
+    def set_default(self, key):
+        """Promote a named navigator to the signal's default (singular) navigator.
+
+        Sets ``signal.navigator = signal.navigators[key]``, making it the
+        first-priority navigator for subsequent ``plot()`` calls.
+        """
+        if key not in self._dict:
+            raise KeyError(
+                f"'{key}' not found in navigators. "
+                f"Available keys: {list(self._dict.keys())}"
+            )
+        self._signal.navigator = self._dict[key]
+
+
 class BaseSignal(FancySlicing, MVA, MVATools):
     """
 
@@ -3012,6 +3101,20 @@ class BaseSignal(FancySlicing, MVA, MVATools):
     @navigator.setter
     def navigator(self, navigator):
         self.metadata.set_item("_HyperSpy.navigator", navigator)
+
+    @property
+    def navigators(self):
+        """Named navigator signals as a :class:`~hyperspy.signal.NavigatorsProxy`.
+
+        Assign navigator signals by key; they are validated against the
+        signal's navigation shape and automatically sliced when ``inav`` is used.
+
+        Examples
+        --------
+        >>> s.navigators["Virtual Bright Field"] = vdf_signal
+        >>> s.navigators.set_default("Virtual Bright Field")
+        """
+        return NavigatorsProxy(self)
 
     def plot(self, navigator="auto", axes_manager=None, plot_markers=True, **kwargs):
         """%s

--- a/hyperspy/signal.py
+++ b/hyperspy/signal.py
@@ -7355,6 +7355,9 @@ class BaseSignal(FancySlicing, MVA, MVATools):
             # previous signal.
             del res.metadata.Markers
 
+        if hasattr(res, "_navigators_dict"):
+            del res._navigators_dict
+
         return res
 
     transpose.__doc__ %= OPTIMIZE_ARG

--- a/hyperspy/signal.py
+++ b/hyperspy/signal.py
@@ -6187,6 +6187,8 @@ class BaseSignal(FancySlicing, MVA, MVATools):
                     temp_marker_dict[key],
                 )
             dc.metadata.Markers = markers_dict
+        if hasattr(self, "_navigators_dict"):
+            dc._navigators_dict = copy.deepcopy(self._navigators_dict)
         return dc
 
     def deepcopy(self):

--- a/hyperspy/signal.py
+++ b/hyperspy/signal.py
@@ -3352,37 +3352,58 @@ class BaseSignal(FancySlicing, MVA, MVATools):
             ):
                 navigator = "data"
             elif self.axes_manager.navigation_dimension > 0:
-                if self.axes_manager.signal_dimension == 0:
-                    navigator = self.deepcopy()
+                _nav_dict = getattr(self, "_navigators_dict", {})
+                if _nav_dict:
+                    navigator = next(iter(_nav_dict.values()))
                 else:
-                    navigator = interactive(
-                        f=sum_wrapper,
-                        event=self.events.data_changed,
-                        recompute_out_event=self.axes_manager.events.any_axis_changed,
-                        s=self,
-                        axis=self.axes_manager.signal_axes,
-                    )
-                    # Sets are not ordered, to retrieve the function to disconnect
-                    # take the difference with the previous copy
-                    function_to_disconnect = list(
-                        self.events.data_changed.connected - connected_event_copy
-                    )[0]
-                if navigator.axes_manager.navigation_dimension == 1:
-                    navigator = interactive(
-                        f=navigator.as_signal1D,
-                        event=navigator.events.data_changed,
-                        recompute_out_event=navigator.axes_manager.events.any_axis_changed,
-                        spectral_axis=0,
-                    )
-                else:
-                    navigator = interactive(
-                        f=navigator.as_signal2D,
-                        event=navigator.events.data_changed,
-                        recompute_out_event=navigator.axes_manager.events.any_axis_changed,
-                        image_axes=(0, 1),
-                    )
+                    if self.axes_manager.signal_dimension == 0:
+                        navigator = self.deepcopy()
+                    else:
+                        navigator = interactive(
+                            f=sum_wrapper,
+                            event=self.events.data_changed,
+                            recompute_out_event=self.axes_manager.events.any_axis_changed,
+                            s=self,
+                            axis=self.axes_manager.signal_axes,
+                        )
+                        # Sets are not ordered, to retrieve the function to disconnect
+                        # take the difference with the previous copy
+                        function_to_disconnect = list(
+                            self.events.data_changed.connected - connected_event_copy
+                        )[0]
+                    if navigator.axes_manager.navigation_dimension == 1:
+                        navigator = interactive(
+                            f=navigator.as_signal1D,
+                            event=navigator.events.data_changed,
+                            recompute_out_event=navigator.axes_manager.events.any_axis_changed,
+                            spectral_axis=0,
+                        )
+                    else:
+                        navigator = interactive(
+                            f=navigator.as_signal2D,
+                            event=navigator.events.data_changed,
+                            recompute_out_event=navigator.axes_manager.events.any_axis_changed,
+                            image_axes=(0, 1),
+                        )
             else:
                 navigator = None
+        # Resolve a string navigator key from the navigators dict
+        if isinstance(navigator, str) and navigator not in (
+            "auto",
+            "slider",
+            "data",
+            "spectrum",
+        ):
+            _nav_dict = getattr(self, "_navigators_dict", {})
+            if navigator in _nav_dict:
+                navigator = _nav_dict[navigator]
+            else:
+                raise ValueError(
+                    f"'{navigator}' is not a valid navigator. "
+                    f"Valid named navigators: {list(_nav_dict.keys())}. "
+                    f"Built-in modes: 'auto', 'slider', 'data', 'spectrum'."
+                )
+
         # Navigator properties
         if axes_manager.navigation_axes:
             # check first if we have a signal to avoid comparison of signal with

--- a/hyperspy/signal.py
+++ b/hyperspy/signal.py
@@ -3210,6 +3210,25 @@ class BaseSignal(FancySlicing, MVA, MVATools):
                 result._navigators_dict = sliced
         return result
 
+    def compute_navigator(self):
+        """Compute a sum navigator and save it as ``navigators["Signal Sum Image"]``.
+
+        Sums over all signal axes to produce a static navigator spanning the
+        full navigation space. Saves the result to ``navigators["Signal Sum Image"]``
+        and sets it as the default ``navigator``.
+
+        For lazy signals, use the overridden version in
+        :class:`~hyperspy._signals.lazy.LazySignal` which computes efficiently
+        over a single chunk.
+        """
+        nav = self.sum(self.axes_manager.signal_axes)
+        nav = nav.T
+        nav.metadata.General.title = "Signal Sum Image"
+        if not hasattr(self, "_navigators_dict"):
+            self._navigators_dict = {}
+        self._navigators_dict["Signal Sum Image"] = nav
+        self.navigator = nav
+
     def plot(self, navigator="auto", axes_manager=None, plot_markers=True, **kwargs):
         """%s
         %s

--- a/hyperspy/signal.py
+++ b/hyperspy/signal.py
@@ -3176,7 +3176,7 @@ class BaseSignal(FancySlicing, MVA, MVATools):
 
     @property
     def navigators(self):
-        """Named navigator signals as a :class:`~hyperspy.signal.NavigatorsProxy`.
+        """Named navigator signals as a ``NavigatorsProxy`` dict-like object.
 
         Assign navigator signals by key; they are validated against the
         signal's navigation shape and automatically sliced when ``inav`` is used.

--- a/hyperspy/tests/signals/test_navigators.py
+++ b/hyperspy/tests/signals/test_navigators.py
@@ -323,14 +323,10 @@ class TestLazyNavigators:
     def test_lazy_plot_auto_uses_dict_without_recomputing(self):
         """If navigators dict is populated, lazy plot should not call compute_navigator."""
         s = hs.signals.Signal2D(np.ones((5, 7, 16, 16))).as_lazy()
-        nav = hs.signals.Signal2D(np.ones((7, 5)))  # matches nav shape
-        # set axis properties to pass validation
-        nav.axes_manager.signal_axes[0].scale = 1.0
-        nav.axes_manager.signal_axes[1].scale = 1.0
-        # bypass validation and set directly
-        nav_dict = {}
-        nav_dict["precomputed"] = nav
-        s.metadata.set_item("_HyperSpy.navigators", nav_dict)
+        # parent nav_shape display = (7, 5); Signal2D(5,7) has signal_shape=(7,5)
+        nav = hs.signals.Signal2D(np.ones((5, 7)))
+        # set directly in _navigators_dict to bypass proxy validation
+        s._navigators_dict = {"precomputed": nav}
 
         called = []
         original_compute = s.compute_navigator

--- a/hyperspy/tests/signals/test_navigators.py
+++ b/hyperspy/tests/signals/test_navigators.py
@@ -1,0 +1,350 @@
+import matplotlib
+
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt
+import numpy as np
+import pytest
+
+import hyperspy.api as hs
+
+
+def _make_signal_with_2d_nav():
+    """Signal2D with nav=(15, 10), sig=(64, 64). Data shape (10, 15, 64, 64)."""
+    s = hs.signals.Signal2D(np.ones((10, 15, 64, 64)))
+    # navigation_axes display order (innermost first):
+    #   [0] inner nav: data-axis 1, size=15
+    #   [1] outer nav: data-axis 0, size=10
+    s.axes_manager.navigation_axes[0].scale = 2.0
+    s.axes_manager.navigation_axes[0].units = "nm"
+    s.axes_manager.navigation_axes[1].scale = 1.5
+    s.axes_manager.navigation_axes[1].units = "nm"
+    return s
+
+
+def _make_nav_for_2d(s):
+    """Pure-signal navigator whose data matches the parent nav shape."""
+    # nav_shape = (15, 10); data (10, 15)
+    nav = hs.signals.Signal2D(np.ones((10, 15)))
+    # Signal2D(10, 15): nav_shape=(), sig_shape=(15, 10) display order
+    # signal_axes[0] = inner (data-axis 1, size=15); [1] = outer (data-axis 0, size=10)
+    nav.axes_manager.signal_axes[0].scale = 2.0
+    nav.axes_manager.signal_axes[0].units = "nm"
+    nav.axes_manager.signal_axes[1].scale = 1.5
+    nav.axes_manager.signal_axes[1].units = "nm"
+    return nav
+
+
+class TestNavigatorsProxyBasic:
+    def test_set_and_get(self):
+        s = _make_signal_with_2d_nav()
+        nav = _make_nav_for_2d(s)
+        s.navigators["VBF"] = nav
+        assert s.navigators["VBF"] is nav
+
+    def test_contains(self):
+        s = _make_signal_with_2d_nav()
+        nav = _make_nav_for_2d(s)
+        s.navigators["VBF"] = nav
+        assert "VBF" in s.navigators
+        assert "other" not in s.navigators
+
+    def test_delete(self):
+        s = _make_signal_with_2d_nav()
+        nav = _make_nav_for_2d(s)
+        s.navigators["VBF"] = nav
+        del s.navigators["VBF"]
+        assert "VBF" not in s.navigators
+
+    def test_keys_values_items(self):
+        s = _make_signal_with_2d_nav()
+        nav = _make_nav_for_2d(s)
+        s.navigators["VBF"] = nav
+        assert list(s.navigators.keys()) == ["VBF"]
+        assert list(s.navigators.values()) == [nav]
+        assert list(s.navigators.items()) == [("VBF", nav)]
+
+    def test_len_and_iter(self):
+        s = _make_signal_with_2d_nav()
+        nav = _make_nav_for_2d(s)
+        s.navigators["VBF"] = nav
+        assert len(s.navigators) == 1
+        assert list(s.navigators) == ["VBF"]
+
+
+class TestNavigatorsProxyValidation:
+    def test_wrong_type_raises_typeerror(self):
+        s = _make_signal_with_2d_nav()
+        with pytest.raises(TypeError, match="BaseSignal"):
+            s.navigators["bad"] = np.ones((10, 15))
+
+    def test_wrong_ndim_raises_valueerror(self):
+        s = _make_signal_with_2d_nav()
+        # 1D navigator for a 2D nav signal
+        nav_1d = hs.signals.Signal1D(np.ones((10,)))
+        with pytest.raises(ValueError, match="2 total dimensions"):
+            s.navigators["bad"] = nav_1d
+
+    def test_wrong_shape_raises_valueerror(self):
+        s = _make_signal_with_2d_nav()
+        # 2D but wrong sizes
+        nav_bad = hs.signals.Signal2D(np.ones((8, 12)))
+        with pytest.raises(ValueError, match="compatible"):
+            s.navigators["bad"] = nav_bad
+
+    def test_correct_shape_passes(self):
+        s = _make_signal_with_2d_nav()
+        nav = _make_nav_for_2d(s)
+        s.navigators["VBF"] = nav  # should not raise
+
+
+def _make_5d_signal_and_navigator():
+    """
+    Parent: Signal2D, data (3, 5, 7, 64, 64)
+      nav axes (display, innermost first):
+        [0] inner:  data-axis 2, size=7,  scale=2.0, units="nm"  (y)
+        [1] middle: data-axis 1, size=5,  scale=1.5, units="nm"  (x)
+        [2] outer:  data-axis 0, size=3,  scale=0.1, units="s"   (time)
+      nav_shape display = (7, 5, 3)
+
+    Navigator: Signal2D, data (3, 5, 7)  -> nav=(time=3,), sig=(x=5, y=7)
+      Signal2D(np.ones((3, 5, 7))):
+        data shape (3, 5, 7)
+        Signal2D -> signal_dimension=2
+        nav axis: data-axis 0 (size=3)
+        sig axes: data-axis 1 (size=5), data-axis 2 (size=7)
+        signal_axes display (innermost first): [0]=data-axis2(size=7), [1]=data-axis1(size=5)
+        navigation_axes display: [0]=data-axis0(size=3)
+    """
+    s = hs.signals.Signal2D(np.zeros((3, 5, 7, 64, 64)))
+    s.axes_manager.navigation_axes[0].scale = 2.0  # y (inner, size=7)
+    s.axes_manager.navigation_axes[0].units = "nm"
+    s.axes_manager.navigation_axes[0].offset = 0.0
+    s.axes_manager.navigation_axes[1].scale = 1.5  # x (middle, size=5)
+    s.axes_manager.navigation_axes[1].units = "nm"
+    s.axes_manager.navigation_axes[1].offset = 0.0
+    s.axes_manager.navigation_axes[2].scale = 0.1  # time (outer, size=3)
+    s.axes_manager.navigation_axes[2].units = "s"
+    s.axes_manager.navigation_axes[2].offset = 0.0
+
+    nav = hs.signals.Signal2D(np.zeros((3, 5, 7)))
+    # navigation_axes[0] = data-axis 0 (size=3) = time
+    # signal_axes[0]     = data-axis 2 (size=7) = y (inner)
+    # signal_axes[1]     = data-axis 1 (size=5) = x
+    nav.axes_manager.navigation_axes[0].scale = 0.1  # time
+    nav.axes_manager.navigation_axes[0].units = "s"
+    nav.axes_manager.navigation_axes[0].offset = 0.0
+    nav.axes_manager.signal_axes[0].scale = 2.0  # y (inner sig)
+    nav.axes_manager.signal_axes[0].units = "nm"
+    nav.axes_manager.signal_axes[0].offset = 0.0
+    nav.axes_manager.signal_axes[1].scale = 1.5  # x
+    nav.axes_manager.signal_axes[1].units = "nm"
+    nav.axes_manager.signal_axes[1].offset = 0.0
+
+    return s, nav
+
+
+class TestInavSlicing:
+    def test_inav_2d_nav_slice(self):
+        """2D nav: inav[0:5, 0:8] slices both signal dims of the navigator."""
+        s = _make_signal_with_2d_nav()
+        nav = _make_nav_for_2d(s)
+        s.navigators["nav"] = nav
+
+        # Parent nav_shape display (innermost first) = (15, 10)
+        # inav[0:5, 0:8]: s0=0:5 -> inner(15->5), s1=0:8 -> outer(10->8)
+        sliced = s.inav[0:5, 0:8]
+
+        assert "nav" in sliced.navigators
+        # Navigator had data (10, 15): outer-in-array=10, inner-in-array=15
+        # After isig[0:5, 0:8]: inner(15->5), outer(10->8)
+        # Result data shape: outer(8) x inner(5) = (8, 5)
+        assert sliced.navigators["nav"].data.shape == (8, 5)
+
+    def test_inav_5d_mixed_slice(self):
+        """5D signal: inav slices propagate to mixed nav|sig navigator."""
+        s, nav = _make_5d_signal_and_navigator()
+        s.navigators["nav"] = nav
+
+        # Parent nav display order: [0]=y(7), [1]=x(5), [2]=time(3)
+        # inav[0:4, 0:3, 0:2]:
+        #   s0=0:4 -> y(7->4)
+        #   s1=0:3 -> x(5->3)
+        #   s2=0:2 -> time(3->2)
+        sliced = s.inav[0:4, 0:3, 0:2]
+
+        assert "nav" in sliced.navigators
+        nav_sliced = sliced.navigators["nav"]
+        # Navigator original data: (time=3, x=5, y=7)
+        # After inav[0:2] on time: (2, 5, 7)
+        # After isig[0:4, 0:3]:
+        #   signal_axes[0]=y(inner,7) -> 0:4 -> 4
+        #   signal_axes[1]=x(5)       -> 0:3 -> 3
+        # Result: (2, 3, 4)
+        assert nav_sliced.data.shape == (2, 3, 4)
+
+    def test_inav_integer_removes_nav_dim(self):
+        """Integer inav index removes the corresponding nav dim from navigator."""
+        s, nav = _make_5d_signal_and_navigator()
+        s.navigators["nav"] = nav
+
+        # inav[0:4, 0:3, 1]:
+        #   s0=0:4 -> y(7->4)
+        #   s1=0:3 -> x(5->3)
+        #   s2=1   -> time(3->removed)
+        sliced = s.inav[0:4, 0:3, 1]
+
+        assert "nav" in sliced.navigators
+        nav_sliced = sliced.navigators["nav"]
+        # Navigator original data: (time=3, x=5, y=7)
+        # After inav[1] on time: removes nav dim -> data (5, 7) but as signal
+        # After isig[0:4, 0:3]: y(7->4), x(5->3)
+        # Result shape: (3, 4)
+        assert nav_sliced.data.shape == (3, 4)
+        # No navigation dimension remaining
+        assert nav_sliced.axes_manager.navigation_dimension == 0
+
+
+class TestSetDefault:
+    def test_set_default_sets_singular_navigator(self):
+        s = _make_signal_with_2d_nav()
+        nav = _make_nav_for_2d(s)
+        s.navigators["VBF"] = nav
+        assert s.navigator is None  # not yet set
+
+        s.navigators.set_default("VBF")
+        assert s.navigator is nav
+
+    def test_set_default_missing_key_raises_keyerror(self):
+        s = _make_signal_with_2d_nav()
+        with pytest.raises(KeyError, match="not found"):
+            s.navigators.set_default("nonexistent")
+
+
+class TestComputeNavigator:
+    def test_compute_navigator_saves_to_dict(self):
+        s = hs.signals.Signal2D(np.ones((5, 7, 16, 16)))
+        s.compute_navigator()
+        assert "Signal Sum Image" in s.navigators
+
+    def test_compute_navigator_sets_singular_navigator(self):
+        s = hs.signals.Signal2D(np.ones((5, 7, 16, 16)))
+        s.compute_navigator()
+        assert s.navigator is not None
+        assert s.navigator is s.navigators["Signal Sum Image"]
+
+    def test_compute_navigator_shape_matches_nav(self):
+        s = hs.signals.Signal2D(np.ones((5, 7, 16, 16)))
+        s.compute_navigator()
+        nav = s.navigators["Signal Sum Image"]
+        # Total data shape of nav should be (5, 7) or (7, 5)
+        assert set(nav.data.shape) == {5, 7}
+
+    def test_compute_navigator_values_are_sum(self):
+        data = np.arange(5 * 7 * 16 * 16, dtype=float).reshape(5, 7, 16, 16)
+        s = hs.signals.Signal2D(data)
+        s.compute_navigator()
+        nav = s.navigators["Signal Sum Image"]
+        # sum over signal axes (last 2 dims, size 16x16=256)
+        expected_sum = data.sum(axis=(-2, -1))
+        # nav.data should equal expected_sum (possibly transposed)
+        assert np.allclose(sorted(nav.data.ravel()), sorted(expected_sum.ravel()))
+
+
+class TestPlotIntegration:
+    def test_plot_string_key_resolves(self):
+        """plot(navigator='VBF') resolves the named navigator without error."""
+        s = _make_signal_with_2d_nav()
+        nav = _make_nav_for_2d(s)
+        s.navigators["VBF"] = nav
+        try:
+            s.plot(navigator="VBF")
+        finally:
+            plt.close("all")
+
+    def test_plot_invalid_key_raises_valueerror(self):
+        s = _make_signal_with_2d_nav()
+        nav = _make_nav_for_2d(s)
+        s.navigators["VBF"] = nav
+        with pytest.raises(ValueError, match="VBF"):
+            s.plot(navigator="no_such_key")
+
+    def test_plot_auto_fallback_uses_first_navigator(self):
+        """plot(navigator='auto') uses first dict entry when self.navigator is None."""
+        s = _make_signal_with_2d_nav()
+        nav = _make_nav_for_2d(s)
+        s.navigators["VBF"] = nav
+        assert s.navigator is None  # no singular navigator set
+        try:
+            # Should use "VBF" from dict without error
+            s.plot(navigator="auto")
+            # Confirm the plot was created (no exception)
+        finally:
+            plt.close("all")
+
+    def test_plot_auto_singular_navigator_takes_priority(self):
+        """self.navigator takes priority over the navigators dict."""
+        s = _make_signal_with_2d_nav()
+        nav = _make_nav_for_2d(s)
+        s.navigators["VBF"] = nav
+        s.navigator = nav  # set explicitly
+        try:
+            s.plot(navigator="auto")
+        finally:
+            plt.close("all")
+
+
+class TestMapPreservation:
+    def test_map_inplace_true_preserves_navigators(self):
+        s = _make_signal_with_2d_nav()
+        nav = _make_nav_for_2d(s)
+        s.navigators["VBF"] = nav
+        s.map(lambda x: x * 2, inplace=True)
+        assert "VBF" in s.navigators
+        assert s.navigators["VBF"] is nav
+
+    def test_map_inplace_false_copies_navigators(self):
+        s = _make_signal_with_2d_nav()
+        nav = _make_nav_for_2d(s)
+        s.navigators["VBF"] = nav
+        result = s.map(lambda x: x * 2, inplace=False)
+        assert "VBF" in result.navigators
+        # Deep copy — different object but same data
+        assert result.navigators["VBF"] is not nav
+        assert np.allclose(result.navigators["VBF"].data, nav.data)
+
+
+class TestLazyNavigators:
+    def test_lazy_compute_navigator_saves_to_dict(self):
+        s = hs.signals.Signal2D(np.ones((5, 7, 16, 16))).as_lazy()
+        s.compute_navigator(chunks_number=2)
+        assert "Signal Sum Image" in s.navigators
+        assert s.navigator is not None
+
+    def test_lazy_plot_auto_uses_dict_without_recomputing(self):
+        """If navigators dict is populated, lazy plot should not call compute_navigator."""
+        s = hs.signals.Signal2D(np.ones((5, 7, 16, 16))).as_lazy()
+        nav = hs.signals.Signal2D(np.ones((7, 5)))  # matches nav shape
+        # set axis properties to pass validation
+        nav.axes_manager.signal_axes[0].scale = 1.0
+        nav.axes_manager.signal_axes[1].scale = 1.0
+        # bypass validation and set directly
+        nav_dict = {}
+        nav_dict["precomputed"] = nav
+        s.metadata.set_item("_HyperSpy.navigators", nav_dict)
+
+        called = []
+        original_compute = s.compute_navigator
+
+        def mock_compute(*a, **kw):
+            called.append(True)
+            return original_compute(*a, **kw)
+
+        s.compute_navigator = mock_compute
+        try:
+            s.plot(navigator="auto")
+        finally:
+            plt.close("all")
+
+        assert not called, (
+            "compute_navigator should not be called when dict is populated"
+        )


### PR DESCRIPTION
### Description of the change
This adds in the `navigators` property to the `BaseSignal` class. The main idea for the `navigators` property is that it is a collection of signals that have the same number of dimensions/shape as the navigation axis. This extends the idea of the navigator and I think helps to formalize some things that are commonly done in pyxem where virtual images are often saved in the metdata.

- Add BaseSignal.navigators
- Add NavigatorsProxy class which handles the underlying dict like structure in the DictionaryTree Browser
- Navigators are also sliced when the BaseSignal is sliced in the navigation dimensions 

### Progress of the PR
- [x] Change implemented (can be split into several points),
- [x] update docstring (if appropriate),
- [x] update user guide (if appropriate),
- [ ] add an changelog entry in the `upcoming_changes` folder (see [`upcoming_changes/README.rst`](https://github.com/hyperspy/hyperspy/blob/RELEASE_next_minor/upcoming_changes/README.rst)),
- [x] Check formatting changelog entry in the `readthedocs` doc build of this PR (link in github checks)
- [x] add tests,
- [ ] ready for review.

### Minimal example of the bug fix or the new feature
```python
import hyperspy.api as hs
import numpy as np
s = hs.signals.Signal2D(np.random.rand(10,11,12,13))
s.navigators["Virtual Bright Field"] = hs.signals.Signal2D(np.random.rand(10,11))

s.plot(navigator = "Virtual Bright Field")


# slicing


sliced = s.inav[0:5, 0:5]

assert sliced.navigators["Virtual Bright Field"].data.shape ==(5, 5)

```