### PR TITLE
Fix 3 bugs in LazySignal.decomposition()

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1436,11 +1436,11 @@ This release fixes compatibility issues with Python 3.7.
 
 This is a minor release. Follow the following links for details on all
 the `bugs fixed
-<https://github.com/hyperspy/hyperspy/issues?utf8=%E2%9C%93&q=is%3Aclosed+milestone%3Av1.4+label%3A%22type%3A+bug%22+>`__,
+<https://github.com/hyperspy/hyperspy/issues?utf8=%E2%9C%93&q=is%3Aclosed+milestone%3Av1.4+label%3A"type%3A+bug"+>`__,
 `enhancements
-<https://github.com/hyperspy/hyperspy/issues?q=is%3Aclosed+milestone%3Av1.4+label%3A%22type%3A+enhancement%22>`__
+<https://github.com/hyperspy/hyperspy/issues?q=is%3Aclosed+milestone%3Av1.4+label%3A"type%3A+enhancement">`__
 and `new features
-<https://github.com/hyperspy/hyperspy/issues?q=is%3Aclosed+milestone%3Av1.4+label%3A%22type%3A+New+feature%22>`__.
+<https://github.com/hyperspy/hyperspy/issues?q=is%3Aclosed+milestone%3Av1.4+label%3A"type%3A+New+feature">`__.
 
 NEW
 ---
@@ -1519,7 +1519,7 @@ the `bugs fixed
 `feature
 <https://github.com/hyperspy/hyperspy/issues?q=is%3Aclosed+milestone%3Av1.3+label%3A"type%3A+enhancement">`__
 and `documentation
-<https://github.com/hyperspy/hyperspy/issues?utf8=%E2%9C%93&q=is%3Aclosed%20milestone%3Av1.3%20label%3A%22affects%3A%20documentation%22%20>`__ enhancements,
+<https://github.com/hyperspy/hyperspy/issues?utf8=%E2%9C%93&q=is%3Aclosed%20milestone%3Av1.3%20label%3A"affects%3A+documentation"%20>`__ enhancements,
 and `new features
 <https://github.com/hyperspy/hyperspy/issues?q=is%3Aclosed+milestone%3Av1.3+label%3A"type%3A+New+feature">`__.
 

--- a/hyperspy/_signals/lazy.py
+++ b/hyperspy/_signals/lazy.py
@@ -841,6 +841,11 @@ class LazySignal(signals.BaseSignal):
         sig_reshape = (signalsize,) if signalsize else ()
         data = data.reshape((self.axes_manager.navigation_shape[::-1] + sig_reshape))
         if signalsize:
+            # Ensure the signal dimension is a single chunk so that the
+            # index appended in the loop below retrieves the full signal
+            # vector rather than only the first chunk.  This matters when
+            # the on-disk chunk size is smaller than the signal size
+            # (e.g. after unfold()).
             data = data.rechunk({-1: -1})
 
         if signal_mask is None:
@@ -1059,6 +1064,9 @@ class LazySignal(signals.BaseSignal):
                 coeff = (
                     raG[(...,) + (None,) * rbH.ndim] * rbH[(None,) * raG.ndim + (...,)]
                 )
+                # Capture the return value — map_blocks returns a new dask
+                # array; the original line discarded the result, making the
+                # normalisation a silent no-op.
                 coeff = coeff.map_blocks(np.nan_to_num)
                 coeff = da.where(coeff == 0, 1, coeff)
                 data = data / coeff

--- a/hyperspy/_signals/lazy.py
+++ b/hyperspy/_signals/lazy.py
@@ -1102,6 +1102,9 @@ class LazySignal(signals.BaseSignal):
                 finally:
                     if self._unfolded4decomposition is True:
                         self.fold()
+                        # BUGFIX: was ``is False`` (identity comparison, always no-op);
+                        # must be ``= False`` assignment to clear the flag so the signal
+                        # does not remain permanently unfolded.
                         self._unfolded4decomposition = False
             else:
                 self._check_navigation_mask(navigation_mask)

--- a/hyperspy/_signals/lazy.py
+++ b/hyperspy/_signals/lazy.py
@@ -840,6 +840,8 @@ class LazySignal(signals.BaseSignal):
         signalsize = self.axes_manager.signal_size
         sig_reshape = (signalsize,) if signalsize else ()
         data = data.reshape((self.axes_manager.navigation_shape[::-1] + sig_reshape))
+        if signalsize:
+            data = data.rechunk({-1: -1})
 
         if signal_mask is None:
             signal_mask = (
@@ -1057,7 +1059,7 @@ class LazySignal(signals.BaseSignal):
                 coeff = (
                     raG[(...,) + (None,) * rbH.ndim] * rbH[(None,) * raG.ndim + (...,)]
                 )
-                coeff.map_blocks(np.nan_to_num)
+                coeff = coeff.map_blocks(np.nan_to_num)
                 coeff = da.where(coeff == 0, 1, coeff)
                 data = data / coeff
                 self.data = data
@@ -1092,7 +1094,7 @@ class LazySignal(signals.BaseSignal):
                 finally:
                     if self._unfolded4decomposition is True:
                         self.fold()
-                        self._unfolded4decomposition is False
+                        self._unfolded4decomposition = False
             else:
                 self._check_navigation_mask(navigation_mask)
                 self._check_signal_mask(signal_mask)

--- a/hyperspy/tests/learn/test_lazy_decomposition.py
+++ b/hyperspy/tests/learn/test_lazy_decomposition.py
@@ -244,3 +244,38 @@ class TestPrintInfo:
         nav_mask = (s.isig[0].data < 0.5).compute()[:-2]
         with pytest.raises(ValueError):
             s.decomposition(algorithm="PCA", navigation_mask=nav_mask)
+
+
+class TestLazyDecompositionBugfixes:
+    """Regression tests for PR #3655: fix-lazy-signal-bugs."""
+
+    def setup_method(self, method):
+        rng = np.random.default_rng(42)
+        self.s = Signal1D(rng.random((12, 25, 48))).as_lazy()
+
+    def test_poissonian_noise_normalization_scales_data(self):
+        """#3607: verify normalize_poissonian_noise=True produces valid
+        reconstruction. Bug: coeff.map_blocks() result discarded (no-op)."""
+        s = self.s
+        s.decomposition(
+            normalize_poissonian_noise=True, output_dimension=3, algorithm="ORNMF"
+        )
+        rec = s.get_decomposition_model().data.compute()
+        assert np.all(np.isfinite(rec))
+
+    def test_unfolded4decomposition_false_after_svd(self):
+        """#3608: _unfolded4decomposition should be False after lazy SVD.
+        The bug was ```is False``` (comparison) instead of ```= False```."""
+        s = self.s.deepcopy()
+        s.decomposition(output_dimension=3)
+        assert s._unfolded4decomposition is False
+
+    def test_block_iterator_rechunks_signal(self):
+        """#3610: _block_iterator should rechunk signal dimension to single
+        chunk so that sub-signal chunk layouts work correctly."""
+        s = self.s
+        blocks = list(s._block_iterator(flat_signal=True))
+        assert len(blocks) > 0
+        # Each block should have signal_size columns
+        for block in blocks:
+            assert block.shape[1] == s.axes_manager.signal_size

--- a/upcoming_changes/3607.bugfix.rst
+++ b/upcoming_changes/3607.bugfix.rst
@@ -1,0 +1,3 @@
+Fix Poissonian noise normalisation being silently a no-op in lazy decomposition.
+``coeff.map_blocks(np.nan_to_num)`` returns a new dask array; the result was
+never assigned back, so the data was not rescaled before decomposition.

--- a/upcoming_changes/3608.bugfix.rst
+++ b/upcoming_changes/3608.bugfix.rst
@@ -1,0 +1,4 @@
+Fix lazy signal being left permanently unfolded after SVD decomposition.
+``self._unfolded4decomposition is False`` was an identity comparison (no-op)
+instead of the assignment ``= False``, so the flag was never cleared and the
+signal remained in the unfolded state after decomposition returned.

--- a/upcoming_changes/3610.bugfix.rst
+++ b/upcoming_changes/3610.bugfix.rst
@@ -1,0 +1,4 @@
+Fix ``_block_iterator`` reading only the first signal chunk when the on-disk chunk
+size is smaller than the full signal length (e.g. per-spectrum HDF5 chunking).
+The signal dimension is now rechunked to a single chunk before iteration, so all
+signal channels are always read correctly.


### PR DESCRIPTION
## Bugs Fixed
- **#3607**: Poissonian noise normalisation silently a no-op — map_blocks result discarded
- **#3608**: Signal left permanently unfolded after lazy SVD — identity comparison vs assignment
- **#3610**: _block_iterator reads only first signal chunk — rechunk signal axis

## Notes
- File: hyperspy/_signals/lazy.py  
- All fixes are in a single file, touching ~15 lines total.
- CHANGES.rst URL encoding fix included.

Assisted-by: opencode:deepseek-v4-pro