### PR TITLE
Fix SAMFire plot cleanup: close() never called + leaked handler

### DIFF
--- a/hyperspy/samfire.py
+++ b/hyperspy/samfire.py
@@ -579,10 +579,22 @@ class Samfire:
             connect_other_navigation1, {"obj": "axes_manager"}
         )
 
-        self.model._plot.signal_plot.events.closed.connect(lambda: mark._plot.close, [])
+        # BUG FIX: must call close() — without parens the lambda returns the
+        # method object without invoking it, so the mark plot was never closed.
+        self.model._plot.signal_plot.events.closed.connect(
+            lambda: mark._plot.close(), []
+        )
         self.model._plot.signal_plot.events.closed.connect(
             lambda: self.model.axes_manager.events.indices_changed.disconnect(
                 connect_other_navigation1
+            ),
+            [],
+        )
+        # BUG FIX: connect_other_navigation2 was connected (line 575) but never
+        # disconnected on plot close — this leaked the handler on repeated opens.
+        self.model._plot.signal_plot.events.closed.connect(
+            lambda: mark.axes_manager.events.indices_changed.disconnect(
+                connect_other_navigation2
             ),
             [],
         )

--- a/upcoming_changes/3647.bugfix.rst
+++ b/upcoming_changes/3647.bugfix.rst
@@ -1,0 +1,1 @@
+Fix two bugs in SAMFire plot cleanup: a lambda was missing ``()`` so ``mark._plot.close`` was never actually called (the method object was returned instead of invoked), and ``connect_other_navigation2`` was connected but never disconnected on plot close, leaking the handler.


### PR DESCRIPTION
Two fixes in `hyperspy/samfire.py`:

**Bug A — plot close never called**: Lambda on line 582 was `lambda: mark._plot.close` — missing `()` means it returned the method object instead of invoking it. Changed to `lambda: mark._plot.close()`.

**Bug B — connect_other_navigation2 handler leaked**: `connect_other_navigation2` was connected on line 575 but only `connect_other_navigation1` got a disconnect on the closed event. Added a disconnect lambda for `connect_other_navigation2`.

All 52 SAMFire tests pass (2 xfailed), ruff clean.

Closes #3647