### PR TITLE
Fix test_parallel_pool_ipyparallel_not_installed test

### DIFF
--- a/hyperspy/tests/utils/test_parallel_pool.py
+++ b/hyperspy/tests/utils/test_parallel_pool.py
@@ -38,5 +38,5 @@ def test_parallel_pool_ipyparallel_not_installed():
         assert not pool.is_ipyparallel
 
         # Explicitly requesting ipyparallel when not installed should raise
-        with pytest.raises(ValueError, match="ipyparralel must be installed"):
+        with pytest.raises(ValueError, match="ipyparallel must be installed"):
             ParallelPool(ipyparallel=True)

--- a/hyperspy/tests/utils/test_parallel_pool.py
+++ b/hyperspy/tests/utils/test_parallel_pool.py
@@ -15,7 +15,7 @@
 # You should have received a copy of the GNU General Public License
 # along with HyperSpy. If not, see <https://www.gnu.org/licenses/#GPL>.
 
-import importlib
+from unittest.mock import patch
 
 import pytest
 
@@ -29,12 +29,14 @@ def test_parallel_pool_multiprocessing():
 
 
 def test_parallel_pool_ipyparallel_not_installed():
-    pool = ParallelPool()
-    ipyparallel_spec = importlib.util.find_spec("ipyparallel")
-    if ipyparallel_spec is None:
-        # ipyparallel is installed, use multiprocessing instead
+    """Test that multiprocessing fallback works when ipyparallel is not installed."""
+    with patch("hyperspy.utils.parallel_pool._ipyparallel_installed", False):
+        # When ipyparallel is not installed and ipyparallel=None (default),
+        # should fall back to multiprocessing
+        pool = ParallelPool()
         assert pool.is_multiprocessing
         assert not pool.is_ipyparallel
 
-        with pytest.raises(ValueError):
+        # Explicitly requesting ipyparallel when not installed should raise
+        with pytest.raises(ValueError, match="ipyparralel must be installed"):
             ParallelPool(ipyparallel=True)

--- a/hyperspy/utils/parallel_pool.py
+++ b/hyperspy/utils/parallel_pool.py
@@ -142,7 +142,7 @@ class ParallelPool:
         if not self.has_pool:
             if not _ipyparallel_installed:
                 if ipyparallel is True:
-                    raise ValueError("ipyparralel must be installed")
+                    raise ValueError("ipyparallel must be installed")
                 else:
                     _logger.info(
                         "ipyparallel is not installed, "

--- a/upcoming_changes/3659.maintenance.rst
+++ b/upcoming_changes/3659.maintenance.rst
@@ -1,0 +1,1 @@
+Fix ``test_parallel_pool_ipyparallel_not_installed`` test that was hitting a 15-second timeout instead of testing the intended code path.


### PR DESCRIPTION
The test was broken: it tried to test the 'ipyparallel not installed' code path, but when ipyparallel IS installed, it hit a 15s timeout instead of testing anything.

Fix by mocking  to False so the test actually exercises the 'not installed' fallback path. Test now runs in ~4s instead of ~16s.

### Changes
- Mock  to  to test the actual 'not installed' code path
- Fix the incorrect comment (was backwards)
- Add match string to  for more precise error checking