### PR TITLE
Fix inverted disconnect logic in _remove_widget

### DIFF
--- a/hyperspy/roi.py
+++ b/hyperspy/roi.py
@@ -599,11 +599,12 @@ class BaseInteractiveROI(BaseROI):
         widget.close(render_figure=render_figure)
         for signal, w in self.signal_map.items():
             if w[0] == widget:
+                # Disconnect before break: only the matching signal's handler
+                # needs cleanup, and break would skip it if placed after.
+                if self.update in signal.axes_manager.events.any_axis_changed.connected:
+                    signal.axes_manager.events.any_axis_changed.disconnect(self.update)
                 self.signal_map.pop(signal)
                 break
-            # disconnect events which has been added when
-            if self.update in signal.axes_manager.events.any_axis_changed.connected:
-                signal.axes_manager.events.any_axis_changed.disconnect(self.update)
 
     def remove_widget(self, signal=None, render_figure=True):
         """

--- a/upcoming_changes/3643.bugfix.rst
+++ b/upcoming_changes/3643.bugfix.rst
@@ -1,0 +1,1 @@
+Fix inverted disconnect logic in :meth:`~.roi.BaseInteractiveROI._remove_widget`: the :attr:`~.axes.AxesManager.any_axis_changed` handler was disconnected from the wrong signal (non-matching ones) and never disconnected from the matching signal, due to a misplaced ``break`` in the iteration.

--- a/upcoming_changes/3643.bugfix.rst
+++ b/upcoming_changes/3643.bugfix.rst
@@ -1,1 +1,1 @@
-Fix inverted disconnect logic in :meth:`~.roi.BaseInteractiveROI._remove_widget`: the :attr:`~.axes.AxesManager.any_axis_changed` handler was disconnected from the wrong signal (non-matching ones) and never disconnected from the matching signal, due to a misplaced ``break`` in the iteration.
+Fix inverted disconnect logic in ``_remove_widget``: the ``any_axis_changed`` handler was disconnected from the wrong signal (non-matching ones) and never disconnected from the matching signal, due to a misplaced ``break`` in the iteration.


### PR DESCRIPTION
## Description

The `any_axis_changed` disconnect in `BaseInteractiveROI._remove_widget()` was placed after `break` in the iteration loop, which meant:

- The **matching** widget's signal handler was never disconnected (leak)
- **Non-matching** signals' handlers were incorrectly disconnected

**Fix**: Move the disconnect inside the `if w[0] == widget:` block, before `break`, so only the correct signal's handler is cleaned up.

### Before
```python
for signal, w in self.signal_map.items():
    if w[0] == widget:
        self.signal_map.pop(signal)
        break  # ← disconnect on lines below never reached for match
    if self.update in signal.axes_manager.events.any_axis_changed.connected:
        signal.axes_manager.events.any_axis_changed.disconnect(self.update)
```

### After
```python
for signal, w in self.signal_map.items():
    if w[0] == widget:
        # Disconnect before break: only the matching signal's handler
        # needs cleanup, and break would skip it if placed after.
        if self.update in signal.axes_manager.events.any_axis_changed.connected:
            signal.axes_manager.events.any_axis_changed.disconnect(self.update)
        self.signal_map.pop(signal)
        break
```

Closes #3643