### PR TITLE
docs: add AI-assisted proposals workflow

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -11,3 +11,11 @@ The [issue tracker](https://github.com/hyperspy/hyperspy/issues) can be used to 
 ## Contribute
 
 If you want to contribute to the HyperSpy source code, you can send us a [pull requests](https://github.com/hyperspy/hyperspy/pulls). For more information, please read the [developer guide](https://hyperspy.readthedocs.io/en/latest/dev_guide/intro.html).
+
+## AI-Assisted Contributions
+
+Non-trivial AI-assisted changes (>1 file or architectural change) require an accepted proposal in [hyperspy/hyperspy-proposals](https://github.com/hyperspy/hyperspy-proposals) before the implementation PR will be reviewed. Trivial AI-assisted changes (typo fixes, single-file bug fixes) do not require a proposal.
+
+For more details, see the [proposals section](https://hyperspy.readthedocs.io/en/latest/dev_guide/proposals.html) of the developer guide.
+
+All AI-assisted commits must include the `Assisted-by: <tool>:<model>` trailer.

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -14,7 +14,7 @@ If you want to contribute to the HyperSpy source code, you can send us a [pull r
 
 ## AI-Assisted Contributions
 
-Non-trivial AI-assisted changes (>1 file or architectural change) require an accepted proposal in [hyperspy/hyperspy-proposals](https://github.com/hyperspy/hyperspy-proposals) before the implementation PR will be reviewed. Trivial AI-assisted changes (typo fixes, single-file bug fixes) do not require a proposal.
+Non-trivial AI-assisted changes require an accepted proposal in [hyperspy/hyperspy-proposals](https://github.com/hyperspy/hyperspy-proposals) before the implementation PR will be reviewed. Trivial AI-assisted changes do not require a proposal.
 
 For more details, see the [proposals section](https://hyperspy.readthedocs.io/en/latest/dev_guide/proposals.html) of the developer guide.
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -13,6 +13,9 @@ A few sentences and/or a bulleted list to describe and motivate the change:
 - etc.
 
 ### Progress of the PR
+- [ ] Is this an AI-assisted contribution? If yes, and non-trivial, link to the accepted proposal:
+      - [ ] N/A (human-only contribution or trivial change)
+      - [ ] Proposal accepted: <link to PR in hyperspy/hyperspy-proposals>
 - [ ] Change implemented (can be split into several points),
 - [ ] if AI-assisted, ``Assisted-by: <tool>:<model>`` in every commit,
 - [ ] manually tested on realistic data or a representative workflow,

--- a/doc/dev_guide/index.rst
+++ b/doc/dev_guide/index.rst
@@ -26,4 +26,5 @@ HyperSpy is a community project maintained for and by its users. There are many 
     lazy_import.rst
     useful_information.rst
     coding_with_ai.rst
+    proposals.rst
     maintenance.rst

--- a/doc/dev_guide/proposals.rst
+++ b/doc/dev_guide/proposals.rst
@@ -19,14 +19,14 @@ AI tools were used to assist in its creation.
 
    * - Contribution type
      - Proposal required?
-   * - **AI-assisted, non-trivial** (>1 file or architectural change)
-     - **Yes** — implementation PRs will not be reviewed without an accepted proposal.
-   * - **AI-assisted, trivial** (1 file, typo fix, small bug fix)
-     - No — the PR review is sufficient.
-   * - **Human-only, non-trivial** (architecture change, new feature, API break)
-     - **Recommended** — not mandatory, but strongly encouraged for large changes.
-   * - **Human-only, trivial** (bug fix, doc improvement, test addition)
-     - No — the PR review is sufficient.
+   * - **AI-assisted, non-trivial**
+      - **Yes** — implementation PRs will not be reviewed without an accepted proposal.
+   * - **AI-assisted, trivial**
+      - No — the PR review is sufficient.
+   * - **Human-only, non-trivial**
+      - **Recommended** — not mandatory, but strongly encouraged for large changes.
+   * - **Human-only, trivial**
+      - No — the PR review is sufficient.
 
 For more information on AI-assisted development, see :ref:`coding_with_ai-label`.
 

--- a/doc/dev_guide/proposals.rst
+++ b/doc/dev_guide/proposals.rst
@@ -3,75 +3,15 @@
 HyperSpy Proposals
 ==================
 
-HyperSpy uses a formal proposal process for significant changes to the ecosystem.
-This ensures that the community can review and discuss the **approach** before
-investing time in the **implementation**.
-
-When is a proposal required?
-----------------------------
-
-The requirement for a proposal depends on the nature of the change and whether
-AI tools were used to assist in its creation.
-
-.. list-table::
-   :widths: 40 60
-   :header-rows: 1
-
-   * - Contribution type
-     - Proposal required?
-   * - **AI-assisted, non-trivial**
-      - **Yes** — implementation PRs will not be reviewed without an accepted proposal.
-   * - **AI-assisted, trivial**
-      - No — the PR review is sufficient.
-   * - **Human-only, non-trivial**
-      - **Recommended** — not mandatory, but strongly encouraged for large changes.
-   * - **Human-only, trivial**
-      - No — the PR review is sufficient.
+HyperSpy uses a formal proposal process for significant changes to the
+ecosystem. Proposals are submitted as pull requests to the
+`hyperspy/hyperspy-proposals <https://github.com/hyperspy/hyperspy-proposals>`_
+repository. See its
+`README <https://github.com/hyperspy/hyperspy-proposals#readme>`_
+for full details on when proposals are required, how to submit, how review
+works, and what happens after acceptance.
 
 For more information on AI-assisted development, see :ref:`coding_with_ai-label`.
-
-How to submit a proposal
-------------------------
-
-Proposals are submitted as pull requests to the `hyperspy/hyperspy-proposals <https://github.com/hyperspy/hyperspy-proposals>`_ repository.
-
-1. **Create a markdown file** named ``<PR_NUMBER>-<short-slug>.md`` (e.g., ``0042-hspy-spec.md``).
-   Use the PR number you will get when you open the PR — if unsure, use a placeholder and rename after.
-
-2. **Start the file with a YAML metadata block**:
-
-   .. code-block:: yaml
-
-      ---
-      proposal: 0042
-      title: "hspy-spec — a metadata specification system for HyperSpy 3.0"
-      type: Architecture          # Architecture | Feature | Bugfix | Process
-      target_branch: hyperspy/hyperspy:RELEASE_next_major
-      target_repos: [hyperspy/hyperspy, hyperspy/rosettasciio, hyperspy/hspy-spec]
-      status: review              # review | accepted | implemented | superseded
-      ai_assisted: true
-      created: 2026-06-30
-      ---
-
-3. **Write the proposal**. Include the problem being solved, the proposed approach,
-   affected repositories, breaking changes, and questions for the community.
-
-4. **Open a PR** to the proposals repository with the markdown file.
-
-How review works
-----------------
-
-- **Inline comments**: Reviewers comment on specific lines or paragraphs using standard GitHub PR reviews.
-- **Consensus**: A proposal is accepted when maintainers of the affected repositories approve.
-- **Deadline**: A feedback deadline (typically 2-4 weeks) should be set in the PR description.
-
-After acceptance
-----------------
-
-1. **Merge the proposal PR**. The proposal is now accepted and lives in the repository permanently.
-2. **Implement the changes** in the target repositories.
-3. **Reference the proposal** in each implementation PR: "Implements `proposal 0042 <https://github.com/hyperspy/hyperspy-proposals/blob/main/0042-hspy-spec.md>`_."
-4. **Update proposal status**: After the implementation is merged, update the proposal's metadata to ``status: implemented``.
 
 AI-assisted plan-to-proposal workflow
 -------------------------------------
@@ -87,9 +27,3 @@ Guidelines for transformation:
 - **ADD**: High-level rationale, user-facing impact, and alternatives considered.
 - **FORMAT**: Use clear headings, tables for complex comparisons, and code blocks for API examples.
 - **LENGTH**: Aim for a document that a human can read and understand in 5-10 minutes.
-
-Full details
-------------
-
-For the complete documentation on the proposals process, including licensing and
-detailed metadata definitions, see the `README of the hyperspy-proposals repository <https://github.com/hyperspy/hyperspy-proposals>`_.

--- a/doc/dev_guide/proposals.rst
+++ b/doc/dev_guide/proposals.rst
@@ -1,0 +1,95 @@
+.. _proposals-label:
+
+HyperSpy Proposals
+==================
+
+HyperSpy uses a formal proposal process for significant changes to the ecosystem.
+This ensures that the community can review and discuss the **approach** before
+investing time in the **implementation**.
+
+When is a proposal required?
+----------------------------
+
+The requirement for a proposal depends on the nature of the change and whether
+AI tools were used to assist in its creation.
+
+.. list-table::
+   :widths: 40 60
+   :header-rows: 1
+
+   * - Contribution type
+     - Proposal required?
+   * - **AI-assisted, non-trivial** (>1 file or architectural change)
+     - **Yes** — implementation PRs will not be reviewed without an accepted proposal.
+   * - **AI-assisted, trivial** (1 file, typo fix, small bug fix)
+     - No — the PR review is sufficient.
+   * - **Human-only, non-trivial** (architecture change, new feature, API break)
+     - **Recommended** — not mandatory, but strongly encouraged for large changes.
+   * - **Human-only, trivial** (bug fix, doc improvement, test addition)
+     - No — the PR review is sufficient.
+
+For more information on AI-assisted development, see :ref:`coding_with_ai-label`.
+
+How to submit a proposal
+------------------------
+
+Proposals are submitted as pull requests to the `hyperspy/hyperspy-proposals <https://github.com/hyperspy/hyperspy-proposals>`_ repository.
+
+1. **Create a markdown file** named ``<PR_NUMBER>-<short-slug>.md`` (e.g., ``0042-hspy-spec.md``).
+   Use the PR number you will get when you open the PR — if unsure, use a placeholder and rename after.
+
+2. **Start the file with a YAML metadata block**:
+
+   .. code-block:: yaml
+
+      ---
+      proposal: 0042
+      title: "hspy-spec — a metadata specification system for HyperSpy 3.0"
+      type: Architecture          # Architecture | Feature | Bugfix | Process
+      target_branch: hyperspy/hyperspy:RELEASE_next_major
+      target_repos: [hyperspy/hyperspy, hyperspy/rosettasciio, hyperspy/hspy-spec]
+      status: review              # review | accepted | implemented | superseded
+      ai_assisted: true
+      created: 2026-06-30
+      ---
+
+3. **Write the proposal**. Include the problem being solved, the proposed approach,
+   affected repositories, breaking changes, and questions for the community.
+
+4. **Open a PR** to the proposals repository with the markdown file.
+
+How review works
+----------------
+
+- **Inline comments**: Reviewers comment on specific lines or paragraphs using standard GitHub PR reviews.
+- **Consensus**: A proposal is accepted when maintainers of the affected repositories approve.
+- **Deadline**: A feedback deadline (typically 2-4 weeks) should be set in the PR description.
+
+After acceptance
+----------------
+
+1. **Merge the proposal PR**. The proposal is now accepted and lives in the repository permanently.
+2. **Implement the changes** in the target repositories.
+3. **Reference the proposal** in each implementation PR: "Implements `proposal 0042 <https://github.com/hyperspy/hyperspy-proposals/blob/main/0042-hspy-spec.md>`_."
+4. **Update proposal status**: After the implementation is merged, update the proposal's metadata to ``status: implemented``.
+
+AI-assisted plan-to-proposal workflow
+-------------------------------------
+
+When using an AI agent (like OpenCode) that generates execution plans, you can
+transform these plans into human-friendly proposals.
+
+Guidelines for transformation:
+
+- **KEEP**: The core architectural decisions, data structure changes, and API signatures.
+- **REMOVE**: Low-level implementation details (e.g., "edit line 42 of file X"),
+  internal tool calls, and temporary workspace setup steps.
+- **ADD**: High-level rationale, user-facing impact, and alternatives considered.
+- **FORMAT**: Use clear headings, tables for complex comparisons, and code blocks for API examples.
+- **LENGTH**: Aim for a document that a human can read and understand in 5-10 minutes.
+
+Full details
+------------
+
+For the complete documentation on the proposals process, including licensing and
+detailed metadata definitions, see the `README of the hyperspy-proposals repository <https://github.com/hyperspy/hyperspy-proposals>`_.


### PR DESCRIPTION
Adds the AI-assisted proposals workflow to the HyperSpy developer documentation and contribution guidelines, as described in [hyperspy/hyperspy-proposals](https://github.com/hyperspy/hyperspy-proposals).

## What changed

- Added `doc/dev_guide/proposals.rst` — developer guide section documenting the proposals workflow, linked from `doc/dev_guide/index.rst`
- Updated `.github/CONTRIBUTING.md` — added "AI-Assisted Contributions" section
- Updated `.github/PULL_REQUEST_TEMPLATE.md` — added AI-assisted contribution checkbox
- Removed numerical definition of trivial/non-trivial changes — left to contributor judgment and reviewer consensus

## Related

- The proposals repository: https://github.com/hyperspy/hyperspy-proposals
- hspy-spec proposal (PR #1): https://github.com/hyperspy/hyperspy-proposals/pull/1