### PR TITLE
Fix missing scree plot method docs in BaseSignal API reference

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -460,6 +460,13 @@ copybutton_prompt_is_regexp = True
 
 tls_verify = True
 
+# FIXME: remove when sphinx-doc/sphinx#14089 is closed.
+# Workaround for Sphinx 9.x autodoc regressions (sphinx-doc/sphinx#13721,
+# sphinx-doc/sphinx#13316, tracked at sphinx-doc/sphinx#14089). The new
+# implementation silently skips methods defined on mixin classes several
+# levels deep in the MRO.
+autodoc_use_legacy_class_based = True
+
 
 def setup(app):
     app.add_css_file("custom-styles.css")

--- a/hyperspy/learn/_mva.py
+++ b/hyperspy/learn/_mva.py
@@ -46,7 +46,7 @@ CHUNKS_ARGS = """chunks : str, int, or tuple, default "auto"
             If a tuple of length 2, the first element controls signal
             dimension chunking and the second controls navigation
             chunking (passed as ``nav_chunks`` to
-            :meth:`~._signals.lazy.LazySignal.rechunk`)."""
+            :meth:`~.api.signals.LazySignal.rechunk`)."""
 
 
 decomposition_algorithms = {

--- a/upcoming_changes/3668.maintenance.rst
+++ b/upcoming_changes/3668.maintenance.rst
@@ -1,0 +1,3 @@
+Enable ``autodoc_use_legacy_class_based`` in the documentation configuration
+to work around `Sphinx 9.x autodoc regressions <sphinx-doc/sphinx#14089>`_
+that silently skip inherited methods from mixin classes.

--- a/upcoming_changes/3668.maintenance.rst
+++ b/upcoming_changes/3668.maintenance.rst
@@ -1,3 +1,3 @@
 Enable ``autodoc_use_legacy_class_based`` in the documentation configuration
-to work around `Sphinx 9.x autodoc regressions <sphinx-doc/sphinx#14089>`_
+to work around `Sphinx 9.x autodoc regressions <https://github.com/sphinx-doc/sphinx/issues/14089>`_
 that silently skip inherited methods from mixin classes.


### PR DESCRIPTION
Sphinx autodoc's `:inherited-members:` fails to document `plot_scree_plot`, `get_scree_plot_data`, and `plot_cumulative_scree_plot` (defined on the MVA mixin in `hyperspy.learn._mva`) in some environments. This is a known issue tracked in [sphinx#13721](https://github.com/sphinx-doc/sphinx/issues/13721) and [sphinx#13316](https://github.com/sphinx-doc/sphinx/issues/13316).

**Changes (2 files, +7/-1):**

1. `doc/conf.py` (+6): enable `autodoc_use_legacy_class_based = True` — legacy autodoc correctly picks up inherited mixin methods on CI (Python 3.12). Also avoids Sphinx 9.x autodoc regressions ([sphinx#14089](https://github.com/sphinx-doc/sphinx/issues/14089)).

2. `hyperspy/learn/_mva.py` (-1/+1): fix cross-reference `:meth:`~._signals.lazy.LazySignal.rechunk`` → `:meth:`~.api.signals.LazySignal.rechunk`` — matches the Sphinx-documented path (`hyperspy.api.signals.LazySignal`) so it resolves in nitpick mode.