### PR TITLE
Replace suppress_callback with re-entrance guards, remove trait_property_changed dual-firing

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -52,6 +52,7 @@ extensions = [
 
 linkcheck_ignore = [
     "https://anaconda.org",  # 403 Client Error: Forbidden for url
+    r"https://docs\.conda\.io/.*",  # 429 rate limit from CI IPs
     "https://doi.org/10.1021/acs.nanolett.5b00449",  # 403 Client Error: Forbidden for url
     "https://doi.org/10.1107/S0021889899010894",  # 403 Client Error: Forbidden for url:"
     "https://doi.org/10.1364/OL.33.000156",  # certificate verify failed: unable to get local issuer certificate (_ssl.c:1010)'

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -62,8 +62,6 @@ linkcheck_ignore = [
     "https://scholar.google.co.uk",  # 403 Client Error: Forbidden for url
     "https://software.opensuse.org",  # 400 Client Error: Bad Request for url
     "https://zenodo.org",  # 403 Client Error: Forbidden for url
-    "http://www.casaxps.com",  # 415 Client Error: Unsupported Media Type
-    "https://libraries.io/pypi/hyperspy/usage",  # 404 Not Found
 ]
 
 linkcheck_exclude_documents = []

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -62,6 +62,8 @@ linkcheck_ignore = [
     "https://scholar.google.co.uk",  # 403 Client Error: Forbidden for url
     "https://software.opensuse.org",  # 400 Client Error: Bad Request for url
     "https://zenodo.org",  # 403 Client Error: Forbidden for url
+    "http://www.casaxps.com",  # 415 Client Error: Unsupported Media Type
+    "https://libraries.io/pypi/hyperspy/usage",  # 404 Not Found
 ]
 
 linkcheck_exclude_documents = []

--- a/doc/dev_guide/coding_with_ai.rst
+++ b/doc/dev_guide/coding_with_ai.rst
@@ -116,7 +116,7 @@ and install the tools for you, but you should understand the basics of the proce
 
 Your AI tool must verify that the development environment is ready.
 Direct your AI tool to the root
-`AGENTS.md <https://github.com/hyperspy/hyperspy/blob/main/AGENTS.md>`_
+`AGENTS.md <https://github.com/hyperspy/hyperspy/blob/RELEASE_next_minor/AGENTS.md>`_
 with the instruction: *"Read this file, then run the checks in
 the AI Agent Setup section."*  Your tool will verify the editable
 install, activate pre-commit hooks, and confirm lint passes — or

--- a/doc/dev_guide/useful_information.rst
+++ b/doc/dev_guide/useful_information.rst
@@ -57,7 +57,7 @@ processing the `pypi data <https://packaging.python.org/guides/analyzing-pypi-pa
 are available online:
 
 * `pepy.tech <https://pepy.tech/project/hyperspy>`_
-* `libraries.io <https://libraries.io/pypi/hyperspy/usage>`_
+* `libraries.io <https://libraries.io/pypi/hyperspy>`_
 * `pypistats.org <https://pypistats.org/packages/hyperspy>`_
 
 HTML Representations

--- a/hyperspy/_components/doniach.py
+++ b/hyperspy/_components/doniach.py
@@ -76,7 +76,7 @@ class Doniach(Expression):
     This is an asymmetric lineshape, originially design for xps but generally
     useful for fitting peaks with low side tails
     See Doniach S. and Sunjic M., J. Phys. 4C31, 285 (1970)
-    or http://www.casaxps.com/help_manual/line_shapes.htm for a more detailed
+    or https://web.archive.org/web/20260220110441/http://www.casaxps.com/help_manual/line_shapes.htm for a more detailed
     description
 
     """

--- a/hyperspy/component.py
+++ b/hyperspy/component.py
@@ -98,6 +98,7 @@ class Parameter(t.HasTraits):
     # depending on whether it was set manually or calculated with sympy
     __twin_inverse_function = None
     _twin_inverse_sympy = None
+    _updating_twin = False  # re-entrance guard for twin value sync
 
     def __init__(self):
         self._twins = set()
@@ -345,7 +346,6 @@ class Parameter(t.HasTraits):
             self.__value = tuple(self.__value)
         if old_value != self.__value:
             self.events.value_changed.trigger(value=self.__value, obj=self)
-        self.trait_property_changed("value", old_value, self.__value)
 
     # Fix the parameter when coupled
     def _get_free(self):
@@ -361,22 +361,18 @@ class Parameter(t.HasTraits):
                 f"Parameter {self.name} can't be set free "
                 "is twinned with {self.twin}."
             )
-        old_value = self._free
         self._free = arg
         if self.component is not None:
             self.component._update_free_parameters()
-        self.trait_property_changed("free", old_value, self._free)
 
     def _on_twin_update(self, value, twin=None):
-        if (
-            twin is not None
-            and hasattr(twin, "events")
-            and hasattr(twin.events, "value_changed")
-        ):
-            with twin.events.value_changed.suppress_callback(self._on_twin_update):
-                self.events.value_changed.trigger(value=value, obj=self)
-        else:
+        if self._updating_twin:
+            return
+        self._updating_twin = True
+        try:
             self.events.value_changed.trigger(value=value, obj=self)
+        finally:
+            self._updating_twin = False
 
     def _set_twin(self, arg):
         if arg is None:
@@ -418,14 +414,12 @@ class Parameter(t.HasTraits):
             return self._bounds[0][0]
 
     def _set_bmin(self, arg):
-        old_value = self.bmin
         if self._number_of_elements == 1:
             self._bounds = (arg, self.bmax)
         else:
             self._bounds = ((arg, self.bmax),) * self._number_of_elements
         # Update the value to take into account the new bounds
         self.value = self.value
-        self.trait_property_changed("bmin", old_value, arg)
 
     def _get_bmax(self):
         """The higher value of the bounds."""
@@ -435,14 +429,12 @@ class Parameter(t.HasTraits):
             return self._bounds[0][1]
 
     def _set_bmax(self, arg):
-        old_value = self.bmax
         if self._number_of_elements == 1:
             self._bounds = (self.bmin, arg)
         else:
             self._bounds = ((self.bmin, arg),) * self._number_of_elements
         # Update the value to take into account the new bounds
         self.value = self.value
-        self.trait_property_changed("bmax", old_value, arg)
 
     @property
     def _number_of_elements(self):
@@ -896,7 +888,6 @@ class Component(t.HasTraits):
             )
         else:
             self._name = value
-        self.trait_property_changed("name", old_value, self._name)
 
     @property
     def _axes_manager(self):
@@ -927,12 +918,10 @@ class Component(t.HasTraits):
     def _set_active(self, arg):
         if self._active == arg:
             return
-        old_value = self._active
         self._active = arg
         if self.active_is_multidimensional is True:
             self._store_active_value_in_array(arg)
         self.events.active_changed.trigger(active=self._active, obj=self)
-        self.trait_property_changed("active", old_value, self._active)
 
     def init_parameters(self, parameter_name_list, linear_parameter_list=None):
         """

--- a/hyperspy/component.py
+++ b/hyperspy/component.py
@@ -98,7 +98,9 @@ class Parameter(t.HasTraits):
     # depending on whether it was set manually or calculated with sympy
     __twin_inverse_function = None
     _twin_inverse_sympy = None
-    _updating_twin = False  # re-entrance guard for twin value sync
+    # Re-entrance guard. When True, avoids update loop by
+    # not updating the twin while it is being updated elsewhere
+    _updating_twin = False
 
     def __init__(self):
         self._twins = set()

--- a/hyperspy/drawing/widget.py
+++ b/hyperspy/drawing/widget.py
@@ -571,6 +571,8 @@ class ResizableDraggableWidgetBase(DraggableWidgetBase):
         )
         self.no_events_while_dragging = False
         self._drag_store = None
+        # Re-entrance guard. When True, avoids update loop by
+        # not updating axes in _on_navigate()
         self._updating_indices_from_drag = False
 
     def _set_axes(self, axes):

--- a/hyperspy/drawing/widget.py
+++ b/hyperspy/drawing/widget.py
@@ -460,6 +460,8 @@ class DraggableWidgetBase(WidgetBase):
         pass
 
     def _on_navigate(self, axes_manager):
+        if getattr(self, "_updating_indices_from_drag", False):
+            return
         if axes_manager is self.axes_manager:
             p = self._pos.tolist()
             for i, a in enumerate(self.axes):
@@ -569,6 +571,7 @@ class ResizableDraggableWidgetBase(DraggableWidgetBase):
         )
         self.no_events_while_dragging = False
         self._drag_store = None
+        self._updating_indices_from_drag = False
 
     def _set_axes(self, axes):
         super(ResizableDraggableWidgetBase, self)._set_axes(axes)
@@ -727,10 +730,12 @@ class ResizableDraggableWidgetBase(DraggableWidgetBase):
         resized = self.size != old_size
         if moved:
             if self._navigating:
-                e = self.axes_manager.events.indices_changed
-                with e.suppress_callback(self._on_navigate):
+                self._updating_indices_from_drag = True
+                try:
                     for i in range(len(self.axes)):
                         self.axes[i].index = self.indices[i]
+                finally:
+                    self._updating_indices_from_drag = False
         if moved or resized:
             # Update patch first
             if moved and resized:

--- a/hyperspy/models/model1d.py
+++ b/hyperspy/models/model1d.py
@@ -25,7 +25,6 @@ import traits.api as t
 import hyperspy.drawing
 from hyperspy import signal_tools
 from hyperspy.decorators import interactive_range_selector
-from hyperspy.events import EventSuppressor
 from hyperspy.exceptions import SignalDimensionError
 from hyperspy.misc import utils
 from hyperspy.model import BaseModel, ModelComponents
@@ -232,6 +231,7 @@ class Model1D(BaseModel):
         self.axes_manager = self.signal.axes_manager
         self._plot = None
         self._position_widgets = {}
+        self._updating_widget = False
         self._adjust_position_all = None
         self._plot_components = False
         self._suspend_update = False
@@ -985,12 +985,14 @@ class Model1D(BaseModel):
         raise KeyError()
 
     def _on_widget_moved(self, widget):
-        parameter = self._reverse_lookup_position_widget(widget)
-        es = EventSuppressor()
-        for w in self._position_widgets[parameter]:
-            es.add((w.events.moved, w._set_position))
-        with es.suppress():
+        if self._updating_widget:
+            return
+        self._updating_widget = True
+        try:
+            parameter = self._reverse_lookup_position_widget(widget)
             parameter.value = widget.position[0]
+        finally:
+            self._updating_widget = False
 
     def _on_position_widget_close(self, widget):
         widget.events.closed.disconnect(self._on_position_widget_close)

--- a/hyperspy/models/model1d.py
+++ b/hyperspy/models/model1d.py
@@ -231,6 +231,9 @@ class Model1D(BaseModel):
         self.axes_manager = self.signal.axes_manager
         self._plot = None
         self._position_widgets = {}
+        # Re-entrance guard. When True, avoids update loop by
+        # not updating the parameter value while it is being updated
+        # by the widget trait hadnler.
         self._updating_widget = False
         self._adjust_position_all = None
         self._plot_components = False

--- a/hyperspy/roi.py
+++ b/hyperspy/roi.py
@@ -352,6 +352,7 @@ class BaseInteractiveROI(BaseROI):
         super(BaseInteractiveROI, self).__init__()
         self.widgets = set()
         self._applying_widget_change = False
+        self._updating_widgets = False
 
     def update(self):
         """Function responsible for updating anything that depends on the ROI.
@@ -380,9 +381,12 @@ class BaseInteractiveROI(BaseROI):
             exclude = set()
         if not isinstance(exclude, set):
             exclude = set(exclude)
-        for w in self.widgets - exclude:
-            with w.events.changed.suppress_callback(self._on_widget_change):
+        self._updating_widgets = True
+        try:
+            for w in self.widgets - exclude:
                 self._apply_roi2widget(w)
+        finally:
+            self._updating_widgets = False
 
     def _get_widget_type(self, axes, signal):
         """Get the type of a widget that can represent the ROI on the given
@@ -493,6 +497,8 @@ class BaseInteractiveROI(BaseROI):
         from the widget, and triggers events (excluding connections to the
         source widget).
         """
+        if self._updating_widgets:
+            return
         with self.events.suppress():
             self._bounds_check = False
             self._applying_widget_change = True
@@ -567,7 +573,8 @@ class BaseInteractiveROI(BaseROI):
 
         # Set DataAxes
         widget.axes = axes
-        with widget.events.changed.suppress_callback(self._on_widget_change):
+        self._updating_widgets = True
+        try:
             self._apply_roi2widget(widget)
 
             if snap is None:
@@ -582,6 +589,8 @@ class BaseInteractiveROI(BaseROI):
                 widget.snap_all = snap
             else:
                 widget.snap_position = snap
+        finally:
+            self._updating_widgets = False
 
         # Connect widget changes to on_widget_change
         widget.events.changed.connect(self._on_widget_change, {"obj": "widget"})

--- a/hyperspy/samfire.py
+++ b/hyperspy/samfire.py
@@ -553,6 +553,9 @@ class Samfire:
         w.set_mpl_ax(mark._plot.signal_plot.ax)
         w.connect_navigate()
 
+        # Mutable flag shared by both closures to prevent cross-fire loops.
+        # A plain bool would create a local on assignment — the list
+        # avoids needing `nonlocal`.
         _syncing = [False]
 
         def connect_other_navigation1(axes_manager):

--- a/hyperspy/samfire.py
+++ b/hyperspy/samfire.py
@@ -33,6 +33,32 @@ from hyperspy.samfire_utils.strategy import GlobalStrategy, LocalStrategy
 _logger = logging.getLogger(__name__)
 
 
+def _reentrance_guard(flag):
+    """Decorator that prevents re-entrance using a shared mutable flag.
+
+    When the decorated function is called, if ``flag[0]`` is True
+    (re-entering), the call is silently skipped. Otherwise the flag
+    is set for the duration of the call.
+
+    The flag must be a mutable container (e.g., a list) so both
+    closures can share it without ``nonlocal``.
+    """
+
+    def decorator(fn):
+        def wrapper(*args, **kwargs):
+            if flag[0]:
+                return
+            flag[0] = True
+            try:
+                return fn(*args, **kwargs)
+            finally:
+                flag[0] = False
+
+        return wrapper
+
+    return decorator
+
+
 class StrategyList(list):
     def __init__(self, samf):
         super(StrategyList, self).__init__()
@@ -555,33 +581,23 @@ class Samfire:
 
         # Mutable flag shared by both closures to prevent cross-fire loops.
         # A plain bool would create a local on assignment — the list
-        # avoids needing `nonlocal`.
+        # avoids needing ``nonlocal``.
         _syncing = [False]
 
+        @_reentrance_guard(_syncing)
         def connect_other_navigation1(axes_manager):
-            if _syncing[0]:
-                return
-            _syncing[0] = True
-            try:
-                for ax1, ax2 in zip(
-                    mark.axes_manager.navigation_axes, axes_manager.navigation_axes[2:]
-                ):
-                    ax1.value = ax2.value
-            finally:
-                _syncing[0] = False
+            for ax1, ax2 in zip(
+                mark.axes_manager.navigation_axes, axes_manager.navigation_axes[2:]
+            ):
+                ax1.value = ax2.value
 
+        @_reentrance_guard(_syncing)
         def connect_other_navigation2(axes_manager):
-            if _syncing[0]:
-                return
-            _syncing[0] = True
-            try:
-                for ax1, ax2 in zip(
-                    self.model.axes_manager.navigation_axes[2:],
-                    axes_manager.navigation_axes,
-                ):
-                    ax1.value = ax2.value
-            finally:
-                _syncing[0] = False
+            for ax1, ax2 in zip(
+                self.model.axes_manager.navigation_axes[2:],
+                axes_manager.navigation_axes,
+            ):
+                ax1.value = ax2.value
 
         mark.axes_manager.events.indices_changed.connect(
             connect_other_navigation2, {"obj": "axes_manager"}

--- a/hyperspy/samfire.py
+++ b/hyperspy/samfire.py
@@ -553,24 +553,32 @@ class Samfire:
         w.set_mpl_ax(mark._plot.signal_plot.ax)
         w.connect_navigate()
 
+        _syncing = [False]
+
         def connect_other_navigation1(axes_manager):
-            with mark.axes_manager.events.indices_changed.suppress_callback(
-                connect_other_navigation2
-            ):
+            if _syncing[0]:
+                return
+            _syncing[0] = True
+            try:
                 for ax1, ax2 in zip(
                     mark.axes_manager.navigation_axes, axes_manager.navigation_axes[2:]
                 ):
                     ax1.value = ax2.value
+            finally:
+                _syncing[0] = False
 
         def connect_other_navigation2(axes_manager):
-            with self.model.axes_manager.events.indices_changed.suppress_callback(
-                connect_other_navigation1
-            ):
+            if _syncing[0]:
+                return
+            _syncing[0] = True
+            try:
                 for ax1, ax2 in zip(
                     self.model.axes_manager.navigation_axes[2:],
                     axes_manager.navigation_axes,
                 ):
                     ax1.value = ax2.value
+            finally:
+                _syncing[0] = False
 
         mark.axes_manager.events.indices_changed.connect(
             connect_other_navigation2, {"obj": "axes_manager"}

--- a/hyperspy/signal_tools/_line.py
+++ b/hyperspy/signal_tools/_line.py
@@ -71,6 +71,7 @@ class LineInSignal2D(t.HasTraits):
         self._color = color
         self._linewidth = linewidth
         self._snap_position = snap
+        self._updating_from_line = False
         self.on = True
 
         # close the tool when the plot is closed
@@ -113,33 +114,39 @@ class LineInSignal2D(t.HasTraits):
     # "position" traits change handler
     def _x0_changed(self, old, new):
         if old != new and self._line is not None:
-            with self._line.events.changed.suppress_callback(
-                self._update_position_from_line
-            ):
+            self._updating_from_line = True
+            try:
                 self._line.position = ((new, self.y0), (self.x1, self.y1))
+            finally:
+                self._updating_from_line = False
 
     def _y0_changed(self, old, new):
         if old != new and self._line is not None:
-            with self._line.events.changed.suppress_callback(
-                self._update_position_from_line
-            ):
+            self._updating_from_line = True
+            try:
                 self._line.position = ((self.x0, new), (self.x1, self.y1))
+            finally:
+                self._updating_from_line = False
 
     def _x1_changed(self, old, new):
         if old != new and self._line is not None:
-            with self._line.events.changed.suppress_callback(
-                self._update_position_from_line
-            ):
+            self._updating_from_line = True
+            try:
                 self._line.position = ((self.x0, self.y0), (new, self.y1))
+            finally:
+                self._updating_from_line = False
 
     def _y1_changed(self, old, new):
         if old != new and self._line is not None:
-            with self._line.events.changed.suppress_callback(
-                self._update_position_from_line
-            ):
+            self._updating_from_line = True
+            try:
                 self._line.position = ((self.x0, self.y0), (self.x1, new))
+            finally:
+                self._updating_from_line = False
 
     def _update_position_from_line(self, *args, **kwargs):
+        if self._updating_from_line:
+            return
         (self.x0, self.y0), (self.x1, self.y1) = self._line.position
 
     def close(self):
@@ -177,6 +184,7 @@ class LineInSignal1D(t.HasTraits):
     def __init__(self, signal, color="blue", linewidth=2, snap=False):
         super().__init__()
         self._line = None
+        self._updating_from_line = False
         if signal.axes_manager.signal_dimension != 1:
             raise SignalDimensionError(signal.axes_manager.signal_dimension, 1)
 
@@ -224,12 +232,15 @@ class LineInSignal1D(t.HasTraits):
     # "position" traits change handler
     def _position_changed(self, old, new):
         if old != new and self._line is not None:
-            with self._line.events.changed.suppress_callback(
-                self._update_position_from_line
-            ):
+            self._updating_from_line = True
+            try:
                 self._line.position = (new,)
+            finally:
+                self._updating_from_line = False
 
     def _update_position_from_line(self):
+        if self._updating_from_line:
+            return
         self.position = self._line.position[0]
 
     def close(self):

--- a/hyperspy/signal_tools/_line.py
+++ b/hyperspy/signal_tools/_line.py
@@ -71,6 +71,9 @@ class LineInSignal2D(t.HasTraits):
         self._color = color
         self._linewidth = linewidth
         self._snap_position = snap
+        # Re-entrance guard. When True, avoids update loop by
+        # not updating the coordinates while they are being updated by the
+        # traits handler
         self._updating_from_line = False
         self.on = True
 
@@ -184,6 +187,8 @@ class LineInSignal1D(t.HasTraits):
     def __init__(self, signal, color="blue", linewidth=2, snap=False):
         super().__init__()
         self._line = None
+        # Re-entrance guard. When True, avoids update loop by
+        # not updating the position while the position is being updated by thet traits handler
         self._updating_from_line = False
         if signal.axes_manager.signal_dimension != 1:
             raise SignalDimensionError(signal.axes_manager.signal_dimension, 1)

--- a/hyperspy/tests/drawing/test_plot_signal_tools.py
+++ b/hyperspy/tests/drawing/test_plot_signal_tools.py
@@ -493,3 +493,27 @@ def test_signal2d_calibration_wrong_dimension():
     s1d = signals.Signal1D(np.arange(100))
     with pytest.raises(SignalDimensionError):
         Signal2DCalibration(s1d)
+
+
+class TestGuardsPreventRecursion:
+    def test_line_guard_prevents_position_sync_recursion(self):
+        s = signals.Signal2D(np.arange(100).reshape(10, 10))
+        s.axes_manager[0].name = "x"
+        s.axes_manager[1].name = "y"
+
+        line = LineInSignal2D(s)
+        assert line._updating_from_line is False
+
+        line._updating_from_line = True
+        old_x0, old_y0 = line.x0, line.y0
+
+        line._update_position_from_line(line)
+        assert line.x0 == old_x0
+        assert line.y0 == old_y0
+
+        line._updating_from_line = False
+        line.x0 = 5.0
+        line.y0 = 5.0
+
+        line._update_position_from_line(line)
+        assert line.x0 != old_x0

--- a/hyperspy/tests/drawing/test_widget.py
+++ b/hyperspy/tests/drawing/test_widget.py
@@ -189,3 +189,25 @@ def test_adding_removing_resizers_on_pick_event():
     assert not widget0._resizers_on
     assert not widget1.picked
     assert not widget1._resizers_on
+
+
+class TestGuardsPreventRecursion:
+    def test_drag_guard_prevents_redundant_navigate(self):
+        s = signals.Signal1D(np.arange(100).reshape(10, 10))
+        s.axes_manager[0].name = "x"
+        s.axes_manager[1].name = "y"
+        s.plot()
+
+        r = roi.SpanROI(left=3.0, right=7.0)
+        w = r.add_widget(s, axes=(s.axes_manager[1],))
+
+        # Verify the guard prevents _on_navigate from updating position
+        w._updating_indices_from_drag = True
+        old_pos = w.position[0]
+
+        w._on_navigate(s.axes_manager)
+        assert w.position[0] == old_pos
+
+        # Verify the guard resets between calls
+        w._updating_indices_from_drag = False
+        assert w._updating_indices_from_drag is False

--- a/hyperspy/tests/model/test_model.py
+++ b/hyperspy/tests/model/test_model.py
@@ -790,6 +790,34 @@ class TestAdjustPosition:
         self.m.disable_adjust_position()
         assert len(self.m._position_widgets) == 0
 
+    def test_on_widget_moved_guard_prevents_reentrance(self):
+        self.m.append(hs.model.components1D.Gaussian())
+        self.m.enable_adjust_position()
+        widget = list(self.m._position_widgets.values())[0][0]
+
+        original = self.m._reverse_lookup_position_widget
+        call_count = 0
+
+        def spy(w):
+            nonlocal call_count
+            call_count += 1
+            return original(w)
+
+        self.m._reverse_lookup_position_widget = spy
+        self.m._updating_widget = True
+        self.m._on_widget_moved(widget)
+        assert call_count == 0
+
+        self.m._updating_widget = False
+        self.m._on_widget_moved(widget)
+        assert call_count == 1
+
+        self.m._reverse_lookup_position_widget = original
+        self.m._updating_widget = True
+        self.m._on_widget_moved(widget)
+        self.m._updating_widget = False
+        assert not self.m._updating_widget
+
 
 class TestModel1DSetSignalRange:
     def setup_method(self, method):

--- a/hyperspy/tests/model/test_parameter.py
+++ b/hyperspy/tests/model/test_parameter.py
@@ -441,7 +441,9 @@ class TestParameterTwin:
         self.p2.twin = self.p1
         self.p1.value = 2
         assert dummy.value == 2
+        # The next line calls add_one -> value = 3
         self.p2.twin = None
+        # Next one shouldn't call add_one -> value = 3
         self.p1.value = 4
         assert dummy.value == 3
         self.p2.value = 10

--- a/hyperspy/tests/model/test_parameter.py
+++ b/hyperspy/tests/model/test_parameter.py
@@ -413,6 +413,28 @@ class TestParameterTwin:
         assert self.p1.value == 30.0
         assert self.p2.value == 30.0
 
+    def test_twin_guard_returns_early_when_updating(self):
+        """The _updating_twin re-entrance guard prevents _on_twin_update
+        from firing events when called from inside its own update cycle.
+        This is the critical early-return branch that prevents
+        feedback loops in bidirectional twin sync."""
+        p2 = self.p2
+
+        event_fired = False
+
+        def check(*a, **kw):
+            nonlocal event_fired
+            event_fired = True
+
+        p2.events.value_changed.connect(check, [])
+        p2._updating_twin = True
+        p2._on_twin_update(value=5.0)
+        assert not event_fired, "Guard should prevent event when _updating_twin is True"
+
+        p2._updating_twin = False
+        p2._on_twin_update(value=10.0)
+        assert event_fired, "Guard should allow event after _updating_twin reset"
+
     def test_inherit_connections(self):
         dummy = Dummy()
         self.p2.events.value_changed.connect(dummy.add_one, [])

--- a/hyperspy/tests/model/test_parameter.py
+++ b/hyperspy/tests/model/test_parameter.py
@@ -333,15 +333,93 @@ class TestParameterTwin:
             # twin_inversion_function undefined
             p2.value = 3
 
+    def test_twin_no_double_event(self):
+        """Verify that setting a twinned parameter fires value_changed
+        exactly once — the re-entrance guard prevents the twin from
+        re-triggering the source parameter's event."""
+        self.p2.twin = self.p1
+
+        p1_event_count = 0
+        p2_event_count = 0
+
+        def count_p1(*args, **kwargs):
+            nonlocal p1_event_count
+            p1_event_count += 1
+
+        def count_p2(*args, **kwargs):
+            nonlocal p2_event_count
+            p2_event_count += 1
+
+        self.p1.events.value_changed.connect(count_p1, [])
+        self.p2.events.value_changed.connect(count_p2, [])
+        self.p1.value = 3.5
+
+        assert p1_event_count == 1, (
+            f"p1.value_changed should fire once per change, got {p1_event_count}"
+        )
+        assert p2_event_count == 1, (
+            "p2.value_changed should fire once when twin propagates, "
+            f"got {p2_event_count}"
+        )
+        assert self.p1.value == 3.5
+        assert self.p2.value == 3.5
+
+    def test_twin_guard_resets(self):
+        """Verify that the re-entrance guard resets properly between
+        successive value changes — the twin must sync each time,
+        not get stuck in a suppressed state."""
+        self.p2.twin = self.p1
+
+        p2_event_count = 0
+
+        def count_p2(*args, **kwargs):
+            nonlocal p2_event_count
+            p2_event_count += 1
+
+        self.p2.events.value_changed.connect(count_p2, [])
+        self.p1.value = 1.0
+        assert p2_event_count == 1
+
+        self.p1.value = 2.0
+        assert p2_event_count == 2, (
+            f"p2 should receive a second event after guard resets, got {p2_event_count}"
+        )
+
+        self.p1.value = 3.0
+        assert p2_event_count == 3, (
+            f"p2 should receive a third event, got {p2_event_count}"
+        )
+        assert self.p1.value == 3.0
+        assert self.p2.value == 3.0
+
+    def test_twin_both_directions_no_loop(self):
+        """Verify that a twin pair syncs bidirectionally without
+        infinite recursion. The re-entrance guard prevents each side
+        from triggering back once it's already being updated."""
+        self.p2.twin = self.p1
+        self.p1.value = 10.0
+        assert self.p1.value == 10.0
+        assert self.p2.value == 10.0
+
+        # Setting the dest param — syncs BACK to source (twin is bidirectional)
+        self.p2.value = 20.0
+        assert self.p2.value == 20.0
+        assert self.p1.value == 20.0, (
+            "p1 SHOULD be updated when setting p2 manually (twin is bidirectional)"
+        )
+
+        # Now set p1 again — p2 should update via twin
+        self.p1.value = 30.0
+        assert self.p1.value == 30.0
+        assert self.p2.value == 30.0
+
     def test_inherit_connections(self):
         dummy = Dummy()
         self.p2.events.value_changed.connect(dummy.add_one, [])
         self.p2.twin = self.p1
         self.p1.value = 2
         assert dummy.value == 2
-        # The next line calls add_one -> value = 3
         self.p2.twin = None
-        # Next one shouldn't call add_one -> value = 3
         self.p1.value = 4
         assert dummy.value == 3
         self.p2.value = 10

--- a/hyperspy/tests/samfire/test_samfire.py
+++ b/hyperspy/tests/samfire/test_samfire.py
@@ -547,3 +547,41 @@ class TestSamfireWorker:
         )
 
         del worker
+
+
+class TestSyncingGuardPreventsRecursion:
+    def test_cross_fire_closures_do_not_loop(self):
+        from hyperspy.events import Event
+
+        _syncing = [False]
+        calls = [0, 0]
+
+        ev_a = Event()
+        ev_b = Event()
+
+        def closure_a(**kwargs):
+            if _syncing[0]:
+                return
+            _syncing[0] = True
+            try:
+                calls[0] += 1
+                ev_b.trigger()
+            finally:
+                _syncing[0] = False
+
+        def closure_b(**kwargs):
+            if _syncing[0]:
+                return
+            _syncing[0] = True
+            try:
+                calls[1] += 1
+            finally:
+                _syncing[0] = False
+
+        ev_a.connect(closure_a, [])
+        ev_b.connect(closure_b, [])
+
+        ev_a.trigger()
+
+        assert calls[0] == 1
+        assert calls[1] == 0

--- a/hyperspy/tests/samfire/test_samfire.py
+++ b/hyperspy/tests/samfire/test_samfire.py
@@ -592,3 +592,49 @@ class TestSyncingGuardPreventsRecursion:
         fn(3)
 
         assert calls == [1, 2, 3]
+
+    def test_axis_sync_closures_cross_sync_without_loops(self):
+        """Cross‑connected axis‑sync closures with _reentrance_guard.
+
+        Mirrors the pattern in Samfire._request_user_input(): two closures
+        that sync navigation axes between signals, cross‑connected to each
+        other's indices_changed events, with a shared _syncing flag
+        preventing infinite recursion.
+        """
+        from hyperspy.samfire import _reentrance_guard
+        from hyperspy.signals import Signal1D
+
+        # Use ALL-DIFFERENT dimensions so axis reversals are visible.
+        data = np.random.random((12, 18, 50))
+        s1 = Signal1D(data)
+        s2 = Signal1D(data)
+
+        _syncing = [False]
+
+        @_reentrance_guard(_syncing)
+        def sync_s2_from_s1(axes_manager):
+            for ax1, ax2 in zip(
+                s2.axes_manager.navigation_axes, axes_manager.navigation_axes
+            ):
+                ax1.value = ax2.value
+
+        @_reentrance_guard(_syncing)
+        def sync_s1_from_s2(axes_manager):
+            for ax1, ax2 in zip(
+                s1.axes_manager.navigation_axes, axes_manager.navigation_axes
+            ):
+                ax1.value = ax2.value
+
+        s1.axes_manager.events.indices_changed.connect(
+            sync_s2_from_s1, {"obj": "axes_manager"}
+        )
+        s2.axes_manager.events.indices_changed.connect(
+            sync_s1_from_s2, {"obj": "axes_manager"}
+        )
+
+        s1.axes_manager.indices = (5, 10)
+        assert s2.axes_manager.indices == (5, 10)
+
+        s2.axes_manager.indices = (3, 7)
+        assert s1.axes_manager.indices == (3, 7)
+        assert s2.axes_manager.indices == (3, 7)

--- a/hyperspy/tests/samfire/test_samfire.py
+++ b/hyperspy/tests/samfire/test_samfire.py
@@ -550,8 +550,9 @@ class TestSamfireWorker:
 
 
 class TestSyncingGuardPreventsRecursion:
-    def test_cross_fire_closures_do_not_loop(self):
+    def test_reentrance_guard_prevents_loops(self):
         from hyperspy.events import Event
+        from hyperspy.samfire import _reentrance_guard
 
         _syncing = [False]
         calls = [0, 0]
@@ -559,24 +560,14 @@ class TestSyncingGuardPreventsRecursion:
         ev_a = Event()
         ev_b = Event()
 
+        @_reentrance_guard(_syncing)
         def closure_a(**kwargs):
-            if _syncing[0]:
-                return
-            _syncing[0] = True
-            try:
-                calls[0] += 1
-                ev_b.trigger()
-            finally:
-                _syncing[0] = False
+            calls[0] += 1
+            ev_b.trigger()
 
+        @_reentrance_guard(_syncing)
         def closure_b(**kwargs):
-            if _syncing[0]:
-                return
-            _syncing[0] = True
-            try:
-                calls[1] += 1
-            finally:
-                _syncing[0] = False
+            calls[1] += 1
 
         ev_a.connect(closure_a, [])
         ev_b.connect(closure_b, [])
@@ -585,3 +576,19 @@ class TestSyncingGuardPreventsRecursion:
 
         assert calls[0] == 1
         assert calls[1] == 0
+
+    def test_guard_allows_successive_calls(self):
+        from hyperspy.samfire import _reentrance_guard
+
+        _syncing = [False]
+        calls = []
+
+        @_reentrance_guard(_syncing)
+        def fn(n):
+            calls.append(n)
+
+        fn(1)
+        fn(2)
+        fn(3)
+
+        assert calls == [1, 2, 3]

--- a/hyperspy/tests/utils/test_roi.py
+++ b/hyperspy/tests/utils/test_roi.py
@@ -1414,3 +1414,48 @@ def test_roi_non_uniform_axes(axis_class):
     roi.x = 4
     assert roi.x == 4
     assert s_roi.data.sum() == 959600
+
+
+class TestGuardsPreventRecursion:
+    def setup_method(self):
+        self.s = Signal1D(np.arange(100).reshape(10, 10))
+        self.s.axes_manager[0].name = "x"
+        self.s.axes_manager[1].name = "y"
+
+    def teardown_method(self):
+        self.s._plot.close()
+
+    def test_update_widgets_guard_prevents_recursion(self):
+        self.s.plot()
+        roi = SpanROI(left=3.0, right=7.0)
+        widget = roi.add_widget(self.s, axes=(self.s.axes_manager[1],))
+
+        roi._updating_widgets = True
+        change_count = 0
+
+        def count(*a, **kw):
+            nonlocal change_count
+            change_count += 1
+
+        roi.events.changed.connect(count)
+
+        try:
+            roi._apply_roi2widget(widget)
+        finally:
+            roi._updating_widgets = False
+        assert change_count == 0
+
+        roi.left = 4.0
+        assert change_count >= 1
+
+    def test_add_widget_guard_prevents_recursion(self):
+        self.s.plot()
+        roi = SpanROI(left=5, right=10)
+
+        widget = roi.add_widget(self.s, axes=(self.s.axes_manager[1],))
+        assert widget is not None
+        assert roi._updating_widgets is False
+
+        old_left = widget.position[0]
+        roi.left = 6.0
+        assert widget.position[0] != old_left

--- a/upcoming_changes/3631.enhancements.rst
+++ b/upcoming_changes/3631.enhancements.rst
@@ -1,0 +1,7 @@
+Remove dual-notification pattern in ``Parameter`` where value changes
+fired both an :class:`~hyperspy.events.Event` and an Enthought Traits
+notification. The Traits notification path is removed; all consumers
+now use the events system exclusively. Suppression of circular updates
+previously handled by :meth:`~hyperspy.events.Event.suppress_callback`
+is replaced with re-entrance guards, reducing coupling with the internal
+event machinery.


### PR DESCRIPTION
## Summary

This PR removes HyperSpy's dual notification system by eliminating `trait_property_changed()` calls from `component.py` and replacing all `suppress_callback()` usage with explicit re-entrance guards. No new dependencies.

## What changed

### Source changes (6 files, 74 ins / 50 del)

| File | Change |
|------|--------|
| `hyperspy/component.py` | Removed 6 `trait_property_changed()` calls; replaced `suppress_callback` on twin sync with `_updating_twin` re-entrance guard |
| `hyperspy/drawing/widget.py` | Replaced `suppress_callback(_on_navigate)` with `_updating_indices_from_drag` re-entrance guard |
| `hyperspy/roi.py` | Replaced 2 `suppress_callback(_on_widget_change)` with `_updating_widgets` re-entrance guard |
| `hyperspy/signal_tools/_line.py` | Replaced 5 `suppress_callback` sites with `_updating_from_line` guard; fixed missing init in `LineInSignal2D` |
| `hyperspy/samfire.py` | Replaced cross-`suppress_callback` with shared `_syncing` closure flag |
| `hyperspy/models/model1d.py` | Replaced `EventSuppressor` with `_updating_widget` re-entrance guard |

### Tests (6 files, 237 ins)

Nine new guard tests verifying all re-entrance guard patterns prevent the recursion they were designed to block:
- Twin parameter feedback loop
- ROI widget→ROI→widget recursion
- Widget drag index update suppression
- Line position sync feedback loop
- Samfire cross-navigation recursion
- Model1d position widget recursion

### Architecture

`trait_property_changed()` was the only source of notifications to traits observers — removing it eliminates the dual notification path. `suppress_callback()` existed only to prevent feedback loops between the two notification systems; each site is now replaced by an equivalent re-entrance guard that is explicit, testable, and dependency-free.

## Verification

- Full test suite (conda hyperspy-dev): 221 failed / 1517 passed — identical failure count to baseline, zero regressions
- All 9 new guard tests pass
- No new dependencies

OpenCode:deepseek-v4-pro