### PR TITLE
Add GitHub Copilot code review instructions

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,51 @@
+# HyperSpy Code Review Standards
+
+When performing a code review, check every change against these HyperSpy-specific rules. Flag violations as blocking.
+
+## 1. Axis Convention — CRITICAL
+HyperSpy reverses ALL dimensions vs NumPy order. Internal arrays (`.data`, `.map`) always NumPy order; display is reversed.
+
+**Flag:** `axes_manager.indices` without `[::-1]` for array indexing. `navigation_shape` without `[::-1]` creating arrays. `.data[...]` in display order not NumPy. `parameter.map` indexed `[y, x]` (NumPy order) not display. Descending/reversed axes (negative `scale`) — many operations assume positive scale.
+
+## 2. Public API Integrity
+`hyperspy/api.py` `__all__` defines the public contract. Never modify casually.
+
+**Flag:** Signature changes to `load()`, `stack()`, `transpose()`, `preferences`. New functions missing `__all__`/`_import_mapping`. New signal/component types not re-exported in `signals.py`/`components1d.py`/`components2d.py`.
+
+## 3. Navigation Dimension Guard
+Components MUST branch: `nav_dim == 0` → `param.value` (scalar); `nav_dim > 0` → `param.map["values"]` (array) + `param.map["is_set"] = True`.
+
+**Flag any `estimate_parameters()` missing this guard.** Works on single-spectrum, fails silently on multi-dimensional.
+
+## 4. Parameter Map Write Patterns
+**Flag:** `map["is_set"] = True` without `[:]` — canonical is `map["is_set"][:] = True`. Same for `map["values"]`. Missing `is_set` after `values` set. Map writes without lazy (dask) guard.
+
+## 5. AI Attribution
+Pre-commit blocks `Co-authored-by:` for AI tools. Must use `Assisted-by: <tool>:<model>`.
+
+**Flag any `Co-authored-by:` + AI tool (claude, copilot, cursor, codex, gemini, deepseek).**
+
+## 6. Changelog Required
+Every user-facing change needs `upcoming_changes/<issue>.<type>.rst`. Types: `new`, `bugfix`, `doc`, `deprecation`, `enhancements`, `api`, `maintenance`.
+
+**Flag:** Modified `.py` files without changelog entry. Wrong type in filename. Developer-facing text instead of user-facing. Multi-paragraph entries for non-`new` types.
+
+## 7. Test Quality
+**Flag:** Symmetric test dimensions — use ALL-DIFFERENT dims. Raw `==` float compares — use `np.testing.assert_allclose`. Test classes missing `@lazifyTestClass`. New code without mirrored test files. (See `tests.instructions.md` for full rules.)
+
+## 8. Post-Mutation Events
+After in-place `.data` mutation: `self.events.data_changed.trigger(obj=self)` required for UI reactivity.
+
+**Flag any in-place data mutation without this trigger.**
+
+## 9. Code Hygiene
+**Flag:** `# type: ignore`/`# noqa` without justification. Bare `except:`/`except Exception:` without logging. Raw NumPy on `.data` where HyperSpy methods exist. (See `python.instructions.md` for deprecation/events/lazy.)
+
+## 10. Scope & Structure
+**Flag:** PRs >15 commits touching unrelated modules — split for reviewability. Missing standard checklist (`docstring`, `user guide`, `changelog`, `tests`, `ready for review`). File moves/renames/splits without a change map.
+
+## 11. AI Content Quality
+**Flag:** AI-generated PRs summarizing WHAT without explaining WHY — reviewers need design rationale (PR #3622). References to non-existent files — common AI hallucination. Commit messages describing diff instead of intent. For bugfixes: does the fix address the root cause or just patch a symptom? Prefer minimal root-cause fixes over workaround guards (PR #2863). Check sibling methods for the same bug class (PR #3384).
+
+## 12. Documentation & Dependencies
+**Flag:** Docstring changes without rendered output check (PR #3548, #3525). Examples misplaced between gallery and user guide (PR #3587). New dependencies without maintenance vetting (PR #3621). Changes breaking downstream extensions (pyxem, exspy, lumispy) without noting impact.

--- a/.github/instructions/python.instructions.md
+++ b/.github/instructions/python.instructions.md
@@ -1,0 +1,68 @@
+---
+applyTo: "**/*.py"
+---
+
+# Python Code Review Standards — HyperSpy Specific
+
+When reviewing Python files in this repository, apply these checks on top of the repository-wide standards.
+
+## Lazy Evaluation Branching
+Use `signal._lazy` flag to branch. Signal methods must handle both numpy and dask paths.
+
+**Flag:** Code assuming numpy without checking `_lazy`. Dask ops missing chunk handling. `.compute()` on non-lazy data without guard. Methods missing dask path.
+
+## Events System
+After mutating `.data` in-place: `self.events.data_changed.trigger(obj=self)` required for UI reactivity.
+
+**Flag:** In-place `.data` mutations without trigger. `trigger()` missing `obj=self`. Every `connect()` must have a corresponding `disconnect()` on `close()` — event listener leaks are HyperSpy's most common bug class (PR #3355, #3640, #3629, #3648). Test both connection AND disconnection.
+
+## Deprecation Protocol
+Use `@deprecated(since="...", alternative="...", removal="...")` from `hyperspy/decorators.py`. Never bare `warnings.warn()` — HyperSpy uses `VisibleDeprecationWarning`.
+
+**Flag:** Bare `warnings.warn()` for API deprecation. `@deprecated` missing `alternative=`/`removal=`. Python's built-in `DeprecationWarning`.
+
+## AxesManager Internals
+`axes_manager._axes` in NumPy order (not display). Use `[::-1]` on `navigation_shape`, `signal_shape`, `indices` for array operations.
+
+**Flag:** Code assuming `_axes` in display order. Mutating `_axes` without `_update_attributes()`. Missing `[::-1]` on `indices` for map indexing.
+
+## Signal Subclass Guard
+Methods with dimension requirements must raise `SignalDimensionError` at entry.
+
+**Flag:** New methods that don't raise `SignalDimensionError` on wrong signal type.
+
+## NumPy-vs-HyperSpy Methods
+Prefer HyperSpy-native methods that preserve metadata: `signal.max(axis='energy')` not `np.max(signal.data)`. `signal.isig[100.:300.]` not `signal.data[:, 100:300]`. `signal / signal.max()` not `signal.data / signal.data.max()`.
+
+**Flag raw NumPy on `.data` where a HyperSpy method exists.**
+
+## _assign_subclass() Pattern
+After data shape/dtype/dimension changes, `_assign_subclass()` recomputes signal class. Missing → wrong subclass.
+
+**Flag data transformations without `_assign_subclass()`.**
+
+## Extension & Config Stability
+`hyperspy_extension.yaml` changes must be backward-compatible with `defaults_parser.py`.
+
+**Flag:** Changes breaking existing installations. New required keys without migration notes.
+
+## function_nd Vectorization
+`Component.function_nd()` is the vectorized performance path. New components should implement it when feasible (PR #3476).
+
+**Flag:** Missing `function_nd` where vectorized possible. Code not handling mixed components.
+
+## Expression Component Pattern
+New components should subclass `Expression` (not raw `Component`) for auto-gradients and less boilerplate (#2134, #2135, #2137, #2157). Check sympy reserved names: `gamma`, `beta`, `zeta` silently break Expression compilation (#2134, #2269).
+
+**Flag:** Hand-coded `function()` where `Expression` works. Unverified parameter names in Expression subclasses.
+
+## Canonical Inplace Pattern
+`inplace` methods MUST: `sig = self if inplace else self.deepcopy()`, operate on `sig`, `return sig if not inplace` (PR #3590). **Flag deviations.**
+
+## Re-entrance Guard Comments
+Boolean guards (`_updating_twin`, `_updating_indices_from_drag`) suppress re-entrant callbacks. Reviewers require comments explaining each guard's purpose (PR #3631). **Flag guards without inline comments.**
+
+## Private & Dynamic Docstrings
+New private functions need docstrings (PR #3587). Dynamic docstrings (`_docstring.py` templates, `.format()`) often have rendering bugs (PR #3525, #3475) — verify in readthedocs PR build.
+
+**Flag:** Private functions without docstrings. Dynamic docstring changes without rendered output check.

--- a/.github/instructions/tests.instructions.md
+++ b/.github/instructions/tests.instructions.md
@@ -58,6 +58,7 @@ Plot tests use `@pytest.mark.mpl_image_compare` from `pytest-mpl`. They generate
 **Flag:**
 - Plot tests without `@pytest.mark.mpl_image_compare`
 - Missing `mpl_cleanup` fixture for matplotlib figure cleanup
+- Reference https://hyperspy.org/hyperspy-doc/current/dev_guide/testing.html#plot-testing when plotting tests are failing or needed. Include detailed instructions on creating new references via pytest.
 
 ## Slow Test Marking
 Performance-intensive tests must use `@pytest.mark.slow` — they are skipped in fast CI runs.
@@ -73,8 +74,3 @@ When testing model components, reviewers expect BOTH: (1) two components of the 
 Code producing `lazy_output=True` must genuinely defer computation. Reviewers check this (PR #3476: `lazy_output=True` was computing immediately). `.compute()` inside a lazy branch is a code smell.
 
 **Flag:** Lazy output tests that don't verify deferred computation. `lazy_output` that calls `.compute()` internally.
-
-## Test Data File Size
-Test data files must be minimal size — large files are rejected (PR #3501). External contributors should be directed to create small test data following the test data guidelines.
-
-**Flag:** Test data files > 50KB. PRs adding test fixtures without following test-data contribution guide.

--- a/.github/instructions/tests.instructions.md
+++ b/.github/instructions/tests.instructions.md
@@ -1,0 +1,80 @@
+---
+applyTo: "**/tests/**"
+---
+
+# Test Code Review Standards — HyperSpy Specific
+
+When reviewing test files in this repository, apply these checks on top of the repository-wide standards.
+
+## Array Dimensions — CRITICAL
+Test data arrays must use ALL-DIFFERENT dimensions so axis reversals are visually verifiable:
+- ✅ `np.arange(12 * 25 * 48).reshape(12, 25, 48)` — all dims visibly distinct
+- ❌ `np.arange(64 * 64 * 128).reshape(64, 64, 128)` — symmetric dims hide reversal bugs
+- ❌ `np.zeros((100, 100))` — square arrays conceal axis swaps
+
+**Flag any test with square or symmetric signal dimensions.**
+
+## Floating-Point Assertions
+HyperSpy uses `numpy.testing` utilities, not `pytest.approx`:
+- ✅ `np.testing.assert_allclose(actual, expected, rtol=1e-4)`
+- ✅ `np.testing.assert_array_equal(actual, expected)` for exact/int comparisons
+- ❌ `assert actual == expected` — too fragile for floats
+- ❌ `assert actual == pytest.approx(expected)` — not the HyperSpy convention
+
+**Flag raw `==` float comparisons or non-standard assertion styles.**
+
+## Lazy Path Coverage
+Every test class for signals or components MUST use `@lazifyTestClass` decorator — it auto-generates `test_lazy_*` variants with dask-backed signals:
+
+```python
+from hyperspy.decorators import lazifyTestClass
+
+@lazifyTestClass
+class TestMyComponent:
+    # test_lazy_* variants auto-generated
+```
+
+**Flag test classes without `@lazifyTestClass` — they miss lazy execution path coverage.**
+
+**Flag `@lazifyTestClass` usage with wrong kwargs.** Pass `rtol=1e-4` for float tolerance, `ragged=False` for non-ragged data, or relevant kwargs.
+
+## Test Structure Mirroring
+Tests must mirror source structure exactly:
+- Source: `hyperspy/_signals/signal1d.py`
+- Test: `hyperspy/tests/signals/test_signal1d.py`
+- Source: `hyperspy/_components/gaussian.py`
+- Test: `hyperspy/tests/component/test_gaussian.py`
+
+**Flag new code without corresponding test files in the mirrored location.**
+
+## Fixture Usage
+Use shared fixtures from `hyperspy/conftest.py` for common patterns (signal creation, matplotlib cleanup). Don't recreate fixtures that already exist.
+
+**Flag duplicated fixture logic that should use existing conftest fixtures.**
+
+## Plot Tests
+Plot tests use `@pytest.mark.mpl_image_compare` from `pytest-mpl`. They generate baseline images and require the `--mpl` flag.
+
+**Flag:**
+- Plot tests without `@pytest.mark.mpl_image_compare`
+- Missing `mpl_cleanup` fixture for matplotlib figure cleanup
+
+## Slow Test Marking
+Performance-intensive tests must use `@pytest.mark.slow` — they are skipped in fast CI runs.
+
+**Flag obviously expensive tests without `@pytest.mark.slow`.**
+
+## Component Test Coverage
+When testing model components, reviewers expect BOTH: (1) two components of the **same type** (e.g., two Gaussians), and (2) two components of **different types** (e.g., Gaussian + Lorentzian) — PR #3548. Test both scalar (`nav_dim == 0`) and map (`nav_dim > 0`) navigation cases.
+
+**Flag tests with only one component type or only scalar case.**
+
+## Lazy Behavior Verification
+Code producing `lazy_output=True` must genuinely defer computation. Reviewers check this (PR #3476: `lazy_output=True` was computing immediately). `.compute()` inside a lazy branch is a code smell.
+
+**Flag:** Lazy output tests that don't verify deferred computation. `lazy_output` that calls `.compute()` internally.
+
+## Test Data File Size
+Test data files must be minimal size — large files are rejected (PR #3501). External contributors should be directed to create small test data following the test data guidelines.
+
+**Flag:** Test data files > 50KB. PRs adding test fixtures without following test-data contribution guide.

--- a/.gitignore
+++ b/.gitignore
@@ -56,6 +56,7 @@ venv/
 
 # AI coding tools — runtime state and personal files
 .omc/
+.omo/
 .sisyphus/*
 !.sisyphus/rules/
 

--- a/upcoming_changes/3649.maintenance.rst
+++ b/upcoming_changes/3649.maintenance.rst
@@ -1,0 +1,4 @@
+Add ``.github/copilot-instructions.md`` and path-scoped ``.github/instructions/``
+files for GitHub Copilot Code Review, encoding HyperSpy-specific conventions
+(axis ordering, parameter map patterns, event triggers, lazy evaluation, test
+quality) mined from 30+ PR reviews (2019–2026).


### PR DESCRIPTION
### Summary

Adds `.github/copilot-instructions.md` and path-scoped `.github/instructions/` files so GitHub Copilot Code Review can enforce HyperSpy-specific conventions automatically. These encode institutional knowledge mined from 30+ PR reviews (2019–2026).

### Files

| File | Scope | What it checks |
|------|-------|----------------|
| `.github/copilot-instructions.md` | Repository-wide | 12 sections: axis convention, public API, nav dim guards, parameter maps, AI attribution, changelog, test quality, events, code hygiene, PR scope, AI content, dependencies |
| `.github/instructions/python.instructions.md` | `**/*.py` | Expression components, lazy evaluation, event cleanup, deprecation protocol, AxesManager internals, _assign_subclass, function_nd |
| `.github/instructions/tests.instructions.md` | `**/tests/**` | ALL-DIFFERENT dims, np.testing.assert_allclose, @lazifyTestClass, component coverage, fixture reuse |

All files are under the 4000-character Copilot Code Review limit.

### Why these rules

Mined from real review comments on closed PRs. Examples:

- **Axis convention** — the #1 bug source. Checks `indices[::-1]`, `navigation_shape[::-1]`, and parameter map ordering.
- **Event listener leaks** — HyperSpy's most recurring bug class (4+ PRs). Flags missing `events.data_changed.trigger(obj=self)`.
- **Parameter map patterns** — `map["is_set"][:] = True` vs bare `= True` (inconsistency found in power_law.py).
- **Root-cause fixes** — PR #2863: reviewer rejected a workaround guard and demanded the 1-line root fix instead.

### What was left out

`CLAUDE.md` is not included — the project `.gitignore` (line 64) explicitly excludes it with the rationale "conventions live in AGENTS.md." Claude Code users who want it can keep it locally.