### PR TITLE
Fix Model2D not initializing _residual_line

### DIFF
--- a/hyperspy/models/model2d.py
+++ b/hyperspy/models/model2d.py
@@ -91,6 +91,10 @@ class Model2D(BaseModel):
         self._plot_components = False
         self._suspend_update = False
         self._model_line = None
+        # _residual_line is referenced by BaseModel.update_plot() and
+        # _connect_parameters2update_plot(); Model1D initializes it in its
+        # own __init__, so Model2D must do the same to avoid AttributeError.
+        self._residual_line = None
         self.xaxis, self.yaxis = np.meshgrid(
             self.axes_manager.signal_axes[0].axis, self.axes_manager.signal_axes[1].axis
         )

--- a/hyperspy/tests/model/test_model2d.py
+++ b/hyperspy/tests/model/test_model2d.py
@@ -300,3 +300,9 @@ class TestModel2DSetSignalRange:
     def test_initial_mask(self):
         m = self.m
         assert m._channel_switches.shape == (10, 20)
+
+
+def test_residual_line_initialized():
+    s = hs.signals.Signal2D(np.ones((5, 7, 13, 15)))
+    m = s.create_model()
+    assert m._residual_line is None

--- a/upcoming_changes/3637.bugfix.rst
+++ b/upcoming_changes/3637.bugfix.rst
@@ -1,4 +1,4 @@
 Fix ``AttributeError`` when ``BaseModel`` code references ``_residual_line`` on
-:class:`~.models.model2d.Model2D` instances, which never initialized this
-attribute (only :class:`~.models.model1d.Model1D` did).
+``Model2D`` instances, which never initialized this attribute (only
+``Model1D`` did).
 

--- a/upcoming_changes/3637.bugfix.rst
+++ b/upcoming_changes/3637.bugfix.rst
@@ -1,0 +1,4 @@
+Fix ``AttributeError`` when ``BaseModel`` code references ``_residual_line`` on
+:class:`~.models.model2d.Model2D` instances, which never initialized this
+attribute (only :class:`~.models.model1d.Model1D` did).
+


### PR DESCRIPTION
## Description

`Model2D.__init__()` never initialized `_residual_line`, unlike `Model1D.__init__()`. When `BaseModel.update_plot()` or `_connect_parameters2update_plot()` reference `_residual_line`, it raises `AttributeError`.

### Fix

Add `self._residual_line = None` to `Model2D.__init__()`.

### Test

Added `test_residual_line_initialized` to verify the attribute exists after construction.

Closes #3637