### PR TITLE
Add close() method to Interactive class

### DIFF
--- a/doc/user_guide/interactive_operations.rst
+++ b/doc/user_guide/interactive_operations.rst
@@ -40,3 +40,27 @@ Interactive operations can be performed in a chain.
     >>> s.events.data_changed.trigger(obj=s)
     >>> ssum_mean.data
     array([300.,  330.,  360.,  390.])
+
+.. _interactive_cleanup-label:
+
+Cleaning up
+===========
+
+When an interactive operation is no longer needed, call the
+``Interactive.close`` method to disconnect all
+event handlers and release internal references. This prevents the
+operation from continuing to respond to changes in the original signal
+and avoids leaking memory through lingering event callbacks.
+
+.. code-block:: python
+
+    >>> from hyperspy.interactive import Interactive
+    >>> s = hs.signals.Signal1D(np.arange(10.))
+    >>> ssum = Interactive(s.sum, axis=0)
+    >>> ssum.out.data
+    array([45.])
+    >>> s.data /= 10
+    >>> ssum.close()
+    >>> s.events.data_changed.trigger(s)
+    >>> ssum.out.data  # no change after close
+    array([45.])

--- a/hyperspy/interactive.py
+++ b/hyperspy/interactive.py
@@ -29,6 +29,19 @@ def _connect_events(event, to_connect):
         event.connect(to_connect, [])
 
 
+def _disconnect_events(event, to_disconnect):
+    """Disconnect a callable from one or more events.
+
+    Mirrors :func:`_connect_events` — handles both single events and
+    iterables of events.
+    """
+    try:
+        for ev in event:
+            ev.disconnect(to_disconnect)
+    except TypeError:
+        event.disconnect(to_disconnect)
+
+
 class Interactive:
     r"""
     Chainable operations on Signals that update on events. The operation
@@ -99,6 +112,9 @@ class Interactive:
             recompute_out_event = (
                 None if recompute_out_event == "auto" else recompute_out_event
             )
+        self._event = event
+        self._recompute_out_event = recompute_out_event
+        self._has_out = has_out
         if recompute_out_event:
             _connect_events(recompute_out_event, self.recompute_out)
         if event:
@@ -122,6 +138,36 @@ class Interactive:
 
     def update(self):
         self.f(*self.args, out=self.out, **self.kwargs)
+
+    def close(self):
+        """Disconnect all event handlers and release internal references.
+
+        After calling this method, the operation will no longer respond to
+        any previously connected events. The ``out`` attribute remains
+        accessible for reading the last computed result.
+
+        Examples
+        --------
+        >>> from hyperspy.interactive import Interactive
+        >>> s = hs.signals.Signal1D(np.arange(10.))
+        >>> op = Interactive(s.sum, event=None, recompute_out_event=None, axis=0)
+        >>> op.close()
+        >>> op.out.data
+        array([45.])
+        """
+        # Disconnect event handlers to prevent handler leaks — the
+        # Interactive object would otherwise remain reachable through
+        # the event system's internal callback registries and could
+        # never be garbage-collected.
+        if self._recompute_out_event:
+            _disconnect_events(self._recompute_out_event, self.recompute_out)
+        if self._event:
+            if self._has_out:
+                _disconnect_events(self._event, self.update)
+            else:
+                _disconnect_events(self._event, self.recompute_out)
+        self._event = None
+        self._recompute_out_event = None
 
 
 def interactive(f, event="auto", recompute_out_event="auto", *args, **kwargs):

--- a/hyperspy/tests/test_interactive.py
+++ b/hyperspy/tests/test_interactive.py
@@ -25,6 +25,7 @@ import pytest
 
 import hyperspy.api as hs
 from hyperspy.events import Event
+from hyperspy.interactive import Interactive
 
 
 class TestInteractive:
@@ -148,3 +149,54 @@ class TestInteractive:
 
         hs.interactive(function_return_None, e)
         e.trigger()
+
+    def test_close_disconnects_explicit_event(self):
+        s = self.s
+        e = Event()
+        op = Interactive(s.sum, event=e, recompute_out_event=None, axis=0)
+        initial_data = op.out.data.copy()
+        s.data += 3.2
+        op.close()
+        e.trigger()
+        # After close, event should have no effect — data unchanged
+        np.testing.assert_array_equal(op.out.data, initial_data)
+
+    def test_close_disconnects_recompute_out_event(self):
+        s = self.s
+        e1 = Event()
+        e2 = Event()
+        op = Interactive(s.sum, event=e1, recompute_out_event=e2, axis=0)
+        initial_data = op.out.data.copy()
+        s.crop(1, 1)
+        op.close()
+        # Triggering should NOT update after close
+        e1.trigger()
+        np.testing.assert_array_equal(op.out.data, initial_data)
+
+    def test_close_keeps_out_accessible(self):
+        s = self.s
+        e = Event()
+        op = Interactive(s.sum, event=e, recompute_out_event=None, axis=0)
+        op.close()
+        # out should still be readable
+        assert op.out is not None
+        np.testing.assert_array_equal(op.out.data, np.sum(s.data, axis=1))
+
+    def test_close_idempotent(self):
+        s = self.s
+        e = Event()
+        op = Interactive(s.sum, event=e, recompute_out_event=None, axis=0)
+        op.close()
+        # Second close should not raise
+        op.close()
+        assert op.out is not None
+
+    def test_close_auto_event(self):
+        s = self.s
+        op = Interactive(s.sum, axis=0)
+        initial_data = op.out.data.copy()
+        s.data += 3.2
+        op.close()
+        s.events.data_changed.trigger(s)
+        # After close, data_changed should have no effect
+        np.testing.assert_array_equal(op.out.data, initial_data)

--- a/upcoming_changes/3645.enhancements.rst
+++ b/upcoming_changes/3645.enhancements.rst
@@ -1,0 +1,3 @@
+Add ``Interactive.close`` method to disconnect all event handlers and
+release internal references, preventing callback leaks when an interactive
+operation is no longer needed.


### PR DESCRIPTION
Adds a close() method to the Interactive class that disconnects all event handlers and clears internal references, allowing garbage collection.

Changes:
- Store event/recompute_out_event/has_out as instance attributes
- Add _disconnect_events() helper (mirrors _connect_events)
- Add close() with full docstring, usage example, and GC prevention comment
- 5 new tests (14 total pass) in test_interactive.py
- New 'Cleaning up' section in User Guide with code example
- Changelog entry at upcoming_changes/3645.enhancements.rst

Verification: ruff clean, 14 tests pass, docs build zero new warnings.
Closes #3645