### PR TITLE
Fix AxesManager.set_axis replacing the wrong axis for multi-axis signals

### DIFF
--- a/hyperspy/axes.py
+++ b/hyperspy/axes.py
@@ -1877,7 +1877,13 @@ class AxesManager(t.HasTraits):
             with the axis passed in argument.
 
         """
-        self._axes[index_in_axes_manager] = axis
+        # ``index_in_axes_manager`` is a natural-order index (as used by
+        # ``axes_manager[i]``), which does not match the array order of
+        # ``self._axes`` when navigation/signal grouping reverses an axis
+        # group. Resolve the target axis in natural order first, then replace
+        # it at its actual position in ``self._axes`` (see gh#3294).
+        old_axis = self._get_axes_in_natural_order()[index_in_axes_manager]
+        self._axes[self._axes.index(old_axis)] = axis
 
     def _update_max_index(self):
         self._max_index = 1

--- a/hyperspy/signal.py
+++ b/hyperspy/signal.py
@@ -3666,7 +3666,10 @@ class BaseSignal(FancySlicing, MVA, MVATools):
 
         if new_axis is not old_axis:
             # user specifies a new_axis != "uniform"
-            s.axes_manager.set_axis(new_axis, axis_idx)
+            # ``set_axis`` takes a natural-order index (``index_in_axes_manager``);
+            # ``axis_idx`` above is the array-order index needed for the numpy
+            # interpolation, so pass the natural-order index explicitly (gh#3294).
+            s.axes_manager.set_axis(new_axis, old_axis.index_in_axes_manager)
 
         if not inplace:
             return s

--- a/hyperspy/tests/axes/test_axes_manager.py
+++ b/hyperspy/tests/axes/test_axes_manager.py
@@ -127,6 +127,28 @@ class TestAxesManager:
         assert am[-2].offset == am[-1].offset
         assert am[-2].scale == am[-1].scale
 
+    @pytest.mark.parametrize("index", [0, 1])
+    def test_set_axis_natural_order(self, index):
+        # set_axis takes a natural-order index (as used by axes_manager[i]),
+        # which differs from the array order of _axes for multi-axis signals
+        # (gh#3294). Replacing by natural-order index must replace the axis
+        # actually located there, identified here by name -- each case starts
+        # from a fresh signal so the assertion targets a single set_axis call.
+        s = hs.signals.Signal2D(
+            np.arange(80).reshape(8, 10),
+            axes=[
+                {"name": "short", "size": 8},
+                {"name": "long", "size": 10},
+            ],
+        )
+        am = s.axes_manager
+        replacement = am[index].copy()
+        replacement.name = "replaced"
+        expected = [ax.name for ax in am._get_axes_in_natural_order()]
+        expected[index] = "replaced"
+        am.set_axis(replacement, index)
+        assert [ax.name for ax in am._get_axes_in_natural_order()] == expected
+
     def test_set_attributes(self):
         am = self.am
         am.signal_axes.set(name=("kx", "ky"), offset=(1, 2), scale=3, units="nm^{-1}")

--- a/upcoming_changes/3294.bugfix.rst
+++ b/upcoming_changes/3294.bugfix.rst
@@ -1,0 +1,1 @@
+Fix :meth:`~.axes.AxesManager.set_axis` replacing the wrong axis for signals with more than one axis: the ``index_in_axes_manager`` argument is now interpreted in natural order (as used by ``axes_manager[i]``) instead of the internal array order.


### PR DESCRIPTION
Closes #3294.

### Why

`AxesManager.set_axis(axis, index_in_axes_manager)` is documented (and named) to take a *natural-order* index — the order used by `axes_manager[i]`. But it indexed the internal list directly: `self._axes[index_in_axes_manager] = axis`. `self._axes` is stored in *array* order, and HyperSpy reverses each axis group (navigation/signal) relative to array order to build the natural order (`_update_attributes` → `_get_axes_in_natural_order()`). So whenever a group has more than one axis, the two orders differ and `set_axis` replaced a *different* axis than the caller referenced — exactly the report in #3294 (a `Signal2D` where `set_axis(am[0], 0)` destroyed the *other* signal axis).

The distinction already exists in the codebase: `BaseDataAxis.index_in_array` (`self.axes_manager._axes.index(self)`) vs `index_in_axes_manager` (`self.axes_manager._get_axes_in_natural_order().index(self)`). `set_axis` was the one place conflating them.

### What

- `axes.py`: resolve the target axis in natural order, then replace it at its real position in `_axes`:
  ```python
  old_axis = self._get_axes_in_natural_order()[index_in_axes_manager]
  self._axes[self._axes.index(old_axis)] = axis
  ```
  (`_axes.index` matches by object identity — no axis class defines `__eq__` — so it always targets the intended axis, even when two axes are otherwise identical.)
- `signal.py`: the only internal caller, `interpolate_on_axis`, previously passed `old_axis.index_in_array` (array order), which matched the old, buggy-but-self-consistent behaviour. It now passes `old_axis.index_in_axes_manager` (natural order) so it keeps replacing the intended axis. (`axis_idx` = `index_in_array` is still used for the numpy interpolation axis, which genuinely needs array order.)

### Tests

- New parametrized `test_set_axis_natural_order` reproduces #3294 (a `Signal2D` with two distinctly-named signal axes) and asserts *by name* that the axis at the given natural-order index is the one replaced. It fails on the current code and passes with this change. (The pre-existing `test_set_axis` only compared scale/offset between neighbours, so it passed regardless of which axis was replaced.)
- The existing multi-axis `interpolate_on_axis` tests (`test_interpolate_1s2n`, `_2s1n`, `_random_switch`) guard the caller-side change and still pass — without the `signal.py` change, two of them fail.

Verified locally (macOS arm64, Python 3.12, hyperspy 2.4.1.dev): the new test fails on the parent commit and passes with the fix; `test_axes_manager.py` and `test_interpolate_on_axis.py` pass together (59 tests); `ruff check` and `ruff format --check` clean.
