### PR TITLE
Fix unresolved LazySignal.rechunk cross-reference in MVA docstrings

### DIFF
--- a/hyperspy/learn/_mva.py
+++ b/hyperspy/learn/_mva.py
@@ -53,7 +53,7 @@ CHUNKS_ARGS = """chunks : str, int, or tuple, default "auto"
             If a tuple of length 2, the first element controls signal
             dimension chunking and the second controls navigation
             chunking (passed as ``nav_chunks`` to
-            :meth:`~._signals.lazy.LazySignal.rechunk`)."""
+            :meth:`~.api.signals.LazySignal.rechunk`)."""
 
 
 decomposition_algorithms = {


### PR DESCRIPTION
The :meth:`~._signals.lazy.LazySignal.rechunk reference in the
decomposition ``chunks`` parameter docstring uses the internal
module path. Sphinx 9.1.0 cannot resolve it, emitting:

  WARNING: py:meth reference target not found:
    _signals.lazy.LazySignal.rechunk [ref.meth]

The public re-export path :meth:`~.api.signals.LazySignal.rechunk
resolves correctly in both the CI build (Python 3.12) and the
readthedocs build (Python 3.11) — same pattern used in
`upcoming_changes/3667.maintenance.rst`.

Renders identically (the method link points to the same
`BaseSignal.rechunk` method); no changelog entry needed.

## Relation to PR #3668

PR #3668 was bundled with a second change (`autodoc_use_legacy_class_based = True`
in `doc/conf.py`) that turned out to be unnecessary — the scree plot
methods (`plot_scree_plot`, `get_scree_plot_data`, `plot_cumulative_scree_plot`)
are documented correctly in both the readthedocs build and the
current CI build, with the `plot_scree_plot` section on
`BaseSignal.html` byte-identical (9985 characters) between the two.
That PR will be closed and replaced by this one.

Assisted-by: opencode:minimax-m3