### PR TITLE
Add back `trait_property_changed` to update the GUI

### DIFF
--- a/hyperspy/component.py
+++ b/hyperspy/component.py
@@ -348,6 +348,8 @@ class Parameter(t.HasTraits):
             self.__value = tuple(self.__value)
         if old_value != self.__value:
             self.events.value_changed.trigger(value=self.__value, obj=self)
+            # To update the widget connected to the value property
+            self.trait_property_changed("value", old_value, self.__value)
 
     # Fix the parameter when coupled
     def _get_free(self):
@@ -358,14 +360,17 @@ class Parameter(t.HasTraits):
             return False
 
     def _set_free(self, arg):
+        old_value = self._free
         if arg and self.twin:
             raise ValueError(
-                f"Parameter {self.name} can't be set free "
-                "is twinned with {self.twin}."
+                f"Parameter {self.name} can't be set free, "
+                f"because it is twinned with {self.twin}."
             )
         self._free = arg
         if self.component is not None:
             self.component._update_free_parameters()
+        # To update the widget connected to the free property
+        self.trait_property_changed("free", old_value, self._free)
 
     def _on_twin_update(self, value, twin=None):
         if self._updating_twin:
@@ -416,12 +421,15 @@ class Parameter(t.HasTraits):
             return self._bounds[0][0]
 
     def _set_bmin(self, arg):
+        old_value = self.bmin
         if self._number_of_elements == 1:
             self._bounds = (arg, self.bmax)
         else:
             self._bounds = ((arg, self.bmax),) * self._number_of_elements
         # Update the value to take into account the new bounds
         self.value = self.value
+        # To update the widget connected to the bmin property
+        self.trait_property_changed("bmin", old_value, arg)
 
     def _get_bmax(self):
         """The higher value of the bounds."""
@@ -431,12 +439,15 @@ class Parameter(t.HasTraits):
             return self._bounds[0][1]
 
     def _set_bmax(self, arg):
+        old_value = self.bmax
         if self._number_of_elements == 1:
             self._bounds = (self.bmin, arg)
         else:
             self._bounds = ((self.bmin, arg),) * self._number_of_elements
         # Update the value to take into account the new bounds
         self.value = self.value
+        # To update the widget connected to the bmax property
+        self.trait_property_changed("bmax", old_value, arg)
 
     @property
     def _number_of_elements(self):
@@ -890,6 +901,8 @@ class Component(t.HasTraits):
             )
         else:
             self._name = value
+        # To update the widget connected to the name property
+        self.trait_property_changed("name", old_value, self._name)
 
     @property
     def _axes_manager(self):
@@ -920,10 +933,13 @@ class Component(t.HasTraits):
     def _set_active(self, arg):
         if self._active == arg:
             return
+        old_value = self._active
         self._active = arg
         if self.active_is_multidimensional is True:
             self._store_active_value_in_array(arg)
         self.events.active_changed.trigger(active=self._active, obj=self)
+        # To update the widget connected to the active property
+        self.trait_property_changed("active", old_value, self._active)
 
     def init_parameters(self, parameter_name_list, linear_parameter_list=None):
         """

--- a/hyperspy/tests/learn/test_bss.py
+++ b/hyperspy/tests/learn/test_bss.py
@@ -534,6 +534,7 @@ class TestReturnInfo:
 class TestBSSModelCorruptionFix:
     """Regression test: get_bss_model() should not corrupt learning_results."""
 
+    @skip_sklearn
     def test_lazy_with_numpy_bss_arrays_preserves_decomposition(self):
         """#3657: get_bss_model() on lazy signal with numpy bss arrays should
         wrap them as dask, compute, then restore original factors/loadings."""
@@ -555,6 +556,7 @@ class TestBSSModelCorruptionFix:
         assert s.learning_results.factors is saved_factors
         assert s.learning_results.loadings is saved_loadings
 
+    @skip_sklearn
     def test_non_lazy_preserves_decomposition(self):
         """#3657: get_bss_model() on non-lazy signal should be a no-op
         for learning_results (takes the else return path)."""


### PR DESCRIPTION
Follow up of https://github.com/hyperspy/hyperspy/pull/3631 to fix a failure of the ipywidgets GUIs test suite (see for example: https://github.com/hyperspy/hyperspy-extensions-list/actions/runs/26963523581/job/79560016585)

The value of bmin should update in the widgets, but it doesn't:
<img width="557" height="253" alt="image" src="https://github.com/user-attachments/assets/79f5c945-1546-4ba7-8606-9f2f4e8e1db7" />

### Progress of the PR
- [x] Add back `trait_property_changed` to update the GUI widget,
- [n/a] if AI-assisted, ``Assisted-by: <tool>:<model>`` in every commit,
- [x] manually tested on realistic data or a representative workflow,
- [n/a] for structural changes, change map in PR description,
- [x] non-obvious design choices annotated with inline comments,
- [n/a] update docstring (if appropriate),
- [n/a] update user guide (if appropriate),
- [n/a] add an changelog entry in the `upcoming_changes` folder (see [`upcoming_changes/README.rst`](https://github.com/hyperspy/hyperspy/blob/RELEASE_next_minor/upcoming_changes/README.rst)),
- [n/a] Check formatting changelog entry in the `readthedocs` doc build of this PR (link in github checks)
- [n/a] add tests,
- [x] ready for review.

### Minimal example of the bug fix or the new feature
Run in a notebook
```python
import hyperspy.api as hs
from hyperspy.component import Parameter 

hs.preferences.GUIs.enable_traitsui_gui = True

p = Parameter()
p.bmin = None
p.bmax = 10
p.value = 1.5
```

