### PR TITLE
Fix duplicate key_press handlers and blit-bypass in ImagePlot

### DIFF
--- a/hyperspy/drawing/image.py
+++ b/hyperspy/drawing/image.py
@@ -117,6 +117,10 @@ class ImagePlot(BlittedFigure):
         self._auto_scalebar = False
         self._user_axes_ticks = None
         self._auto_axes_ticks = True
+        # Store mpl_connect cid so we can disconnect before reconnecting;
+        # unlike Event.connect which deduplicates via connected list,
+        # canvas.mpl_connect always creates a new handler each call.
+        self._key_press_cid = None
         self._is_rgb = False
 
     @property
@@ -619,7 +623,11 @@ class ImagePlot(BlittedFigure):
     def connect(self):
         # in case the figure is not displayed
         if self.figure is not None:
-            self.figure.canvas.mpl_connect("key_press_event", self.on_key_press)
+            if self._key_press_cid is not None:
+                self.figure.canvas.mpl_disconnect(self._key_press_cid)
+            self._key_press_cid = self.figure.canvas.mpl_connect(
+                "key_press_event", self.on_key_press
+            )
         if self.axes_manager:
             if self.update not in self.axes_manager.events.indices_changed.connected:
                 self.axes_manager.events.indices_changed.connect(self.update, [])
@@ -643,7 +651,9 @@ class ImagePlot(BlittedFigure):
         if self.colorbar:
             self._colorbar.remove()
             self._add_colorbar()
-            self.figure.canvas.draw_idle()
+            # Use render_figure instead of canvas.draw_idle() to go through the
+            # blit render pipeline when supported (see BlittedFigure.render_figure).
+            self.figure.render_figure()
 
     def set_quantity_label(self):
         if "power_spectrum" in self.data_function_kwargs.keys():

--- a/upcoming_changes/3641.bugfix.rst
+++ b/upcoming_changes/3641.bugfix.rst
@@ -1,1 +1,1 @@
-Fix duplicate ``key_press_event`` handler accumulation on repeated ``connect()`` calls in :class:`~.drawing.image.ImagePlot`, and use blit-aware rendering in :meth:`~.drawing.image.ImagePlot.toggle_norm` instead of bypassing the blit pipeline with ``canvas.draw_idle()``.
+Fix duplicate ``key_press_event`` handler accumulation on repeated ``connect()`` calls in ``ImagePlot``, and use blit-aware rendering in ``toggle_norm`` instead of bypassing the blit pipeline with ``canvas.draw_idle()``.

--- a/upcoming_changes/3641.bugfix.rst
+++ b/upcoming_changes/3641.bugfix.rst
@@ -1,0 +1,1 @@
+Fix duplicate ``key_press_event`` handler accumulation on repeated ``connect()`` calls in :class:`~.drawing.image.ImagePlot`, and use blit-aware rendering in :meth:`~.drawing.image.ImagePlot.toggle_norm` instead of bypassing the blit pipeline with ``canvas.draw_idle()``.


### PR DESCRIPTION
## Description

Two fixes in `hyperspy/drawing/image.py`:

### Fix A — Duplicate key_press handlers
Store the `mpl_connect` cid as `self._key_press_cid`. Before creating a new connection, disconnect the previous one. This prevents handler accumulation on repeated `connect()` calls. Unlike HyperSpy's `Event.connect()` which deduplicates via the `connected` list, `canvas.mpl_connect` has no built-in deduplication — hence the manual guard.

### Fix B — toggle_norm() blit bypass
Replace `canvas.draw_idle()` with `figure.render_figure()` in `toggle_norm()`. `ImagePlot` extends `BlittedFigure` which provides `render_figure()` — this goes through the blit render pipeline when supported instead of bypassing it with a raw canvas draw.

### Non-obvious code
Both changes include inline comments explaining the rationale:
- Why `mpl_connect` needs manual deduplication while `Event.connect` doesn't
- Why `render_figure()` is needed instead of `draw_idle()` (blit pipeline bypass)

Closes #3641