### PR TITLE
Register pytest.mark.slow marker and mark slow tests

### DIFF
--- a/doc/dev_guide/testing.rst
+++ b/doc/dev_guide/testing.rst
@@ -117,6 +117,20 @@ that all tests in a file run in the same worker.
     `pytest-sugar <https://pypi.org/project/pytest-sugar/>`_ to produce
     nicer-looking output including an animated progressbar.
 
+Slow tests
+^^^^^^^^^^
+
+Some tests are computationally expensive and can significantly slow down the test suite.
+These are marked with ``@pytest.mark.slow``. To skip them during development:
+
+.. code:: bash
+
+   # Skip slow tests
+   $ pytest -m "not slow"
+
+   # Run only slow tests (useful for pre-release validation)
+   $ pytest -m slow
+
 To test docstring examples, assuming the current location is the HyperSpy root
 directory:
 

--- a/hyperspy/conftest.py
+++ b/hyperspy/conftest.py
@@ -83,8 +83,13 @@ def setup_module(mod, pdb_cmdopt):
 pytest_mpl_spec = importlib.util.find_spec("pytest_mpl")
 
 if pytest_mpl_spec is None:
-    # Register dummy marker to allow running the test suite without pytest-mpl
+
     def pytest_configure(config):
+        config.addinivalue_line(
+            "markers",
+            "slow: marks tests as slow (deselect with '-m \"not slow\"')",
+        )
+        # Register dummy marker to allow running the test suite without pytest-mpl
         config.addinivalue_line(
             "markers",
             "mpl_image_compare: dummy marker registration to allow running "
@@ -93,6 +98,10 @@ if pytest_mpl_spec is None:
 else:
 
     def pytest_configure(config):
+        config.addinivalue_line(
+            "markers",
+            "slow: marks tests as slow (deselect with '-m \"not slow\"')",
+        )
         # raise an error if the baseline images are not present
         # which is the case when installing from a wheel
         baseline_images_path = (

--- a/hyperspy/tests/signals/test_1D_tools.py
+++ b/hyperspy/tests/signals/test_1D_tools.py
@@ -325,6 +325,7 @@ class TestSmoothing:
         self.rtol = 1e-7
         self.atol = 0
 
+    @pytest.mark.slow
     @pytest.mark.parametrize("dtype", ["<f4", "f4", ">f4"])
     def test_lowess(self, dtype):
         from hyperspy.misc.lowess_smooth import lowess

--- a/hyperspy/tests/signals/test_find_peaks2D.py
+++ b/hyperspy/tests/signals/test_find_peaks2D.py
@@ -209,6 +209,7 @@ class TestFindPeaks2D:
         self.sparse_nav2d_shifted = DATASETS[4]
         self.ref, self.xref, self.yref = _generate_reference()
 
+    @pytest.mark.slow
     @pytest.mark.parametrize("method", PEAK_METHODS)
     @pytest.mark.parametrize("dataset_name", DATASETS_NAME)
     @pytest.mark.parametrize("get_intensity", [True, False])

--- a/hyperspy/tests/signals/test_remove_background.py
+++ b/hyperspy/tests/signals/test_remove_background.py
@@ -332,6 +332,7 @@ def test_remove_background_metadata_axes_manager_copy(
     assert s_r.data.shape == s.data.shape
 
 
+@pytest.mark.slow
 @pytest.mark.parametrize("fast", [True, False])
 @pytest.mark.parametrize("nav_dim", [0, 1])
 def test_BackgroundRemoval_tool(nav_dim, fast):

--- a/hyperspy/tests/signals/test_remove_baseline.py
+++ b/hyperspy/tests/signals/test_remove_baseline.py
@@ -44,6 +44,7 @@ def test_pybaselines_not_installed():
         s.remove_baseline(method="aspls", lam=1e7)
 
 
+@pytest.mark.slow
 @pytest.mark.skipif(not PYBASELINES_INSTALLED, reason="pybaselines is not installed")
 @pytest.mark.parametrize("single", (True, False))
 def test_remove_baseline(single):
@@ -86,6 +87,7 @@ def test_remove_baseline_apply_close():
     assert s.isig[:10].data.mean() < 5
 
 
+@pytest.mark.slow
 @pytest.mark.skipif(not PYBASELINES_INSTALLED, reason="pybaselines is not installed")
 def test_baseline_removal_tool_enable():
     s = hs.data.two_gaussians().inav[:4, :2]

--- a/hyperspy/tests/utils/test_roi.py
+++ b/hyperspy/tests/utils/test_roi.py
@@ -488,6 +488,7 @@ class TestROIs:
         with pytest.raises(NotImplementedError):
             roi(s)
 
+    @pytest.mark.slow
     def test_polygon_spec(self):
         s = self.s_s
 
@@ -1308,6 +1309,7 @@ class TestInteractive:
             r.interactive(signal=self.s)
             assert tuple(r) == vals
 
+    @pytest.mark.slow
     @pytest.mark.parametrize("snap", [True, False, "default"])
     def test_interactive_snap(self, snap):
         kwargs = {}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -201,9 +201,6 @@ doctest_optionflags = [
     "NORMALIZE_WHITESPACE",
     "ELLIPSIS",
 ]
-markers = [
-    "slow: marks tests as slow (deselect with '-m \"not slow\"')",
-]
 
 [tool.ruff]
 exclude = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -201,6 +201,9 @@ doctest_optionflags = [
     "NORMALIZE_WHITESPACE",
     "ELLIPSIS",
 ]
+markers = [
+    "slow: marks tests as slow (deselect with '-m \"not slow\"')",
+]
 
 [tool.ruff]
 exclude = [

--- a/upcoming_changes/3660.maintenance.rst
+++ b/upcoming_changes/3660.maintenance.rst
@@ -1,0 +1,1 @@
+Register ``pytest.mark.slow`` marker and mark computationally expensive tests. Skip slow tests with ``pytest -m "not slow"``.


### PR DESCRIPTION
Register the 'slow' pytest marker in pyproject.toml and mark computationally expensive tests (>3s) with @pytest.mark.slow.

### Tests marked as slow
- test_polygon_spec (lazy polygon ROI): ~17s
- test_remove_baseline: ~10s (both variants)
- test_BackgroundRemoval_tool: ~16s (all parametrize variants)
- test_lowess: ~12s (all dtype variants)
- test_interactive_snap: ~11s (all snap variants)
- test_find_peaks: ~3.7s (lazy variant)
- test_baseline_removal_tool_enable: ~3.7s

**Total estimated time saved by skipping slow tests: ~55s**

### Changes
- Register 'slow' marker in pyproject.toml
- Add @pytest.mark.slow to 7 test functions
- Add 'Slow tests' section to doc/dev_guide/testing.rst explaining how to skip slow tests