### PR TITLE
Fix reshape in `get_decomposition_model` for `Signal2D`

### DIFF
--- a/hyperspy/learn/_mva.py
+++ b/hyperspy/learn/_mva.py
@@ -1709,6 +1709,7 @@ class MVA:
             nav_chunks = "auto"
 
         nav_shape = self.axes_manager.navigation_shape[::-1]  # numpy order
+        sig_shape = self.axes_manager.signal_shape[::-1]  # numpy order
         n_comp = loadings.shape[1]
 
         if lazy_output or self._lazy:
@@ -1759,14 +1760,13 @@ class MVA:
             #   a = factors @ loadings.T  # (sig_size, n_comp) @ (n_comp, nav_size)
             #   a.T.reshape(nav_shape + (sig_size,))
             a = da.einsum("sc,...c->...s", factors_da, loadings_da)
+            a = a.reshape(nav_shape + sig_shape)
         else:
             # Non-lazy path: standard matrix multiply with explicit
             # transposition of loadings and numpy reshape (always safe).
             loadings_T = loadings.T  # (n_comp, nav_size)
             a = factors @ loadings_T  # (sig_size, nav_size)
-            a = a.T.reshape(
-                nav_shape + (factors.shape[0],)
-            )  # → (ny, nx, ..., sig_size)
+            a = a.T.reshape(nav_shape + sig_shape)
 
         sc = self.deepcopy()
         sc.data = a
@@ -1776,7 +1776,7 @@ class MVA:
             # Reshape to match the multi-dimensional nav axes so that
             # broadcasting works regardless of whether sc.data is unfolded
             # (non-lazy path) or already multi-dimensional (lazy path).
-            sc.data += target.mean.reshape(nav_shape + (-1,))
+            sc.data += target.mean.reshape(nav_shape + (1,) * len(sig_shape))
 
         if lazy_output:
             if not sc._lazy:

--- a/hyperspy/tests/learn/test_decomposition.py
+++ b/hyperspy/tests/learn/test_decomposition.py
@@ -190,6 +190,7 @@ class TestGetModel:
         s = self.s
         s.decomposition(algorithm="SVD", output_dimension=3)
         sc = self.s.get_decomposition_model(3, lazy_output=lazy_output)
+        assert sc.data.shape == s.data.shape
         if lazy_output or (lazy_output is None and self.s._lazy):
             assert isinstance(sc.data, da.Array)
         else:
@@ -268,6 +269,61 @@ class TestGetModel:
 
         # Check HyperSpy's chunking convention: signal axes whole.
         assert sc.data.chunks[-1] == (sig_len,)
+
+
+@lazifyTestClass
+class TestGetModelSignal2D:
+    def setup_method(self, method):
+        rng = np.random.default_rng(123)
+        nav_y, nav_x, sig_y, sig_x, n_comp = 4, 5, 6, 7, 3
+        loadings = rng.standard_normal((nav_y * nav_x, n_comp))
+        factors = rng.standard_normal((sig_y * sig_x, n_comp))
+        data = (loadings @ factors.T).reshape(nav_y, nav_x, sig_y, sig_x)
+        self.n_comp = n_comp
+        self.sig_shape = (sig_y, sig_x)
+        self.s = signals.Signal2D(data)
+
+    @pytest.mark.parametrize("lazy_output", [True, False, None])
+    def test_get_decomposition_model(self, lazy_output):
+        s = self.s
+        s.decomposition(algorithm="SVD", output_dimension=self.n_comp)
+        sc = s.get_decomposition_model(self.n_comp, lazy_output=lazy_output)
+
+        assert sc.data.shape == s.data.shape
+        assert sc.axes_manager.signal_dimension == 2
+        if lazy_output or (lazy_output is None and s._lazy):
+            assert isinstance(sc.data, da.Array)
+        else:
+            assert isinstance(sc.data, np.ndarray)
+
+        rms = np.sqrt(((sc.data - s.data) ** 2).sum())
+        if isinstance(rms, da.Array):
+            rms = rms.compute()
+        assert rms < 5e-7
+
+    def test_get_decomposition_model_centre(self):
+        s = self.s
+        s.decomposition(algorithm="SVD", centre="signal", output_dimension=self.n_comp)
+
+        assert s.learning_results.mean is not None
+
+        sc = s.get_decomposition_model(self.n_comp)
+        assert sc.data.shape == s.data.shape
+        assert sc.axes_manager.signal_dimension == 2
+
+        rms = np.sqrt(((sc.data - s.data) ** 2).sum())
+        if isinstance(rms, da.Array):
+            rms = rms.compute()
+        assert rms < 5e-7
+
+    def test_get_decomposition_model_lazy_output_chunks(self):
+        s = self.s
+        s.decomposition(algorithm="SVD", output_dimension=self.n_comp)
+        sc = s.get_decomposition_model(self.n_comp, lazy_output=True, chunks=-1)
+
+        assert isinstance(sc.data, da.Array)
+        assert sc.axes_manager.signal_dimension == 2
+        assert sc.data.chunks[-2:] == ((self.sig_shape[0],), (self.sig_shape[1],))
 
 
 @lazifyTestClass


### PR DESCRIPTION
Fix some failures mentioned in #3671. For example:

```python
=================================== FAILURES ===================================
__________________ TestDecomposition.test_lazy_decomposition ___________________

self = <test_ebsd.TestDecomposition object at 0x7f1838a280e0>
dummy_signal = <EBSD, title: , dimensions: (3, 3|3, 3)>

    def test_lazy_decomposition(self, dummy_signal):
        lazy_signal = dummy_signal.as_lazy()
        lazy_signal.change_dtype(np.float32)
>       lazy_signal.decomposition()

/home/runner/miniconda3/envs/test/lib/python3.12/site-packages/kikuchipy/tests/test_signals/test_ebsd.py:1731: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
/home/runner/miniconda3/envs/test/lib/python3.12/site-packages/hyperspy/_signals/lazy.py:1856: in decomposition
    self._validate_decomposition_inputs(
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

self = <LazyEBSD, title: , dimensions: (3, 3|3, 3)>, output_dimension = None
centre = None, reproject = None, svd_solver = 'randomized'

    def _validate_decomposition_inputs(
        self, output_dimension, centre, reproject, svd_solver=None
    ):
        """Validate inputs shared by lazy and non-lazy decomposition().
    
        Parameters
        ----------
        output_dimension : int or None
            Number of components to compute; ``None`` means all.
        centre : str or None
            Centering strategy (``'navigation'``, ``'signal'``, or ``None``).
        reproject : str or None
            Reprojection mode (``'navigation'``, ``'signal'``, ``'both'``, or ``None``).
        svd_solver : str or None, default None
            When provided (lazy path only), also validates that
            ``output_dimension`` is supplied for solvers that require it
            (``'randomized'`` and ``'incremental'``).
    
        Raises
        ------
        TypeError
            If the data is not a floating-point array.
        ValueError
            If any of the other inputs are invalid.
        """
        if self.data.dtype.char not in np.typecodes["AllFloat"]:
            raise TypeError(
                "To perform a decomposition the data must be of the "
                f"floating-point (including complex) type, but the current type is '{self.data.dtype}'. "
                "To fix this issue, you can change the type using the "
                "change_dtype method (e.g. s.change_dtype('float64')) "
                "and then repeat the decomposition.\n"
                "No decomposition was performed."
            )
    
        if self.axes_manager.navigation_size < 2:
            raise ValueError(
                "It is not possible to decompose a dataset with navigation_size < 2"
            )
    
        if output_dimension is not None:
        lazy_signal.learning_results.loadings = da.from_array(
            lazy_signal.learning_results.loadings
        )
    
        # Get decomposition model
        model_signal = lazy_signal.get_decomposition_model(
            components=components, dtype_out=np.float32
        )
    
        # Check data shape, signal class and image intensities in model
        # signal after rescaling to 8 bit unsigned integer
>       assert model_signal.data.shape == lazy_signal.data.shape
E       assert (3, 3, 9) == (3, 3, 3, 3)
E         
E         At index 2 diff: 9 != 3
E         Right contains one more item: 3
E         
E         Full diff:
E           (
E               3,
E               3,
E         -     3,
E         ?     ^
E         +     9,
E         ?     ^
E         -     3,
E           )

/home/runner/miniconda3/envs/test/lib/python3.12/site-packages/kikuchipy/tests/test_signals/test_ebsd.py:1791: AssertionError
```

