### PR TITLE
Rename `line_color_ipy` traits to `line_color`

### DIFF
--- a/hyperspy/signal_tools/_smoothing.py
+++ b/hyperspy/signal_tools/_smoothing.py
@@ -31,7 +31,7 @@ _logger = logging.getLogger(__name__)
 
 
 class Smoothing(t.HasTraits):
-    line_color_ipy = t.Str("blue")
+    line_color = t.Str("blue")
     differential_order = t.Int(0)
 
     @property
@@ -45,9 +45,9 @@ class Smoothing(t.HasTraits):
                     # PySide
                     return np.array(self.line_color.getRgb()) / 255.0
                 except BaseException:
-                    return matplotlib.colors.to_rgb(self.line_color_ipy)
+                    return matplotlib.colors.to_rgb(self.line_color)
         else:
-            return matplotlib.colors.to_rgb(self.line_color_ipy)
+            return matplotlib.colors.to_rgb(self.line_color)
 
     def __init__(self, signal):
         super().__init__()
@@ -93,12 +93,6 @@ class Smoothing(t.HasTraits):
             color=self.line_color_rgb, type="line"
         )
         self.signal._plot.signal_plot.add_line(self.smooth_diff_line, ax="right")
-
-    def _line_color_ipy_changed(self):
-        if hasattr(self, "line_color"):
-            self.line_color = str(self.line_color_ipy)
-        else:
-            self._line_color_changed()
 
     def turn_diff_line_off(self):
         if self.smooth_diff_line is None:

--- a/hyperspy/signal_tools/_smoothing.py
+++ b/hyperspy/signal_tools/_smoothing.py
@@ -34,21 +34,6 @@ class Smoothing(t.HasTraits):
     line_color = t.Str("blue")
     differential_order = t.Int(0)
 
-    @property
-    def line_color_rgb(self):
-        if hasattr(self, "line_color"):
-            try:
-                # PyQt and WX
-                return np.array(self.line_color.Get()) / 255.0
-            except AttributeError:
-                try:
-                    # PySide
-                    return np.array(self.line_color.getRgb()) / 255.0
-                except BaseException:
-                    return matplotlib.colors.to_rgb(self.line_color)
-        else:
-            return matplotlib.colors.to_rgb(self.line_color)
-
     def __init__(self, signal):
         super().__init__()
         self.ax = None
@@ -58,6 +43,10 @@ class Smoothing(t.HasTraits):
         self.single_spectrum = self.signal.get_current_signal().deepcopy()
         self.axis = self.signal.axes_manager.signal_axes[0].axis
         self.plot()
+
+    @property
+    def line_color_rgb(self):
+        return matplotlib.colors.to_rgb(self.line_color)
 
     def plot(self):
         if self.signal._plot is None or not self.signal._plot.is_active:


### PR DESCRIPTION
The refactor in https://github.com/hyperspy/hyperspy/pull/3662 introduce a regression. This PR needs https://github.com/hyperspy/hyperspy_gui_ipywidgets/pull/102.

An alternative to this fix is to keep the `line_color_ipy` traits but use `@t.observe("line_color_ipy")` instead of `@t.observe("line_color")` but it would be good to simplify the code by removing the redirection.

Failure noticed in https://github.com/hyperspy/hyperspy-extensions-list/issues/107:

```python
___________________________ TestTools.test_smooth_sg ___________________________

self = <hyperspy_gui_ipywidgets.tests.test_tools.TestTools object at 0x7f0d1ee2f050>

    def test_smooth_sg(self):
        s = self.s
        s.add_gaussian_noise(0.1, random_state=0)
        s2 = s.deepcopy()
>       wd = s.smooth_savitzky_golay(**KWARGS)["ipywidgets"]["wdict"]
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

../../miniconda3/envs/test/lib/python3.12/site-packages/hyperspy_gui_ipywidgets/tests/test_tools.py:75: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
../../miniconda3/envs/test/lib/python3.12/site-packages/hyperspy/_signals/signal1d.py:944: in smooth_savitzky_golay
    smoother = signal_tools.SmoothingSavitzkyGolay(self)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
../../miniconda3/envs/test/lib/python3.12/site-packages/hyperspy/signal_tools/_smoothing.py:53: in __init__
    super().__init__()
../../miniconda3/envs/test/lib/python3.12/site-packages/traits/has_traits.py:3408: in _init_trait_observers
    observe_api.apply_observers(
../../miniconda3/envs/test/lib/python3.12/site-packages/traits/observation/observe.py:98: in apply_observers
    add_or_remove_notifiers(
../../miniconda3/envs/test/lib/python3.12/site-packages/traits/observation/_observe.py:54: in add_or_remove_notifiers
    callable_()
../../miniconda3/envs/test/lib/python3.12/site-packages/traits/observation/_observe.py:94: in __call__
    step()
../../miniconda3/envs/test/lib/python3.12/site-packages/traits/observation/_observe.py:163: in _add_or_remove_notifiers
    for observable in self.graph.node.iter_observables(self.object):
                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

self = NamedTraitObserver(name='line_color', notify=True, optional=False)
object = <hyperspy.signal_tools._smoothing.SmoothingSavitzkyGolay object at 0x7f0d1840c6b0>

    def iter_observables(self, object):
        """ Yield the named instance trait from the given object. If the named
        trait cannot be found and optional is false, raise an error.
    
        Parameters
        ----------
        object: object
            Object provided by another observers or by the user.
    
        Yields
        ------
        CTrait
    
        Raises
        ------
        ValueError
            If the trait is not found and optional flag is set to false.
        """
        if not object_has_named_trait(object, self.name):
            if self.optional:
                return
>           raise ValueError(
                "Trait named {!r} not found on {!r}.".format(self.name, object)
            )
E           ValueError: Trait named 'line_color' not found on <hyperspy.signal_tools._smoothing.SmoothingSavitzkyGolay object at 0x7f0d1840c6b0>.

../../miniconda3/envs/test/lib/python3.12/site-packages/traits/observation/_named_trait_observer.py:97: ValueError
```

### Progress of the PR
- [x] Rename `line_color_ipy` traits to `line_color` to avoid redirection,
- [x] tidy up code,
- [n/a] if AI-assisted, ``Assisted-by: <tool>:<model>`` in every commit,
- [n/a] manually tested on realistic data or a representative workflow,
- [n/a] for structural changes, change map in PR description,
- [n/a] non-obvious design choices annotated with inline comments,
- [n/a] update docstring (if appropriate),
- [n/a] update user guide (if appropriate),
- [n/a] add an changelog entry in the `upcoming_changes` folder (see [`upcoming_changes/README.rst`](https://github.com/hyperspy/hyperspy/blob/RELEASE_next_minor/upcoming_changes/README.rst)),
- [n/a] Check formatting changelog entry in the `readthedocs` doc build of this PR (link in github checks)
- [n/a] add tests,
- [x] ready for review.

