### PR TITLE
fix: disconnect on_trait_change observers in PeaksFinder2D

### DIFF
--- a/hyperspy/signal_tools/_peaks_finder2d.py
+++ b/hyperspy/signal_tools/_peaks_finder2d.py
@@ -196,9 +196,11 @@ class PeaksFinder2D(t.HasTraits):
         self._update_peak_finding()
 
     def _set_parameters_observer(self):
+        self._observed_parameters = []
         for parameters_mapping in self._attribute_argument_mapping_dict.values():
             for parameter in list(parameters_mapping.keys()):
                 self.on_trait_change(self._parameter_changed, parameter)
+                self._observed_parameters.append(parameter)
 
     def _get_parameters(self, method):
         # Get the attribute to argument mapping for the given method
@@ -253,6 +255,14 @@ class PeaksFinder2D(t.HasTraits):
         am = self.signal.axes_manager
         if self._update_peak_finding in am.events.indices_changed.connected:
             am.events.indices_changed.disconnect(self._update_peak_finding)
+        # disconnect trait observers
+        self.on_trait_change(
+            self.set_random_navigation_position,
+            "random_navigation_position",
+            remove=True,
+        )
+        for parameter in self._observed_parameters:
+            self.on_trait_change(self._parameter_changed, parameter, remove=True)
 
     def set_random_navigation_position(self):
         index = self._rng.integers(0, self.signal.axes_manager._max_index)

--- a/hyperspy/tests/signals/test_find_peaks2D.py
+++ b/hyperspy/tests/signals/test_find_peaks2D.py
@@ -341,6 +341,30 @@ class TestFindPeaks2D:
 
         assert peaks.data.shape == (3, 2)
 
+    def test_disconnect_removes_trait_observers(self):
+        sig = self.sparse_nav2d_shifted
+        sig.axes_manager.indices = (0, 0)
+        axes_dict = sig.axes_manager._get_axes_dicts(sig.axes_manager.navigation_axes)
+        peaks = BaseSignal(np.empty(sig.axes_manager.navigation_shape), axes=axes_dict)
+        pf2D = PeaksFinder2D(sig, method="local_max", peaks=peaks)
+
+        assert hasattr(pf2D, "_observed_parameters")
+        assert len(pf2D._observed_parameters) > 0
+
+        pf2D.disconnect()
+
+        call_count = [0]
+        original_update = pf2D._update_peak_finding
+
+        def counting_update(*args, **kwargs):
+            call_count[0] += 1
+            return original_update(*args, **kwargs)
+
+        pf2D._update_peak_finding = counting_update
+
+        pf2D.local_max_threshold = 5
+        assert call_count[0] == 0
+
 
 @pytest.mark.filterwarnings("ignore:invalid value encountered:RuntimeWarning")
 @pytest.mark.parametrize(

--- a/upcoming_changes/3628.bugfix.rst
+++ b/upcoming_changes/3628.bugfix.rst
@@ -1,1 +1,1 @@
-Fix :class:`~.signal_tools.PeaksFinder2D` not disconnecting ``on_trait_change`` observers on close, causing parameter changes to trigger updates on a potentially stale signal.
+Fix ``PeaksFinder2D`` not disconnecting ``on_trait_change`` observers on close, causing parameter changes to trigger updates on a potentially stale signal.

--- a/upcoming_changes/3628.bugfix.rst
+++ b/upcoming_changes/3628.bugfix.rst
@@ -1,0 +1,1 @@
+Fix :class:`~.signal_tools.PeaksFinder2D` not disconnecting ``on_trait_change`` observers on close, causing parameter changes to trigger updates on a potentially stale signal.


### PR DESCRIPTION
## Description

Fixes #3628

PeaksFinder2D registered ~25 trait observers via `on_trait_change` in `_set_parameters_observer()` and `__init__()` but never removed them in `disconnect()`. After `close()`, trait changes still triggered `_update_peak_finding()` on a potentially stale signal.

## Changes

- `_set_parameters_observer()` now stores registered parameter names in `self._observed_parameters`
- `disconnect()` now removes both the `random_navigation_position` button observer and all parameter observers via `on_trait_change(..., remove=True)`

## Testing

Added `test_disconnect_removes_trait_observers` to verify trait observers are inactive after `disconnect()`.

## Verification

- `ruff check` — passed
- `pytest hyperspy/tests/signals/test_find_peaks2D.py` — 172 passed

Assisted-by: OpenCode:deepseek-v4-pro