### PR TITLE
Fix reST inline-strong warning in Signal1D.spikes_diagnosis docstring

### DIFF
--- a/hyperspy/_signals/signal1d.py
+++ b/hyperspy/_signals/signal1d.py
@@ -349,7 +349,7 @@ class Signal1D(signals.BaseSignal, CommonSignal1D):
         ----------
         %s
         %s
-        **kwargs : dict
+        ``**kwargs`` : dict
             Keyword arguments pass to
             :meth:`~hyperspy.api.signals.BaseSignal.get_histogram`
 


### PR DESCRIPTION
Escape ``**kwargs`` as an inline literal in
:meth:`~.api.signals.Signal1D.spikes_diagnosis` to prevent docutils
from treating ``**`` as the start of an unclosed "inline strong"
markup.

The warning:

```
WARNING: Inline strong start-string without end-string. [docutils]
```

The same escape pattern is already used elsewhere in the file
(`SPIKES_DIAGNOSIS_DOCSTRING`, `SPIKES_REMOVAL_TOOL_DOCSTRING`,
`Model.fit`) — this brings `spikes_diagnosis` in line with the
rest. The rendered HTML is unchanged for users
(``**kwargs`` and `**kwargs` both render as `<code>**kwargs</code>`),
so no changelog entry is required.

Assisted-by: opencode:minimax-m3