### PR TITLE
Fix residual line not updated by update_plot and not suppressed during suspend_update

### DIFF
--- a/hyperspy/model.py
+++ b/hyperspy/model.py
@@ -1020,6 +1020,10 @@ class BaseModel(list):
                     self._model_line.update(
                         render_figure=render_figure, update_ylimits=update_ylimits
                     )
+                if self._residual_line is not None:
+                    self._residual_line.update(
+                        render_figure=render_figure, update_ylimits=update_ylimits
+                    )
                 if self._plot_components:
                     for component in self.active_components:
                         self._update_component_line(component)
@@ -1043,6 +1047,13 @@ class BaseModel(list):
                 es.add(c.events, f)
                 if c._position:
                     es.add(c._position.events)
+                for p in c.parameters:
+                    es.add(p.events, f)
+
+        if self._residual_line:
+            f = self._residual_line._auto_update_line
+            for c in self:
+                es.add(c.events, f)
                 for p in c.parameters:
                     es.add(p.events, f)
 

--- a/hyperspy/tests/drawing/test_plot_model1d.py
+++ b/hyperspy/tests/drawing/test_plot_model1d.py
@@ -16,6 +16,8 @@
 # You should have received a copy of the GNU General Public License
 # along with HyperSpy. If not, see <https://www.gnu.org/licenses/#GPL>.
 
+from unittest.mock import patch
+
 import numpy as np
 import pytest
 
@@ -97,3 +99,40 @@ class TestModelPlot:
             assert len(p.events.value_changed.connected) == 0
         assert self.m._model_line is None
         assert self.m._residual_line is None
+
+    def test_update_plot_updates_residual(self):
+        self.m.plot(plot_residual=True)
+        residual_line = self.m._residual_line
+        assert residual_line is not None
+        with patch.object(residual_line, "update", wraps=residual_line.update) as mock:
+            self.m.update_plot()
+            mock.assert_called_once()
+        self.m._plot.close()
+
+    def test_update_plot_no_residual(self):
+        self.m.plot(plot_residual=False)
+        assert self.m._residual_line is None
+        self.m.update_plot()
+        self.m._plot.close()
+
+    def test_suspend_update_updates_residual_on_resume(self):
+        self.m.plot(plot_residual=True)
+        residual_line = self.m._residual_line
+        assert residual_line is not None
+        with patch.object(residual_line, "update", wraps=residual_line.update) as mock:
+            with self.m.suspend_update():
+                self.m[0].a.value = 2.0
+            mock.assert_called_once()
+        self.m._plot.close()
+
+    def test_suspend_update_suppresses_residual_events(self):
+        self.m.plot(plot_residual=True)
+        residual_line = self.m._residual_line
+        assert residual_line is not None
+        with patch.object(residual_line, "update", wraps=residual_line.update) as mock:
+            with self.m.suspend_update():
+                self.m[0].a.value = 3.0
+                self.m[0].a.value = 4.0
+                mock.assert_not_called()
+            mock.assert_called_once()
+        self.m._plot.close()

--- a/upcoming_changes/3635.bugfix.rst
+++ b/upcoming_changes/3635.bugfix.rst
@@ -1,1 +1,1 @@
-Fix residual line not being updated by :meth:`~.model.BaseModel.update_plot` and not having its events suppressed during :meth:`~.model.BaseModel.suspend_update`, which could leave the residual stale after batched parameter changes.
+Fix residual line not being updated by ``update_plot`` and not having its events suppressed during ``suspend_update``, which could leave the residual stale after batched parameter changes.

--- a/upcoming_changes/3635.bugfix.rst
+++ b/upcoming_changes/3635.bugfix.rst
@@ -1,0 +1,1 @@
+Fix residual line not being updated by :meth:`~.model.BaseModel.update_plot` and not having its events suppressed during :meth:`~.model.BaseModel.suspend_update`, which could leave the residual stale after batched parameter changes.


### PR DESCRIPTION
## Description

`update_plot()` only refreshes the model line, but not the residual line. `suspend_update()` only suppresses events for the model line, but not for the residual line. This PR fixes both inconsistencies.

### Fix 1 — update_plot()
Add `_residual_line.update()` call, guarded by `if self._residual_line is not None`, mirroring the model line call.

### Fix 2 — suspend_update()
Add `_residual_line._auto_update_line` to the `EventSuppressor`, mirroring the model line event suppression.

### Tests
Added 4 tests to `test_plot_model1d.py`:
- `test_update_plot_updates_residual`
- `test_update_plot_no_residual`
- `test_suspend_update_updates_residual_on_resume`
- `test_suspend_update_suppresses_residual_events`

Closes #3635