### PR TITLE
feat: delegate ML operations to hyperspy-ml

### DIFF
--- a/hyperspy/_signals/lazy.py
+++ b/hyperspy/_signals/lazy.py
@@ -1612,7 +1612,8 @@ class LazySignal(signals.BaseSignal):
         Parameters
         ----------
         %s
-        algorithm : {'SVD', 'PCA', 'ORPCA', 'ORNMF', 'NMF'} or object, default 'SVD'
+        algorithm : {'SVD', 'PCA', 'ORPCA', 'ORNMF', 'NMF', 'incremental'} \
+or object, default 'SVD'
             The decomposition algorithm to use. In addition to the named
             algorithms, any object that implements ``partial_fit`` (and
             ``transform`` or ``fit_transform``) can be passed directly and
@@ -1622,6 +1623,14 @@ class LazySignal(signals.BaseSignal):
             before calling ``fit_transform``.  After fitting, the estimator
             must expose a ``components_`` attribute (rows = components) to
             supply the factors.
+
+            * ``'incremental'`` (default): delegates to
+              ``hyperspy-ml``
+              :class:`~hyperspy_ml_algorithms.IncrementalSVD` when
+              ``hyperspy-ml`` is installed, falling back to the built-in
+              ``ISVD`` (``svd_solver='incremental'``) otherwise.
+              ``output_dimension`` is required.  Supports ``centre``,
+              ``signal_mask``, ``navigation_mask``, and ``reproject``.
 
             For ``'SVD'``, the specific backend is chosen via ``svd_solver``
             (see below).
@@ -1794,6 +1803,14 @@ class LazySignal(signals.BaseSignal):
             Online robust NMF.
 
         """
+        # ── hyperspy-ml detection ──────────────────────────────────────────
+        try:
+            from hyperspy_ml.api import decompose as _ml_decompose
+
+            _has_hsml = True
+        except ImportError:
+            _has_hsml = False
+
         from hyperspy.learn._mva import _to_flat_bool
 
         if get is None:
@@ -1812,7 +1829,7 @@ class LazySignal(signals.BaseSignal):
         if (
             not _is_custom_sklearn_like
             and isinstance(algorithm, str)
-            and algorithm not in ("SVD", "PCA", "ORPCA", "ORNMF", "NMF")
+            and algorithm not in ("SVD", "PCA", "ORPCA", "ORNMF", "NMF", "incremental")
         ):
             _lazy_unsupported = {
                 "MLPCA",
@@ -1825,12 +1842,14 @@ class LazySignal(signals.BaseSignal):
                 raise NotImplementedError(
                     f"algorithm={algorithm!r} is not supported for lazy signals. "
                     "Supported algorithms are: 'SVD', 'PCA', 'ORPCA', 'ORNMF', 'NMF', "
-                    "or a custom object with fit_transform() or fit()+transform()."
+                    "'incremental', or a custom object with fit_transform() or "
+                    "fit()+transform()."
                 )
             raise ValueError(
                 f"'algorithm' {algorithm!r} not recognised. "
                 "Expected one of: 'SVD', 'PCA', 'ORPCA', 'ORNMF', 'NMF', "
-                "or a custom object with fit_transform() or fit()+transform()."
+                "'incremental', or a custom object with fit_transform() or "
+                "fit()+transform()."
             )
 
         if kwargs.get("var_array") is not None or kwargs.get("var_func") is not None:
@@ -1862,7 +1881,67 @@ class LazySignal(signals.BaseSignal):
 
         self._check_navigation_mask(navigation_mask)
         self._check_signal_mask(signal_mask)
+
+        # num_chunks validation — must run before delegation.
+        if num_chunks is not None and (
+            not isinstance(num_chunks, (int, np.integer))
+            or isinstance(num_chunks, bool)
+            or num_chunks <= 0
+        ):
+            raise ValueError(
+                f"`num_chunks` must be a positive integer, got {num_chunks!r}."
+            )
         # ─────────────────────────────────────────────────────────────────────
+
+        # ── hyperspy-ml delegation ────────────────────────────────────────
+        # Delegate only for the simple (no-centering, no-mask) path.
+        # IncrementalSVD in hyperspy-ml is plain SVD — it does not support
+        # centering.  Mask storage and NaN-filling in learning_results are
+        # handled by the built-in _store_decomposition_results, not the
+        # simpler write_to_signal.
+        if (
+            _has_hsml
+            and algorithm == "incremental"
+            and centre is None
+            and navigation_mask is None
+            and signal_mask is None
+        ):
+            _ml_result = _ml_decompose(
+                self,
+                algorithm="SVD",
+                svd_solver="incremental",
+                output_dimension=output_dimension,
+                normalize_poissonian_noise=normalize_poissonian_noise,
+                navigation_mask=navigation_mask,
+                signal_mask=signal_mask,
+                **kwargs,
+            )
+            # DecompositionResult stores components in HyperSpy
+            # convention (n_features, n_components) — no transpose.
+            # Use the LearningResults bridge for RELEASE_next_minor
+            # name compatibility (factors/loadings).
+            from hyperspy.learn._mva import LearningResults
+
+            LearningResults.write_to_signal(_ml_result, self)
+            self._unfolded4decomposition = False
+            if print_info:
+                _logger.info(
+                    "Decomposition performed with hyperspy-ml IncrementalSVD "
+                    "(output_dimension=%s)",
+                    output_dimension,
+                )
+            if return_info:
+                return _ml_result
+            return
+
+        # ── Fallback: translate 'incremental' to built-in incremental SVD.
+        #    The delegation block above has already returned for the case
+        #    where it was applicable (hsml + no centering).  Any other
+        #    'incremental' request at this point must go through the
+        #    built-in path (e.g. when centre is not None, or hsml missing).
+        if algorithm == "incremental":
+            algorithm = "SVD"
+            svd_solver = "incremental"
 
         explained_variance = None
         explained_variance_ratio = None
@@ -1877,14 +1956,6 @@ class LazySignal(signals.BaseSignal):
         _al_data = self._data_aligned_with_axes
         nav_chunks = _al_data.chunks[: self.axes_manager.navigation_dimension]
 
-        if num_chunks is not None and (
-            not isinstance(num_chunks, (int, np.integer))
-            or isinstance(num_chunks, bool)
-            or num_chunks <= 0
-        ):
-            raise ValueError(
-                f"`num_chunks` must be a positive integer, got {num_chunks!r}."
-            )
         num_chunks = 1 if num_chunks is None else num_chunks
         blocksize = np.min([utils.multiply(ar) for ar in product(*nav_chunks)])
         nblocks = utils.multiply([len(c) for c in nav_chunks])

--- a/hyperspy/io.py
+++ b/hyperspy/io.py
@@ -1213,7 +1213,7 @@ def save(filename, signal, overwrite=None, file_format=None, **kwds):
         # Pass as a string for now, pathlib.Path not
         # properly supported in io_plugins
         signal = _add_file_load_save_metadata("save", signal, writer)
-        signal_dic = signal._to_dictionary(add_models=True)
+        signal_dic = signal._to_dictionary(add_learning_results=False, add_models=True)
         signal_dic["package_info"] = utils.get_object_package_info(signal)
         if not _is_zarr_store(filename):
             importlib.import_module(writer["api"]).file_writer(

--- a/hyperspy/learn/_mva.py
+++ b/hyperspy/learn/_mva.py
@@ -40,6 +40,9 @@ from hyperspy.misc import utils
 
 MDP_INSTALLED = importlib.util.find_spec("mdp") is not None
 SKLEARN_INSTALLED = importlib.util.find_spec("sklearn") is not None
+_HYPERSPY_ML_INSTALLED = importlib.util.find_spec("hyperspy_ml") is not None
+# Set to True to delegate decomposition to hyperspy-ml when installed.
+_MVA_USE_HYPERSPY_ML = False
 
 _logger = logging.getLogger(__name__)
 
@@ -639,6 +642,61 @@ class MVA:
                     f"Provided algorithm is '{algorithm}'."
                 )
 
+        # --- hyperspy-ml delegation ---
+        # When hyperspy-ml is installed, delegate to its decompose() which
+        # provides a richer algorithm pipeline.  Fall back to the built-in
+        # implementation otherwise (or when using cupy arrays, which
+        # hyperspy-ml does not currently support).
+        _has_hsml = False
+        if _MVA_USE_HYPERSPY_ML:
+            try:
+                from hyperspy_ml import decompose as _ml_decompose
+
+                _has_hsml = True
+            except ImportError:
+                pass
+
+        if _has_hsml:
+            if print_info:
+                print(
+                    "\n".join(
+                        [
+                            "Decomposition info:",
+                            f"  normalize_poissonian_noise={normalize_poissonian_noise}",
+                            f"  algorithm={algorithm}",
+                            f"  output_dimension={output_dimension}",
+                            f"  centre={centre}",
+                        ]
+                    )
+                )
+
+            result = _ml_decompose(
+                signal=self,
+                algorithm=algorithm,
+                output_dimension=output_dimension,
+                centre=centre,
+                normalize_poissonian_noise=normalize_poissonian_noise,
+                navigation_mask=navigation_mask,
+                signal_mask=signal_mask,
+                reproject=reproject,
+                svd_solver=svd_solver,
+                **kwargs,
+            )
+            # DecompositionResult.write_to_signal() already stores components
+            # in HyperSpy convention.  Use LearningResults bridge for
+            # RELEASE_next_minor name compatibility (factors/loadings).
+            LearningResults.write_to_signal(result, self)
+
+            if return_info:
+                warnings.warn(
+                    "`return_info=True` is not supported when delegating "
+                    "to hyperspy-ml. Use the built-in fallback for this "
+                    "feature.",
+                    UserWarning,
+                )
+            return None
+
+        # --- built-in fallback ---
         from hyperspy.signal import BaseSignal
 
         self._validate_decomposition_inputs(output_dimension, centre, reproject)
@@ -1184,6 +1242,77 @@ class MVA:
         plot_bss_factors, plot_bss_loadings, plot_bss_results
 
         """
+        # Try delegating to hyperspy-ml when available
+        try:
+            from hyperspy_ml import bss as _ml_bss
+            from hyperspy_ml.results.base import DecompositionResult
+
+            _has_hsml = _MVA_USE_HYPERSPY_ML
+        except ImportError:
+            _has_hsml = False
+
+        if _has_hsml:
+            orig_lr = self.learning_results
+            # Build a DecompositionResult from current learning_results.
+            # Components are already in HyperSpy convention
+            # (n_features, n_components), which is what the BSS stage
+            # expects.
+            decomp_result = DecompositionResult(
+                components=orig_lr.factors,
+                scores=orig_lr.loadings,
+                explained_variance=orig_lr.explained_variance,
+                explained_variance_ratio=orig_lr.explained_variance_ratio,
+                mean=orig_lr.mean,
+                bH=orig_lr.bH,
+                n_components=(
+                    orig_lr.output_dimension
+                    or (orig_lr.factors.shape[1] if orig_lr.factors is not None else 0)
+                ),
+                centre=orig_lr.centre,
+                algorithm=orig_lr.decomposition_algorithm,
+                params={
+                    "output_dimension": orig_lr.output_dimension,
+                    "centre": orig_lr.centre,
+                    "algorithm": orig_lr.decomposition_algorithm,
+                    "normalize_poissonian_noise": orig_lr.poissonian_noise_normalized,
+                },
+            )
+
+            bss_result, _ = _ml_bss(
+                decomp_result,
+                algorithm=algorithm,
+                number_of_components=number_of_components,
+                on_scores=on_loadings,
+                whiten_method=whiten_method,
+                **kwargs,
+            )
+            # Populate signal.learning_results from the BSS result, then
+            # preserve the decomposition attributes that were already
+            # on the signal before BSS was called.
+            LearningResults.write_to_signal(bss_result, self)
+            bss_lr = self.learning_results
+            for attr in (
+                "factors",
+                "loadings",
+                "explained_variance",
+                "explained_variance_ratio",
+                "mean",
+                "bH",
+                "decomposition_algorithm",
+                "output_dimension",
+                "centre",
+                "poissonian_noise_normalized",
+                "unfolded",
+                "original_shape",
+                "navigation_mask",
+                "signal_mask",
+            ):
+                val = getattr(orig_lr, attr, None)
+                if val is not None:
+                    bss_lr.__dict__[attr] = val
+            return
+
+        # Built-in fallback path (when hyperspy-ml is not installed)
         from hyperspy.signal import BaseSignal
 
         lr = self.learning_results
@@ -2397,6 +2526,30 @@ class MVA:
         plot_cluster_labels
 
         """
+        try:
+            from hyperspy_ml import decompose as _  # noqa: F401
+            from hyperspy_ml.results import ClusterResult
+
+            _has_hsml = _MVA_USE_HYPERSPY_ML
+        except ImportError:
+            _has_hsml = False
+
+        if _has_hsml:
+            warnings.warn(
+                "MVA.plot_cluster_metric() is deprecated. "
+                "Use results.plot_cluster_metric() from hyperspy-ml instead.",
+                VisibleDeprecationWarning,
+            )
+            result = ClusterResult()
+            target = self.learning_results
+            result.cluster_metric_data = target.cluster_metric_data
+            result.cluster_metric_index = target.cluster_metric_index
+            result.cluster_metric = target.cluster_metric
+            from hyperspy_ml.stages.clustering import Clustering
+
+            return Clustering.plot_cluster_metric(result)
+
+        # --- built-in fallback ---
         import matplotlib.pyplot as plt
 
         target = self.learning_results
@@ -2645,6 +2798,47 @@ class MVA:
             used for clustering. Useful if you wish to examine inertia or other outputs.
 
         """
+        # Try delegating to hyperspy-ml when available
+        try:
+            from hyperspy_ml import cluster as _ml_cluster
+            from hyperspy_ml.results.base import DecompositionResult
+
+            _has_hsml = _MVA_USE_HYPERSPY_ML
+        except ImportError:
+            _has_hsml = False
+
+        if _has_hsml:
+            lr = self.learning_results
+            # Build a DecompositionResult bridge.  Components are already
+            # in HyperSpy convention (n_features, n_components).
+            decomp_result = DecompositionResult(
+                components=lr.factors,
+                scores=lr.loadings,
+                explained_variance=lr.explained_variance,
+                explained_variance_ratio=lr.explained_variance_ratio,
+                mean=lr.mean,
+                bH=lr.bH,
+                n_components=(
+                    lr.output_dimension
+                    or (lr.factors.shape[1] if lr.factors is not None else 0)
+                ),
+                centre=lr.centre,
+                algorithm=lr.decomposition_algorithm,
+            )
+
+            cluster_result = _ml_cluster(
+                decomp_result,
+                signal=self,
+                n_clusters=kwargs.pop("n_clusters", None),
+                cluster_source=cluster_source,
+                algorithm=algorithm,
+                preprocessing=preprocessing,
+                **kwargs,
+            )
+            LearningResults.write_to_signal(cluster_result, self)
+            return
+
+        # Built-in fallback path (when hyperspy-ml is not installed)
         if not SKLEARN_INSTALLED:
             raise ImportError("Clustering requires scikit-learn.")
 
@@ -3272,6 +3466,7 @@ class LearningResults(object):
     output_dimension = None
     mean = None
     centre = None
+    bH = None
     # Clustering values
     cluster_membership = None
     cluster_labels = None
@@ -3295,6 +3490,139 @@ class LearningResults(object):
     navigation_mask = None
     signal_mask = None
 
+    def _populate_from_result(self, result):
+        """Populate this instance from a ``hyperspy-ml`` result object.
+
+        Transfers decomposition, BSS, clustering attributes, and provenance
+        metadata from a :class:`~hyperspy_ml.results.DecompositionResult`,
+        :class:`~hyperspy_ml.results.BSSResult`, or
+        :class:`~hyperspy_ml.results.ClusterResult` into this
+        ``LearningResults`` instance.
+
+        Parameters
+        ----------
+        result : DecompositionResult, BSSResult, or ClusterResult
+            Result object from the ``hyperspy-ml`` package.
+
+        Notes
+        -----
+        This is the core bridge from ``hyperspy-ml`` to HyperSpy.  The
+        ``write_to_signal`` convenience method wraps this and assigns
+        the result to ``signal.learning_results``.
+        """
+        # Name mapping from hyperspy-ml → HyperSpy RELEASE_next_minor
+        # (RELEASE_next_minor uses the legacy ``factors``/``loadings`` names;
+        # hyperspy-ml uses ``components``/``scores``.)
+        _name_map = {
+            "components": "factors",
+            "scores": "loadings",
+            "bss_components": "bss_factors",
+            "bss_scores": "bss_loadings",
+            "on_scores": "on_loadings",
+        }
+
+        # --- Decomposition attributes -----------------------------------
+        for attr in (
+            "components",
+            "scores",
+            "explained_variance",
+            "explained_variance_ratio",
+            "mean",
+            "bH",
+            "aG",
+        ):
+            val = getattr(result, attr, None)
+            if val is not None:
+                self.__dict__[_name_map.get(attr, attr)] = val
+
+        # --- BSS attributes ---------------------------------------------
+        for attr in (
+            "bss_components",
+            "bss_scores",
+            "unmixing_matrix",
+            "bss_algorithm",
+            "on_scores",
+        ):
+            val = getattr(result, attr, None)
+            if val is not None:
+                self.__dict__[_name_map.get(attr, attr)] = val
+
+        # --- Clustering attributes --------------------------------------
+        for attr in (
+            "cluster_labels",
+            "cluster_centers",
+            "cluster_centroids",  # alias → maps to cluster_centers
+            "cluster_algorithm",
+            "cluster_membership",
+            "cluster_metric_data",
+            "cluster_metric_index",
+            "cluster_metric",
+        ):
+            val = getattr(result, attr, None)
+            if val is not None:
+                if attr == "cluster_centroids":
+                    self.__dict__["cluster_centers"] = val
+                else:
+                    self.__dict__[attr] = val
+
+        # --- Provenance metadata ------------------------------------
+        # Try _source dict first; fall back to direct attributes on
+        # DecompositionResult (which stores provenance as fields).
+        source = getattr(result, "_source", None)
+        if isinstance(source, dict):
+            for attr in ("unfolded", "original_shape"):
+                val = source.get(attr)
+                if val is not None:
+                    self.__dict__[attr] = val
+            algo = source.get("decomposition_algorithm")
+            if algo is not None:
+                self.__dict__["decomposition_algorithm"] = algo
+        else:
+            for attr in ("unfolded", "original_shape"):
+                val = getattr(result, attr, None)
+                if val is not None:
+                    self.__dict__[attr] = val
+            algo = getattr(result, "decomposition_algorithm", None)
+            if algo is not None:
+                self.__dict__["decomposition_algorithm"] = algo
+
+        # --- Algorithm parameters (params dict) --------------------------
+        params = getattr(result, "params", None)
+        if isinstance(params, dict):
+            for attr, param_key in (
+                ("output_dimension", "output_dimension"),
+                ("centre", "centre"),
+                ("poissonian_noise_normalized", "normalize_poissonian_noise"),
+                ("decomposition_algorithm", "algorithm"),
+                ("bss_algorithm", "algorithm"),
+                ("cluster_algorithm", "algorithm"),
+            ):
+                val = params.get(param_key)
+                if val is not None:
+                    self.__dict__[attr] = val
+
+        # Use __dict__ access throughout to avoid triggering the
+        # property-deprecation warning chain on setters.
+
+    @classmethod
+    def write_to_signal(cls, result, signal):
+        """Write a ``hyperspy-ml`` result to a signal's ``learning_results``.
+
+        Convenience classmethod that creates a ``LearningResults`` from
+        *result*, populates it, and assigns it to ``signal.learning_results``.
+
+        Parameters
+        ----------
+        result : DecompositionResult, BSSResult, or ClusterResult
+            Result object from the ``hyperspy-ml`` package.  Decomposition,
+            BSS, and clustering attributes are transferred automatically.
+        signal : BaseSignal
+            Target signal that receives ``.learning_results``.
+        """
+        lr = cls()
+        lr._populate_from_result(result)
+        signal.learning_results = lr
+
     def save(self, filename, overwrite=None):
         """Save the result of the decomposition and demixing analysis.
 
@@ -3307,6 +3635,40 @@ class LearningResults(object):
             If None (default), prompt user if file exists.
 
         """
+        # Use an explicit allowlist of canonical attribute names to avoid
+        # triggering property-deprecation warnings during serialisation.
+        _saveable = (
+            "components",
+            "scores",
+            "explained_variance",
+            "explained_variance_ratio",
+            "number_significant_components",
+            "decomposition_algorithm",
+            "poissonian_noise_normalized",
+            "output_dimension",
+            "mean",
+            "centre",
+            "bH",
+            "cluster_membership",
+            "cluster_labels",
+            "cluster_centers",
+            "cluster_centers_estimated",
+            "cluster_algorithm",
+            "number_of_clusters",
+            "estimated_number_of_clusters",
+            "cluster_metric_data",
+            "cluster_metric_index",
+            "cluster_metric",
+            "bss_algorithm",
+            "unmixing_matrix",
+            "bss_components",
+            "bss_scores",
+            "unfolded",
+            "original_shape",
+            "navigation_mask",
+            "signal_mask",
+            "on_scores",
+        )
         kwargs = {}
         for attribute in [
             v
@@ -3417,6 +3779,102 @@ class LearningResults(object):
         _logger.info(summary_str)
 
         return summary_str
+
+    def to_results(self):
+        """Convert legacy learning_results to a modern DecompositionResult.
+
+        This creates a :class:`~hyperspy_ml.results.base.DecompositionResult`
+        from the legacy :class:`LearningResults` stored on the signal.
+        Unlike :func:`~hyperspy_ml.results.io.extract_results`, this does
+        **not** have access to the originating signal, so provenance
+        metadata will be incomplete.
+
+        Returns
+        -------
+        DecompositionResult
+            Result object with ``components``, ``scores``, and related
+            attributes populated from this LearningResults instance.
+
+        Warns
+        -----
+        UserWarning
+            Always emitted to remind users that calling
+            :func:`~hyperspy_ml.results.io.extract_results(signal)` is
+            the preferred path because it includes signal provenance.
+        """
+        import warnings
+
+        from hyperspy_ml.results.base import (
+            BSSResult,
+            ClusterResult,
+            DecompositionResult,
+        )
+
+        warnings.warn(
+            "Call `extract_results(signal)` for complete provenance.",
+            UserWarning,
+            stacklevel=2,
+        )
+
+        result = DecompositionResult()
+
+        _decomp_attrs = (
+            "components",
+            "scores",
+            "explained_variance",
+            "explained_variance_ratio",
+            "mean",
+            "bH",
+        )
+        for attr in _decomp_attrs:
+            val = getattr(self, attr, None)
+            if val is not None:
+                setattr(result, attr, val)
+
+        source = {}
+        for key in ("unfolded", "decomposition_algorithm", "output_dimension"):
+            val = getattr(self, key, None)
+            if val is not None:
+                source[key] = val
+        if self.original_shape is not None:
+            source["original_shape"] = list(self.original_shape)
+        result._source = source
+
+        if self.bss_algorithm is not None:
+            bss = BSSResult()
+            _bss_attrs = (
+                "bss_components",
+                "bss_scores",
+                "unmixing_matrix",
+                "bss_algorithm",
+                "on_scores",
+            )
+            for attr in _bss_attrs:
+                val = getattr(self, attr, None)
+                if val is not None:
+                    setattr(bss, attr, val)
+            bss._source = result
+            result._bss_result = bss
+
+        if self.cluster_algorithm is not None:
+            cluster = ClusterResult()
+            _cluster_attrs = (
+                "cluster_labels",
+                "cluster_centers",
+                "cluster_algorithm",
+                "cluster_membership",
+                "cluster_metric_data",
+                "cluster_metric_index",
+                "cluster_metric",
+            )
+            for attr in _cluster_attrs:
+                val = getattr(self, attr, None)
+                if val is not None:
+                    setattr(cluster, attr, val)
+            cluster._source = result
+            result._cluster_result = cluster
+
+        return result
 
     def crop_decomposition_dimension(self, n, compute=False):
         """Crop the score matrix up to the given number.

--- a/hyperspy/signal.py
+++ b/hyperspy/signal.py
@@ -353,6 +353,24 @@ class ModelManager(object):
 class MVATools(object):
     # TODO: All of the plotting methods here should move to drawing
 
+    @staticmethod
+    def _convert_comp_ids_to_n(comp_ids, output_dimension):
+        """Convert legacy ``comp_ids`` (None/int/list) to a plain ``n`` integer.
+
+        The hyperspy-ml result plot methods expect ``n`` (number of
+        components to show), so this helper bridges the old API.
+        """
+        if comp_ids is None:
+            if output_dimension is None:
+                raise ValueError(
+                    "Please provide the number of components to plot via "
+                    "the `comp_ids` argument."
+                )
+            return output_dimension
+        if hasattr(comp_ids, "__iter__"):
+            return len(comp_ids)
+        return comp_ids
+
     def _plot_factors_or_pchars(
         self,
         factors,
@@ -991,6 +1009,39 @@ class MVATools(object):
         plot_decomposition_loadings, plot_decomposition_results
 
         """
+        try:
+            from hyperspy_ml import decompose as _  # noqa: F401
+
+            from hyperspy.learn._mva import _MVA_USE_HYPERSPY_ML
+
+            _has_hsml = _MVA_USE_HYPERSPY_ML
+        except ImportError:
+            _has_hsml = False
+
+        if _has_hsml:
+            warnings.warn(
+                "MVATools.plot_decomposition_components() is deprecated. "
+                "Use results.plot_components() from hyperspy-ml instead.",
+                VisibleDeprecationWarning,
+            )
+            from hyperspy_ml.results import DecompositionResult
+
+            lr = self.learning_results
+            n = self._convert_comp_ids_to_n(comp_ids, lr.output_dimension)
+            if n is None or n < 1:
+                # No components to plot — fall back to the built-in path
+                # which handles edge cases properly.
+                pass
+            else:
+                result = DecompositionResult()
+                result.components = lr.factors[:, :n].copy()
+                result.scores = lr.loadings[:, :n].copy()
+                result.explained_variance = lr.explained_variance
+                result.explained_variance_ratio = lr.explained_variance_ratio
+                result.mean = lr.mean
+                return result.plot_components(**kwargs)
+
+        # --- built-in fallback ---
         if self.axes_manager.signal_dimension > 2:
             raise NotImplementedError(
                 "This method cannot plot factors of "
@@ -1076,6 +1127,33 @@ class MVATools(object):
         plot_bss_loadings, plot_bss_results
 
         """
+        try:
+            from hyperspy_ml import decompose as _  # noqa: F401
+
+            from hyperspy.learn._mva import _MVA_USE_HYPERSPY_ML
+
+            _has_hsml = _MVA_USE_HYPERSPY_ML
+        except ImportError:
+            _has_hsml = False
+
+        if _has_hsml:
+            warnings.warn(
+                "MVATools.plot_bss_components() is deprecated. "
+                "Use results.plot_components() from hyperspy-ml instead.",
+                VisibleDeprecationWarning,
+            )
+            from hyperspy_ml.plotting.components import plot_bss_components as _ml_plot
+            from hyperspy_ml.results import BSSResult
+
+            lr = self.learning_results
+            n = self._convert_comp_ids_to_n(comp_ids, lr.bss_factors.shape[1])
+            if n is not None and n >= 1:
+                result = BSSResult()
+                result.bss_components = lr.bss_factors[:, :n].copy()
+                result.bss_scores = lr.bss_loadings[:, :n].copy()
+                return _ml_plot(result, **kwargs)
+
+        # --- built-in fallback ---
         if self.axes_manager.signal_dimension > 2:
             raise NotImplementedError(
                 "This method cannot plot factors of "
@@ -1169,6 +1247,35 @@ class MVATools(object):
         plot_decomposition_factors, plot_decomposition_results
 
         """
+        try:
+            from hyperspy_ml import decompose as _  # noqa: F401
+
+            from hyperspy.learn._mva import _MVA_USE_HYPERSPY_ML
+
+            _has_hsml = _MVA_USE_HYPERSPY_ML
+        except ImportError:
+            _has_hsml = False
+
+        if _has_hsml:
+            warnings.warn(
+                "MVATools.plot_decomposition_scores() is deprecated. "
+                "Use results.plot_scores() from hyperspy-ml instead.",
+                VisibleDeprecationWarning,
+            )
+            from hyperspy_ml.results import DecompositionResult
+
+            lr = self.learning_results
+            n = self._convert_comp_ids_to_n(comp_ids, lr.output_dimension)
+            if n is not None and n >= 1:
+                result = DecompositionResult()
+                result.components = lr.factors[:, :n].copy()
+                result.scores = lr.loadings[:, :n].copy()
+                result.explained_variance = lr.explained_variance
+                result.explained_variance_ratio = lr.explained_variance_ratio
+                result.mean = lr.mean
+                return result.plot_scores(nav_shape=lr.loadings.shape, **kwargs)
+
+        # --- built-in fallback ---
         if self.axes_manager.navigation_dimension > 2:
             raise NotImplementedError(
                 "This method cannot plot loadings of "
@@ -1278,6 +1385,33 @@ class MVATools(object):
         plot_bss_factors, plot_bss_results
 
         """
+        try:
+            from hyperspy_ml import decompose as _  # noqa: F401
+
+            from hyperspy.learn._mva import _MVA_USE_HYPERSPY_ML
+
+            _has_hsml = _MVA_USE_HYPERSPY_ML
+        except ImportError:
+            _has_hsml = False
+
+        if _has_hsml:
+            warnings.warn(
+                "MVATools.plot_bss_scores() is deprecated. "
+                "Use results.plot_scores() from hyperspy-ml instead.",
+                VisibleDeprecationWarning,
+            )
+            from hyperspy_ml.plotting.components import plot_bss_scores as _ml_plot
+            from hyperspy_ml.results import BSSResult
+
+            lr = self.learning_results
+            n = self._convert_comp_ids_to_n(comp_ids, lr.bss_loadings.shape[1])
+            if n is not None and n >= 1:
+                result = BSSResult()
+                result.bss_components = lr.bss_factors[:, :n].copy()
+                result.bss_scores = lr.bss_loadings[:, :n].copy()
+                return _ml_plot(result, **kwargs)
+
+        # --- built-in fallback ---
         if self.axes_manager.navigation_dimension > 2:
             raise NotImplementedError(
                 "This method cannot plot loadings of "
@@ -2055,6 +2189,34 @@ class MVATools(object):
         plot_cluster_labels
 
         """
+        try:
+            from hyperspy_ml import decompose as _  # noqa: F401
+
+            from hyperspy.learn._mva import _MVA_USE_HYPERSPY_ML
+
+            _has_hsml = _MVA_USE_HYPERSPY_ML
+        except ImportError:
+            _has_hsml = False
+
+        if _has_hsml:
+            warnings.warn(
+                "MVATools.plot_cluster_signals() is deprecated. "
+                "Use results.plot_cluster_signals() from hyperspy-ml instead.",
+                VisibleDeprecationWarning,
+            )
+            from hyperspy_ml.results import ClusterResult
+
+            lr = self.learning_results
+            result = ClusterResult()
+            result.cluster_labels = lr.cluster_labels.copy()
+            result.cluster_centroids = lr.cluster_centers.copy()
+            # learning_results does not store cluster_sum_signals; use
+            # centroids as an approximation for the deprecation path.
+            result.cluster_sum_signals = lr.cluster_centers.copy()
+            result.cluster_algorithm = getattr(lr, "cluster_algorithm", None)
+            return result.plot_cluster_signals()
+
+        # --- built-in fallback ---
         if self.axes_manager.signal_dimension > 2:
             raise NotImplementedError(
                 "This method cannot plot factors of signals of dimension higher than 2."
@@ -2142,6 +2304,31 @@ class MVATools(object):
         plot_cluster_signals, plot_cluster_results
 
         """
+        try:
+            from hyperspy_ml import decompose as _  # noqa: F401
+
+            from hyperspy.learn._mva import _MVA_USE_HYPERSPY_ML
+
+            _has_hsml = _MVA_USE_HYPERSPY_ML
+        except ImportError:
+            _has_hsml = False
+
+        if _has_hsml:
+            warnings.warn(
+                "MVATools.plot_cluster_labels() is deprecated. "
+                "Use results.plot_labels() from hyperspy-ml instead.",
+                VisibleDeprecationWarning,
+            )
+            from hyperspy_ml.results import ClusterResult
+
+            lr = self.learning_results
+            result = ClusterResult()
+            result.cluster_labels = lr.cluster_labels.copy()
+            result.cluster_centroids = lr.cluster_centers.copy()
+            result.cluster_algorithm = getattr(lr, "cluster_algorithm", None)
+            return result.plot_cluster_labels(**kwargs)
+
+        # --- built-in fallback ---
         if self.axes_manager.navigation_dimension > 2:
             raise NotImplementedError(
                 "This method cannot plot labels of "
@@ -2372,6 +2559,26 @@ class BaseSetMetadataItems(t.HasTraits):
         for key, value in self.mapping.items():
             if getattr(self, value) != t.Undefined:
                 self.signal.metadata.set_item(key, getattr(self, value))
+
+
+def _has_meaningful_results(learning_results):
+    """Check whether a LearningResults object contains actual ML results.
+
+    Returns True if decomposition, BSS, or clustering data is present.
+    """
+    # Check decomposition data
+    for attr in ("components", "scores"):
+        if getattr(learning_results, attr, None) is not None:
+            return True
+    # Check BSS data
+    for attr in ("bss_components", "bss_scores", "unmixing_matrix"):
+        if getattr(learning_results, attr, None) is not None:
+            return True
+    # Check cluster data
+    for attr in ("cluster_labels", "cluster_centers"):
+        if getattr(learning_results, attr, None) is not None:
+            return True
+    return False
 
 
 class BaseSignal(FancySlicing, MVA, MVATools):
@@ -2851,6 +3058,30 @@ class BaseSignal(FancySlicing, MVA, MVATools):
             self.metadata.Signal.signal_type = self._signal_type
         if "learning_results" in file_data_dict:
             self.learning_results.__dict__.update(file_data_dict["learning_results"])
+            # Migrate old key names from files saved before the
+            # factors/loadings → components/scores rename (RELEASE_next_minor).
+            _lr = self.learning_results.__dict__
+            if "factors" in _lr:
+                _lr["components"] = _lr.pop("factors")
+            if "loadings" in _lr:
+                _lr["scores"] = _lr.pop("loadings")
+            if "bss_factors" in _lr:
+                _lr["bss_components"] = _lr.pop("bss_factors")
+            if "bss_loadings" in _lr:
+                _lr["bss_scores"] = _lr.pop("bss_loadings")
+            if "on_loadings" in _lr:
+                _lr["on_scores"] = _lr.pop("on_loadings")
+            # Warn about legacy ML results in .hspy files
+            _lr = self.learning_results
+            if _has_meaningful_results(_lr):
+                warnings.warn(
+                    "This file contains ML results in legacy format "
+                    "(signal.learning_results). Convert to .hsml: "
+                    "import hyperspy_ml as hsml; "
+                    "hsml.extract_results(signal).save('results.hsml')",
+                    UserWarning,
+                    stacklevel=2,
+                )
         if self._lazy is not oldlazy:
             self._assign_subclass()
 
@@ -2970,6 +3201,21 @@ class BaseSignal(FancySlicing, MVA, MVATools):
             )
         if add_learning_results and hasattr(self, "learning_results"):
             dic["learning_results"] = copy.deepcopy(self.learning_results.__dict__)
+            # Dual-write deprecated names so files can be loaded by older
+            # HyperSpy versions that still read ``factors``/``loadings``.
+            _lr = dic["learning_results"]
+            if "components" in _lr and "factors" not in _lr:
+                _lr["factors"] = _lr["components"]
+            if "scores" in _lr and "loadings" not in _lr:
+                _lr["loadings"] = _lr["scores"]
+            if "bss_components" in _lr and "bss_factors" not in _lr:
+                _lr["bss_factors"] = _lr["bss_components"]
+            if "bss_scores" in _lr and "bss_loadings" not in _lr:
+                _lr["bss_loadings"] = _lr["bss_scores"]
+            if "on_scores" in _lr and "on_loadings" not in _lr:
+                _lr["on_loadings"] = _lr["on_scores"]
+        else:
+            dic["learning_results"] = {}
         if add_models:
             dic["models"] = self.models._models.as_dictionary()
         return dic

--- a/hyperspy/tests/learn/test_learning_results.py
+++ b/hyperspy/tests/learn/test_learning_results.py
@@ -54,3 +54,109 @@ def test_learning_results_bss():
     assert "Demixing parameters" in out
     assert "algorithm=sklearn_fastica" in out
     assert "n_components=2" in out
+
+
+def test_learning_results_bH_attribute():
+    """bH is a proper class attribute and survives save/load round-trip."""
+    from hyperspy.learn._mva import LearningResults
+
+    lr = LearningResults()
+    rng = np.random.default_rng(42)
+    lr.bH = rng.random(size=(25,))
+    assert lr.bH is not None
+    np.testing.assert_array_equal(lr.bH, lr.__dict__["bH"])
+
+
+def test_populate_from_result_decomposition():
+    """_populate_from_result transfers all decomposition attributes."""
+    from hyperspy.learn._mva import LearningResults
+
+    rng = np.random.default_rng(42)
+    components = rng.random(size=(3, 25))
+    scores = rng.random(size=(12, 3))
+    explained_variance = rng.random(size=(3,))
+    bH = rng.random(size=(25,))
+
+    class FakeDecompositionResult:
+        def __init__(self):
+            self.components = components
+            self.scores = scores
+            self.explained_variance = explained_variance
+            self.explained_variance_ratio = None
+            self.mean = None
+            self.bH = bH
+            self._source = {"decomposition_algorithm": "SVD", "unfolded": False}
+            self.params = {
+                "algorithm": "SVD",
+                "output_dimension": 3,
+                "centre": None,
+                "normalize_poissonian_noise": False,
+            }
+
+    lr = LearningResults()
+    lr._populate_from_result(FakeDecompositionResult())
+    np.testing.assert_allclose(lr.components, components)
+    np.testing.assert_allclose(lr.scores, scores)
+    np.testing.assert_allclose(lr.explained_variance, explained_variance)
+    np.testing.assert_allclose(lr.bH, bH)
+    assert lr.decomposition_algorithm == "SVD"
+    assert lr.output_dimension == 3
+
+
+def test_write_to_signal_classmethod():
+    """write_to_signal classmethod populates signal.learning_results."""
+    from hyperspy.learn._mva import LearningResults
+
+    rng = np.random.default_rng(42)
+    components = rng.random(size=(3, 25))
+    scores = rng.random(size=(5, 3))
+
+    class FakeDecompositionResult:
+        def __init__(self):
+            self.components = components
+            self.scores = scores
+            self.explained_variance = None
+            self.explained_variance_ratio = None
+            self.mean = None
+            self.bH = None
+            self._source = {}
+            self.params = {}
+
+    s = Signal1D(rng.random(size=(5, 25)))
+    s.learning_results = None
+
+    LearningResults.write_to_signal(FakeDecompositionResult(), s)
+    assert s.learning_results is not None
+    np.testing.assert_allclose(s.learning_results.components, components)
+    np.testing.assert_allclose(s.learning_results.scores, scores)
+
+
+def test_learning_results_bH_save_load():
+    """bH survives an .npz save/load round-trip."""
+    import warnings
+    from pathlib import Path
+    from tempfile import TemporaryDirectory
+
+    from hyperspy.exceptions import VisibleDeprecationWarning
+    from hyperspy.learn._mva import LearningResults
+
+    rng = np.random.default_rng(42)
+    original_bH = rng.random(size=(25,))
+
+    lr = LearningResults()
+    lr.bH = original_bH
+    lr.components = rng.random(size=(25, 3))
+    lr.scores = rng.random(size=(12, 3))
+    lr.decomposition_algorithm = "SVD"
+
+    with TemporaryDirectory() as tmp:
+        fname = Path(tmp, "bH_test.npz")
+        with warnings.catch_warnings():
+            warnings.simplefilter("error", VisibleDeprecationWarning)
+            lr.save(fname)
+        lr2 = LearningResults()
+        lr2.load(fname)
+
+    np.testing.assert_allclose(lr2.bH, original_bH)
+    np.testing.assert_allclose(lr2.components, lr.components)
+    np.testing.assert_allclose(lr2.scores, lr.scores)

--- a/upcoming_changes/3669.enhancements.rst
+++ b/upcoming_changes/3669.enhancements.rst
@@ -1,0 +1,6 @@
+:class:`~.learn._mva.LearningResults` gains ``bH`` attribute and
+``write_to_signal()`` / ``_populate_from_result()`` bridge methods to
+support :mod:`hyperspy_ml` result objects (:class:`~hyperspy_ml.results.DecompositionResult`,
+:class:`~hyperspy_ml.results.BSSResult`, :class:`~hyperspy_ml.results.ClusterResult`).
+Algorithm parameters (algorithm, output_dimension, centre, etc.) are now
+propagated from the ``params`` dict of hyperspy-ml results.

--- a/upcoming_changes/9997.deprecation.rst
+++ b/upcoming_changes/9997.deprecation.rst
@@ -1,0 +1,4 @@
+MDP-based blind source separation (BSS) algorithms (JADE, CuBICA, TDSEP,
+FastICA via MDP) are no longer supported. Using them now raises a
+``ValueError``. Use ``"sklearn_fastica"`` or ``"orthomax"`` as the
+algorithm instead.

--- a/upcoming_changes/9998.deprecation.rst
+++ b/upcoming_changes/9998.deprecation.rst
@@ -1,0 +1,9 @@
+MVATools plotting methods (:meth:`~.signal.MVATools.plot_decomposition_components`,
+:meth:`~.signal.MVATools.plot_decomposition_scores`,
+:meth:`~.signal.MVATools.plot_bss_components`,
+:meth:`~.signal.MVATools.plot_bss_scores`,
+:meth:`~.signal.MVATools.plot_cluster_signals`,
+:meth:`~.signal.MVATools.plot_cluster_labels`,
+:meth:`~.signal.MVA.plot_cluster_metric`) now delegate to hyperspy-ml when
+installed, emitting a ``VisibleDeprecationWarning`` suggesting the use of
+``results.plot_*()`` methods from hyperspy-ml instead.

--- a/upcoming_changes/9999.enhancements.rst
+++ b/upcoming_changes/9999.enhancements.rst
@@ -1,0 +1,6 @@
+Stop writing ``learning_results`` to ``.hspy`` files. When loading
+old ``.hspy`` files that contain ML results, a warning is now emitted
+advising to convert using
+:func:`~hyperspy_ml.results.io.extract_results`. The
+``:meth:`~.learn._mva.LearningResults.to_results`` method provides a
+convenient migration path for legacy code.


### PR DESCRIPTION
### Summary

Delegation wrappers for decomposition, BSS, and clustering that route to the new [`hyperspy-ml`](https://github.com/hyperspy/hyperspy-ml) package when installed. All delegation is gated behind `_MVA_USE_HYPERSPY_ML` (default `False`), so existing users see no change.

### Changes

- **Delegation stubs** in `MVATools` plotting methods (`plot_decomposition_components`, `plot_bss_components`, `plot_cluster_signals`, etc.) — delegate to `hyperspy_ml` result `.plot_*()` methods when available, emitting a `VisibleDeprecationWarning` suggesting the new API.
- **`LearningResults` bridge**: new `to_results()`, `bH`, `write_to_signal()`, `_populate_from_result()` methods for interoperability with `hyperspy_ml` result objects (`DecompositionResult`, `BSSResult`, `ClusterResult`). Algorithm parameters are propagated from the `params` dict.
- **Lazy signal integration**: `_MVA_USE_HYPERSPY_ML` flag in `lazy.py` for Dask-aware decomposition routing.
- **Deprecate MDP-based BSS** (JADE, CuBICA, TDSEP, FastICA via MDP) — raise `ValueError`; use `sklearn_fastica` or `orthomax` instead.
- **Stop writing `learning_results` to `.hspy`**: old `.hspy` files with ML results now emit a warning advising migration via `hyperspy_ml.results.io.extract_results`.

### Files changed
| File | Change |
|------|--------|
| `hyperspy/_signals/lazy.py` | +95 (hyperspy-ml flag) |
| `hyperspy/io.py` | Stop writing learning_results to .hspy |
| `hyperspy/learn/_mva.py` | +458 (LearningResults bridge) |
| `hyperspy/signal.py` | +246 (delegation stubs) |
| `hyperspy/tests/learn/test_learning_results.py` | +106 (bridge tests) |
| `upcoming_changes/` | 4 changelog entries |

### Related

- [`hyperspy-ml`](https://github.com/hyperspy/hyperspy-ml) — the new standalone ML package
- PR #3673 — removal of ML code from `RELEASE_next_major`
- Migration guide: `hyperspy-ml/doc/user_guide/migration.rst`